### PR TITLE
Start generating code for the XKB extension

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -503,6 +503,11 @@ class Module(object):
         if function_name == "await":
             function_name = "await_"
 
+        if name in [('xcb', 'xkb', 'SetMap'), ('xcb', 'xkb', 'GetKbdByName'), ('xcb', 'xkb', 'SetNames')]:
+            self.trait_out("fn %s(&self) { unimplemented!(\"Not yet supported by the code generator\") }", function_name)
+            self.out("pub fn %s<Conn>(_conn: &Conn) where Conn: RequestConnection + ?Sized { unimplemented!(\"Not yet supported by the code generator\") }", function_name)
+            return
+
         is_list_fonts_with_info = name == ('xcb', 'ListFontsWithInfo')
 
         # Does this have a <switch>? If so, we generate an *Aux structure

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -503,7 +503,7 @@ class Module(object):
         if function_name == "await":
             function_name = "await_"
 
-        if name in [('xcb', 'xkb', 'SetMap'), ('xcb', 'xkb', 'GetKbdByName'), ('xcb', 'xkb', 'SetNames')]:
+        if name in [('xcb', 'xkb', 'GetKbdByName')]:
             self.trait_out("fn %s(&self) { unimplemented!(\"Not yet supported by the code generator\") }", function_name)
             self.out("pub fn %s<Conn>(_conn: &Conn) where Conn: RequestConnection + ?Sized { unimplemented!(\"Not yet supported by the code generator\") }", function_name)
             return

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -179,6 +179,7 @@ class Module(object):
         self.out("#![allow(clippy::identity_op)]")
         self.out("#![allow(clippy::trivially_copy_pass_by_ref)]")
         self.out("#![allow(clippy::eq_op)]")
+        self.out("#![allow(clippy::cognitive_complexity)]")
         self.out("use std::convert::TryFrom;")
         self.out("#[allow(unused_imports)]")
         self.out("use std::convert::TryInto;")

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -506,7 +506,8 @@ class Module(object):
 
         if name in [('xcb', 'xkb', 'GetKbdByName')]:
             self.trait_out("fn %s(&self) { unimplemented!(\"Not yet supported by the code generator\") }", function_name)
-            self.out("pub fn %s<Conn>(_conn: &Conn) where Conn: RequestConnection + ?Sized { unimplemented!(\"Not yet supported by the code generator\") }", function_name)
+            self.out("pub fn %s<Conn>(_conn: &Conn) where Conn: RequestConnection + ?Sized {", function_name)
+            self.out("unimplemented!(\"Not yet supported by the code generator\") }")
             return
 
         is_list_fonts_with_info = name == ('xcb', 'ListFontsWithInfo')

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1376,8 +1376,14 @@ class Module(object):
             with Indent(self.out):
                 self.out("let mut result = Vec::new();")
                 for field in switch.type.fields:
-                    self.out("if let Some(value) = self.%s {", self._aux_field_name(field))
-                    self.out.indent("result.extend(value.to_ne_bytes().iter());")
+                    self.out("if let Some(value) = &self.%s {", self._aux_field_name(field))
+                    with Indent(self.out):
+                        if field.type.is_list:
+                            self.out("for obj in value.iter() {")
+                            self.out.indent("result.extend(obj.to_ne_bytes().iter());")
+                            self.out("}")
+                        else:
+                            self.out("result.extend(value.to_ne_bytes().iter());")
                     self.out("}")
                 self.out("result")
             self.out("}")

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1404,9 +1404,10 @@ class Module(object):
 
             for field in switch.type.fields:
                 aux_name = self._aux_field_name(field)
+                field_type = self._to_complex_owned_rust_type(field)
                 self.out("/// Set the %s field of this structure.", field.field_name)
                 self.out("pub fn %s<I>(mut self, value: I) -> Self where I: Into<RustOption<%s>> {",
-                         aux_name, self._field_type(field))
+                         aux_name, field_type)
                 with Indent(self.out):
                     self.out("self.%s = value.into();", aux_name)
                     self.out("self")

--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -106,7 +106,6 @@ from xcbgen.state import Module  # noqa
 names = glob.glob(input_dir + "/*.xml")
 unsupported = [
         "xinput.xml",    # InputInfo has a <switch name="info"> that causes problems
-        "xkb.xml",       # NoneType has no attribute op: DeviceLedInfo has a <popcount> in an <op>
         ]
 names = [name for name in names if os.path.basename(name) not in unsupported]
 


### PR DESCRIPTION
We are now in a state where the code generator manages to (mostly) generate code for the XKB extension that the Rust compiler accepts. The only exception is the `GetKbdByName` request, but that one does not seem to be properly described in the XML file (lots of commented out stuff and a "FIXME").

Thus, we now support the XKB extension and this fixes #56!