### PR TITLE
Events/errors: Implement From<GenericEvent> / From<GenericError> instead of TryFrom

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -619,11 +619,11 @@ class Module(object):
         self.out("")
 
     def _emit_from_generic(self, name, from_generic_type, extra_name):
-        self.out("impl TryFrom<%s> for %s%s {", from_generic_type, self._name(name), extra_name)
+        self.out("impl From<%s> for %s%s {", from_generic_type, self._name(name), extra_name)
         with Indent(self.out):
-            self.out("type Error = ParseError;")
-            self.out("fn try_from(value: %s) -> Result<Self, Self::Error> {", from_generic_type)
-            self.out.indent("Self::try_from(Into::<Buffer>::into(value))")
+            self.out("fn from(value: %s) -> Self {", from_generic_type)
+            self.out.indent("Self::try_from(Into::<Buffer>::into(value))" +
+                            ".expect(\"Buffer should be large enough so that parsing cannot fail\")")
             self.out("}")
         self.out("}")
 

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -51,41 +51,34 @@ fn main() {
         let event = conn.wait_for_event().unwrap();
         match event.response_type() {
             EXPOSE_EVENT => {
-                let event = ExposeEvent::try_from(event);
+                let event = ExposeEvent::from(event);
                 println!("{:?})", event);
-                if let Ok(event) = event {
-                    if event.count == 0 {
-                        // We ought to clear the background before drawing something new, but...
-                        // whatever
-                        let (width, height): (i16, i16) = (width as _, height as _);
-                        let points = [
-                            Point { x: width, y: height },
-                            Point { x: -10, y: -10 },
-                            Point { x: -10, y: height + 10 },
-                            Point { x: width + 10, y: -10 },
-                        ];
-                        conn.poly_line(CoordMode::Origin, win_id, gc_id, &points).unwrap();
-                        conn.flush();
-                    }
+                if event.count == 0 {
+                    // We ought to clear the background before drawing something new, but...
+                    // whatever
+                    let (width, height): (i16, i16) = (width as _, height as _);
+                    let points = [
+                        Point { x: width, y: height },
+                        Point { x: -10, y: -10 },
+                        Point { x: -10, y: height + 10 },
+                        Point { x: width + 10, y: -10 },
+                    ];
+                    conn.poly_line(CoordMode::Origin, win_id, gc_id, &points).unwrap();
+                    conn.flush();
                 }
             },
             CONFIGURE_NOTIFY_EVENT => {
-                let event = ConfigureNotifyEvent::try_from(event);
-                println!("{:?})", event);
-                if let Ok(event) = event {
-                    width = event.width;
-                    height = event.height;
-                }
+                let event = ConfigureNotifyEvent::from(event);
+                width = event.width;
+                height = event.height;
             },
             CLIENT_MESSAGE_EVENT => {
-                let event = ClientMessageEvent::try_from(event);
+                let event = ClientMessageEvent::from(event);
                 println!("{:?})", event);
-                if let Ok(event) = event {
-                    let data = event.data.as_data32();
-                    if event.format == 32 && event.window == win_id && data[0] == wm_delete_window {
-                        println!("Window was asked to close");
-                        return;
-                    }
+                let data = event.data.as_data32();
+                if event.format == 32 && event.window == win_id && data[0] == wm_delete_window {
+                    println!("Window was asked to close");
+                    return;
                 }
             }
             0 => { println!("Unknown error {:?}", GenericError::try_from(event)); },

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -19,8 +19,6 @@
 
 extern crate x11rb;
 
-use std::convert::TryFrom;
-
 use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::{Connection, SequenceNumber};
 use x11rb::x11_utils::Event;
@@ -899,12 +897,12 @@ fn example_wait_for_event<C: Connection>(conn: &C) -> Result<(), ConnectionError
         match event.response_type() {
             xproto::EXPOSE_EVENT => {
                 // Handle the expose event type
-                let ev = ExposeEvent::try_from(event)?;
+                let ev = ExposeEvent::from(event);
                 // ....
             },
             xproto::BUTTON_PRESS_EVENT => {
                 // Handle the button press event type
-                let ev = ButtonPressEvent::try_from(event)?;
+                let ev = ButtonPressEvent::from(event);
                 // ....
             },
             _ => {
@@ -1215,12 +1213,12 @@ fn example7() -> Result<(), ConnectionErrorOrX11Error> {
         let event = conn.wait_for_event()?;
         match event.response_type() {
             xproto::EXPOSE_EVENT => {
-                let ev = ExposeEvent::try_from(event)?;
+                let ev = ExposeEvent::from(event);
                 println!("Window {} exposed. Region to be redrawn at location ({},{}) \
                          with dimensions ({},{})", ev.window, ev.x, ev.y, ev.width, ev.height);
             },
             xproto::BUTTON_PRESS_EVENT => {
-                let ev = ButtonPressEvent::try_from(event)?;
+                let ev = ButtonPressEvent::from(event);
                 print_modifiers(ev.state);
                 match ev.detail {
                     4 => println!("Wheel Button up in window {}, at coordinates ({},{})",
@@ -1232,33 +1230,33 @@ fn example7() -> Result<(), ConnectionErrorOrX11Error> {
                 }
             },
             xproto::BUTTON_RELEASE_EVENT => {
-                let ev = ButtonReleaseEvent::try_from(event)?;
+                let ev = ButtonReleaseEvent::from(event);
                 print_modifiers(ev.state);
                 println!("Button {} released in window {}, at coordinates ({},{})",
                          ev.detail, ev.event, ev.event_x, ev.event_y);
             },
             xproto::MOTION_NOTIFY_EVENT => {
-                let ev = MotionNotifyEvent::try_from(event)?;
+                let ev = MotionNotifyEvent::from(event);
                 println!("Mouse moved in window {} at coordinates ({},{})",
                          ev.event, ev.event_x, ev.event_y);
             },
             xproto::ENTER_NOTIFY_EVENT => {
-                let ev = EnterNotifyEvent::try_from(event)?;
+                let ev = EnterNotifyEvent::from(event);
                 println!("Mouse entered window {} at coordinates ({},{})",
                          ev.event, ev.event_x, ev.event_y);
             },
             xproto::LEAVE_NOTIFY_EVENT => {
-                let ev = LeaveNotifyEvent::try_from(event)?;
+                let ev = LeaveNotifyEvent::from(event);
                 println!("Mouse left window {} at coordinates ({},{})",
                          ev.event, ev.event_x, ev.event_y);
             },
             xproto::KEY_PRESS_EVENT => {
-                let ev = KeyPressEvent::try_from(event)?;
+                let ev = KeyPressEvent::from(event);
                 print_modifiers(ev.state);
                 println!("Key pressed in window {}", ev.event);
             },
             xproto::KEY_RELEASE_EVENT => {
-                let ev = KeyReleaseEvent::try_from(event)?;
+                let ev = KeyReleaseEvent::from(event);
                 print_modifiers(ev.state);
                 println!("Key released in window {}", ev.event);
             },
@@ -1420,7 +1418,7 @@ fn example8() -> Result<(), ConnectionErrorOrX11Error> {
                 conn.flush();
             },
             xproto::KEY_RELEASE_EVENT => {
-                let ev = KeyReleaseEvent::try_from(event)?;
+                let ev = KeyReleaseEvent::from(event);
                 if ev.detail == 9 {
                     // ESC
                     return Ok(())
@@ -2234,7 +2232,7 @@ fn example10() -> Result<(), ConnectionErrorOrX11Error> {
                 conn.flush();
             },
             xproto::BUTTON_PRESS_EVENT => {
-                let ev = ButtonPressEvent::try_from(event)?;
+                let ev = ButtonPressEvent::from(event);
                 let length = "click here to change cursor".len() as i16;
 
                 if (ev.event_x >= (WIDTH - 7 * length) / 2) &&
@@ -2252,7 +2250,7 @@ fn example10() -> Result<(), ConnectionErrorOrX11Error> {
                 conn.flush();
             },
             xproto::KEY_RELEASE_EVENT => {
-                let ev = KeyReleaseEvent::try_from(event)?;
+                let ev = KeyReleaseEvent::from(event);
                 if ev.detail == 9 {
                     // ESC
                     return Ok(());

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -2,8 +2,6 @@
 
 extern crate x11rb;
 
-use std::convert::TryFrom;
-
 use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::Connection;
 use x11rb::x11_utils::Event;
@@ -261,40 +259,32 @@ fn main() {
         while let Some(event) = event_option {
             match event.response_type() {
                 EXPOSE_EVENT => {
-                    let event = ExposeEvent::try_from(event);
-                    if let Ok(event) = event {
-                        if event.count == 0 {
-                            need_repaint = true;
-                        }
+                    let event = ExposeEvent::from(event);
+                    if event.count == 0 {
+                        need_repaint = true;
                     }
                 }
                 CONFIGURE_NOTIFY_EVENT => {
-                    let event = ConfigureNotifyEvent::try_from(event);
-                    if let Ok(event) = event {
-                        window_size = (event.width, event.height);
-                        pixmap = create_pixmap_wrapper(&conn, screen.root_depth, win_id,
-                                                       window_size).unwrap();
-                        need_reshape = true;
-                    }
+                    let event = ConfigureNotifyEvent::from(event);
+                    window_size = (event.width, event.height);
+                    pixmap = create_pixmap_wrapper(&conn, screen.root_depth, win_id,
+                                                   window_size).unwrap();
+                    need_reshape = true;
                 }
                 MOTION_NOTIFY_EVENT => {
-                    let event = MotionNotifyEvent::try_from(event);
-                    if let Ok(event) = event {
-                        mouse_position = (event.event_x, event.event_y);
-                        need_repaint = true;
-                    }
+                    let event = MotionNotifyEvent::from(event);
+                    mouse_position = (event.event_x, event.event_y);
+                    need_repaint = true;
                 }
                 MAP_NOTIFY_EVENT => {
                     need_reshape = true;
                 }
                 CLIENT_MESSAGE_EVENT => {
-                    let event = ClientMessageEvent::try_from(event);
-                    if let Ok(event) = event {
-                        let data = event.data.as_data32();
-                        if event.format == 32 && event.window == win_id && data[0] == wm_delete_window {
-                            println!("Window was asked to close");
-                            return;
-                        }
+                    let event = ClientMessageEvent::from(event);
+                    let data = event.data.as_data32();
+                    if event.format == 32 && event.window == win_id && data[0] == wm_delete_window {
+                        println!("Window was asked to close");
+                        return;
                     }
                 }
                 0 => { println!("Unknown error {:?}", event); },


### PR DESCRIPTION
Since all errors and (non-XGE) events have a fixed size of 32 bytes, the conversion cannot fail. Thus, we can use `From` instead of `TryFrom`.