### PR TITLE
Make RustConnection properly thread safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,20 @@ addons:
       - pycodestyle
       - xvfb
 
+install:
+  # Run the examples as 'integration tests'. For this, there is a special
+  # timeout mode where the examples close automatically after some time.
+  - |
+    run_examples() {
+        for example in examples/*.rs; do
+            example=${example/examples\//}
+            example=${example/.rs/}
+            if [ "$example" != tutorial ] ; then
+                X11RB_EXAMPLE_TIMEOUT=1 xvfb-run -a cargo run --example "$example" "$@" || exit 1
+            fi
+        done
+    }
+
 script:
   # Check the code generator against python 2 and 3. Both versions should
   # produce identical output.
@@ -41,15 +55,10 @@ script:
 
   - pycodestyle --show-pep8 --show-source $(git ls-files '*.py' | grep -v xcbproto-1.13) --max-line-length=130
 
-  # Run the examples as 'integration tests'. For this, there is a special
-  # timeout mode where the examples close automatically after some time.
-  - |
-    for example in examples/*.rs; do
-        example=${example/examples\//}
-        example=${example/.rs/}
-        if [ "$example" != tutorial ] ; then
-            X11RB_EXAMPLE_TIMEOUT=1 xvfb-run -a cargo run --example "$example" || exit 1
-        fi
-    done
+  # Run the examples as 'integration tests'.
+  - run_examples
 
   - cargo build --verbose --all-targets --no-default-features --features vendor-xcb-proto
+
+  # Run the examples as 'integration tests'. This time using RustConnection.
+  - run_examples --no-default-features --features vendor-xcb-proto

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -107,6 +107,7 @@ where W: Write
             authorization_protocol_data: auth_data,
         };
         write.write_all(&request.serialize())?;
+        write.flush()?;
         Ok(())
     }
 

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -297,6 +297,10 @@ where W: Write
         self.pending_events.pop_front()
             .map(|event| event.try_into().unwrap())
     }
+
+    pub(crate) fn flush(&mut self) -> Result<(), std::io::Error> {
+        self.write.flush()
+    }
 }
 
 // FIXME: Clean up this error stuff... somehow

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -36,6 +36,9 @@ where W: Write
     // this struct (for synchronisation reasons).
     write: W,
 
+    // Member that is used by `RustConnection` for synchronisation purpose
+    pub(crate) have_reader: bool,
+
     // The sequence number of the last request that was written
     last_sequence_written: SequenceNumber,
     // Sorted(!) list with information on requests that were written, but no answer received yet.
@@ -61,6 +64,7 @@ where W: Write
         let setup = Self::read_setup(read)?;
         let result = ConnectionInner {
             write,
+            have_reader: false,
             last_sequence_written: 0,
             next_reply_expected: 0,
             last_sequence_read: 0,

--- a/src/rust_connection/stream.rs
+++ b/src/rust_connection/stream.rs
@@ -96,6 +96,19 @@ impl Stream {
             .unwrap_or_else(Vec::new);
         Ok((Family::Local, hostname))
     }
+
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// The returned `Stream` is a reference to the same stream that this object references. Both
+    /// handles will read and write the same stream of data, and options set on one stream will be
+    /// propagated to the other stream.
+    pub fn try_clone(&self) -> Result<Stream> {
+        match self {
+            Stream::TcpStream(stream) => Ok(Stream::TcpStream(stream.try_clone()?)),
+            #[cfg(unix)]
+            Stream::UnixStream(stream) => Ok(Stream::UnixStream(stream.try_clone()?)),
+        }
+    }
 }
 
 impl Read for Stream {


### PR DESCRIPTION
This PR fixes #203. A thread calling `RustConnection::wait_for_event()` no longer blocks other threads that want to send a request. It does so be moving the actual "read from the wire" from the inner struct to `RustConnection`. That way, the mutex protecting the inner struct can be dropped while reading.

This also makes `RustConnection` use `BufReader` and `BufWriter` by default. Thus, code that did not call `RustConnection::flush()` before could now break.

Both of the above points require the single `Stream: Read + Write` parameter of `RustConnection` to be split into separate `Read` and `Write` parts.

Finally, now that #203 is fixed, the `examples/` can be used as "integration tests" and be run on Travis. Future work is to make this also run on AppVeyor.