### PR TITLE
Some API changes and error handling changes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,41 @@ impl From<std::num::TryFromIntError> for ParseError {
     }
 }
 
+/// An error that occurred while connecting to an X11 server
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ConnectError {
+    UnknownError,
+    ConnectionError,
+    InsufficientMemory,
+    DisplayParsingError,
+    InvalidScreen,
+    ParseError,
+}
+
+impl Error for ConnectError {}
+
+impl std::fmt::Display for ConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ConnectError::UnknownError => write!(f, "Unknown connection error"),
+            ConnectError::ConnectionError => write!(f, "Error with the underlying connection"),
+            ConnectError::InsufficientMemory => write!(f, "Insufficient memory"),
+            ConnectError::DisplayParsingError => write!(f, "Display parsing error"),
+            ConnectError::InvalidScreen => write!(f, "Invalid screen"),
+            ConnectError::ParseError => write!(f, "Parsing error"),
+        }
+    }
+}
+
+impl From<ParseError> for ConnectError {
+    fn from(err: ParseError) -> Self {
+        match err {
+            ParseError::ParseError => ConnectError::ParseError,
+        }
+    }
+}
+
+/// An error that occurred on an already established X11 connection
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ConnectionError {
     UnknownError,
@@ -36,8 +71,6 @@ pub enum ConnectionError {
     UnsupportedExtension,
     InsufficientMemory,
     MaximumRequestLengthExceeded,
-    DisplayParsingError,
-    InvalidScreen,
     FDPassingFailed,
     ParseError,
 }
@@ -54,8 +87,6 @@ impl std::fmt::Display for ConnectionError {
             ConnectionError::MaximumRequestLengthExceeded => {
                 write!(f, "Maximum request length exceeded")
             }
-            ConnectionError::DisplayParsingError => write!(f, "Display parsing error"),
-            ConnectionError::InvalidScreen => write!(f, "Invalid screen"),
             ConnectionError::FDPassingFailed => write!(f, "FD passing failed"),
             ConnectionError::ParseError => write!(f, "Parsing error"),
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,8 +2,8 @@
 
 use std::error::Error;
 
-use crate::x11_utils::GenericError;
 use crate::generated::xproto::{SetupAuthenticate, SetupFailed};
+use crate::x11_utils::GenericError;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ParseError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@
 //! use x11rb::errors::ConnectionErrorOrX11Error;
 //! use x11rb::COPY_DEPTH_FROM_PARENT;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let (conn, screen_num) = x11rb::connect(None)?;
+//! fn main() -> Result<(), ConnectionErrorOrX11Error> {
+//!     let (conn, screen_num) = x11rb::connect(None).unwrap();
 //!     let screen = &conn.setup().roots[screen_num];
 //!     let win_id = conn.generate_id();
 //!     conn.create_window(COPY_DEPTH_FROM_PARENT, win_id, screen.root, 0, 0, 100, 100, 0, WindowClass::InputOutput,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,8 @@ pub mod generated {
 pub mod wrapper;
 
 use connection::Connection;
-use generated::xproto::{KEYSYM, TIMESTAMP};
 use errors::ConnectError;
+use generated::xproto::{KEYSYM, TIMESTAMP};
 
 /// Establish a new connection to an X11 server.
 ///
@@ -107,7 +107,10 @@ pub fn connect(
 ) -> Result<(impl Connection + Send + Sync, usize), ConnectError> {
     #[cfg(feature = "allow-unsafe-code")]
     {
-        let dpy_name = dpy_name.map(std::ffi::CString::new).transpose().map_err(|_| ConnectError::DisplayParsingError)?;
+        let dpy_name = dpy_name
+            .map(std::ffi::CString::new)
+            .transpose()
+            .map_err(|_| ConnectError::DisplayParsingError)?;
         let dpy_name = dpy_name.as_ref().map(|d| &**d);
         xcb_ffi::XCBConnection::connect(dpy_name)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub fn connect(
     }
     #[cfg(not(feature = "allow-unsafe-code"))]
     {
-        rust_connection::RustConnection::connect(dpy_name).map_err(|_| ConnectError::UnknownError) // FIXME
+        rust_connection::RustConnection::connect(dpy_name)
     }
 }
 

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -1,6 +1,6 @@
 use crate::connection::RequestConnection;
-use crate::generated::xc_misc::ConnectionExt as _;
 use crate::errors::ConnectError;
+use crate::generated::xc_misc::ConnectionExt as _;
 
 /// An allocator for X11 IDs.
 ///

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -181,7 +181,7 @@ where
             let mut count = self.write.write_vectored(bufs)?;
             if count == 0 {
                 return Err(
-                    std::io::Error::new(ErrorKind::WriteZero, "failed to write anything").into(),
+                    std::io::Error::new(ErrorKind::WriteZero, "failed to write anything"),
                 );
             }
             while count > 0 {

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -81,7 +81,11 @@ where
         Ok((Self::new(write), setup))
     }
 
-    fn new(write: W) -> Self {
+    /// Crate a `ConnectionInner` wrapping the given write stream.
+    ///
+    /// It is assumed that the connection was just established. This means that the next request
+    /// that is sent will have sequence number one.
+    pub(crate) fn new(write: W) -> Self {
         ConnectionInner {
             write,
             last_sequence_written: 0,

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -180,9 +180,10 @@ where
         while !bufs.is_empty() {
             let mut count = self.write.write_vectored(bufs)?;
             if count == 0 {
-                return Err(
-                    std::io::Error::new(ErrorKind::WriteZero, "failed to write anything"),
-                );
+                return Err(std::io::Error::new(
+                    ErrorKind::WriteZero,
+                    "failed to write anything",
+                ));
             }
             while count > 0 {
                 if count >= bufs[0].len() {
@@ -418,9 +419,9 @@ mod test {
 
     use super::{read_setup, ConnectionInner};
     use crate::connection::RequestKind;
+    use crate::errors::ConnectError;
     use crate::generated::xproto::{Setup, SetupAuthenticate, SetupFailed};
     use crate::x11_utils::Serialize;
-    use crate::errors::ConnectError;
 
     #[test]
     fn read_setup_success() {

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -7,7 +7,7 @@ use std::sync::{Condvar, Mutex, MutexGuard, TryLockError};
 
 use crate::connection::{Connection, DiscardMode, RequestConnection, RequestKind, SequenceNumber};
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-use crate::errors::{ConnectionError, ConnectionErrorOrX11Error, ParseError};
+use crate::errors::{ConnectionError, ConnectError, ConnectionErrorOrX11Error, ParseError};
 use crate::extension_information::ExtensionInformation;
 use crate::generated::bigreq;
 use crate::generated::xproto::{QueryExtensionReply, Setup};
@@ -44,7 +44,7 @@ impl RustConnection<BufReader<stream::Stream>, BufWriter<stream::Stream>> {
     pub fn connect(dpy_name: Option<&str>) -> Result<(Self, usize), Box<dyn Error>> {
         // Parse display information
         let parsed_display =
-            parse_display::parse_display(dpy_name).ok_or(ConnectionError::DisplayParsingError)?;
+            parse_display::parse_display(dpy_name).ok_or(ConnectError::DisplayParsingError)?;
 
         // Establish connection
         let protocol = parsed_display.protocol.as_ref().map(|s| &**s);
@@ -98,7 +98,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
 
         // Check that we got a valid screen number
         if screen >= setup.roots.len() {
-            return Err(Box::new(ConnectionError::InvalidScreen));
+            return Err(Box::new(ConnectError::InvalidScreen));
         }
 
         // Success! Set up our state

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -6,7 +6,7 @@ use std::sync::{Condvar, Mutex, MutexGuard, TryLockError};
 
 use crate::connection::{Connection, DiscardMode, RequestConnection, RequestKind, SequenceNumber};
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-use crate::errors::{ConnectionError, ConnectError, ConnectionErrorOrX11Error, ParseError};
+use crate::errors::{ConnectError, ConnectionError, ConnectionErrorOrX11Error, ParseError};
 use crate::extension_information::ExtensionInformation;
 use crate::generated::bigreq;
 use crate::generated::xproto::{QueryExtensionReply, Setup};
@@ -113,7 +113,11 @@ impl<R: Read, W: Write> RustConnection<R, W> {
         Self::for_inner(read, inner::ConnectionInner::new(write), setup)
     }
 
-    fn for_inner(read: R, inner: inner::ConnectionInner<W>, setup: Setup) -> Result<Self, ConnectError> {
+    fn for_inner(
+        read: R,
+        inner: inner::ConnectionInner<W>,
+        setup: Setup,
+    ) -> Result<Self, ConnectError> {
         let allocator =
             id_allocator::IDAllocator::new(setup.resource_id_base, setup.resource_id_mask)?;
         Ok(RustConnection {

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -102,7 +102,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
         }
 
         // Success! Set up our state
-        Ok(Self::for_inner(read, inner, setup))
+        Self::for_inner(read, inner, setup)
     }
 
     /// Establish a new connection for an already connected stream.
@@ -110,14 +110,14 @@ impl<R: Read, W: Write> RustConnection<R, W> {
     /// `read` is used for reading data from the X11 server and `write` is used for writing.
     /// It is assumed that `setup` was just received from the server. Thus, the first reply to a
     /// request that is sent will have sequence number one.
-    pub fn for_connected_stream(read: R, write: W, setup: Setup) -> Self {
+    pub fn for_connected_stream(read: R, write: W, setup: Setup) -> Result<Self, Box<dyn Error>> {
         Self::for_inner(read, inner::ConnectionInner::new(write), setup)
     }
 
-    fn for_inner(read: R, inner: inner::ConnectionInner<W>, setup: Setup) -> Self {
+    fn for_inner(read: R, inner: inner::ConnectionInner<W>, setup: Setup) -> Result<Self, Box<dyn Error>> {
         let allocator =
-            id_allocator::IDAllocator::new(setup.resource_id_base, setup.resource_id_mask);
-        RustConnection {
+            id_allocator::IDAllocator::new(setup.resource_id_base, setup.resource_id_mask)?;
+        Ok(RustConnection {
             inner: Mutex::new(inner),
             read: Mutex::new(read),
             reader_condition: Condvar::new(),
@@ -125,7 +125,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
             setup,
             extension_information: Default::default(),
             maximum_request_bytes: Mutex::new(None),
-        }
+        })
     }
 
     /// Internal function for actually sending a request.

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -157,7 +157,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
     fn read_packet_and_enqueue<'a>(
         &'a self,
         mut inner: MutexGuardInner<'a, W>,
-    ) -> Result<MutexGuardInner<'a, W>, Box<dyn Error>> {
+    ) -> Result<MutexGuardInner<'a, W>, std::io::Error> {
         // 0.1. Try to lock the `read` mutex.
         match self.read.try_lock() {
             Err(TryLockError::WouldBlock) => {
@@ -391,7 +391,7 @@ impl<R: Read, W: Write> Connection for RustConnection<R, W> {
 //
 // This function only supports errors, events, and replies. Namely, this cannot be used to receive
 // the initial setup reply from the X11 server.
-fn read_packet(read: &mut impl Read) -> Result<Buffer, Box<dyn Error>> {
+fn read_packet(read: &mut impl Read) -> Result<Buffer, std::io::Error> {
     let mut buffer = vec![0; 32];
     read.read_exact(&mut buffer)?;
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -183,9 +183,7 @@ impl<'c, C: Connection> LazyAtom<'c, C> {
         match self {
             LazyAtom::Pending(_) => {
                 // We need to move the cookie out of self to call reply()
-                if let LazyAtom::Pending(cookie) =
-                    std::mem::replace(self, LazyAtom::Resolved(0))
-                {
+                if let LazyAtom::Pending(cookie) = std::mem::replace(self, LazyAtom::Resolved(0)) {
                     // Now get the reply and replace self again with the correct value
                     let reply = cookie.reply().map(|reply| reply.atom);
                     *self = match reply {
@@ -198,7 +196,7 @@ impl<'c, C: Connection> LazyAtom<'c, C> {
                 }
             }
             LazyAtom::Resolved(result) => Ok(*result),
-            LazyAtom::Errored => Err(ConnectionError::UnknownError.into())
+            LazyAtom::Errored => Err(ConnectionError::UnknownError.into()),
         }
     }
 }

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -7,7 +7,7 @@
 use super::generated::xproto::{QueryExtensionReply, Setup};
 use crate::connection::{Connection, DiscardMode, RequestConnection, RequestKind, SequenceNumber};
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-use crate::errors::{ConnectionError, ConnectError, ConnectionErrorOrX11Error, ParseError};
+use crate::errors::{ConnectError, ConnectionError, ConnectionErrorOrX11Error, ParseError};
 use crate::extension_information::ExtensionInformation;
 use crate::utils::{Buffer, CSlice, RawFdContainer};
 use crate::x11_utils::{GenericError, GenericEvent};

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -7,7 +7,7 @@
 use super::generated::xproto::{QueryExtensionReply, Setup};
 use crate::connection::{Connection, DiscardMode, RequestConnection, RequestKind, SequenceNumber};
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-use crate::errors::{ConnectionError, ConnectionErrorOrX11Error, ParseError};
+use crate::errors::{ConnectionError, ConnectError, ConnectionErrorOrX11Error, ParseError};
 use crate::extension_information::ExtensionInformation;
 use crate::utils::{Buffer, CSlice, RawFdContainer};
 use crate::x11_utils::{GenericError, GenericEvent};
@@ -52,10 +52,23 @@ impl XCBConnection {
             EXT_NOTSUPPORTED => ConnectionError::UnsupportedExtension,
             MEM_INSUFFICIENT => ConnectionError::InsufficientMemory,
             REQ_LEN_EXCEED => ConnectionError::MaximumRequestLengthExceeded,
-            PARSE_ERR => ConnectionError::DisplayParsingError,
-            INVALID_SCREEN => ConnectionError::InvalidScreen,
             FDPASSING_FAILED => ConnectionError::FDPassingFailed,
             _ => ConnectionError::UnknownError,
+            // Not possible here: PARSE_ERR, INVALID_SCREEN
+        }
+    }
+
+    fn connect_error_from_c_error(error: i32) -> ConnectError {
+        use crate::xcb_ffi::raw_ffi::connection_errors::*;
+
+        assert_ne!(error, 0);
+        match error {
+            ERROR => ConnectError::ConnectionError,
+            MEM_INSUFFICIENT => ConnectError::InsufficientMemory,
+            PARSE_ERR => ConnectError::DisplayParsingError,
+            INVALID_SCREEN => ConnectError::InvalidScreen,
+            _ => ConnectError::UnknownError,
+            // Not possible here: EXT_NOTSUPPORTED, REQ_LEN_EXCEED, FDPASSING_FAILED
         }
     }
 
@@ -64,7 +77,7 @@ impl XCBConnection {
     /// If a `dpy_name` is provided, it describes the display that should be connected to, for
     /// example `127.0.0.1:1`. If no value is provided, the `$DISPLAY` environment variable is
     /// used.
-    pub fn connect(dpy_name: Option<&CStr>) -> Result<(XCBConnection, usize), ConnectionError> {
+    pub fn connect(dpy_name: Option<&CStr>) -> Result<(XCBConnection, usize), ConnectError> {
         use libc::c_int;
         unsafe {
             let mut screen: c_int = 0;
@@ -73,8 +86,8 @@ impl XCBConnection {
             let error = raw_ffi::xcb_connection_has_error(connection);
             if error != 0 {
                 raw_ffi::xcb_disconnect(connection);
-                Err(Self::connection_error_from_c_error(
-                    error.try_into().or(Err(ConnectionError::UnknownError))?,
+                Err(Self::connect_error_from_c_error(
+                    error.try_into().or(Err(ConnectError::UnknownError))?,
                 ))
             } else {
                 let setup = raw_ffi::xcb_get_setup(connection);

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -209,7 +209,7 @@ fn test_too_large_request() -> Result<(), ConnectionError> {
     let y: i16 = 7;
     let res = conn.poly_text16(drawable, gc, x, y, &big_buffer);
     match res.unwrap_err() {
-        ConnectionError::MaximumRequestLengthExceeded => {},
+        ConnectionError::MaximumRequestLengthExceeded => {}
         err => panic!("Wrong error: {:?}", err),
     };
     Ok(())

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -208,10 +208,10 @@ fn test_too_large_request() -> Result<(), ConnectionError> {
     let x: i16 = 21;
     let y: i16 = 7;
     let res = conn.poly_text16(drawable, gc, x, y, &big_buffer);
-    assert_eq!(
-        ConnectionError::MaximumRequestLengthExceeded,
-        res.unwrap_err()
-    );
+    match res.unwrap_err() {
+        ConnectionError::MaximumRequestLengthExceeded => {},
+        err => panic!("Wrong error: {:?}", err),
+    };
     Ok(())
 }
 


### PR DESCRIPTION
This...
- adds the new API that I proposed in #233 
- fixes #235 (replace an `assert` with an error return)
- fixes #14 (I guess)
- makes `RustConnection` return useful errors instead of `UnknownError`
- adds even more error variants by splitting up into "errors that can happen while establishing a connection" and "errors that can happen on an already established connection". Dunno if that is really a good idea...

The only uses of `dyn` left are in examples and I guess they can stay.