### PR TITLE
RustConnection: Move reading from `inner` to the outer connection

### DIFF
--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -269,6 +269,7 @@ where Stream: Read + Write
         if self.next_reply_expected < sequence {
             self.send_sync()?;
         }
+        assert!(self.next_reply_expected >= sequence);
         Ok(())
     }
 

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -214,7 +214,7 @@ where Stream: Read + Write
         Some(full_number)
     }
 
-    fn read_packet_and_enqueue(&mut self) -> Result<(), Box<dyn Error>> {
+    pub(crate) fn read_packet_and_enqueue(&mut self) -> Result<(), Box<dyn Error>> {
         let packet = self.read_packet()?;
         let kind = packet[0];
 
@@ -298,18 +298,7 @@ where Stream: Read + Write
         }
     }
 
-    pub(crate) fn wait_for_event(&mut self) -> Result<GenericEvent, Box<dyn Error>> {
-        loop {
-            let event = self.pending_events.pop_front();
-            if let Some(event) = event {
-                return Ok(event.try_into()?);
-            }
-            self.read_packet_and_enqueue()?;
-        }
-    }
-
     pub(crate) fn poll_for_event(&mut self) -> Result<Option<GenericEvent>, Box<dyn Error>> {
-        // FIXME: Check if something can be read from the wire
         self.pending_events.pop_front()
             .map(TryInto::try_into)
             .transpose()


### PR DESCRIPTION
This is a first (small) step for #203. The "inner" part now only manages the state, but does not interact with the stream directly any more. At least that is the goal and this PR moves the current situation slightly in that direction. More move-in-that-direction has to wait for tomorrow.

----

This is the easy part of the change: The caller can just read a single packet from the stream and then tell the inner connection to enqueue it into its state. The hard part is sending a request. For that one, I am not yet sure how to move the actual "do the work" into the caller. I'll have to come up with something tomorrow.