### PR TITLE
Allow connections to be unsized

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -603,7 +603,7 @@ class Module(object):
         generics_str = "<%s>" % ", ".join(["'c", "Conn"] + generics)
         _emit_doc(self.out, obj.doc)
         self.out("pub fn %s%s(%s) -> Result<%s, ConnectionError>", function_name, generics_str, ", ".join(args), result_type_func)
-        prefix_where = ['Conn: RequestConnection']
+        prefix_where = ['Conn: RequestConnection + ?Sized']
         self.out("where %s", ", ".join(prefix_where + where))
         self.out("{")
         with Indent(self.out):


### PR DESCRIPTION
There is no reason that so much code requires Connection and
RequestConnection to be Sized. The only reason why this was the case is
that it was easier to add a single ?Sized than the many that this commit
replaces that single one with.

Signed-off-by: Uli Schlachter <psychon@znc.in>