### PR TITLE
Add full Xau support to RustConnection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["xcb", "X11"]
 
 [dependencies]
 libc = "0.2"
+gethostname = "0.2.1"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -44,7 +44,7 @@ impl RustConnection<stream::Stream> {
         let screen = parsed_display.screen.into();
 
         let (family, address) = stream.peer_addr()?;
-        let (auth_name, auth_data) = xauth::get_auth(&family, &address, parsed_display.display)
+        let (auth_name, auth_data) = xauth::get_auth(family, &address, parsed_display.display)
             // Ignore all errors while determining auth; instead we just try without auth info.
             .unwrap_or(None)
             .unwrap_or_else(|| (Vec::new(), Vec::new()));

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -43,7 +43,9 @@ impl RustConnection<stream::Stream> {
         let stream = stream::Stream::connect(&*parsed_display.host, protocol, parsed_display.display)?;
         let screen = parsed_display.screen.into();
 
-        let (auth_name, auth_data) = xauth::get_auth(parsed_display.display)?
+        let (auth_name, auth_data) = xauth::get_auth(parsed_display.display)
+            // Ignore all errors while determining auth; instead we just try without auth info.
+            .unwrap_or(None)
             .unwrap_or_else(|| (Vec::new(), Vec::new()));
 
         Ok((Self::connect_to_stream_with_auth_info(stream, screen, auth_name, auth_data)?, screen))

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -43,7 +43,8 @@ impl RustConnection<stream::Stream> {
         let stream = stream::Stream::connect(&*parsed_display.host, protocol, parsed_display.display)?;
         let screen = parsed_display.screen.into();
 
-        let (auth_name, auth_data) = xauth::get_auth(parsed_display.display)
+        // FIXME proper arguments
+        let (auth_name, auth_data) = xauth::get_auth(&xauth::Family::Wild, &[], parsed_display.display)
             // Ignore all errors while determining auth; instead we just try without auth info.
             .unwrap_or(None)
             .unwrap_or_else(|| (Vec::new(), Vec::new()));

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -43,8 +43,8 @@ impl RustConnection<stream::Stream> {
         let stream = stream::Stream::connect(&*parsed_display.host, protocol, parsed_display.display)?;
         let screen = parsed_display.screen.into();
 
-        // FIXME proper arguments
-        let (auth_name, auth_data) = xauth::get_auth(&xauth::Family::Wild, &[], parsed_display.display)
+        let (family, address) = stream.peer_addr()?;
+        let (auth_name, auth_data) = xauth::get_auth(&family, &address, parsed_display.display)
             // Ignore all errors while determining auth; instead we just try without auth info.
             .unwrap_or(None)
             .unwrap_or_else(|| (Vec::new(), Vec::new()));

--- a/src/rust_connection/stream.rs
+++ b/src/rust_connection/stream.rs
@@ -4,7 +4,6 @@ use std::os::unix::net::UnixStream;
 use std::io::{Read, Write, Result, IoSlice, IoSliceMut};
 
 use super::xauth::Family;
-use crate::generated::xproto::Family as X11Family;
 
 /// A wrapper around a `TcpStream` or `UnixStream`.
 #[derive(Debug)]
@@ -72,16 +71,14 @@ impl Stream {
                             ip
                         } else {
                             // Okay, this is really a v6 address
-                            let family = Family::X11Family(X11Family::Internet6);
-                            return Ok((family, ip.octets().to_vec()));
+                            return Ok((Family::Internet6, ip.octets().to_vec()));
                         }
                     }
                 };
 
                 // Handle the v4 address
                 if !ip.is_loopback() {
-                    let family = Family::X11Family(X11Family::Internet);
-                    return Ok((family, ip.octets().to_vec()));
+                    return Ok((Family::Internet, ip.octets().to_vec()));
                 } else {
                     // This is only reached for loopback addresses. The code below handles this.
                 }

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -1,14 +1,12 @@
 //! Helpers for working with `~/.Xauthority`.
 
-use std::io::{Read, Error, ErrorKind, BufReader};
-use std::path::PathBuf;
-use std::env::var_os;
-use std::fs::File;
+use std::io::Error;
 
 use crate::generated::xproto::Family as X11Family;
 
 const MIT_MAGIC_COOKIE_1: &[u8] = b"MIT-MAGIC-COOKIE-1";
 
+/// A family describes how to interpret some bytes as an address in an `AuthEntry`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Family {
     // Per a comment in xcb-proto/src/xproto.xml on the "Family" enum:
@@ -49,6 +47,7 @@ impl From<u16> for Family {
     }
 }
 
+/// A single entry of an `.Xauthority` file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AuthEntry {
     family: Family,
@@ -58,121 +57,157 @@ pub(crate) struct AuthEntry {
     data: Vec<u8>,
 }
 
-fn read_u16<R: Read>(read: &mut R) -> Result<u16, Error> {
-    let mut buffer = [0; 2];
-    read.read_exact(&mut buffer)?;
-    Ok(u16::from_be_bytes(buffer))
-}
+mod file {
+    //! Code for actually reading `~/.Xauthority`.
 
-fn read_string<R: Read>(read: &mut R) -> Result<Vec<u8>, Error> {
-    let length = read_u16(read)?;
-    let mut result = vec![0; length.into()];
-    read.read_exact(&mut result[..])?;
-    Ok(result)
-}
+    use std::io::{Read, Error, ErrorKind, BufReader};
+    use std::path::PathBuf;
+    use std::env::var_os;
+    use std::fs::File;
 
-fn read_entry<R: Read>(read: &mut R) -> Result<Option<AuthEntry>, Error> {
-    let family = match read_u16(read) {
-        Ok(family) => family,
-        Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
-        Err(e) => return Err(e),
-    }.into();
-    let address = read_string(read)?;
-    let number = read_string(read)?;
-    let name = read_string(read)?;
-    let data = read_string(read)?;
-    Ok(Some(AuthEntry { family, address, number, name, data }))
-}
+    use super::AuthEntry;
 
-fn get_xauthority_file_name() -> Option<PathBuf> {
-    if let Some(name) = var_os("XAUTHORITY") {
-        return Some(name.into());
+    fn read_u16<R: Read>(read: &mut R) -> Result<u16, Error> {
+        let mut buffer = [0; 2];
+        read.read_exact(&mut buffer)?;
+        Ok(u16::from_be_bytes(buffer))
     }
-    var_os("HOME").map(|prefix| {
-        let mut result = PathBuf::new();
-        result.push(prefix);
-        result.push(".Xauthority");
-        result
-    })
+
+    fn read_string<R: Read>(read: &mut R) -> Result<Vec<u8>, Error> {
+        let length = read_u16(read)?;
+        let mut result = vec![0; length.into()];
+        read.read_exact(&mut result[..])?;
+        Ok(result)
+    }
+
+    fn read_entry<R: Read>(read: &mut R) -> Result<Option<AuthEntry>, Error> {
+        let family = match read_u16(read) {
+            Ok(family) => family,
+            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e),
+        }.into();
+        let address = read_string(read)?;
+        let number = read_string(read)?;
+        let name = read_string(read)?;
+        let data = read_string(read)?;
+        Ok(Some(AuthEntry { family, address, number, name, data }))
+    }
+
+    fn get_xauthority_file_name() -> Option<PathBuf> {
+        if let Some(name) = var_os("XAUTHORITY") {
+            return Some(name.into());
+        }
+        var_os("HOME").map(|prefix| {
+            let mut result = PathBuf::new();
+            result.push(prefix);
+            result.push(".Xauthority");
+            result
+        })
+    }
+
+    /// An iterator over the entries of an `.Xauthority` file
+    #[derive(Debug)]
+    pub(crate) struct XAuthorityEntries(BufReader<File>);
+
+    impl XAuthorityEntries {
+        pub(crate) fn new() -> Result<Option<XAuthorityEntries>, Error> {
+            get_xauthority_file_name()
+                .map(File::open)
+                .transpose()?
+                // At this point we have Option<File> and errors while opening the file were
+                // returned to the caller.
+                .map(|file| Ok(XAuthorityEntries(BufReader::new(file))))
+                .transpose()
+        }
+    }
+
+    impl Iterator for XAuthorityEntries {
+        type Item = Result<AuthEntry, Error>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            read_entry(&mut self.0).transpose()
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use std::io::Cursor;
+        use super::super::{AuthEntry, Family, X11Family};
+        use super::read_entry;
+
+        #[test]
+        fn test_read() {
+            // Data generated via xauth -f /tmp/file add :1 bar deadbeef
+            let data = [
+                0x01, 0x00, 0x00, 0x07, 0x5a, 0x77, 0x65, 0x69, 0x4c, 0x45,
+                0x44, 0x00, 0x01, 0x31, 0x00, 0x03, 0x62, 0x61, 0x72, 0x00,
+                0x04, 0xde, 0xad, 0xbe, 0xef,
+            ];
+            let mut cursor = Cursor::new(&data[..]);
+            let entry = read_entry(&mut cursor).unwrap();
+            assert_eq!(entry, Some(AuthEntry {
+                family: Family::Local,
+                address: b"ZweiLED".to_vec(),
+                number: b"1".to_vec(),
+                name: b"bar".to_vec(),
+                data: u32::to_be_bytes(0xdead_beef).to_vec(),
+            }));
+        }
+
+        #[test]
+        fn test_read_iterate() {
+            // Data generated via:
+            //   xauth -f /tmp/file add :1 bar deadbeef
+            //   xauth -f /tmp/file add 1.2.3.4:2 baz aabbccdd
+            let data = [
+                0x01, 0x00, 0x00, 0x07, 0x5a, 0x77, 0x65, 0x69, 0x4c, 0x45,
+                0x44, 0x00, 0x01, 0x31, 0x00, 0x03, 0x62, 0x61, 0x72, 0x00,
+                0x04, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x04, 0x01,
+                0x02, 0x03, 0x04, 0x00, 0x01, 0x32, 0x00, 0x03, 0x62, 0x61,
+                0x7a, 0x00, 0x04, 0xaa, 0xbb, 0xcc, 0xdd
+            ];
+            let mut cursor = Cursor::new(&data[..]);
+            for expected in &[
+               AuthEntry {
+                   family: Family::Local,
+                   address: b"ZweiLED".to_vec(),
+                   number: b"1".to_vec(),
+                   name: b"bar".to_vec(),
+                   data: u32::to_be_bytes(0xdead_beef).to_vec(),
+               },
+               AuthEntry {
+                   family: Family::X11Family(X11Family::Internet),
+                   address: vec![1, 2, 3, 4],
+                   number: b"2".to_vec(),
+                   name: b"baz".to_vec(),
+                   data: u32::to_be_bytes(0xaabb_ccdd).to_vec(),
+               },
+            ] {
+                let entry = read_entry(&mut cursor).unwrap();
+                assert_eq!(entry.as_ref(), Some(expected));
+            }
+            let entry = read_entry(&mut cursor).unwrap();
+            assert_eq!(entry, None);
+        }
+    }
 }
 
 pub(crate) type AuthInfo = (Vec<u8>, Vec<u8>);
 
 pub(crate) fn get_auth(display: u16) -> Result<Option<AuthInfo>, Error> {
-    let file = match get_xauthority_file_name() {
-        None => return Ok(None),
-        Some(file) => file
-    };
-    let mut file = BufReader::new(File::open(file)?);
-
     let display = display.to_string();
     let display = display.as_bytes();
-    while let Some(entry) = read_entry(&mut file)? {
+
+    let entries = match file::XAuthorityEntries::new()? {
+        None => return Ok(None),
+        Some(entries) => entries,
+    };
+    for entry in entries {
+        let entry = entry?;
         // FIXME: Implement proper matching
         if entry.number == &display[..] && entry.name == MIT_MAGIC_COOKIE_1 {
             return Ok(Some((entry.name, entry.data)));
         }
     }
     Ok(None)
-}
-
-#[cfg(test)]
-mod test {
-    use std::io::Cursor;
-    use super::{AuthEntry, read_entry, Family, X11Family};
-
-    #[test]
-    fn test_read() {
-        // Data generated via xauth -f /tmp/file add :1 bar deadbeef
-        let data = [
-            0x01, 0x00, 0x00, 0x07, 0x5a, 0x77, 0x65, 0x69, 0x4c, 0x45,
-            0x44, 0x00, 0x01, 0x31, 0x00, 0x03, 0x62, 0x61, 0x72, 0x00,
-            0x04, 0xde, 0xad, 0xbe, 0xef,
-        ];
-        let mut cursor = Cursor::new(&data[..]);
-        let entry = read_entry(&mut cursor).unwrap();
-        assert_eq!(entry, Some(AuthEntry {
-            family: Family::Local,
-            address: b"ZweiLED".to_vec(),
-            number: b"1".to_vec(),
-            name: b"bar".to_vec(),
-            data: u32::to_be_bytes(0xdead_beef).to_vec(),
-        }));
-    }
-
-    #[test]
-    fn test_read_iterate() {
-        // Data generated via:
-        //   xauth -f /tmp/file add :1 bar deadbeef
-        //   xauth -f /tmp/file add 1.2.3.4:2 baz aabbccdd
-        let data = [
-            0x01, 0x00, 0x00, 0x07, 0x5a, 0x77, 0x65, 0x69, 0x4c, 0x45,
-            0x44, 0x00, 0x01, 0x31, 0x00, 0x03, 0x62, 0x61, 0x72, 0x00,
-            0x04, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x04, 0x01,
-            0x02, 0x03, 0x04, 0x00, 0x01, 0x32, 0x00, 0x03, 0x62, 0x61,
-            0x7a, 0x00, 0x04, 0xaa, 0xbb, 0xcc, 0xdd
-        ];
-        let mut cursor = Cursor::new(&data[..]);
-        for expected in &[
-           AuthEntry {
-               family: Family::Local,
-               address: b"ZweiLED".to_vec(),
-               number: b"1".to_vec(),
-               name: b"bar".to_vec(),
-               data: u32::to_be_bytes(0xdead_beef).to_vec(),
-           },
-           AuthEntry {
-               family: Family::X11Family(X11Family::Internet),
-               address: vec![1, 2, 3, 4],
-               number: b"2".to_vec(),
-               name: b"baz".to_vec(),
-               data: u32::to_be_bytes(0xaabb_ccdd).to_vec(),
-           },
-        ] {
-            let entry = read_entry(&mut cursor).unwrap();
-            assert_eq!(entry.as_ref(), Some(expected));
-        }
-        let entry = read_entry(&mut cursor).unwrap();
-        assert_eq!(entry, None);
-    }
 }

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -9,15 +9,29 @@ const MIT_MAGIC_COOKIE_1: &[u8] = b"MIT-MAGIC-COOKIE-1";
 /// A family describes how to interpret some bytes as an address in an `AuthEntry`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Family {
-    // Per a comment in xcb-proto/src/xproto.xml on the "Family" enum:
-    //    also used and extended for Xau authentication
-    X11Family(X11Family),
+    Internet,
+    DECnet,
+    Chaos,
+    ServerInterpreted,
+    Internet6,
     Wild,
     Local,
     Netname,
     Krb5Principal,
     LocalHost,
     Unknown(u16),
+}
+
+impl From<X11Family> for Family {
+    fn from(value: X11Family) -> Self {
+        match value {
+            X11Family::Internet => Family::Internet,
+            X11Family::DECnet => Family::DECnet,
+            X11Family::Chaos => Family::Chaos,
+            X11Family::ServerInterpreted => Family::ServerInterpreted,
+            X11Family::Internet6 => Family::Internet6,
+        }
+    }
 }
 
 impl From<u16> for Family {
@@ -34,7 +48,7 @@ impl From<u16> for Family {
         };
         if let Some(x11family) = x11family {
             assert_eq!(value, x11family.into());
-            return Family::X11Family(x11family);
+            return x11family.into();
         }
         match value {
             65535 => Family::Wild,
@@ -153,7 +167,7 @@ mod file {
     #[cfg(test)]
     mod test {
         use std::io::Cursor;
-        use super::super::{AuthEntry, Family, X11Family};
+        use super::super::{AuthEntry, Family};
         use super::read_entry;
 
         #[test]
@@ -197,7 +211,7 @@ mod file {
                    data: u32::to_be_bytes(0xdead_beef).to_vec(),
                },
                AuthEntry {
-                   family: Family::X11Family(X11Family::Internet),
+                   family: Family::Internet,
                    address: vec![1, 2, 3, 4],
                    number: b"2".to_vec(),
                    name: b"baz".to_vec(),


### PR DESCRIPTION
This contains the necessary magic to fix #196. Some of this code is a bit ugly, but I believe that all of this actually works. No idea if anyone will ever use this library in such a way that some of the more arcane bits of this code are executed...

This PR adds a new dependency on the `gethostname` crate. Yay for "bypassing" `forbid(unsafe_code)` by just using other people's unsafe code.