### PR TITLE
Simplify interpreting the 'value' in GetPropertyReply

### DIFF
--- a/code_generator_helpers/special_cases.py
+++ b/code_generator_helpers/special_cases.py
@@ -1,0 +1,22 @@
+"""
+This module handles some special cases where we emit code that is not based on
+the XML, but hand-written. Thus, this handles special cases.
+"""
+
+def skip_request(out, trait_out, obj, name, function_name):
+    # We use this hook to also rewrite some parameter types.
+    if name == ('xcb', 'InternAtom'):
+        for field in obj.fields:
+            if field.field_name == 'only_if_exists':
+                from xcbgen.xtypes import SimpleType
+                field.type = SimpleType(('uint8_t',), 1)
+                field.type.xml_type = 'BOOL'
+
+    # This request has a <switch> inside of another <switch>. Supporting
+    # this requires moving <switch>-handling to complex_type(), I guess.
+    if name == ('xcb', 'xkb', 'GetKbdByName'):
+        trait_out("fn %s(&self) { unimplemented!(\"Not yet supported by the code generator\") }", function_name)
+        out("pub fn %s<Conn>(_conn: &Conn) where Conn: RequestConnection + ?Sized {", function_name)
+        out("unimplemented!(\"Not yet supported by the code generator\") }")
+        return True
+    return False

--- a/code_generator_helpers/special_cases.py
+++ b/code_generator_helpers/special_cases.py
@@ -3,6 +3,9 @@ This module handles some special cases where we emit code that is not based on
 the XML, but hand-written. Thus, this handles special cases.
 """
 
+from .output import Indent
+
+
 def skip_request(out, trait_out, obj, name, function_name):
     # We use this hook to also rewrite some parameter types.
     if name == ('xcb', 'InternAtom'):
@@ -12,6 +15,9 @@ def skip_request(out, trait_out, obj, name, function_name):
                 field.type = SimpleType(('uint8_t',), 1)
                 field.type.xml_type = 'BOOL'
 
+    if name == ('xcb', 'GetProperty'):
+        extra_get_property_impl(out)
+
     # This request has a <switch> inside of another <switch>. Supporting
     # this requires moving <switch>-handling to complex_type(), I guess.
     if name == ('xcb', 'xkb', 'GetKbdByName'):
@@ -20,3 +26,80 @@ def skip_request(out, trait_out, obj, name, function_name):
         out("unimplemented!(\"Not yet supported by the code generator\") }")
         return True
     return False
+
+
+def extra_get_property_impl(out):
+    """Emit extra code for xproto's GetProperty reply."""
+    # The following values are used for the doc test below. They must work
+    # on every possible endian. Right now this simply means: They are
+    # symmetric.
+    example_value = {
+            8: "1, 2, 3, 4",
+            16: "1, 1, 2, 2",
+            32: "1, 2, 2, 1",
+    }
+    example_expected = {
+            8: [1, 2, 3, 4],
+            16: [(1 << 8) + 1, 2 * ((1 << 8) + 1)],
+            32: [(1 << 24) + (2 << 16) + (2 << 8) + 1],
+    }
+
+    out("impl GetPropertyReply {")
+    with Indent(out):
+        for width in [8, 16, 32]:
+            out("/// Iterate over the contained value if its format is %d.", width)
+            out("///")
+            out("/// This function checks if the `format` member of the reply")
+            out("/// is %d. If it it is not, `None` is returned.  Otherwise", width)
+            out("/// and iterator is returned that interprets the value in")
+            out("/// this reply as type `u%d`.", width)
+            out("///")
+            out("/// # Examples")
+            out("///")
+            out("/// Successfully iterate over the value:")
+            out("/// ```")
+            out("/// // First, we have to 'invent' a GetPropertyReply.")
+            out("/// let reply = x11rb::generated::xproto::GetPropertyReply {")
+            out("///     response_type: 1,")
+            out("///     format: %d,", width)
+            out("///     sequence: 0,")
+            out("///     length: 0, // This value is incorrect")
+            out("///     type_: 0, // This value is incorrect")
+            out("///     bytes_after: 0,")
+            out("///     value_len: 4,")
+            out("///     value: vec![%s],", example_value[width])
+            out("/// };")
+            out("///")
+            out("/// // This is the actual example: Iterate over the value.")
+            out("/// let mut iter = reply.value%d().unwrap();", width)
+            for expect in example_expected[width]:
+                out("/// assert_eq!(iter.next(), Some(%d));", expect)
+            out("/// assert_eq!(iter.next(), None);")
+            out("/// ```")
+            out("///")
+            out("/// An iterator is only returned when the `format` is correct.")
+            out("/// The following example shows this.")
+            out("/// ```")
+            out("/// // First, we have to 'invent' a GetPropertyReply.")
+            out("/// let reply = x11rb::generated::xproto::GetPropertyReply {")
+            out("///     response_type: 1,")
+            out("///     format: 42, // Not allowed in X11, but used for the example")
+            out("///     sequence: 0,")
+            out("///     length: 0, // This value is incorrect")
+            out("///     type_: 0, // This value is incorrect")
+            out("///     bytes_after: 0,")
+            out("///     value_len: 4,")
+            out("///     value: vec![1, 2, 3, 4],")
+            out("/// };")
+            out("/// assert!(reply.value%d().is_none());", width)
+            out("/// ```")
+            out("#[allow(single_use_lifetimes)] // Work around a rustc bug")
+            out("pub fn value%d<'a>(&'a self) -> Option<impl Iterator<Item=u%d> + 'a> {", width, width)
+            with Indent(out):
+                out("if self.format == %d {", width)
+                out.indent("Some(crate::wrapper::PropertyIterator::new(&self.value))")
+                out("} else {")
+                out.indent("None")
+                out("}")
+            out("}")
+    out("}")

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,11 +1,52 @@
 //! Some wrappers around the generated code to simplify use.
 
 use std::convert::TryInto;
+use std::marker::PhantomData;
 
 use super::generated::xproto::{ConnectionExt as XProtoConnectionExt, InternAtomReply, ATOM};
 use super::connection::Connection;
 use super::cookie::{VoidCookie, Cookie};
 use super::errors::{ConnectionError, ConnectionErrorOrX11Error};
+use super::x11_utils::TryParse;
+
+/// Iterator implementation used by `GetPropertyReply`.
+///
+/// This is the actual type returned by `GetPropertyReply::value8`, `GetPropertyReply::value16`,
+/// and `GetPropertyReply::value32`. This type needs to be public due to Rust's visibility rules.
+#[derive(Debug, Clone)]
+pub struct PropertyIterator<'a, T>(&'a [u8], PhantomData<T>);
+
+impl<'a, T> PropertyIterator<'a, T> {
+    pub(crate) fn new(value: &'a [u8]) -> Self {
+        PropertyIterator(value, PhantomData)
+    }
+}
+
+impl<T> Iterator for PropertyIterator<'_, T>
+where T: TryParse
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match T::try_parse(self.0) {
+            Ok((value, remaining)) => {
+                self.0 = remaining;
+                Some(value)
+            },
+            Err(_) => {
+                self.0 = &[];
+                None
+            },
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.0.len() / std::mem::size_of::<T>();
+        (size, Some(size))
+    }
+}
+
+impl<T: TryParse> std::iter::FusedIterator for PropertyIterator<'_, T> {}
 
 /// Extension trait that simplifies API use
 pub trait ConnectionExt: XProtoConnectionExt {


### PR DESCRIPTION
Simplify interpreting the 'value' in GetPropertyReply

The reply to GetProperty contains a 'value' list. In the XML, this is
described as a list of bytes, i.e. Vec<u8>. However, depending on the
value of the `format` field of the reply, this actually contains u8,
u16, or u32. Interpreting this field correctly was complicated.

This commit adds utility methods to `GetPropertyReply`. value8(),
value16(), and value32() return an iterator that interprets the values
from the reply as u8, u16, and u32, respectively. This iterator stops on
the first parsing error and returns None.

The only possible parsing errors here is "too few bytes in input" and it
should be impossible to hit in well-behaving X11 servers, so I am fine
with interpreting any errors this way.

Fixes: https://github.com/psychon/x11rb/issues/163
Signed-off-by: Uli Schlachter <psychon@znc.in>
