### PR TITLE
Support duplicate field types in unions

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -465,11 +465,12 @@ class Module(object):
             self.out("}")
         self.out("}")
 
-        # Check that all fields have different types
-        field_types = [field.type for field in union.fields]
-        assert len(field_types) == len(set(field_types))
+        # Get unique field types
+        seen = set()
+        field_types = [field for field in union.fields
+                       if not (field.type in seen or seen.add(field.type))]
 
-        for field in union.fields:
+        for field in field_types:
             assert not field.isfd
             rust_type = self._to_complex_rust_type(field, None, '')
             self.out("impl From<%s> for %s {", rust_type, rust_name)


### PR DESCRIPTION
XKB has some union where all fields have technically different type, but
some of the types are typedefs for other types. This leads to
duplicates.

This commit makes the code generator handle this by only implementing
From for each appearing type once.

Signed-off-by: Uli Schlachter <psychon@znc.in>