### PR TITLE
Do not generate "match" as a variable name

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1493,6 +1493,8 @@ class Module(object):
     def _to_rust_variable(self, name):
         if name == "type":
             name = "type_"
+        if name == "match":
+            name = "match_"
 
         # Check for camel case names and deal with them
         if any(c.isupper() for c in name):


### PR DESCRIPTION
XKB's struct SymInterpret has a field with name "match".

Signed-off-by: Uli Schlachter <psychon@znc.in>