### PR TITLE
Rust connection error handling and thread safety fixes

### DIFF
--- a/examples/check_unchecked_requests.rs
+++ b/examples/check_unchecked_requests.rs
@@ -7,7 +7,6 @@
 
 extern crate x11rb;
 
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::Connection;
 use x11rb::generated::xproto::ConnectionExt;
 use x11rb::errors::ConnectionErrorOrX11Error;
@@ -17,7 +16,7 @@ use x11rb::wrapper::ConnectionExt as _;
 const INVALID_WINDOW: u32 = 0;
 
 fn main() -> Result<(), ConnectionErrorOrX11Error> {
-    let (conn, _) = XCBConnection::connect(None).unwrap();
+    let (conn, _) = x11rb::connect(None).unwrap();
 
     // For requests with responses, there are four possibilities:
 

--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -5,16 +5,14 @@ use std::process::exit;
 use std::convert::TryFrom;
 
 use x11rb::connection::{RequestConnection as _, Connection as _};
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::generated::xproto::{CreateWindowAux, ConfigureWindowAux, WindowClass, ConnectionExt as _, GE_GENERIC_EVENT, GeGenericEvent};
 use x11rb::generated::present;
-use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::Event;
 use x11rb::COPY_DEPTH_FROM_PARENT;
 
-fn main() -> Result<(), ConnectionErrorOrX11Error>
+fn main() -> Result<(), Box<dyn std::error::Error>>
 {
-    let (conn, screen_num) = XCBConnection::connect(None)?;
+    let (conn, screen_num) = x11rb::connect(None)?;
     let screen = &conn.setup().roots[screen_num];
 
     let present_info = match conn.extension_information(present::X11_EXTENSION_NAME) {

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -8,7 +8,6 @@ use std::thread;
 use std::time::Duration;
 use std::sync::{Arc, Mutex};
 use std::f64::consts::PI;
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::Connection;
 use x11rb::errors::ConnectionErrorOrX11Error;
 use x11rb::x11_utils::Event;
@@ -33,7 +32,7 @@ struct Window {
 
 fn main()
 {
-    let (conn, screen_num) = XCBConnection::connect(None).unwrap();
+    let (conn, screen_num) = x11rb::connect(None).unwrap();
     let conn = Arc::new(conn);
     let screen = &conn.setup().roots[screen_num];
 

--- a/examples/list_fonts.rs
+++ b/examples/list_fonts.rs
@@ -2,11 +2,10 @@
 
 extern crate x11rb;
 
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::generated::xproto::{ConnectionExt, FontDraw};
 
 fn main() {
-    let (conn, _) = XCBConnection::connect(None).unwrap();
+    let (conn, _) = x11rb::connect(None).unwrap();
     let (ltr, rtl): (u8, u8) = (FontDraw::LeftToRight.into(), FontDraw::RightToLeft.into());
 
     println!("DIR  MIN  MAX EXIST DFLT PROP ASC DESC NAME");

--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -113,6 +113,7 @@ fn receive_fd<C: Connection>(conn: &C, screen_num: usize) -> Result<(), Connecti
 
 fn main() {
     let file = make_file().expect("Failed to create temporary file for FD passing");
+    // FIXME: Use x11rb::connect() once RustConnection supports FD passing
     match XCBConnection::connect(None) {
         Err(err) => eprintln!("Failed to connect to the X11 server: {}", err),
         Ok((conn, screen_num)) => {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -2,14 +2,13 @@ extern crate x11rb;
 
 use std::convert::TryFrom;
 
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::x11_utils::{Event, GenericError};
 use x11rb::generated::xproto::*;
 use x11rb::connection::Connection;
 use x11rb::wrapper::{ConnectionExt as _, LazyAtom};
 
 fn main() {
-    let (conn, screen_num) = XCBConnection::connect(None).unwrap();
+    let (conn, screen_num) = x11rb::connect(None).unwrap();
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
     let conn1 = std::sync::Arc::new(conn);

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -6,7 +6,6 @@ extern crate x11rb;
 use std::process::exit;
 use std::collections::HashSet;
 
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::Connection;
 use x11rb::generated::xproto::*;
 use x11rb::errors::ConnectionErrorOrX11Error;
@@ -278,7 +277,7 @@ fn become_wm<C: Connection>(conn: &C, screen: &Screen) -> Result<(), ConnectionE
 }
 
 fn main() {
-    let (conn, screen_num) = XCBConnection::connect(None).unwrap();
+    let (conn, screen_num) = x11rb::connect(None).unwrap();
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
     let conn1 = std::sync::Arc::new(conn);

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -2,7 +2,6 @@
 
 extern crate x11rb;
 
-use x11rb::xcb_ffi::XCBConnection;
 use x11rb::connection::{RequestConnection as _, Connection};
 use x11rb::x11_utils::Event;
 use x11rb::generated::xproto::*;
@@ -231,7 +230,7 @@ fn create_gc_with_foreground<C: Connection>(conn: &C, win_id: WINDOW, foreground
 }
 
 fn main() {
-    let (conn, screen_num) = XCBConnection::connect(None).expect("Failed to connect to the X11 server");
+    let (conn, screen_num) = x11rb::connect(None).expect("Failed to connect to the X11 server");
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
     let conn1 = std::sync::Arc::new(conn);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ use connection::Connection;
 /// example `127.0.0.1:1`. If no value is provided, the `$DISPLAY` environment variable is
 /// used.
 pub fn connect(dpy_name: Option<&str>) -> Result<(impl Connection + Send + Sync, usize), Box<dyn Error>> {
-    let dpy_name = dpy_name.map(|d| CString::new(d)).transpose()?;
+    let dpy_name = dpy_name.map(CString::new).transpose()?;
     let dpy_name = dpy_name.as_ref().map(|d| &**d);
     Ok(xcb_ffi::XCBConnection::connect(dpy_name)?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,22 @@ pub mod generated {
 }
 pub mod wrapper;
 
+use std::error::Error;
+use std::ffi::CString;
+
 use generated::xproto::{KEYSYM, TIMESTAMP};
+use connection::Connection;
+
+/// Establish a new connection to an X11 server.
+///
+/// If a `dpy_name` is provided, it describes the display that should be connected to, for
+/// example `127.0.0.1:1`. If no value is provided, the `$DISPLAY` environment variable is
+/// used.
+pub fn connect(dpy_name: Option<&str>) -> Result<(impl Connection + Send + Sync, usize), Box<dyn Error>> {
+    let dpy_name = dpy_name.map(|d| CString::new(d)).transpose()?;
+    let dpy_name = dpy_name.as_ref().map(|d| &**d);
+    Ok(xcb_ffi::XCBConnection::connect(dpy_name)?)
+}
 
 /// The universal null resource or null atom parameter value for many core X requests
 pub const NONE: u32 = 0;

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -120,12 +120,8 @@ impl RequestConnection for RustConnection {
     }
 
     fn check_for_error(&self, sequence: SequenceNumber) -> Result<Option<GenericError>, ConnectionError> {
-        let reply = self.inner.borrow_mut().wait_for_reply_or_error(sequence).map_err(|_| ConnectionError::UnknownError)?;
-        if reply[0] == 0 {
-            Ok(Some(reply.try_into()?))
-        } else {
-            Ok(None)
-        }
+        let reply = self.inner.borrow_mut().check_for_reply_or_error(sequence).map_err(|_| ConnectionError::UnknownError)?;
+        Ok(reply.and_then(|r| r.try_into().ok()))
     }
 
     fn wait_for_reply_with_fds(&self, _sequence: SequenceNumber) -> Result<(Buffer, Vec<RawFdContainer>), ConnectionErrorOrX11Error> {


### PR DESCRIPTION
Fix a mistake in `RustConnection`'s X11 error handling (an X11 error packet ended up in the wrong queue). This also makes `RustConnection` `Send + Sync` by using `Mutex` where necessary. Note that this is currently not yet really usable, since `wait_for_event()` locks the mutex, so that other threads cannot do anything.