### PR TITLE
Clippy warnings

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -189,7 +189,7 @@ class Module(object):
         if self.namespace.is_ext:
             self.out("")
             self.out("/// The X11 name of the extension for QueryExtension")
-            self.out("pub const X11_EXTENSION_NAME: &'static str = \"%s\";", self.namespace.ext_xname)
+            self.out("pub const X11_EXTENSION_NAME: &str = \"%s\";", self.namespace.ext_xname)
         self.out("")
 
     def close(self, outer_module):

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -154,6 +154,13 @@ class Module(object):
         self.trait_out = Output()
         self.namespace = outer_module.namespace
 
+        self.out("#![allow(clippy::unreadable_literal)]")
+        self.out("#![allow(clippy::too_many_arguments)]")
+        self.out("#![allow(clippy::needless_lifetimes)]")
+        self.out("#![allow(clippy::identity_op)]")
+        self.out("#![allow(clippy::trivially_copy_pass_by_ref)]")
+        self.out("#![allow(clippy::eq_op)]")
+        self.out("#![allow(clippy::erasing_op)]")
         self.out("use std::convert::TryFrom;")
         self.out("#[allow(unused_imports)]")
         self.out("use std::convert::TryInto;")

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -453,7 +453,7 @@ where C: Connection
     fn new(connection: &C, sequence_number: SequenceNumber) -> RawCookie<C> {
         RawCookie {
             connection,
-            sequence_number: sequence_number
+            sequence_number,
         }
     }
 

--- a/src/xcb_ffi.rs
+++ b/src/xcb_ffi.rs
@@ -67,8 +67,8 @@ mod pending_errors {
             }
 
             // Check if any of the still in-flight responses got a reply/error
-            while let Some(Reverse(seqno)) = inner.in_flight.peek() {
-                let result = match conn.poll_for_reply(*seqno) {
+            while let Some(&Reverse(seqno)) = inner.in_flight.peek() {
+                let result = match conn.poll_for_reply(seqno) {
                     Err(()) => {
                         // This request was not answered/errored yet, so later request will not
                         // have answers as well.
@@ -77,8 +77,6 @@ mod pending_errors {
                     Ok(reply) => reply
                 };
 
-                let seqno = *seqno;
-                std::mem::forget(seqno);
                 let seqno2 = inner.in_flight.pop();
                 assert_eq!(Some(Reverse(seqno)), seqno2);
 
@@ -366,9 +364,9 @@ impl Connection for XCBConnection {
         let buffer = self.wait_for_reply_or_error(sequence)?;
 
         // Get a pointer to the array of integers where libxcb saved the FD numbers
-        let fd_ptr = match &buffer {
-            &Buffer::Vec(_) => unreachable!(), // wait_for_reply() always returns a CSlice
-            &Buffer::CSlice(ref slice) => {
+        let fd_ptr = match buffer {
+            Buffer::Vec(_) => unreachable!(), // wait_for_reply() always returns a CSlice
+            Buffer::CSlice(ref slice) => {
                 // libxcb saves the list of FDs after the data of the reply
                 (unsafe { slice.as_ptr().add(slice.len()) }) as *const RawFd
             }


### PR DESCRIPTION
Clippy is the standard Rust linter. This pull request suppresses some of the warnings in the generated code that are difficult to avoid when automatically generating code, and then fixes some of the warnings. The remaining warnings (and errors) should probably be fixed too.