### PR TITLE
Return a copy from extension_information()

### DIFF
--- a/src/rust_connection.rs
+++ b/src/rust_connection.rs
@@ -261,7 +261,7 @@ impl Connection for RustConnection {
         unimplemented!();
     }
 
-    fn extension_information(&self, extension_name: &'static str) -> Option<&QueryExtensionReply> {
+    fn extension_information(&self, extension_name: &'static str) -> Option<QueryExtensionReply> {
         self.extension_information.extension_information(self, extension_name)
     }
 

--- a/src/xcb_ffi.rs
+++ b/src/xcb_ffi.rs
@@ -311,7 +311,7 @@ impl Connection for XCBConnection {
         }
     }
 
-    fn extension_information(&self, extension_name: &'static str) -> Option<&QueryExtensionReply> {
+    fn extension_information(&self, extension_name: &'static str) -> Option<QueryExtensionReply> {
         self.ext_info.extension_information(self, extension_name)
     }
 

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -70,7 +70,7 @@ impl Connection for FakeConnection {
         // Just ignore this
     }
 
-    fn extension_information(&self, _extension_name: &'static str) -> Option<&QueryExtensionReply> {
+    fn extension_information(&self, _extension_name: &'static str) -> Option<QueryExtensionReply> {
         unimplemented!()
     }
 


### PR DESCRIPTION
Before this commit, extension_information() returned a reference to the
QueryExtensionReply. However, this struct has a size of only 11 bytes
and implements Copy. Just returning a copy instead simplifies things a
bit. Most of all, it gets rid of an unsafe.

Thanks to @dalcde for pointing out that QueryExtensionReply is small and
implements Copy.

Signed-off-by: Uli Schlachter <psychon@znc.in>