### PR TITLE
Deal with some FIXMEs in examples

### DIFF
--- a/examples/check_unchecked_requests.rs
+++ b/examples/check_unchecked_requests.rs
@@ -12,6 +12,7 @@ use x11rb::connection::Connection;
 use x11rb::generated::xproto::ConnectionExt;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::Event;
+use x11rb::wrapper::ConnectionExt as _;
 
 const INVALID_WINDOW: u32 = 0;
 
@@ -60,8 +61,7 @@ fn main() -> Result<(), ConnectionErrorOrX11Error> {
     //   std::mem::drop(conn.destroy_window(INVALID_WINDOW)?);
 
     // Synchronise with the server so that all errors are already received.
-    // FIXME: Add a wrapper to simplify this.
-    conn.get_input_focus()?.reply()?;
+    conn.sync()?;
 
     // Now check if the things above really caused errors. This is the part that is supposed to
     // turn this example into a (bad) integration test.

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -1348,8 +1348,9 @@ fn example_assign_font<C: Connection>(conn: &C, screen: &Screen, window: WINDOW,
 //
 // This example draw a text at 10 pixels (for the base line) of the bottom of a window. Pressing
 // the Esc key exits the program.
-
-// FIXME: This whole example uses checked requests in the original
+//
+// (This whole example uses checked requests in the original, but that does not really seem useful
+// to me, so I changed it.)
 
 fn text_draw<C: Connection>(conn: &C, screen: &Screen, window: WINDOW, x1: i16, y1: i16, label: &str)
 -> Result<(), ConnectionErrorOrX11Error>

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -430,9 +430,11 @@ fn example4() -> Result<(), ConnectionErrorOrX11Error> {
 // }
 //
 // This function flushes all pending requests to the X server (much like the fflush() function is
-// used to flush standard output). The second function is xcb_aux_sync():
+// used to flush standard output). The second function is xcb_aux_sync() / sync():
 //
-//  FIXME There is no xcb_aux_sync() equivalent yet. However, it is just get_input_focus(&conn)?.reply();
+// trait ConnectionExt {
+//     fn sync(&self) -> Result<(), ConnectionErrorOrX11Error>;
+// }
 //
 // This functions also flushes all pending requests to the X server, and then waits until the X
 // server finishing processing these requests. In a normal program, this will not be necessary


### PR DESCRIPTION
Checked requests are available and there is also a `sync()` function, so just use these instead of working around their absence.