### PR TITLE
Fix sumof expression handling

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1278,6 +1278,11 @@ class Module(object):
                     lenfield_name = field.type.expr.lenfield_name
                     field_name = self._to_rust_variable(lenfield_name)
                     if field_name in unresolved_without_type:
+                        # We already generated this argument in a previous iteration
+                        continue
+                    if any(field.field_name == lenfield_name for field in case.type.fields):
+                        # This references a field that is part of the same bitcase,
+                        # so this does not have to become a function argument.
                         continue
                     referenced_field = find_field(switch_type.parents[-1].fields,
                                                   lenfield_name)


### PR DESCRIPTION
Apparently, the sumof support was added some time ago and then
bitrotted. This commit fixes it again. This fixes a problem with XKB's
GetNames request where one of the bitcases includes a <sumof>.

Signed-off-by: Uli Schlachter <psychon@znc.in>