### PR TITLE
Travis: Test a fixed Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: rust
 dist: bionic  # need at least xcb-proto 1.12, because commit a3da4e8c in xcb-proto changes our API
 rust:
+  # std::io::IoSlice was stabilised in 1.36.0, but 1.36.0 fails with a weird
+  # error enabled by deny(single_use_lifetimes).
+  - 1.37.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
This commit adds testing on Rust 1.37.0 to Travis. This is currently the
oldest Rust version that can build x11rb. At least 1.36.0 is required
for std::io::IoSlice, but the build fails due to a single use lifetime
error.

Signed-off-by: Uli Schlachter <psychon@znc.in>