### PR TITLE
Remove unnecessary traits

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -122,8 +122,6 @@ class Module(object):
         self.out("use crate::x11_utils::{GenericEvent as X11GenericEvent, GenericError as X11GenericError};")
         self.out("use crate::x11_utils::TryParse;")
         self.out("#[allow(unused_imports)]")
-        self.out("use crate::x11_utils::TryParseFd;")
-        self.out("#[allow(unused_imports)]")
         self.out("use crate::connection::SequenceNumber;")
         self.out("#[allow(unused_imports)]")
         self.out("use crate::connection::{Cookie, CookieWithFds, Connection as X11Connection};")
@@ -804,12 +802,11 @@ class Module(object):
         self.out("}")
 
         if has_fds:
-            trait = "TryParseFd"
             method = "try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError>"
+            self.out("impl %s%s {", name_transform(self._name(name)), extra_name)
         else:
-            trait = "TryParse"
             method = "try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError>"
-        self.out("impl %s for %s%s {", trait, name_transform(self._name(name)), extra_name)
+            self.out("impl TryParse for %s%s {", name_transform(self._name(name)), extra_name)
         with Indent(self.out):
             self.out("fn %s {", method)
             with Indent(self.out):

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -1,6 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 
-use crate::utils::{RawFdContainer, Buffer};
+use crate::utils::Buffer;
 use crate::errors::ParseError;
 
 /// Common information on events and errors.
@@ -154,15 +154,6 @@ pub trait TryParse: Sized {
     /// If parsing is successful, an instance of the type and a slice for the remaining data should
     /// be returned. Otherwise, an error is returned.
     fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError>;
-}
-
-/// A type implementing this trait can be parsed from some raw bytes and a list of FDs.
-pub trait TryParseFd: Sized {
-    /// Try to parse the given values into an instance of this type.
-    ///
-    /// If parsing is successful, an instance of the type and a slice for the remaining data should
-    /// be returned. Otherwise, an error is returned.
-    fn try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError>;
 }
 
 // Now implement TryParse for some primitive data types that we need.


### PR DESCRIPTION
Fixed #86.

Turns out that the `TryParse` trait is additionally needed, because some extensions want to be able to parse structs defined in other extensions. Thus, structs continue to implement this trait, but requests, errors, etc do not.