### PR TITLE
Add clippy to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ script:
   - python2 rs_code_generator.py -p "$PYDIR" -i "$PROTO" -o /tmp/py2 generated
   - diff -Nurp /tmp/py2 /tmp/py3
 
+  - rustup component add clippy
+  - cargo clippy --all-targets --all-features -- -D warnings
+
   - cargo build --verbose --all-targets
   - cargo test --verbose
 

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -93,7 +93,7 @@ fn run<C: Connection>(conn: Arc<C>, window_state: Arc<Mutex<Window>>,
     conn.poly_fill_rectangle(pixmap, white, &[rect])?;
 
     let mut theta: f64 = 0.0;
-    let radius = default_size as f64 + 1.0;
+    let radius = f64::from(default_size) + 1.0;
 
     loop {
         let guard = window_state.lock().unwrap();
@@ -191,13 +191,12 @@ where C: Connection + Send + Sync + 'static
     }
 }
 
-fn find_window_by_id(windows: &Vec<Arc<Mutex<Window>>>, window: WINDOW) -> Option<&Arc<Mutex<Window>>>
+fn find_window_by_id(windows: &[Arc<Mutex<Window>>], window: WINDOW) -> Option<&Arc<Mutex<Window>>>
 {
     windows.iter()
-        .filter(|state| state.lock()
+        .find(|state| state.lock()
                 .map(|state| state.window == window)
                 .unwrap_or(false))
-        .next()
 }
 
 include!("integration_test_util/util.rs");

--- a/examples/integration_test_util/util.rs
+++ b/examples/integration_test_util/util.rs
@@ -22,8 +22,8 @@ mod util {
         };
 
         let (wm_protocols, wm_delete_window) = {
-            let protocols = conn.intern_atom(false, "WM_PROTOCOLS".as_bytes()).unwrap();
-            let delete = conn.intern_atom(false, "WM_DELETE_WINDOW".as_bytes()).unwrap();
+            let protocols = conn.intern_atom(false, b"WM_PROTOCOLS").unwrap();
+            let delete = conn.intern_atom(false, b"WM_DELETE_WINDOW").unwrap();
             (protocols.reply().unwrap().atom, delete.reply().unwrap().atom)
         };
 

--- a/examples/list_fonts.rs
+++ b/examples/list_fonts.rs
@@ -10,7 +10,7 @@ fn main() {
     let (ltr, rtl): (u8, u8) = (FontDraw::LeftToRight.into(), FontDraw::RightToLeft.into());
 
     println!("DIR  MIN  MAX EXIST DFLT PROP ASC DESC NAME");
-    for reply in conn.list_fonts_with_info(u16::max_value(), "*".as_bytes()).unwrap() {
+    for reply in conn.list_fonts_with_info(u16::max_value(), b"*").unwrap() {
         let reply = reply.unwrap();
 
         let dir = if reply.draw_direction == ltr {
@@ -24,7 +24,7 @@ fn main() {
         let (min, max, indicator) = if reply.min_byte1 == 0 && reply.max_byte1 == 0 {
             (reply.min_char_or_byte2, reply.max_char_or_byte2, ' ')
         } else {
-            (reply.min_byte1 as u16, reply.max_byte1 as u16, '*')
+            (u16::from(reply.min_byte1), u16::from(reply.max_byte1), '*')
         };
 
         let all = if reply.all_chars_exist != 0 { "all" } else { "some" };

--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -95,7 +95,7 @@ fn receive_fd<C: Connection>(conn: &C, screen_num: usize) -> Result<(), Connecti
     let addr = unsafe { mmap(null_mut(), segment_size as _, PROT_READ|PROT_WRITE, MAP_SHARED, shm_fd.as_raw_fd(), 0) };
     if addr == MAP_FAILED {
         shm::detach(conn, shmseg)?;
-        Err(ConnectionError::InsufficientMemory)?
+        return Err(ConnectionError::InsufficientMemory.into());
     }
 
     unsafe {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -20,8 +20,8 @@ fn main() {
     let gc_id = conn.generate_id();
 
     let (wm_protocols, wm_delete_window) = {
-        let protocols = conn.intern_atom(false, "WM_PROTOCOLS".as_bytes()).unwrap();
-        let delete = conn.intern_atom(false, "WM_DELETE_WINDOW".as_bytes()).unwrap();
+        let protocols = conn.intern_atom(false, b"WM_PROTOCOLS").unwrap();
+        let delete = conn.intern_atom(false, b"WM_DELETE_WINDOW").unwrap();
         (protocols.reply().unwrap().atom, delete.reply().unwrap().atom)
     };
 

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -59,7 +59,7 @@ impl<'a, C: Connection> WMState<'a, C> {
         let screen = &conn.setup().roots[screen_num];
         let black_gc = conn.generate_id();
         let font = conn.generate_id();
-        conn.open_font(font, "9x15".as_bytes())?;
+        conn.open_font(font, b"9x15")?;
 
         let gc_aux = CreateGCAux::new()
             .graphics_exposures(0)
@@ -69,8 +69,8 @@ impl<'a, C: Connection> WMState<'a, C> {
         conn.create_gc(black_gc, screen.root, &gc_aux)?;
         conn.close_font(font)?;
 
-        let wm_protocols = conn.intern_atom(false, "WM_PROTOCOLS".as_bytes())?;
-        let wm_delete_window = conn.intern_atom(false, "WM_DELETE_WINDOW".as_bytes())?;
+        let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS")?;
+        let wm_delete_window = conn.intern_atom(false, b"WM_DELETE_WINDOW")?;
 
         Ok(WMState {
             conn,
@@ -165,14 +165,12 @@ impl<'a, C: Connection> WMState<'a, C> {
 
     fn find_window_by_id(&self, win: WINDOW) -> Option<&WindowState> {
         self.windows.iter()
-            .filter(|state| state.window == win || state.frame_window == win)
-            .next()
+            .find(|state| state.window == win || state.frame_window == win)
     }
 
     fn find_window_by_id_mut(&mut self, win: WINDOW) -> Option<&mut WindowState> {
         self.windows.iter_mut()
-            .filter(|state| state.window == win || state.frame_window == win)
-            .next()
+            .find(|state| state.window == win || state.frame_window == win)
     }
 
     /// Handle the given event
@@ -197,7 +195,7 @@ impl<'a, C: Connection> WMState<'a, C> {
                     return true;
                 }
                 conn.destroy_window(state.frame_window).unwrap();
-                return false;
+                false
             });
         Ok(())
     }
@@ -209,16 +207,16 @@ impl<'a, C: Connection> WMState<'a, C> {
         }
         let mut aux = ConfigureWindowAux::default();
         if event.value_mask & Into::<u16>::into(ConfigWindow::X) != 0 {
-            aux = aux.x(event.x as i32);
+            aux = aux.x(i32::from(event.x));
         }
         if event.value_mask & Into::<u16>::into(ConfigWindow::Y) != 0 {
-            aux = aux.y(event.y as i32);
+            aux = aux.y(i32::from(event.y));
         }
         if event.value_mask & Into::<u16>::into(ConfigWindow::Width) != 0 {
-            aux = aux.width(event.width as u32);
+            aux = aux.width(u32::from(event.width));
         }
         if event.value_mask & Into::<u16>::into(ConfigWindow::Height) != 0 {
-            aux = aux.height(event.height as u32);
+            aux = aux.height(u32::from(event.height));
         }
         println!("Configure: {:?}", aux);
         self.conn.configure_window(event.window, &aux)?;

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -361,7 +361,7 @@ pub type WINDOW = u32;
 //
 // Then, XCB supplies the following function to create new windows:
 
-#[allow(unused)]
+#[allow(unused, clippy::too_many_arguments)]
 fn own_create_window<A: Connection, B>(c: &A,               // The connection to use
                                        depth: u8,           // Depth of the screen
                                        wid: u32,            // Id of the window
@@ -742,27 +742,26 @@ fn example6() -> Result<(), ConnectionErrorOrX11Error> {
 
     loop {
         let event = conn.wait_for_event()?;
-        match event.response_type() {
-            xproto::EXPOSE_EVENT => {
-                // We draw the points
-                conn.poly_point(CoordMode::Origin, win, foreground, &points)?;
+        if event.response_type()  == xproto::EXPOSE_EVENT {
+            // We draw the points
+            conn.poly_point(CoordMode::Origin, win, foreground, &points)?;
 
-                // We draw the polygonal line
-                conn.poly_line(CoordMode::Previous, win, foreground, &polyline)?;
+            // We draw the polygonal line
+            conn.poly_line(CoordMode::Previous, win, foreground, &polyline)?;
 
-                // We draw the segments
-                conn.poly_segment(win, foreground, &segments)?;
+            // We draw the segments
+            conn.poly_segment(win, foreground, &segments)?;
 
-                // We draw the rectangles
-                conn.poly_rectangle(win, foreground, &rectangles)?;
+            // We draw the rectangles
+            conn.poly_rectangle(win, foreground, &rectangles)?;
 
-                // We draw the arcs
-                conn.poly_arc(win, foreground, &arcs)?;
+            // We draw the arcs
+            conn.poly_arc(win, foreground, &arcs)?;
 
-                // We flush the request
-                conn.flush();
-            },
-            _ => {} // Unknown event type, ignore it
+            // We flush the request
+            conn.flush();
+        } else {
+            // Unknown event type, ignore it
         }
     }
 }
@@ -2086,7 +2085,7 @@ fn example_fill_colormap<C: Connection>(conn: &C, win: WINDOW, screen: &Screen) 
 fn example_create_glyph_cursor<C: Connection>(conn: &C, win: WINDOW, screen: &Screen) -> Result<(), ConnectionErrorOrX11Error>
 {
     let font = conn.generate_id();
-    conn.open_font(font, "cursor".as_bytes())?;
+    conn.open_font(font, b"cursor")?;
 
     let cursor = conn.generate_id();
     conn.create_glyph_cursor(cursor, font, font,
@@ -2168,7 +2167,7 @@ fn cursor_set<C: Connection>(conn: &C, screen: &Screen, window: WINDOW, cursor_i
 -> Result<(), ConnectionErrorOrX11Error>
 {
     let font = conn.generate_id();
-    conn.open_font(font, "cursor".as_bytes())?;
+    conn.open_font(font, b"cursor")?;
 
     let cursor = conn.generate_id();
     conn.create_glyph_cursor(cursor, font, font,

--- a/src/xcb_ffi.rs
+++ b/src/xcb_ffi.rs
@@ -1,5 +1,7 @@
 //! A FFI-based connection to an X11 server, using libxcb.
 
+#![allow(clippy::cast_ptr_alignment)] // FIXME: Remove this
+
 use std::ptr::{null, null_mut};
 use std::convert::{TryFrom, TryInto};
 use std::ffi::CStr;

--- a/tests/parsing_tests.rs
+++ b/tests/parsing_tests.rs
@@ -9,15 +9,15 @@ fn get_setup_data() -> Vec<u8> {
     let num_pixmap_formats: u8 = 1;
     let roots_len: u8 = 18;
     let header: u16 = 10;
-    let length: u16 = header + vendor_len + 2 * num_pixmap_formats as u16 + roots_len as u16;
+    let length: u16 = header + vendor_len + 2 * u16::from(num_pixmap_formats) + u16::from(roots_len);
 
     s.extend(&[1, 0]); // Status "success" and padding
     s.extend(&11u16.to_ne_bytes()); // major version
     s.extend(&0u16.to_ne_bytes()); // minor version
     s.extend(&length.to_ne_bytes()); // length
-    s.extend(&0x12345678u32.to_ne_bytes()); // release number
-    s.extend(&0x10000000u32.to_ne_bytes()); // resource id base
-    s.extend(&0x000000ffu32.to_ne_bytes()); // resource id mask
+    s.extend(&0x1234_5678u32.to_ne_bytes()); // release number
+    s.extend(&0x1000_0000u32.to_ne_bytes()); // resource id base
+    s.extend(&0x0000_00ffu32.to_ne_bytes()); // resource id mask
     s.extend(&0u32.to_ne_bytes()); // motion buffer size
     s.extend(&6u16.to_ne_bytes()); // vendor length
     s.extend(&0x100u16.to_ne_bytes()); // maximum request length
@@ -40,7 +40,7 @@ fn get_setup_data() -> Vec<u8> {
     s.push(42); // bits per pixel
     s.push(21); // scanline pad
     s.extend(&[0, 0, 0, 0, 0]); // padding
-    assert_eq!(s.len(), (header + vendor_len + 2 * num_pixmap_formats as u16) as usize * 4);
+    assert_eq!(s.len(), 4 * usize::from(header + vendor_len + 2 * u16::from(num_pixmap_formats)));
 
     // Screens, we said above there is one entry
     s.extend(&1u32.to_ne_bytes()); // root window
@@ -73,7 +73,7 @@ fn get_setup_data() -> Vec<u8> {
 
     assert_eq!(s.len(), length as usize * 4);
 
-    return s;
+    s
 }
 
 #[test]
@@ -84,9 +84,9 @@ fn parse_setup() -> Result<(), ParseError> {
     assert_eq!(remaining.len(), 0);
 
     assert_eq!((1, 11, 0), (setup.status, setup.protocol_major_version, setup.protocol_minor_version));
-    assert_eq!(0x12345678, setup.release_number);
+    assert_eq!(0x1234_5678, setup.release_number);
     assert_eq!((0, 0xff), (setup.min_keycode, setup.max_keycode));
-    assert_eq!("Vendor".as_bytes(), &setup.vendor[..]);
+    assert_eq!(b"Vendor", &setup.vendor[..]);
 
     assert_eq!(1, setup.pixmap_formats.len());
     let format = &setup.pixmap_formats[0];

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -125,7 +125,7 @@ fn test_poly_segment() -> Result<(), ConnectionErrorOrX11Error> {
 #[test]
 fn test_big_requests() -> Result<(), ConnectionError> {
     let conn = FakeConnection::default();
-    let big_buffer = [0; 262145 /* 2^18 + 1 */];
+    let big_buffer = [0; (1 << 18) + 1];
     let drawable: u32 = 42;
     let gc: u32 = 0x1337;
     let x: i16 = 21;
@@ -157,7 +157,7 @@ fn test_big_requests() -> Result<(), ConnectionError> {
 #[test]
 fn test_too_large_request() -> Result<(), ConnectionError> {
     let conn = FakeConnection::default();
-    let big_buffer = [0; 524289 /* 2^19 + 1 */];
+    let big_buffer = [0; (1 << 19) + 1];
     let drawable: u32 = 42;
     let gc: u32 = 0x1337;
     let x: i16 = 21;


### PR DESCRIPTION
This commit makes Travis run clippy and abort on warnings/errors. This
can help identify questionable patterns and to get rid of them.

To make this work, this commit adds an #[allow] to get rid of a warning
for such a questionable pattern. Future work should get rid of this
again. However, for now there is value in having clippy, even if part of
it is being silenced by this #[allow].

Thanks to @dalcde for making me do this.

Signed-off-by: Uli Schlachter <psychon@znc.in>