### PR TITLE
Convert `multithread_test` from an example to a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,11 @@ script:
   - cargo build --verbose --all-targets --all-features
   - cargo test --verbose --all-features
 
+  # Run tests that requiere a X11 server
+  - xvfb-run -a cargo test --verbose --test x11_server_dependant_tests -- --ignored --test-threads=1 --nocapture
+  # Run tests that requiere a X11 server using RustConnection
+  - xvfb-run -a cargo test --verbose --no-default-features --features vendor-xcb-proto --test x11_server_dependant_tests -- --ignored --test-threads=1 --nocapture
+
   - pycodestyle --show-pep8 --show-source $(git ls-files '*.py' | grep -v xcbproto-1.13) --max-line-length=130
 
   # Run the examples as 'integration tests'.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,12 +21,14 @@ test_script:
   - set "DISPLAY=127.0.0.1:0"
   - set "X11RB_EXAMPLE_TIMEOUT=1"
 
+  # Run tests that requiere a X11 server
+  - cargo test --verbose --no-default-features --features vendor-xcb-proto --test x11_server_dependant_tests -- --ignored --test-threads=1 --nocapture
+
   # FIXME: Can this list be automated? somehow?
   - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example check_unchecked_requests
   - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example generic_events
   - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example hypnomoire
   - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example list_fonts
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example multithread_test
   - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example simple_window
   - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example simple_window_manager
   #- cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example tutorial

--- a/tests/x11_server_dependant_tests.rs
+++ b/tests/x11_server_dependant_tests.rs
@@ -1,4 +1,5 @@
-// Regression test for https://github.com/psychon/x11rb/issues/231
+//! Tests that requiere a running X11 server, so they are disabled by
+//! default.
 
 use std::sync::Arc;
 
@@ -10,7 +11,10 @@ use x11rb::generated::xproto::{
 use x11rb::x11_utils::Event as _;
 use x11rb::COPY_DEPTH_FROM_PARENT;
 
-fn main() {
+/// Regression test for https://github.com/psychon/x11rb/issues/231
+#[test]
+#[ignore]
+fn bug_231_multithread_hang_test() {
     let (conn, screen_num) = x11rb::connect(None).unwrap();
     let conn = Arc::new(conn);
 
@@ -27,7 +31,7 @@ fn main() {
         0,
         WindowClass::InputOutput,
         screen.root_visual,
-        &CreateWindowAux::new().event_mask(EventMask::NoEvent),
+        &CreateWindowAux::new(),
     )
     .unwrap();
     conn.flush().unwrap();


### PR DESCRIPTION
The test is disabled by default because it requieres a running X11 server.

CI has been configured to run it.