### PR TITLE
Add basic Xauth support

### DIFF
--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -18,6 +18,7 @@ mod inner;
 mod id_allocator;
 mod parse_display;
 mod stream;
+mod xauth;
 
 /// A connection to an X11 server implemented in pure rust
 #[derive(Debug)]

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -43,7 +43,10 @@ impl RustConnection<stream::Stream> {
         let stream = stream::Stream::connect(&*parsed_display.host, protocol, parsed_display.display)?;
         let screen = parsed_display.screen.into();
 
-        Ok((Self::connect_to_stream(stream, screen)?, screen))
+        let (auth_name, auth_data) = xauth::get_auth(parsed_display.display)?
+            .unwrap_or_else(|| (Vec::new(), Vec::new()));
+
+        Ok((Self::connect_to_stream_with_auth_info(stream, screen, auth_name, auth_data)?, screen))
     }
 }
 

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -114,9 +114,9 @@ mod test {
         let entry = read_entry(&mut cursor).unwrap();
         assert_eq!(entry, Some(AuthEntry {
             family: Family::Local,
-            address: "ZweiLED".as_bytes().to_vec(),
-            number: "1".as_bytes().to_vec(),
-            name: "bar".as_bytes().to_vec(),
+            address: b"ZweiLED".to_vec(),
+            number: b"1".to_vec(),
+            name: b"bar".to_vec(),
             data: u32::to_be_bytes(0xdead_beef).to_vec(),
         }));
     }
@@ -137,16 +137,16 @@ mod test {
         for expected in &[
            AuthEntry {
                family: Family::Local,
-               address: "ZweiLED".as_bytes().to_vec(),
-               number: "1".as_bytes().to_vec(),
-               name: "bar".as_bytes().to_vec(),
+               address: b"ZweiLED".to_vec(),
+               number: b"1".to_vec(),
+               name: b"bar".to_vec(),
                data: u32::to_be_bytes(0xdead_beef).to_vec(),
            },
            AuthEntry {
                family: Family::Unknown(0), // No idea why this is Unknown
                address: vec![1, 2, 3, 4],
-               number: "2".as_bytes().to_vec(),
-               name: "baz".as_bytes().to_vec(),
+               number: b"2".to_vec(),
+               name: b"baz".to_vec(),
                data: u32::to_be_bytes(0xaabb_ccdd).to_vec(),
            },
         ] {

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -77,7 +77,9 @@ fn get_xauthority_file_name() -> Option<PathBuf> {
     })
 }
 
-pub(crate) fn get_auth(display: u16) -> Result<Option<(Vec<u8>, Vec<u8>)>, Error> {
+pub(crate) type AuthInfo = (Vec<u8>, Vec<u8>);
+
+pub(crate) fn get_auth(display: u16) -> Result<Option<AuthInfo>, Error> {
     let file = match get_xauthority_file_name() {
         None => return Ok(None),
         Some(file) => file
@@ -115,7 +117,7 @@ mod test {
             address: "ZweiLED".as_bytes().to_vec(),
             number: "1".as_bytes().to_vec(),
             name: "bar".as_bytes().to_vec(),
-            data: u32::to_be_bytes(0xdeadbeef).to_vec(),
+            data: u32::to_be_bytes(0xdead_beef).to_vec(),
         }));
     }
 
@@ -138,14 +140,14 @@ mod test {
                address: "ZweiLED".as_bytes().to_vec(),
                number: "1".as_bytes().to_vec(),
                name: "bar".as_bytes().to_vec(),
-               data: u32::to_be_bytes(0xdeadbeef).to_vec(),
+               data: u32::to_be_bytes(0xdead_beef).to_vec(),
            },
            AuthEntry {
                family: Family::Unknown(0), // No idea why this is Unknown
                address: vec![1, 2, 3, 4],
                number: "2".as_bytes().to_vec(),
                name: "baz".as_bytes().to_vec(),
-               data: u32::to_be_bytes(0xaabbccdd).to_vec(),
+               data: u32::to_be_bytes(0xaabb_ccdd).to_vec(),
            },
         ] {
             let entry = read_entry(&mut cursor).unwrap();

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -1,0 +1,65 @@
+//! Helpers for working with `~/.Xauthority`.
+
+use std::io::Read;
+use std::io::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct AuthEntry {
+    family: u16,
+    address: Vec<u8>,
+    number: Vec<u8>,
+    name: Vec<u8>,
+    data: Vec<u8>,
+}
+
+fn read_u16<R: Read>(read: &mut R) -> Result<u16, Error> {
+    let mut buffer = [0; 2];
+    read.read_exact(&mut buffer)?;
+    Ok(u16::from_be_bytes(buffer))
+}
+
+fn read_string<R: Read>(read: &mut R) -> Result<Vec<u8>, Error> {
+    let length = read_u16(read)?;
+    let mut result = vec![0; length.into()];
+    read.read_exact(&mut result[..])?;
+    Ok(result)
+}
+
+pub(crate) fn read_entry<R: Read>(read: &mut R) -> Result<AuthEntry, Error> {
+    let family = read_u16(read)?;
+    let address = read_string(read)?;
+    let number = read_string(read)?;
+    let name = read_string(read)?;
+    let data = read_string(read)?;
+    Ok(AuthEntry { family, address, number, name, data })
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Cursor;
+    use super::{AuthEntry, read_entry};
+
+    #[test]
+    fn test_read() {
+        // Data generated via xauth -f /tmp/file add :1 bar deadbeef
+        let data = [
+            0x01, 0x00, 0x00, 0x07, 0x5a, 0x77, 0x65, 0x69, 0x4c, 0x45,
+            0x44, 0x00, 0x01, 0x31, 0x00, 0x03, 0x62, 0x61, 0x72, 0x00,
+            0x04, 0xde, 0xad, 0xbe, 0xef,
+        ];
+        let mut cursor = Cursor::new(&data);
+        let entry = read_entry(&mut cursor).unwrap();
+        println!("{:?}", std::str::from_utf8(&entry.address));
+        println!("{:?}", std::str::from_utf8(&entry.number));
+        println!("{:?}", std::str::from_utf8(&entry.name));
+        println!("{:?}", std::str::from_utf8(&entry.data));
+        println!("{:x?}", entry.data);
+        assert_eq!(entry, AuthEntry {
+            family: 0x100,
+            address: "ZweiLED".as_bytes().to_vec(),
+            number: "1".as_bytes().to_vec(),
+            name: "bar".as_bytes().to_vec(),
+            data: u32::to_be_bytes(0xdeadbeef).to_vec(),
+        });
+    }
+}

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -55,7 +55,7 @@ fn read_string<R: Read>(read: &mut R) -> Result<Vec<u8>, Error> {
 fn read_entry<R: Read>(read: &mut R) -> Result<Option<AuthEntry>, Error> {
     let family = match read_u16(read) {
         Ok(family) => family,
-        Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
+        Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
         Err(e) => return Err(e),
     }.into();
     let address = read_string(read)?;

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -1,6 +1,8 @@
 //! Helpers for working with `~/.Xauthority`.
 
 use std::io::{Read, Error, ErrorKind};
+use std::path::PathBuf;
+use std::env::var_os;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum Family {
@@ -57,6 +59,18 @@ pub(crate) fn read_entry<R: Read>(read: &mut R) -> Result<Option<AuthEntry>, Err
     let name = read_string(read)?;
     let data = read_string(read)?;
     Ok(Some(AuthEntry { family, address, number, name, data }))
+}
+
+pub(crate) fn get_xauthority_file_name() -> Option<PathBuf> {
+    if let Some(name) = var_os("XAUTHORITY") {
+        return Some(name.into());
+    }
+    var_os("HOME").map(|prefix| {
+        let mut result = PathBuf::new();
+        result.push(prefix);
+        result.push(".Xauthority");
+        result
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This should be enough to consider #204 fixed (CC @dalcde). However, this does not yet implement "proper" matching, so #196 stays open. The code just uses the first `MIT-MAGIC-COOKIE-1` entry of `~/.Xauthority` with a matching display number. Thus, this will not work correctly if you have entries for non-local displays (think: `DISPLAY=1.2.3.4:0`). Still, this should already cover 90% of uses.

Testing done:
```
$ rm -f /tmp/file && xauth -f /tmp/file add :2 . 1234 && Xephyr -listen tcp -auth /tmp/file :2
$ DISPLAY=127.0.0.1:2 cargo run --example simple_window --no-default-features --features vendor-xcb-proto
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SetupFailed(SetupFailed { status: 0, protocol_major_version: 11, protocol_minor_version: 0, length: 6, reason: [78, 111, 32, 112, 114, 111, 116, 111, 99, 111, 108, 32, 115, 112, 101, 99, 105, 102, 105, 101, 100, 10] })', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
$ XAUTHORITY=/tmp/file DISPLAY=127.0.0.1:2 cargo run --example simple_window --no-default-features --features vendor-xcb-proto                       
Unknown event GenericEvent(Vec([19, 0, 8, 0, 0, 0, 32, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
ExposeEvent { response_type: 12, sequence: 8, window: 2097152, x: 0, y: 0, width: 100, height: 100, count: 0 })
```
(Note to self: You really should write more unit tests)
(Oh and the docs in here really need some improvements, but I wanted to get this done quickly)