### PR TITLE
Some union improvements

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -418,17 +418,14 @@ class Module(object):
             self.out("}")
         self.out("}")
 
-        # Get the size of the union; all variants must have the same size
-        fixed_length = union.fields[0].type.get_total_size()
-        assert all(field.type.get_total_size() == fixed_length for field in union.fields)
-
         self.out("impl TryParse for %s {", rust_name)
         with Indent(self.out):
             self.out("fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {")
             with Indent(self.out):
-                self.out("let inner = value[..%s].iter().copied().collect();", fixed_length)
+                union_size = union.get_total_size()
+                self.out("let inner = value[..%s].iter().copied().collect();", union_size)
                 self.out("let result = %s(inner);", rust_name)
-                self.out("Ok((result, &value[%s..]))", fixed_length)
+                self.out("Ok((result, &value[%s..]))", union_size)
             self.out("}")
         self.out("}")
 

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -423,7 +423,9 @@ class Module(object):
             self.out("fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {")
             with Indent(self.out):
                 union_size = union.get_total_size()
-                self.out("let inner = value[..%s].iter().copied().collect();", union_size)
+                self.out("let inner = value.get(..%s)", union_size)
+                self.out.indent(".ok_or(ParseError::ParseError)?")
+                self.out.indent(".iter().copied().collect();")
                 self.out("let result = %s(inner);", rust_name)
                 self.out("Ok((result, &value[%s..]))", union_size)
             self.out("}")

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -5,9 +5,9 @@ use std::cell::RefCell;
 
 use x11rb::connection::{Connection, Cookie, CookieWithFds, SequenceNumber};
 use x11rb::errors::{ParseError, ConnectionError, ConnectionErrorOrX11Error};
-use x11rb::generated::xproto::{Setup, QueryExtensionReply, ConnectionExt, Segment, KeymapNotifyEvent};
+use x11rb::generated::xproto::{Setup, QueryExtensionReply, ConnectionExt, Segment, KeymapNotifyEvent, ClientMessageData};
 use x11rb::utils::{Buffer, RawFdContainer};
-use x11rb::x11_utils::GenericEvent;
+use x11rb::x11_utils::{GenericEvent, TryParse};
 
 #[derive(Debug)]
 struct SavedRequest {
@@ -220,4 +220,12 @@ fn test_get_keyboard_mapping() -> Result<(), ConnectionError> {
 
     conn.check_requests(&[(false, expected)]);
     Ok(())
+}
+
+#[test]
+fn test_client_message_data_parse() {
+    let short_array = [0, 0, 0];
+    let err = ClientMessageData::try_parse(&short_array);
+    assert!(err.is_err());
+    assert_eq!(err.unwrap_err(), ParseError::ParseError);
 }


### PR DESCRIPTION
This has a small change to the code generator that does not affect the output. The second commit fixes a case where parsing failure could panic instead of returning a `ParseError`.