### PR TITLE
Some Rust connection improvements

### DIFF
--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -28,8 +28,9 @@ where Stream: Read + Write
 impl<Stream> ConnectionInner<Stream>
 where Stream: Read + Write
 {
-    pub(crate) fn connect(mut stream: Stream) -> Result<(Self, Setup), Box<dyn Error>> {
-        Self::write_setup(&mut stream)?;
+    pub(crate) fn connect(mut stream: Stream, auth_name: Vec<u8>, auth_data: Vec<u8>)
+    -> Result<(Self, Setup), Box<dyn Error>> {
+        Self::write_setup(&mut stream, auth_name, auth_data)?;
         let setup = Self::read_setup(&mut stream)?;
         let result = ConnectionInner {
             stream,
@@ -52,13 +53,14 @@ where Stream: Read + Write
         0x42
     }
 
-    fn write_setup(stream: &mut Stream) -> Result<(), Box<dyn Error>> {
+    fn write_setup(stream: &mut Stream, auth_name: Vec<u8>, auth_data: Vec<u8>)
+    -> Result<(), Box<dyn Error>> {
         let request = SetupRequest {
             byte_order: Self::byte_order(),
             protocol_major_version: 11,
             protocol_minor_version: 0,
-            authorization_protocol_name: Vec::new(),
-            authorization_protocol_data: Vec::new(),
+            authorization_protocol_name: auth_name,
+            authorization_protocol_data: auth_data,
         };
         stream.write_all(&request.serialize())?;
         Ok(())

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -82,13 +82,17 @@ impl RequestConnection for RustConnection {
     fn send_request_with_reply_with_fds<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>) -> Result<CookieWithFds<Self, R>, ConnectionError>
         where R: TryFrom<(Buffer, Vec<RawFdContainer>), Error=ParseError>
     {
+        let mut storage = Default::default();
+        let bufs = self.compute_length_field(bufs, &mut storage)?;
+
         let _ = (bufs, fds);
         unimplemented!()
     }
 
     fn send_request_without_reply(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>) -> Result<VoidCookie<Self>, ConnectionError> {
-        // FIXME: Shouldn't this call compute_length_field? (Or rather: the implementation from
-        // send_request_with_reply() should be moved to send_request())
+        let mut storage = Default::default();
+        let bufs = self.compute_length_field(bufs, &mut storage)?;
+
         Ok(VoidCookie::new(self, self.send_request(bufs, fds, false)?))
     }
 

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -60,7 +60,7 @@ impl RustConnection {
         let stream = connect_stream(&*parsed_display.host, parsed_display.protocol.as_ref().map(|s| &**s), parsed_display.display)?;
 
         // Handle X11 connection
-        let (inner, setup) = inner::ConnectionInner::connect(stream)?;
+        let (inner, setup) = inner::ConnectionInner::connect(stream, Vec::new(), Vec::new())?;
 
         // Check that we got a valid screen number
         let screen = parsed_display.screen.into();

--- a/src/rust_connection/parse_display.rs
+++ b/src/rust_connection/parse_display.rs
@@ -1,0 +1,156 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedDisplay {
+    pub(crate) host: String,
+    pub(crate) protocol: Option<String>,
+    pub(crate) display: u16,
+    pub(crate) screen: u16,
+}
+
+pub(crate) fn parse_display(dpy_name: Option<&str>) -> Option<ParsedDisplay> {
+    // If no dpy name was provided, use the env var. If no env var exists, return None.
+    match dpy_name {
+        Some(dpy_name) => parse_display_impl(dpy_name),
+        None => parse_display_impl(&std::env::var("DISPLAY").ok()?)
+    }
+}
+
+fn parse_display_impl(dpy_name: &str) -> Option<ParsedDisplay> {
+    // Everything up to the last '/' is the protocol. This part is optional.
+    let (protocol, remaining) = if let Some(pos) = dpy_name.rfind('/') {
+        (Some(&dpy_name[..pos]), &dpy_name[pos + 1..])
+    } else {
+        (None, dpy_name)
+    };
+
+    // Everything up to the last ':' is the host. This part is required.
+    let pos = remaining.rfind(':')?;
+    let (host, remaining) = (&remaining[..pos], &remaining[pos + 1..]);
+
+    // The remaining part is display.screen. The display is required and the screen optional.
+    let (display, screen) = match remaining.find('.') {
+        Some(pos) => (&remaining[..pos], &remaining[pos + 1..]),
+        None => (remaining, "0")
+    };
+
+    // Parse the display and screen number
+    let (display, screen) = (display.parse().ok()?, screen.parse().ok()?);
+
+    let host = host.to_string();
+    let protocol = protocol.map(|p| p.to_string());
+    Some(ParsedDisplay { host, protocol, display, screen })
+}
+
+#[cfg(test)]
+mod test {
+    use super::{ParsedDisplay, parse_display};
+
+    fn do_parse_display(input: &str) -> Option<ParsedDisplay> {
+        std::env::set_var("DISPLAY", input);
+        let result1 = parse_display(None);
+
+        std::env::remove_var("DISPLAY");
+        let result2 = parse_display(Some(input));
+
+        assert_eq!(result1, result2);
+        result1
+    }
+
+    // The tests modify environment variables. This is process-global. Thus, the tests in this
+    // module cannot be run concurrently. We achieve this by having only a single test functions
+    // that calls all other functions.
+    #[test]
+    fn test_parsing() {
+        test_missing_input();
+        xcb_good_cases();
+        xcb_bad_cases();
+        own_good_cases();
+    }
+
+    fn test_missing_input() {
+        std::env::remove_var("DISPLAY");
+        assert_eq!(parse_display(None), None);
+    }
+
+    fn own_good_cases() {
+        // The XCB test suite does not test protocol parsing
+        for (input, output) in &[
+            ("foo/bar:1", ParsedDisplay { host: "bar".to_string(), protocol: Some("foo".to_string()), display: 1, screen: 0 }),
+            ("foo/bar:1.2", ParsedDisplay { host: "bar".to_string(), protocol: Some("foo".to_string()), display: 1, screen: 2 }),
+            ("a:b/c/foo:bar:1.2", ParsedDisplay { host: "foo:bar".to_string(), protocol: Some("a:b/c".to_string()), display: 1, screen: 2 }),
+        ] {
+            assert_eq!(do_parse_display(input).as_ref(), Some(output), "Failed parsing correctly: {}", input);
+        }
+    }
+
+    // Based on libxcb's test suite; (C) 2001-2006 Bart Massey, Jamey Sharp, and Josh Triplett
+    fn xcb_good_cases() {
+        for (input, output) in &[
+            // unix
+            (":0", ParsedDisplay { host: "".to_string(), protocol: None, display: 0, screen: 0 }),
+            (":1", ParsedDisplay { host: "".to_string(), protocol: None, display: 1, screen: 0 }),
+            (":0.1", ParsedDisplay { host: "".to_string(), protocol: None, display: 0, screen: 1 }),
+            // ip
+            ("x.org:0", ParsedDisplay { host: "x.org".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("expo:0", ParsedDisplay { host: "expo".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("bigmachine:1", ParsedDisplay { host: "bigmachine".to_string(), protocol: None, display: 1, screen: 0 }),
+            ("hydra:0.1", ParsedDisplay { host: "hydra".to_string(), protocol: None, display: 0, screen: 1 }),
+            // ipv4
+            ("198.112.45.11:0", ParsedDisplay { host: "198.112.45.11".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("198.112.45.11:0.1", ParsedDisplay { host: "198.112.45.11".to_string(), protocol: None, display: 0, screen: 1 }),
+            // ipv6
+            (":::0", ParsedDisplay { host: "::".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("1:::0", ParsedDisplay { host: "1::".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("::1:0", ParsedDisplay { host: "::1".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("::1:0.1", ParsedDisplay { host: "::1".to_string(), protocol: None, display: 0, screen: 1 }),
+            ("::127.0.0.1:0", ParsedDisplay { host: "::127.0.0.1".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("::ffff:127.0.0.1:0", ParsedDisplay { host: "::ffff:127.0.0.1".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("2002:83fc:3052::1:0", ParsedDisplay { host: "2002:83fc:3052::1".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("2002:83fc:3052::1:0.1", ParsedDisplay { host: "2002:83fc:3052::1".to_string(), protocol: None, display: 0, screen: 1 }),
+            ("[::]:0", ParsedDisplay { host: "[::]".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("[1::]:0", ParsedDisplay { host: "[1::]".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("[::1]:0", ParsedDisplay { host: "[::1]".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("[::1]:0.1", ParsedDisplay { host: "[::1]".to_string(), protocol: None, display: 0, screen: 1 }),
+            ("[::127.0.0.1]:0", ParsedDisplay { host: "[::127.0.0.1]".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("[2002:83fc:d052::1]:0", ParsedDisplay { host: "[2002:83fc:d052::1]".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("[2002:83fc:d052::1]:0.1", ParsedDisplay { host: "[2002:83fc:d052::1]".to_string(), protocol: None, display: 0, screen: 1 }),
+            // decnet
+            ("myws::0", ParsedDisplay { host: "myws:".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("big::0", ParsedDisplay { host: "big:".to_string(), protocol: None, display: 0, screen: 0 }),
+            ("hydra::0.1", ParsedDisplay { host: "hydra:".to_string(), protocol: None, display: 0, screen: 1 }),
+        ] {
+            assert_eq!(do_parse_display(input).as_ref(), Some(output), "Failed parsing correctly: {}", input);
+        }
+    }
+
+    // Based on libxcb's test suite; (C) 2001-2006 Bart Massey, Jamey Sharp, and Josh Triplett
+    fn xcb_bad_cases() {
+        for input in &[
+            "",
+            ":",
+            "::",
+            ":::",
+            ":.",
+            ":a",
+            ":a.",
+            ":0.",
+            ":.a",
+            ":.0",
+            ":0.a",
+            ":0.0.",
+            "127.0.0.1",
+            "127.0.0.1:",
+            "127.0.0.1::",
+            "::127.0.0.1",
+            "::127.0.0.1:",
+            "::127.0.0.1::",
+            "::ffff:127.0.0.1",
+            "::ffff:127.0.0.1:",
+            "::ffff:127.0.0.1::",
+            "localhost",
+            "localhost:",
+            "localhost::",
+        ] {
+            assert_eq!(do_parse_display(input), None, "Unexpectedly parsed: {}", input);
+        }
+    }
+}


### PR DESCRIPTION
This commit changes lots of code for connection to an X11 server.
This adds

- proper `$DISPLAY` parsing (this gets rid of the hardcoded `DISPLAY=127.0.0.1:1`
- some minor fixes for BigRequest handling in `RustConnection`
- some refactoring in preparation for unix socket support
- some preparation for authentication information
- better connection setup failure handling (the X11 server could reject a connection; previously this would result in a `ParseError`, but now a more informative error is returned)

This is all related to #24.