### PR TITLE
Add a function to create an XCBConnection from a raw pointer

### DIFF
--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -86,8 +86,12 @@ impl XCBConnection {
 
     /// Create a connection wrapper for a raw libxcb `xcb_connection_t`.
     ///
+    /// `xcb_disconnect` is not called on drop.
+    ///
+    /// # Safety
+    ///
     /// It is the caller's responsibility to ensure the connection is valid and lives longer
-    /// than the returned. `xcb_disconnect` is not called on drop.
+    /// than the returned XCBConnection.
     pub unsafe fn from_raw_xcb_connection(ptr: *mut c_void) -> Result<XCBConnection, ConnectionError> {
         let setup = raw_ffi::xcb_get_setup(ptr as *mut raw_ffi::xcb_connection_t);
         Ok(XCBConnection {


### PR DESCRIPTION
Closes https://github.com/psychon/x11rb/issues/176

This is nice for using x11rb with an OpenGL program, since you need an Xlib connection for that, and you can get an XCB connection from it.

As a side note: I think the normal Rust convention for naming types would make this XcbConnection rather than an XCBConnection, is that a change you'd consider making?