### PR TITLE
Add support for sending FDs to the X11 server

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -585,11 +585,11 @@ class Module(object):
 
             if is_list_fonts_with_info:
                 assert obj.reply
-                self.trait_out("Ok(ListFontsWithInfoCookie::new(self.send_request_with_reply(&[%s])?))", slices)
+                self.trait_out("Ok(ListFontsWithInfoCookie::new(self.send_request_with_reply(&[%s], &[])?))", slices)
             elif obj.reply:
-                self.trait_out("Ok(self.send_request_with_reply(&[%s])?)", slices)
+                self.trait_out("Ok(self.send_request_with_reply(&[%s], &[])?)", slices)
             else:
-                self.trait_out("Ok(self.send_request_without_reply(&[%s])?)", slices)
+                self.trait_out("Ok(self.send_request_without_reply(&[%s], &[])?)", slices)
         self.trait_out("}")
         self.trait_out("")
 

--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -2,7 +2,6 @@ extern crate x11rb;
 
 use std::fs::{remove_file, File, OpenOptions};
 use std::io::{Write, Result as IOResult};
-use std::os::unix::io::IntoRawFd;
 
 use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::Connection;
@@ -70,7 +69,7 @@ fn real_main<C: Connection>(conn: &C, screen_num: usize, file: File) -> Result<(
 
 
     let shmseg = conn.generate_id();
-    shm::ConnectionExt::attach_fd(conn, shmseg, file.into_raw_fd(), 0)?;
+    shm::ConnectionExt::attach_fd(conn, shmseg, file, 0)?;
 
     let content = get_shared_memory_content_at_offset(conn, screen, shmseg, 0)?;
     assert_eq!(content[..], TEMP_FILE_CONTENT[0..4]);

--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -1,0 +1,90 @@
+extern crate x11rb;
+
+use std::fs::{remove_file, File, OpenOptions};
+use std::io::{Write, Result as IOResult};
+use std::os::unix::io::IntoRawFd;
+
+use x11rb::xcb_ffi::XCBConnection;
+use x11rb::connection::Connection;
+use x11rb::generated::xproto::{self, ImageFormat, ConnectionExt as _};
+use x11rb::generated::shm;
+use x11rb::errors::ConnectionErrorOrX11Error;
+
+const TEMP_FILE_CONTENT: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd, 0xfc];
+
+struct FreePixmap<'c, C: Connection>(&'c C, xproto::PIXMAP);
+impl<C: Connection> Drop for FreePixmap<'_, C> {
+    fn drop(&mut self) {
+        self.0.free_pixmap(self.1).unwrap();
+    }
+}
+
+/// Get the supported SHM version from the X11 server
+fn check_shm_version<C: Connection>(conn: &C) -> Result<Option<(u16, u16)>, ConnectionErrorOrX11Error>
+{
+    if conn.extension_information(shm::X11_EXTENSION_NAME).is_none() {
+        return Ok(None);
+    }
+
+    let shm_version = shm::ConnectionExt::query_version(conn)?.reply()?;
+    Ok(Some((shm_version.major_version, shm_version.minor_version)))
+}
+
+/// Get the bytes describing the first pixel at the given offset of the given shared memory segment
+/// (interpreted in the screen's root_visual)
+fn get_shared_memory_content_at_offset<C: Connection>(conn: &C, screen: &xproto::Screen, shmseg: shm::SEG, offset: u32)
+-> Result<Vec<u8>, ConnectionErrorOrX11Error>
+{
+    let pixmap = conn.generate_id();
+    shm::ConnectionExt::create_pixmap(conn, pixmap, screen.root, 1, 1, screen.root_depth, shmseg, offset)?;
+    let pixmap = FreePixmap(conn, pixmap);
+
+    let image = xproto::ConnectionExt::get_image(conn, ImageFormat::ZPixmap, pixmap.1, 0, 0, 1, 1, !0)?.reply()?;
+    Ok(image.data)
+}
+
+/// Make a temporary file
+fn make_file() -> IOResult<File>
+{
+    let file_name = "shared_memory.bin";
+    let mut file = OpenOptions::new().create(true).read(true).write(true).truncate(true).open(file_name)?;
+    file.write_all(&TEMP_FILE_CONTENT)?;
+    remove_file(file_name)?;
+    Ok(file)
+}
+
+fn real_main<C: Connection>(conn: &C, screen_num: usize, file: File) -> Result<(), ConnectionErrorOrX11Error> {
+    let screen = &conn.setup().roots[screen_num];
+
+    // Check for SHM 1.2 support (needed for fd passing)
+    if let Some((major, minor)) = check_shm_version(conn)? {
+        if major < 1 || (major == 1 && minor < 2) {
+            eprintln!("X11 server supports version {}.{} of the SHM extension, but version 1.2 is needed",
+                      major, minor);
+            return Ok(());
+        }
+    } else {
+        eprintln!("X11 server does not support SHM extension");
+        return Ok(());
+    }
+
+
+    let shmseg = conn.generate_id();
+    shm::ConnectionExt::attach_fd(conn, shmseg, file.into_raw_fd(), 0)?;
+
+    let content = get_shared_memory_content_at_offset(conn, screen, shmseg, 0)?;
+    assert_eq!(content[..], TEMP_FILE_CONTENT[0..4]);
+
+    let content = get_shared_memory_content_at_offset(conn, screen, shmseg, 4)?;
+    assert_eq!(content[..], TEMP_FILE_CONTENT[4..8]);
+
+    Ok(())
+}
+
+fn main() {
+    let file = make_file().expect("Failed to create temporary file for FD passing");
+    match XCBConnection::connect(None) {
+        Err(err) => eprintln!("Failed to connect to the X11 server: {}", err),
+        Ok((conn, screen_num)) => real_main(&conn, screen_num, file).unwrap()
+    }
+}

--- a/src/regression_tests.rs
+++ b/src/regression_tests.rs
@@ -2,12 +2,11 @@ use std::io::IoSlice;
 use std::convert::TryFrom;
 use std::ops::Deref;
 use std::cell::RefCell;
-use std::os::unix::io::RawFd;
 
 use super::connection::{Connection, Cookie, SequenceNumber};
 use super::errors::{ParseError, ConnectionError, ConnectionErrorOrX11Error};
 use super::generated::xproto::{Setup, QueryExtensionReply, ConnectionExt, Segment, KeymapNotifyEvent};
-use super::utils::Buffer;
+use super::utils::{Buffer, RawFdContainer};
 use super::x11_utils::GenericEvent;
 
 #[derive(Debug)]
@@ -41,13 +40,13 @@ impl FakeConnection {
 }
 
 impl Connection for FakeConnection {
-    fn send_request_with_reply<R>(&self, _bufs: &[IoSlice], _fds: &[RawFd]) -> Result<Cookie<Self, R>, ConnectionError>
+    fn send_request_with_reply<R>(&self, _bufs: &[IoSlice], _fds: Vec<RawFdContainer>) -> Result<Cookie<Self, R>, ConnectionError>
     where R: TryFrom<Buffer, Error=ParseError>
     {
         unimplemented!()
     }
 
-    fn send_request_without_reply(&self, bufs: &[IoSlice], fds: &[RawFd]) -> Result<SequenceNumber, ConnectionError> {
+    fn send_request_without_reply(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>) -> Result<SequenceNumber, ConnectionError> {
         assert_eq!(fds.len(), 0);
 
         let mut storage = Default::default();

--- a/src/regression_tests.rs
+++ b/src/regression_tests.rs
@@ -2,6 +2,7 @@ use std::io::IoSlice;
 use std::convert::TryFrom;
 use std::ops::Deref;
 use std::cell::RefCell;
+use std::os::unix::io::RawFd;
 
 use super::connection::{Connection, Cookie, SequenceNumber};
 use super::errors::{ParseError, ConnectionError, ConnectionErrorOrX11Error};
@@ -40,13 +41,15 @@ impl FakeConnection {
 }
 
 impl Connection for FakeConnection {
-    fn send_request_with_reply<R>(&self, _bufs: &[IoSlice]) -> Result<Cookie<Self, R>, ConnectionError>
+    fn send_request_with_reply<R>(&self, _bufs: &[IoSlice], _fds: &[RawFd]) -> Result<Cookie<Self, R>, ConnectionError>
     where R: TryFrom<Buffer, Error=ParseError>
     {
         unimplemented!()
     }
 
-    fn send_request_without_reply(&self, bufs: &[IoSlice]) -> Result<SequenceNumber, ConnectionError> {
+    fn send_request_without_reply(&self, bufs: &[IoSlice], fds: &[RawFd]) -> Result<SequenceNumber, ConnectionError> {
+        assert_eq!(fds.len(), 0);
+
         let mut storage = Default::default();
         let bufs = self.compute_length_field(bufs, &mut storage)?;
 

--- a/src/xcb_ffi.rs
+++ b/src/xcb_ffi.rs
@@ -83,7 +83,9 @@ impl XCBConnection {
         Ok(result)
     }
 
-    fn send_request(&self, bufs: &[IoSlice], has_reply: bool) -> Result<SequenceNumber, ConnectionError> {
+    fn send_request(&self, bufs: &[IoSlice], fds: &[RawFd], has_reply: bool) -> Result<SequenceNumber, ConnectionError> {
+        assert_eq!(fds.len(), 0);
+
         // For this, we derefence the IoSlices, add two new entries, and create new IoSlices.
         let mut new_bufs = Vec::with_capacity(2 + bufs.len());
 
@@ -139,14 +141,14 @@ impl XCBConnection {
 }
 
 impl Connection for XCBConnection {
-    fn send_request_with_reply<R>(&self, bufs: &[IoSlice]) -> Result<Cookie<Self, R>, ConnectionError>
+    fn send_request_with_reply<R>(&self, bufs: &[IoSlice], fds: &[RawFd]) -> Result<Cookie<Self, R>, ConnectionError>
         where R: TryFrom<Buffer, Error=ParseError>
     {
-        Ok(Cookie::new(self, self.send_request(bufs, true)?))
+        Ok(Cookie::new(self, self.send_request(bufs, fds, true)?))
     }
 
-    fn send_request_without_reply(&self, bufs: &[IoSlice]) -> Result<SequenceNumber, ConnectionError> {
-        self.send_request(bufs, false)
+    fn send_request_without_reply(&self, bufs: &[IoSlice], fds: &[RawFd]) -> Result<SequenceNumber, ConnectionError> {
+        self.send_request(bufs, fds, false)
     }
 
     fn discard_reply(&self, sequence: SequenceNumber) {

--- a/src/xcb_ffi.rs
+++ b/src/xcb_ffi.rs
@@ -173,7 +173,15 @@ impl Connection for XCBConnection {
         unsafe {
             let mut error = null_mut();
             let reply = raw_ffi::xcb_wait_for_reply64((self.0).0, sequence, &mut error);
+
+            // At least one of these pointers must be NULL.
             assert!(reply == null_mut() || error == null_mut());
+
+            // If both pointers are NULL, the xcb connection must be in an error state
+            if reply == null_mut() && error == null_mut() {
+                Err(Self::connection_error_from_connection((self.0).0))?
+            }
+
             if reply != null_mut() {
                 let header = CSlice::new(reply as _, 32);
 


### PR DESCRIPTION
This PR implements the simpler part of of #2: Sending FDs to the X11 server. Receiving FDs from the X11 server is still not possible.

Additionally, this PR fixes a NULL pointer dereference that I came across when investigating what happens when one sends an invalid FD (causing `EBADF`) to the X11 server.