### PR TITLE
Add a helper function for parsing lists

### DIFF
--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -256,6 +256,23 @@ impl Serialize for bool {
     }
 }
 
+/// Parse a list of objects from the given data.
+///
+/// This function parses a list of objects where the length of the list was specified externally.
+/// The wire format for `list_length` instances of `T` will be read from the given data.
+pub fn parse_list<T>(data: &[u8], list_length: usize) -> Result<(Vec<T>, &[u8]), ParseError>
+where T: TryParse
+{
+    let mut remaining = data;
+    let mut result = Vec::with_capacity(list_length);
+    for _ in 0..list_length {
+        let (entry, new_remaining) = T::try_parse(remaining)?;
+        result.push(entry);
+        remaining = new_remaining;
+    }
+    Ok((result, remaining))
+}
+
 impl<T> Serialize for [T]
 where T: Serialize,
       <T as Serialize>::Bytes: AsRef<[u8]>


### PR DESCRIPTION
This commit adds a parse_list() function. This function gets the length
of a list and then calls try_parse() that number of times. The resulting
objects are returned in a vector.

Before this commit, the code generator would generate the necessary loop
wherever it was needed. This commit has a big effect on the generated
code: There are 530 added lines in the diff and 1855 deletions for a net
removal of 1325 lines of code.

There are some special cases that are not handled by this commit. The
code generator still generates the necessary loop itself in these cases.
These cases are lists with implicit length (which only exists once in
all the XML descriptions, so is not worth optimising much) and types
which need extra arguments in their try_parse() method (which are thus
more complicated to work with and since there are only two such types,
this is also not worth optimising for).

Signed-off-by: Uli Schlachter <psychon@znc.in>