### PR TITLE
Add back global functions for sending requests

### DIFF
--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), ConnectionErrorOrX11Error>
 
     // Ask for present ConfigureNotify events
     let event_id = conn.generate_id();
-    present::ConnectionExt::select_input(&conn, event_id, win_id, present::EventMask::ConfigureNotify.into())?;
+    present::select_input(&conn, event_id, win_id, present::EventMask::ConfigureNotify.into())?;
 
     // Cause an event
     conn.configure_window(win_id, &ConfigureWindowAux::new().width(20))?;


### PR DESCRIPTION
Due to name collisions (xproto's `create_pixmap` vs SHM's `create_pixmap`), some of the example code was slightly... un-nice (`shm::ConnectionExt::create_pixmap`). This PR adds the requests as global functions in the module, so that things become slightly less ugly in the presence of name collisions (`shm::create_pixmap`).