### PR TITLE
Use examples as integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - python-xcbgen
       - pkg-config
       - pycodestyle
+      - xvfb
 
 script:
   # Check the code generator against python 2 and 3. Both versions should
@@ -36,3 +37,14 @@ script:
   - cargo test --verbose
 
   - pycodestyle --show-pep8 --show-source $(git ls-files '*.py' | grep -v xcb-proto-1.13) --max-line-length=130
+
+  # Run the examples as 'integration tests'. For this, there is a special
+  # timeout mode where the examples close automatically after some time.
+  - |
+    for example in examples/*.rs; do
+        example=${example/examples\//}
+        example=${example/.rs/}
+        if [ "$example" != tutorial ] ; then
+            X11RB_EXAMPLE_TIMEOUT=1 xvfb-run -a cargo run --example "$example" || exit 1
+        fi
+    done

--- a/examples/integration_test_util/util.rs
+++ b/examples/integration_test_util/util.rs
@@ -1,0 +1,53 @@
+// As far as I can see, I cannot easily share code between different examples. The following code
+// is used by several examples to react to the $X11RB_EXAMPLE_TIMEOUT variable. This code is
+// include!()d in the examples
+
+mod util {
+    use std::thread;
+    use std::env;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use x11rb::connection::Connection;
+    use x11rb::x11_utils::TryParse;
+    use x11rb::generated::xproto::{WINDOW, ConnectionExt as _, EventMask, ClientMessageData, ClientMessageEvent, CLIENT_MESSAGE_EVENT};
+
+    pub fn start_timeout_thread<C>(conn: Arc<C>, window: WINDOW)
+    where C: Connection + Send + Sync + 'static
+    {
+        let timeout = match env::var("X11RB_EXAMPLE_TIMEOUT").ok()
+                .and_then(|str| str.parse().ok()) {
+            None => return,
+            Some(timeout) => timeout
+        };
+
+        let (wm_protocols, wm_delete_window) = {
+            let protocols = conn.intern_atom(false, "WM_PROTOCOLS".as_bytes()).unwrap();
+            let delete = conn.intern_atom(false, "WM_DELETE_WINDOW".as_bytes()).unwrap();
+            (protocols.reply().unwrap().atom, delete.reply().unwrap().atom)
+        };
+
+        let mut data = [0; 20];
+        data[..4].copy_from_slice(&wm_delete_window.to_ne_bytes());
+        let (data, _): (ClientMessageData, _) = TryParse::try_parse(&data).unwrap();
+        let event = ClientMessageEvent {
+            response_type: CLIENT_MESSAGE_EVENT,
+            format: 32,
+            sequence: 0,
+            window: window,
+            type_: wm_protocols,
+            data
+        };
+
+        thread::spawn(move || {
+            thread::sleep(Duration::from_secs(timeout));
+            if let Err(err) = conn.send_event(0, window, EventMask::NoEvent.into(), &event) {
+                eprintln!("Error while sending event: {:?}", err);
+            }
+            if let Err(err) = conn.send_event(0, window, EventMask::SubstructureRedirect.into(), &event) {
+                eprintln!("Error while sending event: {:?}", err);
+            }
+            conn.flush();
+        });
+    }
+}

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -35,7 +35,7 @@ fn main() {
 
     let (mut width, mut height) = (100, 100);
 
-    conn.create_window(24, win_id, screen.root, 0, 0, width, height, 0, WindowClass::InputOutput, 0, &win_aux).unwrap();
+    conn.create_window(screen.root_depth, win_id, screen.root, 0, 0, width, height, 0, WindowClass::InputOutput, 0, &win_aux).unwrap();
 
     util::start_timeout_thread(conn1.clone(), win_id);
 

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -10,8 +10,12 @@ use x11rb::wrapper::ConnectionExt as _;
 
 fn main() {
     let (conn, screen_num) = XCBConnection::connect(None).unwrap();
-    let screen = &conn.setup().roots[screen_num];
 
+    // The following is only needed for start_timeout_thread(), which is used for 'tests'
+    let conn1 = std::sync::Arc::new(conn);
+    let conn = &*conn1;
+
+    let screen = &conn.setup().roots[screen_num];
     let win_id = conn.generate_id();
     let gc_id = conn.generate_id();
 
@@ -32,6 +36,8 @@ fn main() {
     let (mut width, mut height) = (100, 100);
 
     conn.create_window(24, win_id, screen.root, 0, 0, width, height, 0, WindowClass::InputOutput, 0, &win_aux).unwrap();
+
+    util::start_timeout_thread(conn1.clone(), win_id);
 
     let title = "Simple Window";
     conn.change_property8(PropMode::Replace, win_id, Atom::WM_NAME.into(), Atom::STRING.into(), title.as_bytes()).unwrap();
@@ -86,3 +92,5 @@ fn main() {
         }
     }
 }
+
+include!("integration_test_util/util.rs");

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -206,8 +206,8 @@ fn setup_window<C: Connection>(conn: &C, screen: &Screen, window_size: (u16, u16
         .event_mask(EventMask::Exposure | EventMask::StructureNotify | EventMask::PointerMotion)
         .background_pixel(screen.white_pixel);
 
-    conn.create_window(24, win_id, screen.root, 0, 0, window_size.0, window_size.1, 0,
-                  WindowClass::InputOutput, 0, &win_aux)?;
+    conn.create_window(screen.root_depth, win_id, screen.root, 0, 0, window_size.0, window_size.1,
+                       0, WindowClass::InputOutput, 0, &win_aux)?;
 
     let title = "xeyes";
     conn.change_property8(PropMode::Replace, win_id, Atom::WM_NAME.into(), Atom::STRING.into(), title.as_bytes()).unwrap();


### PR DESCRIPTION
This commit makes Travis run all the examples against an X11 server to
test that nothing fails mysteriously. To make this actually work, the
examples that open a window are enhanced with a timeout mode where they
automatically exit after $X11RB_EXAMPLE_TIMEOUT seconds.

Signed-off-by: Uli Schlachter <psychon@znc.in>