### PR TITLE
Add a `LazyAtom` type

### DIFF
--- a/examples/integration_test_util/util.rs
+++ b/examples/integration_test_util/util.rs
@@ -11,6 +11,7 @@ mod util {
     use x11rb::connection::Connection;
     use x11rb::x11_utils::TryParse;
     use x11rb::generated::xproto::{WINDOW, ConnectionExt as _, EventMask, ClientMessageData, ClientMessageEvent, CLIENT_MESSAGE_EVENT};
+    use x11rb::wrapper::LazyAtom;
 
     pub fn start_timeout_thread<C>(conn: Arc<C>, window: WINDOW)
     where C: Connection + Send + Sync + 'static
@@ -21,26 +22,24 @@ mod util {
             Some(timeout) => timeout
         };
 
-        let (wm_protocols, wm_delete_window) = {
-            let protocols = conn.intern_atom(false, b"WM_PROTOCOLS").unwrap();
-            let delete = conn.intern_atom(false, b"WM_DELETE_WINDOW").unwrap();
-            (protocols.reply().unwrap().atom, delete.reply().unwrap().atom)
-        };
-
-        let mut data = [0; 20];
-        data[..4].copy_from_slice(&wm_delete_window.to_ne_bytes());
-        let (data, _): (ClientMessageData, _) = TryParse::try_parse(&data).unwrap();
-        let event = ClientMessageEvent {
-            response_type: CLIENT_MESSAGE_EVENT,
-            format: 32,
-            sequence: 0,
-            window: window,
-            type_: wm_protocols,
-            data
-        };
-
         thread::spawn(move || {
+            let mut wm_protocols = LazyAtom::new(&*conn, false, b"WM_PROTOCOLS");
+            let mut wm_delete_window = LazyAtom::new(&*conn, false, b"WM_DELETE_WINDOW");
+
             thread::sleep(Duration::from_secs(timeout));
+
+            let mut data = [0; 20];
+            data[..4].copy_from_slice(&wm_delete_window.atom().unwrap().to_ne_bytes());
+            let (data, _): (ClientMessageData, _) = TryParse::try_parse(&data).unwrap();
+            let event = ClientMessageEvent {
+                response_type: CLIENT_MESSAGE_EVENT,
+                format: 32,
+                sequence: 0,
+                window: window,
+                type_: wm_protocols.atom().unwrap(),
+                data
+            };
+
             if let Err(err) = conn.send_event(0, window, EventMask::NoEvent.into(), &event) {
                 eprintln!("Error while sending event: {:?}", err);
             }

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -12,6 +12,7 @@ use x11rb::generated::xproto::*;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::{GenericEvent, Event};
 use x11rb::COPY_DEPTH_FROM_PARENT;
+use x11rb::wrapper::LazyAtom;
 
 const TITLEBAR_HEIGHT: u16 = 20;
 
@@ -70,8 +71,8 @@ impl<'a, C: Connection> WMState<'a, C> {
         conn.create_gc(black_gc, screen.root, &gc_aux)?;
         conn.close_font(font)?;
 
-        let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS")?;
-        let wm_delete_window = conn.intern_atom(false, b"WM_DELETE_WINDOW")?;
+        let mut wm_protocols = LazyAtom::new(conn, false, b"WM_PROTOCOLS");
+        let mut wm_delete_window = LazyAtom::new(conn, false, b"WM_DELETE_WINDOW");
 
         Ok(WMState {
             conn,
@@ -79,8 +80,8 @@ impl<'a, C: Connection> WMState<'a, C> {
             black_gc,
             windows: Vec::default(),
             pending_expose: HashSet::default(),
-            wm_protocols: wm_protocols.reply()?.atom,
-            wm_delete_window: wm_delete_window.reply()?.atom,
+            wm_protocols: wm_protocols.atom()?,
+            wm_delete_window: wm_delete_window.atom()?,
         })
     }
 

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -24,7 +24,7 @@ use x11rb::connection::{Connection, SequenceNumber};
 use x11rb::x11_utils::Event;
 use x11rb::errors::{ConnectionError, ConnectionErrorOrX11Error};
 use x11rb::generated::xproto::{self, *};
-use x11rb::wrapper::ConnectionExt as _;
+use x11rb::wrapper::{ConnectionExt as _, LazyAtom};
 use x11rb::COPY_DEPTH_FROM_PARENT;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -230,7 +230,22 @@ fn example1() -> Result<(), ConnectionErrorOrX11Error> {
     println!("good use time: {:?}", diff2);
     println!("ratio:         {:?}", diff.as_nanos() as f64 / diff2.as_nanos() as f64);
 
-    // The original tutorial has an Xlib example. This was not ported to rust.
+    // The original tutorial has an Xlib example. This was not ported to rust. Instead, there is an
+    // x11rb-specific wrapper type that is presented here. This wrapper internally does the good
+    // use above, but simplifies the API.
+
+    println!();
+    let start = Instant::now();
+    let cookies = names.iter()
+        .map(|name| LazyAtom::new(&conn, false, name.as_bytes()))
+        .collect::<Vec<_>>();
+    for (i, mut atom) in cookies.into_iter().enumerate() {
+        atoms[i] = atom.atom()?;
+    }
+    let diff3 = start.elapsed();
+    println!("LazyAtom time: {:?}", diff3);
+    println!("ratio to bad:  {:?}", diff.as_nanos() as f64 / diff3.as_nanos() as f64);
+    println!("ratio to good: {:?}", diff2.as_nanos() as f64 / diff3.as_nanos() as f64);
 
     Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -76,7 +76,7 @@ impl From<std::num::TryFromIntError> for ConnectionError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ConnectionErrorOrX11Error {
     ConnectionError(ConnectionError),
     X11Error(GenericError)

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,8 +2,8 @@
 
 use std::convert::TryInto;
 
-use super::generated::xproto::ConnectionExt as XProtoConnectionExt;
-use super::connection::VoidCookie;
+use super::generated::xproto::{ConnectionExt as XProtoConnectionExt, InternAtomReply, ATOM};
+use super::connection::{VoidCookie, Connection, Cookie};
 use super::errors::{ConnectionError, ConnectionErrorOrX11Error};
 
 /// Extension trait that simplifies API use
@@ -54,3 +54,57 @@ pub trait ConnectionExt: XProtoConnectionExt {
     }
 }
 impl<C: XProtoConnectionExt + ?Sized> ConnectionExt for C {}
+
+/// A type allowing to lazily query atoms.
+///
+/// To avoid round-trips, X11 clients should not send requests and then synchronously wait for the
+/// reply. This is especially true for atoms, because a typical application will need many atoms.
+/// Doing one round-trip for each atom can be quite slow. This type represents an atom that is
+/// lazily resolved on its first use. Thus, this type hides the involved latency and simplifies
+/// code.
+#[derive(Debug)]
+pub enum LazyAtom<'c, C: Connection> {
+    Pending(Cookie<'c, C, InternAtomReply>),
+    Resolved(Result<ATOM, ConnectionErrorOrX11Error>),
+}
+
+impl<'c, C: Connection> LazyAtom<'c, C> {
+    /// Create a new LazyAtom by sending an `InternAtom` request.
+    ///
+    /// The meaning of the arguments is identical to xproto's `InternAtom` request.
+    pub fn new(conn: &'c C, only_if_exists: bool, name: &[u8]) -> Self {
+        match conn.intern_atom(only_if_exists, name) {
+            Ok(cookie) => LazyAtom::Pending(cookie),
+            Err(err) => LazyAtom::Resolved(Err(err.into()))
+        }
+    }
+
+    /// Create a new LazyAtom for the given resolved atom.
+    ///
+    /// This function just wraps an existing atom. The resulting LazyAtom will always return
+    /// `Ok(atom)` from `atom()`.
+    pub fn new_for_atom(atom: ATOM) -> Self {
+        LazyAtom::Resolved(Ok(atom))
+    }
+
+    /// Get the atom that is contained in this type.
+    ///
+    /// This function gets the answer from the X11 server if it was not yet fetched. It returns the atom value.
+    pub fn atom(&mut self) -> Result<ATOM, ConnectionErrorOrX11Error> {
+        match self {
+            LazyAtom::Pending(_) => {
+                // We need to move the cookie out of self to call reply()
+                if let LazyAtom::Pending(cookie) = std::mem::replace(self, LazyAtom::Resolved(Ok(0))) {
+                    // Now get the reply and replace self again with the correct value
+                    let reply = cookie.reply()
+                        .map(|reply| reply.atom);
+                    *self = LazyAtom::Resolved(reply.clone());
+                    reply
+                } else {
+                    unreachable!()
+                }
+            },
+            LazyAtom::Resolved(result) => result.clone(),
+        }
+    }
+}


### PR DESCRIPTION
This implements #84 by adding a LazyAtom type that sends an `InternAtom` request when created and only waits for the reply when the atom is actually needed for the first time.