### PR TITLE
Move generated code to src directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 *.pyc
 **/__pycache__
+src/generated

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@ use std::process::Command;
 use std::path::PathBuf;
 use std::fs::create_dir;
 use std::io::Result;
-use std::env;
 
 fn create_dir_if_not_exist(dir: &PathBuf) -> Result<()> {
     let result = create_dir(dir);
@@ -32,7 +31,7 @@ fn get_paths() -> (String, String) {
 }
 
 fn main() {
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_path = PathBuf::from("src");
     let out_path = out_path.join("generated");
     create_dir_if_not_exist(&out_path).unwrap();
     let out_path = out_path.to_str().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,12 +87,10 @@ pub mod rust_connection;
 pub mod cookie;
 pub mod extension_information;
 
-pub mod generated {
-    include!(concat!(env!("OUT_DIR"), "/generated/mod.rs"));
-}
+pub mod generated;
 pub mod wrapper;
 
-use generated::xproto::{KEYSYM, TIMESTAMP};
+use generated::*;
 
 /// The universal null resource or null atom parameter value for many core X requests
 pub const NONE: u32 = 0;
@@ -109,7 +107,7 @@ pub const COPY_DEPTH_FROM_PARENT: u8 = 0;
 pub const COPY_CLASS_FROM_PARENT: u16 = 0;
 
 /// This constant can be used in most request that take a timestamp argument
-pub const CURRENT_TIME: TIMESTAMP = 0;
+pub const CURRENT_TIME: xproto::TIMESTAMP = 0;
 
 /// This constant can be used to fill unused entries in `KEYSYM` tables
-pub const NO_SYMBOL: KEYSYM = 0;
+pub const NO_SYMBOL: xproto::KEYSYM = 0;


### PR DESCRIPTION
Moved the generated code to the source directory so IDEs have an easier time finding definitions