### PR TITLE
Fix even more clippy warnings

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -542,9 +542,11 @@ class Module(object):
                 args.append("%s: %s" % (self._to_rust_variable(field.field_name), rust_type))
                 arg_names.append(self._to_rust_variable(field.field_name))
                 if field.isfd:
-                    fds.append("%s.into()" % self._to_rust_variable(field.field_name))
                     if field.type.is_list:
                         fds_is_list = True
+                        fds.append(self._to_rust_variable(field.field_name))
+                    else:
+                        fds.append("%s.into()" % self._to_rust_variable(field.field_name))
 
         # Figure out the return type of the request function
         if is_list_fonts_with_info:
@@ -1049,7 +1051,7 @@ class Module(object):
                 else:
                     self.out("// Length is 'everything left in the input'")
                     self.out("let mut %s = Vec::new();", field_name)
-                    self.out("while remaining.len() != 0 {")
+                    self.out("while !remaining.is_empty() {")
 
                 with Indent(self.out):
                     self.out("let (v, new_remaining) = %s::try_parse(%s)?;", rust_type, ", ".join(try_parse_args))

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -449,7 +449,7 @@ where C: RequestConnection + ?Sized
     }
 
     /// Consume this instance and get the contained sequence number out.
-    fn to_sequence_number(self) -> SequenceNumber {
+    fn into_sequence_number(self) -> SequenceNumber {
         let number = self.sequence_number;
         // Prevent drop() from running
         std::mem::forget(self);
@@ -500,13 +500,13 @@ where R: TryFrom<Buffer, Error=ParseError>,
     /// Get the raw reply that the server sent.
     pub fn raw_reply(self) -> Result<Buffer, ConnectionErrorOrX11Error> {
         let conn = self.raw_cookie.connection;
-        Ok(conn.wait_for_reply_or_error(self.raw_cookie.to_sequence_number())?)
+        Ok(conn.wait_for_reply_or_error(self.raw_cookie.into_sequence_number())?)
     }
 
     /// Get the raw reply that the server sent, but have errors handled as events.
     pub fn raw_reply_unchecked(self) -> Result<Option<Buffer>, ConnectionError> {
         let conn = self.raw_cookie.connection;
-        Ok(conn.wait_for_reply(self.raw_cookie.to_sequence_number())?)
+        Ok(conn.wait_for_reply(self.raw_cookie.into_sequence_number())?)
     }
 
     /// Get the reply that the server sent.
@@ -527,7 +527,7 @@ where R: TryFrom<Buffer, Error=ParseError>,
     /// Without this function, errors are treated as events after the cookie is dropped.
     pub fn discard_reply_and_errors(self) {
         let conn = self.raw_cookie.connection;
-        conn.discard_reply(self.raw_cookie.to_sequence_number(), RequestKind::HasResponse, DiscardMode::DiscardReplyAndError)
+        conn.discard_reply(self.raw_cookie.into_sequence_number(), RequestKind::HasResponse, DiscardMode::DiscardReplyAndError)
     }
 }
 
@@ -568,7 +568,7 @@ where R: TryFrom<(Buffer, Vec<RawFdContainer>), Error=ParseError>,
     /// Get the raw reply that the server sent.
     pub fn raw_reply(self) -> Result<(Buffer, Vec<RawFdContainer>), ConnectionErrorOrX11Error> {
         let conn = self.raw_cookie.connection;
-        Ok(conn.wait_for_reply_with_fds(self.raw_cookie.to_sequence_number())?)
+        Ok(conn.wait_for_reply_with_fds(self.raw_cookie.into_sequence_number())?)
     }
 
     /// Get the reply that the server sent.


### PR DESCRIPTION
Clippy says that a method with a name beginning with 'to_' should take
self a by reference instead of value. Thus, this renames
RawCookie::to_sequence_number() to into_sequence_number().

This also gets rid of an identity into() in the generated code and
replaces len() != 0 with !is_empty().

Signed-off-by: Uli Schlachter <psychon@znc.in>