### PR TITLE
Add a `Serialize` trait

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -180,7 +180,6 @@ class Module(object):
         self.out("#![allow(clippy::identity_op)]")
         self.out("#![allow(clippy::trivially_copy_pass_by_ref)]")
         self.out("#![allow(clippy::eq_op)]")
-        self.out("#![allow(clippy::cognitive_complexity)]")
         self.out("use std::convert::TryFrom;")
         self.out("#[allow(unused_imports)]")
         self.out("use std::convert::TryInto;")

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -191,7 +191,7 @@ class Module(object):
         self.out("use crate::utils::{Buffer, RawFdContainer};")
         self.out("#[allow(unused_imports)]")
         self.out("use crate::x11_utils::{GenericEvent as X11GenericEvent, GenericError as X11GenericError, Event as _};")
-        self.out("use crate::x11_utils::TryParse;")
+        self.out("use crate::x11_utils::{TryParse, Serialize};")
         self.out("use crate::connection::RequestConnection;")
         self.out("#[allow(unused_imports)]")
         self.out("use crate::cookie::{Cookie, CookieWithFds, VoidCookie};")
@@ -323,105 +323,106 @@ class Module(object):
         self.complex_type(struct, self._name(name), True)
 
         # And now emit some functions for the struct.
-        self.out("impl %s {", self._name(name))
-        with Indent(self.out):
-            self._generate_to_ne_bytes(struct)
-        self.out("}")
+        self._generate_serialize(self._name(name), struct)
 
         self.out("")
 
-    def _generate_to_ne_bytes(self, complex):
-        if complex.fixed_size():
-            # Everything is fixed-size so we can return an array.
-            length = sum((field.type.get_total_size() for field in complex.fields))
-            wire_type = "[u8; %s]" % length
-        else:
-            # For a variable size list, we do not know beforehand the size of the
-            # serialised data. Thus, return a Vec.
-            length = None
-            wire_type = "Vec<u8>"
-
-        self.out("pub fn to_ne_bytes(&self) -> %s {", wire_type)
-
+    def _generate_serialize(self, type_name, complex):
+        self.out("impl Serialize for %s {", type_name)
         with Indent(self.out):
             if complex.fixed_size():
-                def _emit():
-                    assert False, "We do not have a variable size list, but we do?"
-
-                def _final_emit():
-                    pass
+                # Everything is fixed-size so we can return an array.
+                length = sum((field.type.get_total_size() for field in complex.fields))
+                wire_type = "[u8; %s]" % length
             else:
-                self.out("let mut result = Vec::new();")
+                # For a variable size list, we do not know beforehand the size of the
+                # serialized data. Thus, return a Vec.
+                length = None
+                wire_type = "Vec<u8>"
 
-                def _emit():
-                    if complex.fixed_size() or not result_bytes:
-                        return
-                    self.out("result.extend([")
+            self.out("type Bytes = %s;", wire_type)
+            self.out("fn serialize(&self) -> Self::Bytes {")
+
+            with Indent(self.out):
+                if complex.fixed_size():
+                    def _emit():
+                        assert False, "We do not have a variable size list, but we do?"
+
+                    def _final_emit():
+                        pass
+                else:
+                    self.out("let mut result = Vec::new();")
+
+                    def _emit():
+                        if complex.fixed_size() or not result_bytes:
+                            return
+                        self.out("result.extend([")
+                        for result_value in result_bytes:
+                            self.out.indent("%s,", result_value)
+                        self.out("].iter());")
+                        del result_bytes[:]
+                    _final_emit = _emit
+
+                # This gathers the bytes of the result; its content is copied to
+                # result:Vec<u8> by _emit(). This happens in front of variable sized lists
+                result_bytes = []
+
+                for field in complex.fields:
+                    field_name = self._to_rust_variable(field.field_name)
+                    if field.type.is_pad:
+                        if not complex.fixed_size() and field.type.align != 1:
+                            # Align the output buffer to a multiple of field.type.align
+                            assert field.type.size == 1
+                            assert field.type.nmemb == 1
+                            self.out("while result.len() %% %s != 0 {", field.type.align)
+                            self.out.indent("result.push(0);")
+                            self.out("}")
+                        else:
+                            assert field.type.align == 1
+                            assert field.type.size == 1
+                            for i in range(field.type.nmemb):
+                                result_bytes.append("0")
+                    elif field.type.is_list and field.type.nmemb is None:
+                        # This is a variable sized list, so emit bytes to 'result' and
+                        # then add this list directly to 'result'
+                        _emit()
+                        self.out("for obj in self.%s.iter() {", field_name)
+                        self.out.indent("result.extend(obj.serialize().iter());")
+                        self.out("}")
+                    elif field.type.is_list and field.type.nmemb is not None and field.type.size == 1:
+                        # Fixed-sized list with byte-sized members
+                        for i in range(field.type.nmemb):
+                            result_bytes.append("self.%s[%d]" % (field_name, i))
+                    else:
+                        # Fixed-sized list with "large" members. We have first serialize
+                        # the members individually and then assemble that into the output.
+                        field_name_bytes = self._to_rust_variable(field.field_name + "_bytes")
+                        if hasattr(field, "is_length_field_for"):
+                            # This field is a length field for some list. We get the value
+                            # for this field as the length of the list.
+                            self.out("let %s = self.%s.len() as %s;", field_name,
+                                     field.is_length_field_for.field_name, self._field_type(field))
+                            source = field_name
+                        else:
+                            # Get the value of this field from "self".
+                            source = "self.%s" % field_name
+                            if is_bool(field.type):
+                                source = "(%s as u8)" % source
+                        # First serialize the value itself...
+                        self.out("let %s = %s.serialize();", field_name_bytes, source)
+                        # ...then copy to the output.
+                        for i in range(field.type.size):
+                            result_bytes.append("%s[%d]" % (field_name_bytes, i))
+                _final_emit()
+
+                if complex.fixed_size():
+                    self.out("[")
                     for result_value in result_bytes:
                         self.out.indent("%s,", result_value)
-                    self.out("].iter());")
-                    del result_bytes[:]
-                _final_emit = _emit
-
-            # This gathers the bytes of the result; its content is copied to
-            # result:Vec<u8> by _emit(). This happens in front of variable sized lists
-            result_bytes = []
-
-            for field in complex.fields:
-                field_name = self._to_rust_variable(field.field_name)
-                if field.type.is_pad:
-                    if not complex.fixed_size() and field.type.align != 1:
-                        # Align the output buffer to a multiple of field.type.align
-                        assert field.type.size == 1
-                        assert field.type.nmemb == 1
-                        self.out("while result.len() %% %s != 0 {", field.type.align)
-                        self.out.indent("result.push(0);")
-                        self.out("}")
-                    else:
-                        assert field.type.align == 1
-                        assert field.type.size == 1
-                        for i in range(field.type.nmemb):
-                            result_bytes.append("0")
-                elif field.type.is_list and field.type.nmemb is None:
-                    # This is a variable sized list, so emit bytes to 'result' and
-                    # then add this list directly to 'result'
-                    _emit()
-                    self.out("for obj in self.%s.iter() {", field_name)
-                    self.out.indent("result.extend(obj.to_ne_bytes().iter());")
-                    self.out("}")
-                elif field.type.is_list and field.type.nmemb is not None and field.type.size == 1:
-                    # Fixed-sized list with byte-sized members
-                    for i in range(field.type.nmemb):
-                        result_bytes.append("self.%s[%d]" % (field_name, i))
+                    self.out("]")
                 else:
-                    # Fixed-sized list with "large" members. We have first serialise
-                    # the members individually and then assemble that into the output.
-                    field_name_bytes = self._to_rust_variable(field.field_name + "_bytes")
-                    if hasattr(field, "is_length_field_for"):
-                        # This field is a length field for some list. We get the value
-                        # for this field as the length of the list.
-                        self.out("let %s = self.%s.len() as %s;", field_name,
-                                 field.is_length_field_for.field_name, self._field_type(field))
-                        source = field_name
-                    else:
-                        # Get the value of this field from "self".
-                        source = "self.%s" % field_name
-                        if is_bool(field.type):
-                            source = "(%s as u8)" % source
-                    # First serialise the value itself...
-                    self.out("let %s = %s.to_ne_bytes();", field_name_bytes, source)
-                    # ...then copy to the output.
-                    for i in range(field.type.size):
-                        result_bytes.append("%s[%d]" % (field_name_bytes, i))
-            _final_emit()
-
-            if complex.fixed_size():
-                self.out("[")
-                for result_value in result_bytes:
-                    self.out.indent("%s,", result_value)
-                self.out("]")
-            else:
-                self.out("result")
+                    self.out("result")
+            self.out("}")
         self.out("}")
 
     def union(self, union, name):
@@ -448,9 +449,13 @@ class Module(object):
                     self.out("}")
                     self.out("do_the_parse(&self.0[..]).unwrap()")
                 self.out("}")
+        self.out("}")
 
-            self.out("fn to_ne_bytes(&self) -> &[u8] {")
-            self.out.indent("&self.0")
+        self.out("impl Serialize for %s {", rust_name)
+        with Indent(self.out):
+            self.out("type Bytes = Vec<u8>;")
+            self.out("fn serialize(&self) -> Self::Bytes {")
+            self.out.indent("self.0.clone()")
             self.out("}")
         self.out("}")
 
@@ -483,7 +488,7 @@ class Module(object):
                         assert field.type.fixed_size()
                         with Indent(self.out):
                             for i in range(field.type.nmemb):
-                                self.out("let value%d = value[%d].to_ne_bytes();",
+                                self.out("let value%d = value[%d].serialize();",
                                          i, i)
                             self.out("let value = [")
                             for i in range(field.type.nmemb):
@@ -492,7 +497,7 @@ class Module(object):
                             self.out("];")
                     self.out.indent("Self(value.to_vec())")
                 else:
-                    self.out.indent("Self(value.to_ne_bytes().to_vec())")
+                    self.out.indent("Self(value.serialize().to_vec())")
                 self.out("}")
             self.out("}")
 
@@ -520,7 +525,7 @@ class Module(object):
         self.complex_type(event, self._name(name) + 'Event', False)
         if not event.is_ge_event:
             self._emit_from_generic(name, 'X11GenericEvent', 'Event')
-            self._emit_serialise(event, name, 'Event')
+            self._emit_serialize(event, name, 'Event')
         else:
             self._emit_tryfrom_generic(name, 'X11GenericEvent', 'Event')
         self.out("")
@@ -530,7 +535,7 @@ class Module(object):
         self.emit_opcode(name, 'Error', error.opcodes[name])
         self.complex_type(error, self._name(name) + 'Error', False)
         self._emit_from_generic(name, 'X11GenericError', 'Error')
-        self._emit_serialise(error, name, 'Error')
+        self._emit_serialize(error, name, 'Error')
         self.out("")
 
     def _emit_from_generic(self, name, from_generic_type, extra_name):
@@ -565,7 +570,7 @@ class Module(object):
             self.out("}")
         self.out("}")
 
-    def _emit_serialise(self, obj, name, extra_name):
+    def _emit_serialize(self, obj, name, extra_name):
         # Emit code for serialising an event or an error into an [u8; 32]
         self.out("impl Into<[u8; 32]> for &%s%s {", self._name(name), extra_name)
         with Indent(self.out):
@@ -587,7 +592,7 @@ class Module(object):
                                 if field.type.size == 1:
                                     parts.append("self.%s[%d]" % (field_name, i))
                                 else:
-                                    self.out("let %s_%d = self.%s[%d].to_ne_bytes();",
+                                    self.out("let %s_%d = self.%s[%d].serialize();",
                                              field_name, i, field_name, i)
                                     for n in range(field.type.size):
                                         parts.append("%s_%d[%d]" % (field_name, i, n))
@@ -597,7 +602,7 @@ class Module(object):
                             else:
                                 parts.append("self.%s" % field_name)
                         else:
-                            self.out("let %s = self.%s.to_ne_bytes();", field_name, field_name)
+                            self.out("let %s = self.%s.serialize();", field_name, field_name)
                             for i in range(field.type.size):
                                 parts.append("%s[%d]" % (field_name, i))
 
@@ -725,7 +730,7 @@ class Module(object):
 
     def complex_type(self, complex, name, impl_try_parse):
         """Emit a complex type as a struct. This also adds some parsing code and
-        a to_ne_bytes() implementation."""
+        a Serialize implementation."""
 
         self.complex_type_struct(complex, name)
 
@@ -951,10 +956,7 @@ class Module(object):
                 case.rust_name = name + case.type.name[-1]
                 self.complex_type_struct(case.type, case.rust_name)
 
-                self.out("impl %s {", case.rust_name)
-                with Indent(self.out):
-                    self._generate_to_ne_bytes(case.type)
-                self.out("}")
+                self._generate_serialize(case.rust_name, case.type)
             else:
                 field, = visible_fields
                 case.only_field = field
@@ -977,29 +979,6 @@ class Module(object):
             self.out("/// Create a new instance with all fields unset / not present.")
             self.out("pub fn new() -> Self {")
             self.out.indent("Default::default()")
-            self.out("}")
-
-            self.out("fn to_ne_bytes(&self) -> Vec<u8> {")
-            with Indent(self.out):
-                self.out("let mut result = Vec::new();")
-                for case in switch.type.bitcases:
-                    if hasattr(case, "rust_name"):
-                        self.out("if let Some(value) = &self.%s {", case.type.name[-1])
-                        with Indent(self.out):
-                            self.out("result.extend(value.to_ne_bytes().iter());")
-                        self.out("}")
-                    else:
-                        field = case.only_field
-                        self.out("if let Some(value) = &self.%s {", self._aux_field_name(field))
-                        with Indent(self.out):
-                            if field.type.is_list:
-                                self.out("for obj in value.iter() {")
-                                self.out.indent("result.extend(obj.to_ne_bytes().iter());")
-                                self.out("}")
-                            else:
-                                self.out("result.extend(value.to_ne_bytes().iter());")
-                        self.out("}")
-                self.out("result")
             self.out("}")
 
             self.out("fn value_mask(&self) -> %s {", self._field_type(mask_field))
@@ -1038,7 +1017,33 @@ class Module(object):
                     self.out("self.%s = value.into();", aux_name)
                     self.out("self")
                 self.out("}")
+        self.out("}")
 
+        self.out("impl Serialize for %s {", name)
+        with Indent(self.out):
+            self.out("type Bytes = Vec<u8>;")
+            self.out("fn serialize(&self) -> Vec<u8> {")
+            with Indent(self.out):
+                self.out("let mut result = Vec::new();")
+                for case in switch.type.bitcases:
+                    if hasattr(case, "rust_name"):
+                        self.out("if let Some(value) = &self.%s {", case.type.name[-1])
+                        with Indent(self.out):
+                            self.out("result.extend(value.serialize().iter());")
+                        self.out("}")
+                    else:
+                        field = case.only_field
+                        self.out("if let Some(value) = &self.%s {", self._aux_field_name(field))
+                        with Indent(self.out):
+                            if field.type.is_list:
+                                self.out("for obj in value.iter() {")
+                                self.out.indent("result.extend(obj.serialize().iter());")
+                                self.out("}")
+                            else:
+                                self.out("result.extend(value.serialize().iter());")
+                        self.out("}")
+                self.out("result")
+            self.out("}")
         self.out("}")
 
     def _find_type_for_name(self, name_to_find):

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1035,12 +1035,7 @@ class Module(object):
                         field = case.only_field
                         self.out("if let Some(value) = &self.%s {", self._aux_field_name(field))
                         with Indent(self.out):
-                            if field.type.is_list:
-                                self.out("for obj in value.iter() {")
-                                self.out.indent("result.extend(obj.serialize().iter());")
-                                self.out("}")
-                            else:
-                                self.out("result.extend(value.serialize().iter());")
+                            self.out("result.extend(value.serialize().iter());")
                         self.out("}")
                 self.out("result")
             self.out("}")

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 use crate::utils::{Buffer, RawFdContainer};
 use crate::connection::SequenceNumber;
 use crate::generated::xproto::{Setup, SetupRequest};
-use crate::x11_utils::GenericEvent;
+use crate::x11_utils::{GenericEvent, Serialize};
 
 #[derive(Debug)]
 pub(crate) struct ConnectionInner<Stream>
@@ -66,7 +66,7 @@ where Stream: Read + Write
             authorization_protocol_name: Vec::new(),
             authorization_protocol_data: Vec::new(),
         };
-        stream.write_all(&request.to_ne_bytes())?;
+        stream.write_all(&request.serialize())?;
         Ok(())
     }
 

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -256,6 +256,20 @@ impl Serialize for bool {
     }
 }
 
+impl<T> Serialize for [T]
+where T: Serialize,
+      <T as Serialize>::Bytes: AsRef<[u8]>
+{
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Self::Bytes {
+        let mut result = Vec::new();
+        for item in self {
+            result.extend(item.serialize().as_ref());
+        }
+        result
+    }
+}
+
 // This macro is used by the generated code to implement `std::ops::BitOr` and
 // `std::ops::BitOrAssign`.
 macro_rules! bitmask_binop {

--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -87,6 +87,7 @@ mod mock {
     use std::ffi::CStr;
     use libc::{c_void, c_int, c_char, c_uint};
     use super::{xcb_connection_t, xcb_protocol_request_t, xcb_void_cookie_t};
+    use crate::x11_utils::Serialize;
     use crate::generated::xproto::Setup;
 
     #[repr(C)]
@@ -124,7 +125,7 @@ mod mock {
             pixmap_formats: Default::default(),
             roots: Default::default(),
         };
-        let setup = setup.to_ne_bytes();
+        let setup = setup.serialize();
         assert_eq!(setup.len(), 4 * length_field as usize);
 
         let mock = ConnectionMock {


### PR DESCRIPTION
Instead of ad-hoc having a `to_ne_bytes` method everywhere (that is called `to_ne_bytes` just for symmetry with things like `u32::to_ne_bytes()`), this PR adds a proper serialize trait. This simplifies some of the generated code and allows saving some lines of code. If `LengthAtMost32` were not a thing, this would simplify things even more...