### PR TITLE
Generated code: Less hardcoding of extension names

### DIFF
--- a/code_generator_helpers/request.py
+++ b/code_generator_helpers/request.py
@@ -121,7 +121,7 @@ def pick_return_type(module, obj, name, need_lifetime):
 def request_implementation(module, obj, name, fds, fds_is_list):
     """Generate the code that actually serialises all the arguments."""
     if module.namespace.is_ext:
-        module.out('let extension_information = conn.extension_information("%s")' % module.namespace.ext_xname)
+        module.out('let extension_information = conn.extension_information(X11_EXTENSION_NAME)')
         module.out.indent(".ok_or(ConnectionError::UnsupportedExtension)?;")
 
     # Now generate code for serialising the request. The request bytes


### PR DESCRIPTION
Instead of writing "XC-MISC" in each call to extension_information() in
the generated code, the code now uses the X11_EXTENSION_NAME constant
that is also generated.

Signed-off-by: Uli Schlachter <psychon@znc.in>