### PR TITLE
RustConnection: use a background thread

### DIFF
--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -22,7 +22,7 @@ mod stream;
 /// A connection to an X11 server implemented in pure rust
 #[derive(Debug)]
 pub struct RustConnection {
-    inner: Mutex<inner::ConnectionInner<stream::Stream>>,
+    inner: Mutex<inner::ConnectionInner>,
     id_allocator: Mutex<id_allocator::IDAllocator>,
     setup: Setup,
     extension_information: ExtensionInformation,

--- a/src/rust_connection/stream.rs
+++ b/src/rust_connection/stream.rs
@@ -40,6 +40,16 @@ impl Stream {
             }
         }
     }
+
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// This function calls `try_clone()` on the inner stream.
+    pub(crate) fn try_clone(&self) -> Result<Stream> {
+        match self {
+            Stream::TcpStream(stream) => Ok(Stream::TcpStream(stream.try_clone()?)),
+            Stream::UnixStream(stream) => Ok(Stream::UnixStream(stream.try_clone()?)),
+        }
+    }
 }
 
 impl Read for Stream {


### PR DESCRIPTION
If a X11 client writes to the X11 server without also reading, a deadlock is possible: To protect itself, the X11 server stops accepting requests from a client if there are too many replies for it that could not be sent yet. In this situation, the server would not read from the client, waiting instead for its send buffer to drawin, while the client is blocked sending to the server, waiting for it to react. Up to now, this deadlock was possible with `RustConnection`.

This PR makes `RustConnection` spawn a thread that handles reading from the server. To make this actually work correctly, some fun with `std::sync::Condvar` is necessary. Threads waiting for replies or events block on this condition variable. The reading thread signals it when something is done.

Currently, there is just a single condition variable, thus there is a thundering herd problem: As soon as something is received, *everyone* is woken up. Improving upon this is left as future work.
For now, this PR already results in enough uglyness:
https://github.com/psychon/x11rb/blob/6bcdd15add18b36614b1d5543e3d39e8baec844f/src/rust_connection/inner.rs#L253