### PR TITLE
Decouple parsing from the `Buffer` type.

### DIFF
--- a/doc/generated_code.md
+++ b/doc/generated_code.md
@@ -22,7 +22,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use std::option::Option as RustOption;
 #[allow(unused_imports)]
-use crate::utils::{Buffer, RawFdContainer};
+use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{GenericEvent as X11GenericEvent, GenericError as X11GenericError, Event as _};
 use crate::x11_utils::TryParse;
@@ -81,18 +81,6 @@ impl TryParse for Point {
         remaining = new_remaining;
         let result = Point { x, y };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&Buffer> for Point {
-    type Error = ParseError;
-    fn try_from(value: &Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&**value)
-    }
-}
-impl TryFrom<Buffer> for Point {
-    type Error = ParseError;
-    fn try_from(value: Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&*value)
     }
 }
 impl TryFrom<&[u8]> for Point {
@@ -155,18 +143,6 @@ impl TryParse for Depth {
         remaining = new_remaining;
         let result = Depth { depth, visuals };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&Buffer> for Depth {
-    type Error = ParseError;
-    fn try_from(value: &Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&**value)
-    }
-}
-impl TryFrom<Buffer> for Depth {
-    type Error = ParseError;
-    fn try_from(value: Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&*value)
     }
 }
 impl TryFrom<&[u8]> for Depth {
@@ -639,18 +615,6 @@ impl KeyPressEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&Buffer> for KeyPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&**value)
-    }
-}
-impl TryFrom<Buffer> for KeyPressEvent {
-    type Error = ParseError;
-    fn try_from(value: Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&*value)
-    }
-}
 impl TryFrom<&[u8]> for KeyPressEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
@@ -659,7 +623,7 @@ impl TryFrom<&[u8]> for KeyPressEvent {
 }
 impl From<GenericEvent> for KeyPressEvent {
     fn from(value: GenericEvent) -> Self {
-        Self::try_from(Into::<Buffer>::into(value)).expect("Buffer should be large enough so that parsing cannot fail")
+        Self::try_from(value.raw_bytes()).expect("Buffer should be large enough so that parsing cannot fail")
     }
 }
 impl From<&GenericEvent> for KeyPressEvent {
@@ -736,18 +700,6 @@ impl RequestError {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&Buffer> for RequestError {
-    type Error = ParseError;
-    fn try_from(value: &Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&**value)
-    }
-}
-impl TryFrom<Buffer> for RequestError {
-    type Error = ParseError;
-    fn try_from(value: Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&*value)
-    }
-}
 impl TryFrom<&[u8]> for RequestError {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
@@ -756,7 +708,7 @@ impl TryFrom<&[u8]> for RequestError {
 }
 impl From<GenericError> for RequestError {
     fn from(value: GenericError) -> Self {
-        Self::try_from(Into::<Buffer>::into(value)).expect("Buffer should be large enough so that parsing cannot fail")
+        Self::try_from(value.raw_bytes()).expect("Buffer should be large enough so that parsing cannot fail")
     }
 }
 impl From<&GenericError> for RequestError {
@@ -881,18 +833,6 @@ impl GetInputFocusReply {
         remaining = new_remaining;
         let result = GetInputFocusReply { response_type, revert_to, sequence, length, focus };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&Buffer> for GetInputFocusReply {
-    type Error = ParseError;
-    fn try_from(value: &Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&**value)
-    }
-}
-impl TryFrom<Buffer> for GetInputFocusReply {
-    type Error = ParseError;
-    fn try_from(value: Buffer) -> Result<Self, Self::Error> {
-        Self::try_from(&*value)
     }
 }
 impl TryFrom<&[u8]> for GetInputFocusReply {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -88,7 +88,7 @@ pub trait RequestConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<'_, Self, R>, ConnectionError>
     where
-        R: TryFrom<Buffer, Error = ParseError>;
+        R: for<'a> TryFrom<&'a [u8], Error = ParseError>;
 
     /// Send a request with a reply containing file descriptors to the server.
     ///
@@ -115,7 +115,7 @@ pub trait RequestConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
     where
-        R: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>;
+        R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>;
 
     /// Send a request without a reply to the server.
     ///
@@ -260,13 +260,13 @@ pub trait RequestConnection {
     ///
     ///     fn send_request_with_reply<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>)
     ///     -> Result<Cookie<Self, R>, ConnectionError>
-    ///     where R: TryFrom<Buffer, Error=ParseError> {
+    ///     where R: for<'a> TryFrom<&'a [u8], Error=ParseError> {
     ///         Ok(Cookie::new(self, self.send_request(bufs, fds, true, false)?))
     ///     }
     ///
     ///     fn send_request_with_reply_with_fds<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>)
     ///     -> Result<CookieWithFds<Self, R>, ConnectionError>
-    ///     where R: TryFrom<(Buffer, Vec<RawFdContainer>), Error=ParseError> {
+    ///     where R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error=ParseError> {
     ///         Ok(CookieWithFds::new(self, self.send_request(bufs, fds, true, true)?))
     ///     }
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
     //missing_docs,
     private_doc_tests,
     rust_2018_idioms,
-    single_use_lifetimes,
+    //single_use_lifetimes,
     trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -143,7 +143,7 @@ mod test {
             _fds: Vec<RawFdContainer>,
         ) -> Result<Cookie<'_, Self, R>, ConnectionError>
         where
-            R: TryFrom<Buffer, Error = ParseError>,
+            R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
         {
             Ok(Cookie::new(self, 0))
         }
@@ -154,7 +154,7 @@ mod test {
             _fds: Vec<RawFdContainer>,
         ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
         where
-            R: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>,
+            R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
         {
             unimplemented!()
         }

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -216,7 +216,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<'_, Self, Reply>, ConnectionError>
     where
-        Reply: TryFrom<Buffer, Error = ParseError>,
+        Reply: for<'a> TryFrom<&'a [u8], Error = ParseError>,
     {
         let mut storage = Default::default();
         let bufs = self.compute_length_field(bufs, &mut storage)?;
@@ -233,7 +233,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
         fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<'_, Self, Reply>, ConnectionError>
     where
-        Reply: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>,
+        Reply: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
     {
         let mut storage = Default::default();
         let bufs = self.compute_length_field(bufs, &mut storage)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -130,6 +130,12 @@ impl Deref for Buffer {
     }
 }
 
+impl AsRef<[u8]> for Buffer {
+    fn as_ref(&self) -> &[u8] {
+        &**self
+    }
+}
+
 impl<I> Index<I> for Buffer
 where
     I: SliceIndex<[u8]>,

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -309,7 +309,7 @@ impl RequestConnection for XCBConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<'_, Self, R>, ConnectionError>
     where
-        R: TryFrom<Buffer, Error = ParseError>,
+        R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
     {
         Ok(Cookie::new(
             self,
@@ -323,7 +323,7 @@ impl RequestConnection for XCBConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
     where
-        R: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>,
+        R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
     {
         Ok(CookieWithFds::new(
             self,

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -65,7 +65,7 @@ impl RequestConnection for FakeConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<Self, R>, ConnectionError>
     where
-        R: TryFrom<Buffer, Error = ParseError>,
+        R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
     {
         Ok(Cookie::new(self, self.internal_send_request(bufs, fds)?))
     }
@@ -76,7 +76,7 @@ impl RequestConnection for FakeConnection {
         _fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<Self, R>, ConnectionError>
     where
-        R: TryFrom<(Buffer, Vec<RawFdContainer>), Error = ParseError>,
+        R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
     {
         unimplemented!()
     }


### PR DESCRIPTION
This is a step towards https://github.com/psychon/x11rb/issues/251.

Now, the `TryFrom<Buffer>` and `TryFrom<&Buffer>` are no longer implemented. All the remaining code now uses `TryFrom<&[u8]>`.