### PR TITLE
Remove TryParse and Serialize impls for enums again

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -324,17 +324,6 @@ class Module(object):
                 self.out("}")
             self.out("}")
 
-        self.out("impl Serialize for %s {", rust_name)
-        with Indent(self.out):
-            self.out("type Bytes = <%s as Serialize>::Bytes;", to_type)
-            self.out("fn serialize(&self) -> Self::Bytes {")
-            self.out.indent("%s::from(*self).serialize()", to_type)
-            self.out("}")
-            self.out("fn serialize_into(&self, bytes: &mut Vec<u8>) {")
-            self.out.indent("%s::from(*self).serialize_into(bytes)", to_type)
-            self.out("}")
-        self.out("}")
-
         # Can this enum be parsed? Its values must be unique for this.
         if not has_duplicate_values:
             self.out("impl TryFrom<%s> for %s {", to_type, rust_name)
@@ -348,15 +337,6 @@ class Module(object):
                                         rust_name, ename_to_rust(ename))
                     self.out.indent("_ => Err(ParseError::ParseError)")
                     self.out("}")
-                self.out("}")
-            self.out("}")
-
-            self.out("impl TryParse for %s {", rust_name)
-            with Indent(self.out):
-                self.out("fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {")
-                with Indent(self.out):
-                    self.out("let (value, remaining) = %s::try_parse(value)?;", to_type)
-                    self.out("Ok((Self::try_from(value)?, remaining))")
                 self.out("}")
             self.out("}")
 

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -340,6 +340,15 @@ class Module(object):
                 self.out("}")
             self.out("}")
 
+            for larger_type in larger_types:
+                self.out("impl TryFrom<%s> for %s {", larger_type, rust_name)
+                with Indent(self.out):
+                    self.out("type Error = ParseError;")
+                    self.out("fn try_from(value: %s) -> Result<Self, Self::Error> {", larger_type)
+                    self.out.indent("Self::try_from(%s::try_from(value).or(Err(ParseError::ParseError))?)", to_type)
+                    self.out("}")
+                self.out("}")
+
         # Is this enum a bitmask? It is all values are bits or the special value zero...
         def ok_for_bitmask(ename, value):
             return ename in bits or value == "0"


### PR DESCRIPTION
I only just now added them, but... they cannot really work. An enum is
an "abstract concept" that does not have an on-the-wire size. Only the
uses of an enum define its size.

This was pointed out by @eduardosm in
https://github.com/psychon/x11rb/pull/267#discussion_r389357568.

Signed-off-by: Uli Schlachter <psychon@znc.in>