### PR TITLE
Enable the `rust_2018_idioms` lint

### DIFF
--- a/code_generator_helpers/request.py
+++ b/code_generator_helpers/request.py
@@ -106,15 +106,15 @@ def pick_return_type(module, obj, name, need_lifetime):
             result_type_trait = "%s<'c, Self, %sReply>" % (cookie, module._name(name))
             result_type_func = "%s<'c, Conn, %sReply>" % (cookie, module._name(name))
         else:
-            result_type_trait = "%s<Self, %sReply>" % (cookie, module._name(name))
-            result_type_func = "%s<Conn, %sReply>" % (cookie, module._name(name))
+            result_type_trait = "%s<'_, Self, %sReply>" % (cookie, module._name(name))
+            result_type_func = "%s<'_, Conn, %sReply>" % (cookie, module._name(name))
     else:
         if need_lifetime:
             result_type_trait = "VoidCookie<'c, Self>"
             result_type_func = "VoidCookie<'c, Conn>"
         else:
-            result_type_trait = "VoidCookie<Self>"
-            result_type_func = "VoidCookie<Conn>"
+            result_type_trait = "VoidCookie<'_, Self>"
+            result_type_func = "VoidCookie<'_, Conn>"
     return result_type_trait, result_type_func
 
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -84,9 +84,9 @@ pub trait RequestConnection {
     /// In any case, the request may not be larger than the server's maximum request length.
     fn send_request_with_reply<R>(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<Cookie<Self, R>, ConnectionError>
+    ) -> Result<Cookie<'_, Self, R>, ConnectionError>
     where
         R: TryFrom<Buffer, Error = ParseError>;
 
@@ -111,9 +111,9 @@ pub trait RequestConnection {
     /// In any case, the request may not be larger than the server's maximum request length.
     fn send_request_with_reply_with_fds<R>(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<CookieWithFds<Self, R>, ConnectionError>
+    ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
     where
         R: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>;
 
@@ -138,9 +138,9 @@ pub trait RequestConnection {
     /// In any case, the request may not be larger than the server's maximum request length.
     fn send_request_without_reply(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<VoidCookie<Self>, ConnectionError>;
+    ) -> Result<VoidCookie<'_, Self>, ConnectionError>;
 
     /// A reply to an error should be discarded.
     ///

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -29,7 +29,7 @@ where
     ///
     /// This function should only be used by implementations of
     /// `Connection::send_request_without_reply`.
-    pub fn new(connection: &C, sequence_number: SequenceNumber) -> VoidCookie<C> {
+    pub fn new(connection: &C, sequence_number: SequenceNumber) -> VoidCookie<'_, C> {
         VoidCookie {
             connection,
             sequence_number,
@@ -98,7 +98,7 @@ where
     ///
     /// This function should only be used by implementations of
     /// `RequestConnection::send_request_with_reply`.
-    fn new(connection: &C, sequence_number: SequenceNumber) -> RawCookie<C> {
+    fn new(connection: &C, sequence_number: SequenceNumber) -> RawCookie<'_, C> {
         RawCookie {
             connection,
             sequence_number,
@@ -149,7 +149,7 @@ where
     ///
     /// This function should only be used by implementations of
     /// `RequestConnection::send_request_with_reply`.
-    pub fn new(connection: &C, sequence_number: SequenceNumber) -> Cookie<C, R> {
+    pub fn new(connection: &C, sequence_number: SequenceNumber) -> Cookie<'_, C, R> {
         Cookie {
             raw_cookie: RawCookie::new(connection, sequence_number),
             phantom: PhantomData,
@@ -223,7 +223,7 @@ where
     ///
     /// This function should only be used by implementations of
     /// `RequestConnection::send_request_with_reply`.
-    pub fn new(connection: &C, sequence_number: SequenceNumber) -> CookieWithFds<C, R> {
+    pub fn new(connection: &C, sequence_number: SequenceNumber) -> CookieWithFds<'_, C, R> {
         CookieWithFds {
             raw_cookie: RawCookie::new(connection, sequence_number),
             phantom: PhantomData,
@@ -258,7 +258,9 @@ impl<C> ListFontsWithInfoCookie<'_, C>
 where
     C: RequestConnection + ?Sized,
 {
-    pub(crate) fn new(cookie: Cookie<C, ListFontsWithInfoReply>) -> ListFontsWithInfoCookie<C> {
+    pub(crate) fn new(
+        cookie: Cookie<'_, C, ListFontsWithInfoReply>,
+    ) -> ListFontsWithInfoCookie<'_, C> {
         ListFontsWithInfoCookie(Some(cookie.raw_cookie))
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,7 +15,7 @@ pub enum ParseError {
 impl Error for ParseError {}
 
 impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Error while parsing (not enough data?)")
     }
 }
@@ -67,8 +67,12 @@ pub enum ConnectError {
 impl Error for ConnectError {}
 
 impl std::fmt::Display for ConnectError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fn display(f: &mut std::fmt::Formatter, prefix: &str, value: &[u8]) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn display(
+            f: &mut std::fmt::Formatter<'_>,
+            prefix: &str,
+            value: &[u8],
+        ) -> std::fmt::Result {
             match std::str::from_utf8(value).ok() {
                 Some(value) => write!(f, "{}: '{}'", prefix, value),
                 None => write!(f, "{}: {:?} [message is not utf8]", prefix, value),
@@ -139,7 +143,7 @@ pub enum ConnectionError {
 impl Error for ConnectionError {}
 
 impl std::fmt::Display for ConnectionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConnectionError::UnknownError => write!(f, "Unknown connection error"),
             ConnectionError::UnsupportedExtension => write!(f, "Unsupported extension"),
@@ -186,7 +190,7 @@ pub enum ReplyError {
 impl Error for ReplyError {}
 
 impl std::fmt::Display for ReplyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReplyError::ConnectionError(e) => write!(f, "{}", e),
             ReplyError::X11Error(e) => write!(f, "X11 error {:?}", e),
@@ -236,7 +240,7 @@ pub enum ReplyOrIdError {
 }
 
 impl std::fmt::Display for ReplyOrIdError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReplyOrIdError::IdsExhausted => f.write_str("X11 IDs have been exhausted"),
             ReplyOrIdError::ConnectionError(e) => write!(f, "{}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,19 +62,20 @@
 //! More examples can be found in the
 //! [examples](https://github.com/psychon/x11rb/tree/master/examples) directory.
 
-#![deny(missing_copy_implementations,
-        missing_debug_implementations,
-        //missing_docs,
-        private_doc_tests,
-        single_use_lifetimes,
-        trivial_casts,
-        trivial_numeric_casts,
-        unreachable_pub,
-        unused_extern_crates,
-        unused_import_braces,
-        unused_qualifications,
-        unused_results,
-        )]
+#![deny(
+    missing_copy_implementations,
+    missing_debug_implementations,
+    //missing_docs,
+    private_doc_tests,
+    rust_2018_idioms,
+    single_use_lifetimes,
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results,
+)]
 #![cfg_attr(not(feature = "allow-unsafe-code"), forbid(unsafe_code))]
 
 pub mod utils;

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -139,9 +139,9 @@ mod test {
     impl RequestConnection for DummyConnection {
         fn send_request_with_reply<R>(
             &self,
-            _bufs: &[IoSlice],
+            _bufs: &[IoSlice<'_>],
             _fds: Vec<RawFdContainer>,
-        ) -> Result<Cookie<Self, R>, ConnectionError>
+        ) -> Result<Cookie<'_, Self, R>, ConnectionError>
         where
             R: TryFrom<Buffer, Error = ParseError>,
         {
@@ -150,9 +150,9 @@ mod test {
 
         fn send_request_with_reply_with_fds<R>(
             &self,
-            _bufs: &[IoSlice],
+            _bufs: &[IoSlice<'_>],
             _fds: Vec<RawFdContainer>,
-        ) -> Result<CookieWithFds<Self, R>, ConnectionError>
+        ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
         where
             R: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>,
         {
@@ -161,9 +161,9 @@ mod test {
 
         fn send_request_without_reply(
             &self,
-            _bufs: &[IoSlice],
+            _bufs: &[IoSlice<'_>],
             _fds: Vec<RawFdContainer>,
-        ) -> Result<VoidCookie<Self>, ConnectionError> {
+        ) -> Result<VoidCookie<'_, Self>, ConnectionError> {
             unimplemented!()
         }
 

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -149,7 +149,7 @@ where
     /// Send a request to the X11 server.
     pub(crate) fn send_request(
         &mut self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         kind: RequestKind,
     ) -> Result<SequenceNumber, std::io::Error> {
         if self.next_reply_expected + SequenceNumber::from(u16::max_value())

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -137,7 +137,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
     /// `send_request_without_reply()`.
     fn send_request(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
         kind: RequestKind,
     ) -> Result<SequenceNumber, ConnectionError> {
@@ -212,9 +212,9 @@ impl<R: Read, W: Write> RustConnection<R, W> {
 impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
     fn send_request_with_reply<Reply>(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<Cookie<Self, Reply>, ConnectionError>
+    ) -> Result<Cookie<'_, Self, Reply>, ConnectionError>
     where
         Reply: TryFrom<Buffer, Error = ParseError>,
     {
@@ -229,9 +229,9 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
 
     fn send_request_with_reply_with_fds<Reply>(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<CookieWithFds<Self, Reply>, ConnectionError>
+    ) -> Result<CookieWithFds<'_, Self, Reply>, ConnectionError>
     where
         Reply: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>,
     {
@@ -244,9 +244,9 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
 
     fn send_request_without_reply(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<VoidCookie<Self>, ConnectionError> {
+    ) -> Result<VoidCookie<'_, Self>, ConnectionError> {
         let mut storage = Default::default();
         let bufs = self.compute_length_field(bufs, &mut storage)?;
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -59,7 +59,7 @@ pub trait ConnectionExt: XProtoConnectionExt {
         property: u32,
         type_: u32,
         data: &[u8],
-    ) -> Result<VoidCookie<Self>, ConnectionError>
+    ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
     {
@@ -82,7 +82,7 @@ pub trait ConnectionExt: XProtoConnectionExt {
         property: u32,
         type_: u32,
         data: &[u16],
-    ) -> Result<VoidCookie<Self>, ConnectionError>
+    ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
     {
@@ -109,7 +109,7 @@ pub trait ConnectionExt: XProtoConnectionExt {
         property: u32,
         type_: u32,
         data: &[u32],
-    ) -> Result<VoidCookie<Self>, ConnectionError>
+    ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
     {

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -145,7 +145,7 @@ impl XCBConnection {
 
     fn send_request(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
         has_reply: bool,
         reply_has_fds: bool,
@@ -305,9 +305,9 @@ impl XCBConnection {
 impl RequestConnection for XCBConnection {
     fn send_request_with_reply<R>(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<Cookie<Self, R>, ConnectionError>
+    ) -> Result<Cookie<'_, Self, R>, ConnectionError>
     where
         R: TryFrom<Buffer, Error = ParseError>,
     {
@@ -319,9 +319,9 @@ impl RequestConnection for XCBConnection {
 
     fn send_request_with_reply_with_fds<R>(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<CookieWithFds<Self, R>, ConnectionError>
+    ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
     where
         R: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>,
     {
@@ -333,9 +333,9 @@ impl RequestConnection for XCBConnection {
 
     fn send_request_without_reply(
         &self,
-        bufs: &[IoSlice],
+        bufs: &[IoSlice<'_>],
         fds: Vec<RawFdContainer>,
-    ) -> Result<VoidCookie<Self>, ConnectionError> {
+    ) -> Result<VoidCookie<'_, Self>, ConnectionError> {
         Ok(VoidCookie::new(
             self,
             self.send_request(bufs, fds, false, false)?,

--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -71,13 +71,13 @@ extern "C" {
     pub(crate) fn xcb_send_request64(
         c: *const xcb_connection_t,
         flags: c_int,
-        vector: *mut IoSlice,
+        vector: *mut IoSlice<'_>,
         request: *const xcb_protocol_request_t,
     ) -> u64;
     pub(crate) fn xcb_send_request_with_fds64(
         c: *const xcb_connection_t,
         flags: c_int,
-        vector: *mut IoSlice,
+        vector: *mut IoSlice<'_>,
         request: *const xcb_protocol_request_t,
         num_fds: c_uint,
         fds: *const c_int,
@@ -179,7 +179,7 @@ mod mock {
     pub(crate) unsafe fn xcb_send_request64(
         _c: *const xcb_connection_t,
         _flags: c_int,
-        _vector: *mut IoSlice,
+        _vector: *mut IoSlice<'_>,
         _request: *const xcb_protocol_request_t,
     ) -> u64 {
         unimplemented!();
@@ -188,7 +188,7 @@ mod mock {
     pub(crate) unsafe fn xcb_send_request_with_fds64(
         _c: *const xcb_connection_t,
         _flags: c_int,
-        _vector: *mut IoSlice,
+        _vector: *mut IoSlice<'_>,
         _request: *const xcb_protocol_request_t,
         _num_fds: c_uint,
         _fds: *const c_int,


### PR DESCRIPTION
The `unused_extern_crates` lint is removed because is part of `rust_2018_idioms`.