### PR TITLE
Nicer type names

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -162,6 +162,7 @@ class Module(object):
         self.out = Output()
         self.trait_out = Output()
         self.namespace = outer_module.namespace
+        self.outer_module = outer_module
 
         self.out("#![allow(clippy::unreadable_literal)]")
         self.out("#![allow(clippy::too_many_arguments)]")
@@ -1315,7 +1316,7 @@ class Module(object):
             name = name[1:]
         if len(name) == 2:
             # Must be a type from another module which we imported
-            ext = name[0].lower()  # FIXME: How to get the name of the ext?
+            ext = self.outer_module.get_namespace(name[0]).header
             name = (ext + "::" + name[1],)
         assert len(name) == 1, orig_name
         return name[0]

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -23,6 +23,7 @@ rust_type_mapping = {
         'INT8':     'i8',
         'char':     'u8',
         'BYTE':     'u8',
+        'void':     'u8',
         'float':    'f32',
         'double':   'f64',
         'BOOL':     'bool',
@@ -1224,7 +1225,9 @@ class Module(object):
         if field.type.is_switch:
             return modifier + aux_name
         if not field.isfd:
-            result = self._to_rust_type(field.type)
+            result = self._name(field.field_type)
+            if hasattr(field.type, 'xml_type') and field.type.xml_type == 'BOOL':
+                result = 'bool'
             if field.type.is_list:
                 if field.type.nmemb is None:
                     result = "%s[%s]" % (modifier, result)

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1313,6 +1313,10 @@ class Module(object):
             name = name[1:]
         if self.namespace.is_ext and name[0] == self.namespace.ext_name:
             name = name[1:]
+        if len(name) == 2:
+            # Must be a type from another module which we imported
+            ext = name[0].lower()  # FIXME: How to get the name of the ext?
+            name = (ext + "::" + name[1],)
         assert len(name) == 1, orig_name
         return name[0]
 
@@ -1339,21 +1343,8 @@ class Module(object):
             return rust_type_mapping[field_type.xml_type]
 
         name = field_type.name
-
-        orig_name = name
         if type(name) == tuple:
-            if name[0] == 'xcb':
-                name = name[1:]
-            if self.namespace.is_ext and name[0] == self.namespace.ext_name:
-                name = name[1:]
-            if len(name) == 2:
-                # If this is still a tuple, it should be a type from another module
-                # and we should have imported that module.
-                ext = name[0].lower()  # FIXME: How to get the name of the ext?
-                name = ext + "::" + name[1],
-            assert len(name) == 1, orig_name
-            name = name[0]
-
+            name = self._name(name)
         if name in rust_type_mapping:
             return rust_type_mapping[name]
         elif name.isupper():


### PR DESCRIPTION
This is the result from my work on #135. The result on the generated code is stuff like this:
```diff
@@ -21007,12 +21007,12 @@ pub trait ConnectionExt: RequestConnecti
         list_extensions(self)
     }
 
-    fn change_keyboard_mapping<'c>(&'c self, keycode_count: u8, first_keycode: u8, keysyms_per_keycode: u8, keysyms: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_keyboard_mapping<'c>(&'c self, keycode_count: u8, first_keycode: KEYCODE, keysyms_per_keycode: u8, keysyms: &[KEYSYM]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_keyboard_mapping(self, keycode_count, first_keycode, keysyms_per_keycode, keysyms)
     }
 
-    fn get_keyboard_mapping(&self, first_keycode: u8, count: u8) -> Result<Cookie<Self, GetKeyboardMappingReply>, ConnectionError>
+    fn get_keyboard_mapping(&self, first_keycode: KEYCODE, count: u8) -> Result<Cookie<Self, GetKeyboardMappingReply>, ConnectionError>
     {
         get_keyboard_mapping(self, first_keycode, count)
     }
@@ -21100,7 +21100,7 @@ pub trait ConnectionExt: RequestConnecti
         kill_client(self, resource)
     }
 
-    fn rotate_properties<'c>(&'c self, window: u32, delta: i16, atoms: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn rotate_properties<'c>(&'c self, window: WINDOW, delta: i16, atoms: &[ATOM]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         rotate_properties(self, window, delta, atoms)
     }
@@ -21121,7 +21121,7 @@ pub trait ConnectionExt: RequestConnecti
         get_pointer_mapping(self)
     }
 
-    fn set_modifier_mapping<'c>(&'c self, keycodes: &[u8]) -> Result<Cookie<'c, Self, SetModifierMappingReply>, ConnectionError>
+    fn set_modifier_mapping<'c>(&'c self, keycodes: &[KEYCODE]) -> Result<Cookie<'c, Self, SetModifierMappingReply>, ConnectionError>
     {
         set_modifier_mapping(self, keycodes)
     }
```