### PR TITLE
Fix compilation on non-unix

### DIFF
--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -3,6 +3,7 @@ extern crate x11rb;
 use std::fs::{remove_file, File, OpenOptions};
 use std::io::{Write, Result as IOResult};
 use std::ptr::null_mut;
+#[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 
 use libc::{mmap, PROT_READ, PROT_WRITE, MAP_SHARED, MAP_FAILED};


### PR DESCRIPTION
This commit "hides" all uses of RawFd from the compiler on non-unix
systems. To simplify things, RawFdContainer still exists on non-unix.
This avoids changes elsewhere in the API. The contained RawFd type is
replaced with c_int (but RawFd is a type alias for c_int on unix
anyway).

Fixes: https://github.com/psychon/x11rb/issues/58
Signed-off-by: Uli Schlachter <psychon@znc.in>

----

I spent some time getting appveyor to work, but now I will just give up and hope for the best...