### PR TITLE
Clarify the use of unsafe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ instead of providing a foreign function interface to libxcb, the generated code
 reimplements the serialising and unserialising code that is provided by libxcb.
 libxcb is only used for receiving and sending opaque packets.
 
-This reimplementation is done without any uses of `unsafe` and thus should enjoy
+This reimplementation tries to avoid uses of `unsafe` and thus should enjoy
 Rust's usual safety guarantees. After all, the best way to trust the unsafe code
 coming out of your code generator is if your code generator does not generate
-any unsafe code.
+any unsafe code. Unsafe code is currently necessary for FFI binding to a handful
+of functions from libxcb (see `src/xcb_ffi.rs`) and a special append-only
+data-structure (see `ExtensionInformation` in `src/connection.rs`).
 
 This means that this project is even safer than libxcb, because libxcb forces
 its users to blindly trust length fields that come from the X11 server.


### PR DESCRIPTION
I was disappointed that xcb-rs requires uses of `unsafe` in code using
the library (and the `unsafe` basically is a direct call to
`std::mem::transmute`, which is quite high on "the scale of unsafety").
This lead to me wording this paragraph poorly.

Improve this by not claiming that there is no unsafe code and by
actually explaining what uses of unsafe there are.

Thanks to "po8" for pointing this out on Reddit.

Signed-off-by: Uli Schlachter <psychon@znc.in>