### PR TITLE
Add support for <eventstruct>

### DIFF
--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -75,8 +75,6 @@ def rs_request(self, name):
 
 
 def rs_eventstruct(self, name):
-    print("eventstruct", self, name)
-    assert False
     current_module.eventstruct(self, name)
 
 


### PR DESCRIPTION
Thanks to xcbgen, an <eventstruct> is basically a <union>. They are
wildly different in the XML, but xcbgen resolves the rest for us.

The only complication is that an <eventstruct> is a <union> containing
<event>s and our current name mangling does not do the right thing in
this case, so it needs some help to get things working.

Related-to: https://github.com/psychon/x11rb/issues/55
Signed-off-by: Uli Schlachter <psychon@znc.in>