### PR TITLE
Add an allow-unsafe-code feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,4 @@ script:
         fi
     done
 
-  - cargo build --verbose --all-targets --no-default-features
+  - cargo build --verbose --all-targets --no-default-features --features vendor-xcb-proto

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,5 @@ script:
             X11RB_EXAMPLE_TIMEOUT=1 xvfb-run -a cargo run --example "$example" || exit 1
         fi
     done
+
+  - cargo build --verbose --all-targets --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,13 @@ libc = "0.2"
 pkg-config = "0.3"
 
 [features]
-default = ["vendor-xcb-proto"]
+default = ["vendor-xcb-proto", "allow-unsafe-code"]
 
 # Enable use of the vendored copy of xcb-proto. Without this feature, pkg-config
 # is used to find it instead. Without this feature, no stable API can be
 # guaranteed, because the protocol description can differ.
 vendor-xcb-proto = []
+
+# Without this feature, all uses of `unsafe` in the crate are forbidden via
+# #![deny(unsafe_code)]. This has the effect of disabling the XCB FFI bindings.
+allow-unsafe-code = []

--- a/src/extension_information.rs
+++ b/src/extension_information.rs
@@ -27,7 +27,9 @@ impl ExtensionInformation {
                     let info = info.and_then(|c| c.reply().ok());
                     if let Some(info) = info {
                         // If the extension is not present, we return None, else we box it
-                        if info.present as u8 == 0 {
+                        #[allow(trivial_numeric_casts)]
+                        let present = info.present as u8;
+                        if present == 0 {
                             None
                         } else {
                             Some(info)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
         unused_results,
         )]
 #![cfg_attr(not(feature = "allow-unsafe-code"),
-            deny(unsafe_code))]
+            forbid(unsafe_code))]
 
 #[cfg(feature = "allow-unsafe-code")]
 pub mod xcb_ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,10 @@
         unused_qualifications,
         unused_results,
         )]
+#![cfg_attr(not(feature = "allow-unsafe-code"),
+            deny(unsafe_code))]
 
+#[cfg(feature = "allow-unsafe-code")]
 pub mod xcb_ffi;
 pub mod utils;
 #[macro_use]

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -143,11 +143,13 @@ mod test {
         }
 
         fn extension_information(&self, _extension_name: &'static str) -> Option<QueryExtensionReply> {
+            #[allow(trivial_casts, clippy::unnecessary_cast)]
+            let present = true as _;
             self.0.as_ref().map(|_| QueryExtensionReply {
                 response_type: 1,
                 sequence: 0,
                 length: 0,
-                present: true,
+                present,
                 major_opcode: 127,
                 first_event: 0,
                 first_error: 0,


### PR DESCRIPTION
This commit forbids unsafe code by default (#![deny(unsafe_code)]), but
adds an allow-unsafe-code feature that is enabled by default. This
mostly exists to satisfy anyone who detests `unsafe`. Its existence
proves that the unsafe code in this crate only exists for the FFI and
not for some more fundamental reason.

Fixes: https://github.com/psychon/x11rb/issues/59
Signed-off-by: Uli Schlachter <psychon@znc.in>

---- 

This is WIP because I expect the Travis build to fail. It should fail, because all the examples reference `XCBConnection`. If it does not fail, then that is failure in its own.