### PR TITLE
Fix lots of cases where incorrect requests were generated

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -68,6 +68,10 @@ def mark_length_fields(self):
             related_list.has_length_field = field
             field.visible = False
 
+            expr = related_list.type.expr
+            if expr is not None and expr.op is not None and expr.op != "calculate_len":
+                field.expr_for_length_field = expr
+
 
 def get_derives(obj_type):
     if hasattr(obj_type, "computed_derives"):

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -50,7 +50,7 @@ def mark_length_fields(self):
     simple_lists = []
 
     for field in lists:
-        if len(get_references(field.type.expr)) <= 1:
+        if len(get_references(field.type.expr)) <= 1 and field.type.expr.op != 'popcount':
             simple_lists.append(field)
 
     # Mark length fields for simple list as not visible and map them to their list

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -222,3 +222,22 @@ fn test_client_message_data_parse() {
     assert!(err.is_err());
     assert_eq!(err.unwrap_err(), ParseError::ParseError);
 }
+
+#[test]
+fn test_set_modifier_mapping() -> Result<(), ConnectionError> {
+    let conn = FakeConnection::default();
+    let cookie = conn.set_modifier_mapping(&(1..17).collect::<Vec<_>>())?;
+
+    // Prevent call to discard_reply(), we only check request sending
+    std::mem::forget(cookie);
+
+    let mut expected = Vec::new();
+    let length: u16 = 5;
+    expected.push(118); // request major code
+    expected.push(2); // keycodes per modifier
+    expected.extend(&length.to_ne_bytes()); // length, not in the xml
+    expected.extend(1u8..17u8);
+
+    conn.check_requests(&[(false, expected)]);
+    Ok(())
+}


### PR DESCRIPTION
This PR fixes requests where the length of a list appeared in a popcount (this change causes a new argument to appear on the request function; this happens a lot in xinput) and where the length is a multiple of some constant (this fixes #61).