### PR TITLE
Return errors properly

### DIFF
--- a/src/xcb_ffi.rs
+++ b/src/xcb_ffi.rs
@@ -323,7 +323,7 @@ impl RequestConnection for XCBConnection {
 
             // If both pointers are NULL, the xcb connection must be in an error state
             if reply.is_null() && error.is_null() {
-                Err(Self::connection_error_from_connection((self.conn).0))?
+                return Err(Self::connection_error_from_connection((self.conn).0).into());
             }
 
             if !reply.is_null() {


### PR DESCRIPTION
This fixes a clippy error about using Err(...)?. Instead, the code now
does return Err(....into());.

Signed-off-by: Uli Schlachter <psychon@znc.in>