### PR TITLE
Move new consts and make GenericEvent/Error Clone

### DIFF
--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -10,7 +10,7 @@ use x11rb::generated::xproto::{CreateWindowAux, ConfigureWindowAux, WindowClass,
 use x11rb::generated::present;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::Event;
-use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
+use x11rb::COPY_DEPTH_FROM_PARENT;
 
 fn main() -> Result<(), ConnectionErrorOrX11Error>
 {

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -12,8 +12,8 @@ use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::Connection;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::Event;
-use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
 use x11rb::generated::xproto::*;
+use x11rb::COPY_DEPTH_FROM_PARENT;
 
 /// Lag angle for the follow line
 const LAG: f64 = 0.3;

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -11,7 +11,7 @@ use x11rb::connection::Connection;
 use x11rb::generated::xproto::*;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::{GenericEvent, Event};
-use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
+use x11rb::COPY_DEPTH_FROM_PARENT;
 
 const TITLEBAR_HEIGHT: u16 = 20;
 

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -24,7 +24,8 @@ use x11rb::connection::{Connection, SequenceNumber};
 use x11rb::x11_utils::Event;
 use x11rb::errors::{ConnectionError, ConnectionErrorOrX11Error};
 use x11rb::generated::xproto::{self, *};
-use x11rb::wrapper::{ConnectionExt as _, COPY_DEPTH_FROM_PARENT};
+use x11rb::wrapper::ConnectionExt as _;
+use x11rb::COPY_DEPTH_FROM_PARENT;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -7,8 +7,9 @@ use x11rb::connection::{RequestConnection as _, Connection};
 use x11rb::x11_utils::Event;
 use x11rb::generated::xproto::*;
 use x11rb::generated::shape::{self, ConnectionExt as _};
-use x11rb::wrapper::{ConnectionExt as _, COPY_DEPTH_FROM_PARENT};
+use x11rb::wrapper::ConnectionExt as _;
 use x11rb::errors::ConnectionError;
+use x11rb::COPY_DEPTH_FROM_PARENT;
 
 const PUPIL_SIZE: i16 = 50;
 const EYE_SIZE: i16 = 50;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! use x11rb::xcb_ffi::XCBConnection;
 //! use x11rb::generated::xproto::*;
 //! use x11rb::errors::ConnectionErrorOrX11Error;
-//! use x11rb::wrapper::COPY_DEPTH_FROM_PARENT;
+//! use x11rb::COPY_DEPTH_FROM_PARENT;
 //!
 //! fn main() -> Result<(), ConnectionErrorOrX11Error> {
 //!     let (conn, screen_num) = XCBConnection::connect(None)?;
@@ -89,3 +89,25 @@ pub mod generated {
     include!(concat!(env!("OUT_DIR"), "/generated/mod.rs"));
 }
 pub mod wrapper;
+
+use generated::xproto::{KEYSYM, TIMESTAMP};
+
+/// The universal null resource or null atom parameter value for many core X requests
+pub const NONE: u32 = 0;
+
+/// This constant can be used for many parameters in `create_window`
+pub const COPY_FROM_PARENT: u32 = 0;
+
+/// This constant can be used for the depth parameter in `create_window`. It indicates to use the
+/// parent window's depth.
+pub const COPY_DEPTH_FROM_PARENT: u8 = 0;
+
+/// This constant can be used for the class parameter in `create_window`. It indicates to use the
+/// parent window's class.
+pub const COPY_CLASS_FROM_PARENT: u16 = 0;
+
+/// This constant can be used in most request that take a timestamp argument
+pub const CURRENT_TIME: TIMESTAMP = 0;
+
+/// This constant can be used to fill unused entries in `KEYSYM` tables
+pub const NO_SYMBOL: KEYSYM = 0;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -114,6 +114,12 @@ where I: SliceIndex<[u8]>
     }
 }
 
+impl Clone for Buffer {
+    fn clone(&self) -> Self {
+        Buffer::Vec(self.deref().to_vec())
+    }
+}
+
 /// A simple wrapper around RawFd that closes the fd on drop.
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct RawFdContainer(RawFd);

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,29 +2,9 @@
 
 use std::convert::TryInto;
 
-use super::generated::xproto::{ConnectionExt as XProtoConnectionExt, KEYSYM, TIMESTAMP};
+use super::generated::xproto::ConnectionExt as XProtoConnectionExt;
 use super::connection::VoidCookie;
 use super::errors::{ConnectionError, ConnectionErrorOrX11Error};
-
-/// The universal null resource or null atom parameter value for many core X requests
-pub const NONE: u32 = 0;
-
-/// This constant can be used for many parameters in `create_window`
-pub const COPY_FROM_PARENT: u32 = 0;
-
-/// This constant can be used for the depth parameter in `create_window`. It indicates to use the
-/// parent window's depth.
-pub const COPY_DEPTH_FROM_PARENT: u8 = 0;
-
-/// This constant can be used for the class parameter in `create_window`. It indicates to use the
-/// parent window's class.
-pub const COPY_CLASS_FROM_PARENT: u16 = 0;
-
-/// This constant can be used in most request that take a timestamp argument
-pub const CURRENT_TIME: TIMESTAMP = 0;
-
-/// This constant can be used to fill unused entries in `KEYSYM` tables
-pub const NO_SYMBOL: KEYSYM = 0;
 
 /// Extension trait that simplifies API use
 pub trait ConnectionExt: XProtoConnectionExt {

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -57,7 +57,7 @@ pub trait Event {
 ///
 /// Examine the event's `response_type()` and use `TryInto::try_into()` to convert the event to the
 /// desired type.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GenericEvent(Buffer);
 
 impl Event for GenericEvent {
@@ -108,7 +108,7 @@ impl From<GenericError> for GenericEvent {
 /// This struct is similar to `GenericEvent`, but is specific to error packets. It allows access to
 /// the contained error code. This error code allows you to pick the right error type for
 /// conversion via `TryInto::try_into()`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GenericError(Buffer);
 
 impl GenericError {


### PR DESCRIPTION
Seems like I changed my mind about where these newly added constants should be. This commit moves them from `x11rb::wrapper` to `x11rb`.

Also, this PR makes `GenericEvent` and `GenericError` implement `Clone`. Mostly because that is very easy to do.