### PR TITLE
Add some tests and fix some minor bugs

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -453,6 +453,15 @@ class Module(object):
                             # for this field as the length of the list.
                             self.out("let %s = self.%s.len() as %s;", field_name,
                                      field.is_length_field_for.field_name, self._field_type(field))
+                            expr = field.is_length_field_for.type.expr
+                            if expr.op is not None:
+                                # Sigh. The length cannot be used as-is, but needs to be transformed
+                                assert expr.op in ['*', '/']
+                                op = '*' if expr.op == '/' else '/'
+                                assert expr.lhs.op is None
+                                assert expr.rhs.op is None
+                                assert expr.rhs.nmemb is not None
+                                self.out("let %s = %s %s %s;", field_name, field_name, op, expr.rhs.nmemb)
                             source = field_name
                         else:
                             # Get the value of this field from "self".

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -168,6 +168,11 @@ where W: Write
                     count = 0;
                 }
                 bufs = &bufs[1..];
+
+                // Skip empty slices
+                while bufs.first().map(|s| s.len()) == Some(0) {
+                    bufs = &bufs[1..];
+                }
             }
         }
 
@@ -553,5 +558,15 @@ mod test {
     #[test]
     fn partial_write_slice_border() {
         partial_write_test(&[0; 2], "failed to write anything");
+    }
+
+    #[test]
+    fn full_write_trailing_empty() {
+        let mut written = [0; 4];
+        let mut output = &mut written[..];
+        let mut connection = ConnectionInner::new(&mut output);
+        let (request1, request2) = ([0; 4], [0; 0]);
+        let request = [IoSlice::new(&request1), IoSlice::new(&request2)];
+        let _ = connection.send_request(&request, RequestKind::IsVoid).unwrap();
     }
 }

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -6,9 +6,9 @@ use std::cell::RefCell;
 use x11rb::connection::{RequestConnection, SequenceNumber, RequestKind, DiscardMode};
 use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
 use x11rb::errors::{ParseError, ConnectionError, ConnectionErrorOrX11Error};
-use x11rb::generated::xproto::{QueryExtensionReply, ConnectionExt, Segment, KeymapNotifyEvent, ClientMessageData};
+use x11rb::generated::xproto::{QueryExtensionReply, ConnectionExt, Segment, KeymapNotifyEvent, ClientMessageData, SetupAuthenticate};
 use x11rb::utils::{Buffer, RawFdContainer};
-use x11rb::x11_utils::{GenericError, TryParse};
+use x11rb::x11_utils::{GenericError, TryParse, Serialize};
 
 #[derive(Debug)]
 struct SavedRequest {
@@ -240,4 +240,16 @@ fn test_set_modifier_mapping() -> Result<(), ConnectionError> {
 
     conn.check_requests(&[(false, expected)]);
     Ok(())
+}
+
+#[test]
+fn test_serialize_setup_authenticate() {
+    let setup = SetupAuthenticate {
+        status: 2,
+        reason: b"12345678".to_vec(),
+    };
+    // At the time of writing, the code generator does not produce the correct code...
+    let length = 2u16.to_ne_bytes();
+    let setup_bytes = [2, 0, 0, 0, 0, 0, length[0], length[1], b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8'];
+    assert_eq!(&setup_bytes[..], &setup.serialize()[..]);
 }


### PR DESCRIPTION
I tried writing some tests for `RustConnection` and actually came across some bugs while doing so.
- `xproto::SetupAuthenticate` and `res::ClientIdValue` produced incorrect length fields in their `serialize()` implementations
- `RustConnection` was to eager in sending syncs, because it did not update its `next_reply_expected` member when a request with a reply was sent.
- Partial writes resulted in a panic; now some (ugly) code tries to handle the situation

----

Sigh. The AppVeyor build failed already.
```
     Running `target\debug\examples\generic_events.exe`
Error: UnknownError
error: process didn't exit successfully: `target\debug\examples\generic_events.exe` (exit code: 1)
Command exited with code 1
```
Yay for my error handling by mapping everything to `UnknownError`.