### PR TITLE
Allow using RustConnection with different Stream

### DIFF
--- a/src/rust_connection/stream.rs
+++ b/src/rust_connection/stream.rs
@@ -4,14 +4,14 @@ use std::io::{Read, Write, Result, IoSlice, IoSliceMut};
 
 /// A wrapper around a `TcpStream` or `UnixStream`.
 #[derive(Debug)]
-pub(crate) enum Stream {
+pub enum Stream {
     TcpStream(TcpStream),
     UnixStream(UnixStream),
 }
 
 impl Stream {
     /// Try to connect to the X11 server described by the given arguments.
-    pub(crate) fn connect(host: &str, protocol: Option<&str>, display: u16) -> Result<Self> {
+    pub fn connect(host: &str, protocol: Option<&str>, display: u16) -> Result<Self> {
         const TCP_PORT_BASE: u16 = 6000;
 
         if (protocol.is_none() || protocol != Some("unix")) && !host.is_empty() && host != "unix" {


### PR DESCRIPTION
This commit makes RustConnection generic over the stream object, which
is required to implement Read + Write. We set the default stream to be
stream::Stream so that all previous code will still work.

One application of this is that the user can choose if they want to
buffer their stream themselves (regardless of what x11rb decides to do
ultimately).