### PR TITLE
Add zero constants

### DIFF
--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -10,6 +10,7 @@ use x11rb::generated::xproto::{CreateWindowAux, ConfigureWindowAux, WindowClass,
 use x11rb::generated::present;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::Event;
+use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
 
 fn main() -> Result<(), ConnectionErrorOrX11Error>
 {
@@ -28,7 +29,7 @@ fn main() -> Result<(), ConnectionErrorOrX11Error>
     let win_id = conn.generate_id();
     let win_aux = CreateWindowAux::new()
         .background_pixel(screen.white_pixel);
-    conn.create_window(screen.root_depth, win_id, screen.root, 0, 0, 10, 10, 0, WindowClass::InputOutput, 0, &win_aux)?;
+    conn.create_window(COPY_DEPTH_FROM_PARENT, win_id, screen.root, 0, 0, 10, 10, 0, WindowClass::InputOutput, 0, &win_aux)?;
 
     // Ask for present ConfigureNotify events
     let event_id = conn.generate_id();

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -12,6 +12,7 @@ use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::Connection;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::Event;
+use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
 use x11rb::generated::xproto::*;
 
 /// Lag angle for the follow line
@@ -75,7 +76,7 @@ fn run<C: Connection>(conn: Arc<C>, window_state: Arc<Mutex<Window>>,
         guard.angle_velocity = 0.05;
     }
 
-    conn.create_window(screen.root_depth, window, screen.root,
+    conn.create_window(COPY_DEPTH_FROM_PARENT, window, screen.root,
                        0, 0, /* x and y */
                        default_size, default_size, /* width and height */
                        0, WindowClass::InputOutput,

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -11,6 +11,7 @@ use x11rb::connection::Connection;
 use x11rb::generated::xproto::*;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::{GenericEvent, Event};
+use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
 
 const TITLEBAR_HEIGHT: u16 = 20;
 
@@ -122,7 +123,7 @@ impl<'a, C: Connection> WMState<'a, C> {
         let win_aux = CreateWindowAux::new()
             .event_mask(EventMask::Exposure | EventMask::SubstructureNotify | EventMask::ButtonRelease)
             .background_pixel(screen.white_pixel);
-        self.conn.create_window(screen.root_depth, frame_win, screen.root, geom.x, geom.y, geom.width,
+        self.conn.create_window(COPY_DEPTH_FROM_PARENT, frame_win, screen.root, geom.x, geom.y, geom.width,
                                 geom.height + TITLEBAR_HEIGHT, 1, WindowClass::InputOutput, 0, &win_aux)?;
 
         self.conn.reparent_window(win, frame_win, 0, TITLEBAR_HEIGHT as _)?;

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -24,7 +24,7 @@ use x11rb::connection::{Connection, SequenceNumber};
 use x11rb::x11_utils::Event;
 use x11rb::errors::{ConnectionError, ConnectionErrorOrX11Error};
 use x11rb::generated::xproto::{self, *};
-use x11rb::wrapper::ConnectionExt as _;
+use x11rb::wrapper::{ConnectionExt as _, COPY_DEPTH_FROM_PARENT};
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -397,10 +397,8 @@ fn example4() -> Result<(), ConnectionErrorOrX11Error> {
     // Ask for our window's Id
     let win = conn.generate_id();
 
-    const COPY_FROM_PARENT: u8 = 0; // FIXME: XCB_COPY_FROM_PARENT is a define that is in the hand-written part of xcb
-
     // Create the window
-    conn.create_window(COPY_FROM_PARENT,         // depth (same as root)
+    conn.create_window(COPY_DEPTH_FROM_PARENT,   // depth (same as root)
                        win,                      // window Id
                        screen.root,              // parent window
                        0, 0,                     // x, y
@@ -720,11 +718,10 @@ fn example6() -> Result<(), ConnectionErrorOrX11Error> {
     let win = conn.generate_id();
 
     // Create the window
-    const COPY_FROM_PARENT: u8 = 0; // FIXME: XCB_COPY_FROM_PARENT is a define that is in the hand-written part of xcb
     let values = CreateWindowAux::default()
         .background_pixel(screen.white_pixel)
         .event_mask(EventMask::Exposure);
-    conn.create_window(COPY_FROM_PARENT,         // depth
+    conn.create_window(COPY_DEPTH_FROM_PARENT,   // depth
                        win,                      // window Id
                        screen.root,              // parent window
                        0, 0,                     // x, y
@@ -1189,14 +1186,13 @@ fn example7() -> Result<(), ConnectionErrorOrX11Error> {
     let win = conn.generate_id();
 
     // Create the window
-    const COPY_FROM_PARENT: u8 = 0; // FIXME: XCB_COPY_FROM_PARENT is a define that is in the hand-written part of xcb
     let values = CreateWindowAux::default()
         .background_pixel(screen.white_pixel)
         .event_mask(EventMask::Exposure      | EventMask::ButtonPress   |
                     EventMask::ButtonRelease | EventMask::PointerMotion |
                     EventMask::EnterWindow   | EventMask::LeaveWindow   |
                     EventMask::KeyPress      | EventMask::KeyRelease);
-    conn.create_window(COPY_FROM_PARENT,         // depth
+    conn.create_window(COPY_DEPTH_FROM_PARENT,   // depth
                        win,                      // window Id
                        screen.root,              // parent window
                        0, 0,                     // x, y

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -7,7 +7,7 @@ use x11rb::connection::{RequestConnection as _, Connection};
 use x11rb::x11_utils::Event;
 use x11rb::generated::xproto::*;
 use x11rb::generated::shape::{self, ConnectionExt as _};
-use x11rb::wrapper::ConnectionExt as _;
+use x11rb::wrapper::{ConnectionExt as _, COPY_DEPTH_FROM_PARENT};
 use x11rb::errors::ConnectionError;
 
 const PUPIL_SIZE: i16 = 50;
@@ -206,7 +206,7 @@ fn setup_window<C: Connection>(conn: &C, screen: &Screen, window_size: (u16, u16
         .event_mask(EventMask::Exposure | EventMask::StructureNotify | EventMask::PointerMotion)
         .background_pixel(screen.white_pixel);
 
-    conn.create_window(screen.root_depth, win_id, screen.root, 0, 0, window_size.0, window_size.1,
+    conn.create_window(COPY_DEPTH_FROM_PARENT, win_id, screen.root, 0, 0, window_size.0, window_size.1,
                        0, WindowClass::InputOutput, 0, &win_aux)?;
 
     let title = "xeyes";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,13 @@
 //! use x11rb::xcb_ffi::XCBConnection;
 //! use x11rb::generated::xproto::*;
 //! use x11rb::errors::ConnectionErrorOrX11Error;
+//! use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
 //!
 //! fn main() -> Result<(), ConnectionErrorOrX11Error> {
 //!     let (conn, screen_num) = XCBConnection::connect(None)?;
 //!     let screen = &conn.setup().roots[screen_num];
 //!     let win_id = conn.generate_id();
-//!     conn.create_window(24, win_id, screen.root, 0, 0, 100, 100, 0, WindowClass::InputOutput,
+//!     conn.create_window(COPY_DEPTH_FROM_PARENT, win_id, screen.root, 0, 0, 100, 100, 0, WindowClass::InputOutput,
 //!                        0, &CreateWindowAux::new().background_pixel(screen.white_pixel))?;
 //!     conn.map_window(win_id)?;
 //!     conn.flush();

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,9 +2,29 @@
 
 use std::convert::TryInto;
 
-use super::generated::xproto::ConnectionExt as XProtoConnectionExt;
+use super::generated::xproto::{ConnectionExt as XProtoConnectionExt, KEYSYM, TIMESTAMP};
 use super::connection::VoidCookie;
 use super::errors::{ConnectionError, ConnectionErrorOrX11Error};
+
+/// The universal null resource or null atom parameter value for many core X requests
+pub const NONE: u32 = 0;
+
+/// This constant can be used for many parameters in `create_window`
+pub const COPY_FROM_PARENT: u32 = 0;
+
+/// This constant can be used for the depth parameter in `create_window`. It indicates to use the
+/// parent window's depth.
+pub const COPY_DEPTH_FROM_PARENT: u8 = 0;
+
+/// This constant can be used for the class parameter in `create_window`. It indicates to use the
+/// parent window's class.
+pub const COPY_CLASS_FROM_PARENT: u16 = 0;
+
+/// This constant can be used in most request that take a timestamp argument
+pub const CURRENT_TIME: TIMESTAMP = 0;
+
+/// This constant can be used to fill unused entries in `KEYSYM` tables
+pub const NO_SYMBOL: KEYSYM = 0;
 
 /// Extension trait that simplifies API use
 pub trait ConnectionExt: XProtoConnectionExt {


### PR DESCRIPTION
This adds equivalents of defines like `XCB_NONE` to x11rb. This fixes #83.