### PR TITLE
Add AppVeyor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # X11 rust bindings
 
-[![Build Status](https://travis-ci.org/psychon/x11rb.svg?branch=master)](https://travis-ci.org/psychon/x11rb)
+[![TravisCI Build Status](https://travis-ci.org/psychon/x11rb.svg?branch=master)](https://travis-ci.org/psychon/x11rb)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/950g0t6i8hfc9dup/branch/master?svg=true)](https://ci.appveyor.com/project/psychon/x11rb)
 [![Crate](https://img.shields.io/crates/v/x11rb.svg)](https://crates.io/crates/x11rb)
 [![API](https://docs.rs/x11rb/badge.svg)](https://docs.rs/x11rb)
 ![Minimum rustc version](https://img.shields.io/badge/rustc-1.37+-lightgray.svg)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ install:
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -V
   - cargo -V
+  # This uses libc::mmap and thus is Unix-only
+  - del examples\shared_memory.rs
 
 build: false
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host i686-pc-windows-msvc --profile minimal
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+test_script:
+  # We do not have libxcb and thus cannot build XCBConnection
+  - cargo build --verbose --all-targets --no-default-features --features vendor-xcb-proto
+  - cargo test --verbose --no-default-features --features vendor-xcb-proto

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,13 +42,12 @@
 //! For example, here is how to create a new window with x11rb:
 //! ```no_run
 //! use x11rb::connection::Connection;
-//! use x11rb::xcb_ffi::XCBConnection;
 //! use x11rb::generated::xproto::*;
 //! use x11rb::errors::ConnectionErrorOrX11Error;
 //! use x11rb::COPY_DEPTH_FROM_PARENT;
 //!
-//! fn main() -> Result<(), ConnectionErrorOrX11Error> {
-//!     let (conn, screen_num) = XCBConnection::connect(None)?;
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let (conn, screen_num) = x11rb::connect(None)?;
 //!     let screen = &conn.setup().roots[screen_num];
 //!     let win_id = conn.generate_id();
 //!     conn.create_window(COPY_DEPTH_FROM_PARENT, win_id, screen.root, 0, 0, 100, 100, 0, WindowClass::InputOutput,


### PR DESCRIPTION
Since there is no libxcb on Appveyor and getting libxcb there is hard,
this only runs the tests since they do not depend on libxcb.

Testing XCBConnection on AppVeyor is left as future work. It seems to be quite
hard to make this work. Or, at least I failed.

Fixes: https://github.com/psychon/x11rb/issues/103
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

This PR contains more than just the above commit, but the above is the "main part". The rest fixes some stuff.