### PR TITLE
Minor cleanup

### DIFF
--- a/code_generator_helpers/request.py
+++ b/code_generator_helpers/request.py
@@ -292,17 +292,7 @@ def request_implementation(module, obj, name, fds, fds_is_list):
                 _emit_add_to_requests(rust_variable)
             else:
                 if field.type.size is not None:
-                    if field.type.size <= 32:
-                        module.out("let %s_bytes = %s.serialize();",
-                                   rust_variable, rust_variable)
-                    else:
-                        # I am not happy about the trait std::array::LengthAtMost32
-                        module.out("let mut %s_bytes = Vec::new();",
-                                   rust_variable)
-                        module.out("for value in %s {", rust_variable)
-                        module.out.indent("%s_bytes.extend(value.serialize().iter());",
-                                          rust_variable)
-                        module.out("}")
+                    module.out("let %s_bytes = %s.serialize();", rust_variable, rust_variable)
                 # else: Already called .serialize() on the list above
 
                 _emit_request()

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -111,7 +111,7 @@ mod test {
     }
 
     fn generate_get_xid_range_reply(start_id: u32, count: u32) -> Vec<u8> {
-        let mut reply = [0; 8].to_vec();
+        let mut reply = vec![0; 8];
         reply.extend(&start_id.to_ne_bytes());
         reply.extend(&count.to_ne_bytes());
         reply


### PR DESCRIPTION
- Update code in `doc/generated_code.md`

- Remove unneeded case in `code_generator_helpers/request.py`

- `[0; 8].to_vec()` -> `vec![0; 8]`