### PR TITLE
Travis: Use --all-targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ script:
   - python2 rs_code_generator.py -p "$PYDIR" -i "$PROTO" -o /tmp/py2 generated
   - diff -Nurp /tmp/py2 /tmp/py3
 
-  - cargo build --verbose --examples
+  - cargo build --verbose --all-targets
   - cargo test --verbose


### PR DESCRIPTION
I want to ensure all the code compiles. It seems like the --all-targets
argument to "cargo build" is the right thing to do so. While --examples
builds all the examples, this does not guarantee that there are no
non-examples that could be build.

Signed-off-by: Uli Schlachter <psychon@znc.in>