### PR TITLE
General build.rs changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,10 +42,9 @@ fn list_files_with_extension(dir: impl AsRef<Path>, ext: impl AsRef<OsStr>) -> V
 }
 
 fn main() {
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let out_path = out_path.join("generated");
+    let mut out_path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    out_path.push("generated");
     create_dir_if_not_exist(&out_path).unwrap();
-    let out_path = out_path.to_str().unwrap();
     let (pythondir, includedir) = get_paths();
 
     println!("cargo:rerun-if-changed=rs_code_generator.py");
@@ -60,16 +59,14 @@ fn main() {
     }
 
     let status = Command::new("python")
-        .args(&[
-            OsStr::new("rs_code_generator.py"),
-            OsStr::new("-p"),
-            pythondir.as_ref(),
-            OsStr::new("-i"),
-            includedir.as_ref(),
-            OsStr::new("-o"),
-            out_path.as_ref(),
-            OsStr::new("mod"),
-        ])
+        .arg("rs_code_generator.py")
+        .arg("-p")
+        .arg(&pythondir)
+        .arg("-i")
+        .arg(&includedir)
+        .arg("-o")
+        .arg(&out_path)
+        .arg("mod")
         .status()
         .unwrap();
     assert!(status.success());

--- a/build.rs
+++ b/build.rs
@@ -32,12 +32,12 @@ fn get_paths() -> (PathBuf, PathBuf) {
     (pythondir, includedir)
 }
 
-// Returns a list of files in `dir` whose name ends with `end`.
-fn list_files_with_ending(dir: impl AsRef<Path>, end: &str) -> Vec<PathBuf> {
+// Returns a list of files in `dir` whose extension is `ext`.
+fn list_files_with_extension(dir: impl AsRef<Path>, ext: impl AsRef<OsStr>) -> Vec<PathBuf> {
     read_dir(dir.as_ref())
         .unwrap()
         .map(|entry| entry.unwrap().path())
-        .filter(|path| path.to_string_lossy().ends_with(end))
+        .filter(|path| path.extension() == Some(ext.as_ref()))
         .collect()
 }
 
@@ -49,13 +49,13 @@ fn main() {
     let (pythondir, includedir) = get_paths();
 
     println!("cargo:rerun-if-changed=rs_code_generator.py");
-    for py_file in list_files_with_ending("code_generator_helpers", ".py") {
+    for py_file in list_files_with_extension("code_generator_helpers", "py") {
         println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
     }
-    for py_file in list_files_with_ending(pythondir.join("xcbgen"), ".py") {
+    for py_file in list_files_with_extension(pythondir.join("xcbgen"), "py") {
         println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
     }
-    for xml_file in list_files_with_ending(&includedir, ".xml") {
+    for xml_file in list_files_with_extension(&includedir, "xml") {
         println!("cargo:rerun-if-changed={}", xml_file.to_str().unwrap());
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 extern crate pkg_config;
 
 use std::env;
+use std::ffi::OsStr;
 use std::fs::{create_dir, read_dir};
 use std::io::Result;
 use std::path::{Path, PathBuf};
@@ -17,17 +18,17 @@ fn create_dir_if_not_exist(dir: &PathBuf) -> Result<()> {
 }
 
 #[cfg(not(feature = "vendor-xcb-proto"))]
-fn get_paths() -> (String, String) {
+fn get_paths() -> (PathBuf, PathBuf) {
     let pythondir = pkg_config::get_variable("xcb-proto", "pythondir").unwrap();
     let includedir = pkg_config::get_variable("xcb-proto", "xcbincludedir").unwrap();
-    (pythondir, includedir)
+    (pythondir.into(), includedir.into())
 }
 
 #[cfg(feature = "vendor-xcb-proto")]
-fn get_paths() -> (String, String) {
-    let dir = "xcbproto-1.13-6-ge79f6b0/".to_string();
-    let pythondir = dir.clone();
-    let includedir = dir + "src";
+fn get_paths() -> (PathBuf, PathBuf) {
+    let dir = Path::new("xcbproto-1.13-6-ge79f6b0");
+    let pythondir = dir.to_path_buf();
+    let includedir = dir.join("src");
     (pythondir, includedir)
 }
 
@@ -41,32 +42,33 @@ fn list_files_with_ending(dir: impl AsRef<Path>, end: &str) -> Vec<PathBuf> {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=rs_code_generator.py");
-    for py_file in list_files_with_ending("code_generator_helpers", ".py") {
-        println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
-    }
-    for py_file in list_files_with_ending("xcbproto-1.13-6-ge79f6b0/xcbgen", ".py") {
-        println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
-    }
-    for xml_file in list_files_with_ending("xcbproto-1.13-6-ge79f6b0/src", ".xml") {
-        println!("cargo:rerun-if-changed={}", xml_file.to_str().unwrap());
-    }
-
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let out_path = out_path.join("generated");
     create_dir_if_not_exist(&out_path).unwrap();
     let out_path = out_path.to_str().unwrap();
     let (pythondir, includedir) = get_paths();
+
+    println!("cargo:rerun-if-changed=rs_code_generator.py");
+    for py_file in list_files_with_ending("code_generator_helpers", ".py") {
+        println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
+    }
+    for py_file in list_files_with_ending(pythondir.join("xcbgen"), ".py") {
+        println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
+    }
+    for xml_file in list_files_with_ending(&includedir, ".xml") {
+        println!("cargo:rerun-if-changed={}", xml_file.to_str().unwrap());
+    }
+
     let status = Command::new("python")
         .args(&[
-            "rs_code_generator.py",
-            "-p",
-            &pythondir,
-            "-i",
-            &includedir,
-            "-o",
-            out_path,
-            "mod",
+            OsStr::new("rs_code_generator.py"),
+            OsStr::new("-p"),
+            pythondir.as_ref(),
+            OsStr::new("-i"),
+            includedir.as_ref(),
+            OsStr::new("-o"),
+            out_path.as_ref(),
+            OsStr::new("mod"),
         ])
         .status()
         .unwrap();

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 extern crate pkg_config;
 
 use std::env;
-use std::fs::create_dir;
+use std::fs::{create_dir, read_dir};
 use std::io::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn create_dir_if_not_exist(dir: &PathBuf) -> Result<()> {
@@ -31,7 +31,27 @@ fn get_paths() -> (String, String) {
     (pythondir, includedir)
 }
 
+// Returns a list of files in `dir` whose name ends with `end`.
+fn list_files_with_ending(dir: impl AsRef<Path>, end: &str) -> Vec<PathBuf> {
+    read_dir(dir.as_ref())
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.to_string_lossy().ends_with(end))
+        .collect()
+}
+
 fn main() {
+    println!("cargo:rerun-if-changed=rs_code_generator.py");
+    for py_file in list_files_with_ending("code_generator_helpers", ".py") {
+        println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
+    }
+    for py_file in list_files_with_ending("xcbproto-1.13-6-ge79f6b0/xcbgen", ".py") {
+        println!("cargo:rerun-if-changed={}", py_file.to_str().unwrap());
+    }
+    for xml_file in list_files_with_ending("xcbproto-1.13-6-ge79f6b0/src", ".xml") {
+        println!("cargo:rerun-if-changed={}", xml_file.to_str().unwrap());
+    }
+
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let out_path = out_path.join("generated");
     create_dir_if_not_exist(&out_path).unwrap();


### PR DESCRIPTION
* Print `cargo:rerun-if-changed=` messages from build.rs. These allow cargo to determine when the build script should be run again. You can use `cargo build -vv` to show the output of the script.
* Make more use of `OsStr` and `Path`.