### PR TITLE
Split the Connection trait into two

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -166,7 +166,7 @@ class Module(object):
         self.out("use crate::x11_utils::{GenericEvent as X11GenericEvent, GenericError as X11GenericError, Event as _};")
         self.out("use crate::x11_utils::TryParse;")
         self.out("#[allow(unused_imports)]")
-        self.out("use crate::connection::{Cookie, CookieWithFds, VoidCookie, Connection as X11Connection};")
+        self.out("use crate::connection::{Cookie, CookieWithFds, VoidCookie, RequestConnection};")
         if not self.namespace.is_ext:
             self.out("use crate::connection::ListFontsWithInfoCookie;")
         self.out("use crate::errors::{ParseError, ConnectionError};")
@@ -187,11 +187,11 @@ class Module(object):
 
     def close(self, outer_module):
         self.out("/// Extension trait defining the requests of this extension.")
-        self.out("pub trait ConnectionExt: X11Connection {")
+        self.out("pub trait ConnectionExt: RequestConnection {")
         with Indent(self.out):
             self.out.copy_from(self.trait_out)
         self.out("}")
-        self.out("impl<C: X11Connection + ?Sized> ConnectionExt for C {}")
+        self.out("impl<C: RequestConnection + ?Sized> ConnectionExt for C {}")
 
     def enum(self, enum, name):
         rust_name = self._name(name)
@@ -596,7 +596,7 @@ class Module(object):
         generics_str = "<%s>" % ", ".join(["'c", "Conn"] + generics)
         _emit_doc(self.out, obj.doc)
         self.out("pub fn %s%s(%s) -> Result<%s, ConnectionError>", function_name, generics_str, ", ".join(args), result_type_func)
-        prefix_where = ['Conn: X11Connection']
+        prefix_where = ['Conn: RequestConnection']
         self.out("where %s", ", ".join(prefix_where + where))
         self.out("{")
         with Indent(self.out):

--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -4,7 +4,7 @@
 use std::process::exit;
 use std::convert::TryFrom;
 
-use x11rb::connection::Connection;
+use x11rb::connection::{RequestConnection as _, Connection as _};
 use x11rb::xcb_ffi::XCBConnection;
 use x11rb::generated::xproto::{CreateWindowAux, ConfigureWindowAux, WindowClass, ConnectionExt as _, GE_GENERIC_EVENT, GeGenericEvent};
 use x11rb::generated::present;

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -3,7 +3,7 @@
 extern crate x11rb;
 
 use x11rb::xcb_ffi::XCBConnection;
-use x11rb::connection::Connection;
+use x11rb::connection::{RequestConnection as _, Connection};
 use x11rb::x11_utils::Event;
 use x11rb::generated::xproto::*;
 use x11rb::generated::shape::{self, ConnectionExt as _};

--- a/src/rust_connection.rs
+++ b/src/rust_connection.rs
@@ -9,7 +9,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 
 use crate::utils::{Buffer, RawFdContainer};
-use crate::connection::{Connection, Cookie, CookieWithFds, VoidCookie, SequenceNumber, ExtensionInformation, RequestKind, DiscardMode};
+use crate::connection::{RequestConnection, Connection, Cookie, CookieWithFds, VoidCookie, SequenceNumber, ExtensionInformation, RequestKind, DiscardMode};
 use crate::generated::xproto::{Setup, SetupRequest, QueryExtensionReply};
 use crate::x11_utils::{GenericEvent, GenericError};
 use crate::errors::{ParseError, ConnectionError, ConnectionErrorOrX11Error};
@@ -233,7 +233,7 @@ impl RustConnection {
     }
 }
 
-impl Connection for RustConnection {
+impl RequestConnection for RustConnection {
     fn send_request_with_reply<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>) -> Result<Cookie<Self, R>, ConnectionError>
         where R: TryFrom<Buffer, Error=ParseError>
     {
@@ -281,6 +281,12 @@ impl Connection for RustConnection {
         unimplemented!();
     }
 
+    fn maximum_request_bytes(&self) -> usize {
+        unimplemented!()
+    }
+}
+
+impl Connection for RustConnection {
     fn wait_for_event(&self) -> Result<GenericEvent, ConnectionError> {
         Ok(self.inner.borrow_mut().wait_for_event().map_err(|_| ConnectionError::UnknownError)?)
     }
@@ -299,9 +305,5 @@ impl Connection for RustConnection {
 
     fn generate_id(&self) -> u32 {
         self.inner.borrow_mut().generate_id()
-    }
-
-    fn maximum_request_bytes(&self) -> usize {
-        unimplemented!()
     }
 }

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -3,11 +3,11 @@ use std::convert::TryFrom;
 use std::ops::Deref;
 use std::cell::RefCell;
 
-use x11rb::connection::{Connection, Cookie, CookieWithFds, VoidCookie, SequenceNumber, RequestKind, DiscardMode};
+use x11rb::connection::{RequestConnection, Cookie, CookieWithFds, VoidCookie, SequenceNumber, RequestKind, DiscardMode};
 use x11rb::errors::{ParseError, ConnectionError, ConnectionErrorOrX11Error};
-use x11rb::generated::xproto::{Setup, QueryExtensionReply, ConnectionExt, Segment, KeymapNotifyEvent, ClientMessageData};
+use x11rb::generated::xproto::{QueryExtensionReply, ConnectionExt, Segment, KeymapNotifyEvent, ClientMessageData};
 use x11rb::utils::{Buffer, RawFdContainer};
-use x11rb::x11_utils::{GenericEvent, GenericError, TryParse};
+use x11rb::x11_utils::{GenericError, TryParse};
 
 #[derive(Debug)]
 struct SavedRequest {
@@ -49,7 +49,7 @@ impl FakeConnection {
     }
 }
 
-impl Connection for FakeConnection {
+impl RequestConnection for FakeConnection {
     fn send_request_with_reply<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>) -> Result<Cookie<Self, R>, ConnectionError>
     where R: TryFrom<Buffer, Error=ParseError>
     {
@@ -87,26 +87,6 @@ impl Connection for FakeConnection {
     }
 
     fn check_for_error(&self, _sequence: SequenceNumber) -> Result<Option<GenericError>, ConnectionError> {
-        unimplemented!()
-    }
-
-    fn wait_for_event(&self) -> Result<GenericEvent, ConnectionError> {
-        unimplemented!()
-    }
-
-    fn poll_for_event(&self) -> Result<Option<GenericEvent>, ConnectionError> {
-        unimplemented!()
-    }
-
-    fn flush(&self) {
-        unimplemented!()
-    }
-
-    fn setup(&self) -> &Setup {
-        unimplemented!()
-    }
-
-    fn generate_id(&self) -> u32 {
         unimplemented!()
     }
 


### PR DESCRIPTION
This commit adds a new RequestConnection trait that Connection now
requires. This splits Connection up into "things that users most likely
do not need and that is only used by the generated code" and "things
that are useful to users".

Signed-off-by: Uli Schlachter <psychon@znc.in>