### PR TITLE
code generator: Implement From<> for unions

### DIFF
--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -246,17 +246,14 @@ impl<'a, C: Connection> WMState<'a, C> {
 
     fn handle_button_release(&mut self, event: ButtonReleaseEvent) -> Result<(), ConnectionErrorOrX11Error> {
         if let Some(state) = self.find_window_by_id(event.event) {
-            // FIXME: Send the following as the data (requires new API)
-            let data = [self.wm_delete_window, 0];
-            let _ = data;
-            let (data, _): (ClientMessageData, _) = x11rb::x11_utils::TryParse::try_parse(&[0; 20]).unwrap();
+            let data = [self.wm_delete_window, 0, 0, 0, 0];
             let event = ClientMessageEvent {
                 response_type: CLIENT_MESSAGE_EVENT,
                 format: 32,
                 sequence: 0,
                 window: state.window,
                 type_: self.wm_protocols,
-                data
+                data: data.into(),
             };
             self.conn.send_event(0, state.window, EventMask::NoEvent.into(), &event)?;
         }


### PR DESCRIPTION
This commit adds an implementation to unions so that they can be
constructed from their inner types. Luckily, the inner types are
currently unique. XKB will break this by having unions where multiple
"cases" have the same type. But if they have the same type, then you
cannot tell apart the different union variants anyway...

Fixes: https://github.com/psychon/x11rb/issues/77
Signed-off-by: Uli Schlachter <psychon@znc.in>