### PR TITLE
Reorganize some imports (i.e., `use`s)

### DIFF
--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -8,6 +8,7 @@ use std::f64::consts::PI;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+
 use x11rb::connection::Connection;
 use x11rb::errors::{ReplyError, ReplyOrIdError};
 use x11rb::generated::xproto::*;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -40,13 +40,14 @@
 //! | Get    | `Cookie::reply`                    | `Cookie::reply_unchecked` |
 //! | Ignore | `Cookie::discard_reply_and_errors` | Just drop the cookie      |
 
+use std::convert::{TryFrom, TryInto};
+use std::io::IoSlice;
+
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::generated::xproto::{QueryExtensionReply, Setup};
 use crate::utils::RawFdContainer;
 use crate::x11_utils::{GenericError, GenericEvent};
-use std::convert::{TryFrom, TryInto};
-use std::io::IoSlice;
 
 /// Number type used for referring to things that were sent to the server in responses from the
 /// server.

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -1,12 +1,13 @@
 //! Cookies are handles to future replies or errors from the X11 server.
 
+use std::convert::{TryFrom, TryInto};
+use std::marker::PhantomData;
+
 use crate::connection::{BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber};
 use crate::errors::{ConnectionError, ParseError, ReplyError};
 use crate::generated::xproto::ListFontsWithInfoReply;
 use crate::utils::RawFdContainer;
 use crate::x11_utils::GenericError;
-use std::convert::{TryFrom, TryInto};
-use std::marker::PhantomData;
 
 /// A handle to a possible error from the X11 server.
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,19 +1,21 @@
-#[cfg(not(unix))]
-use libc::c_int;
 use std::mem::forget;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+
+#[cfg(not(unix))]
+use libc::c_int;
 
 #[cfg(not(unix))]
 type RawFd = c_int;
 
 #[cfg(feature = "allow-unsafe-code")]
 mod unsafe_code {
-    use libc::free;
     use std::mem::forget;
     use std::ops::{Deref, Index};
     use std::ptr::NonNull;
     use std::slice::{from_raw_parts, SliceIndex};
+
+    use libc::free;
 
     /// Wrapper around a slice that was allocated in C code.
     ///

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -4,6 +4,17 @@
 
 #![allow(clippy::cast_ptr_alignment)] // FIXME: Remove this
 
+use std::convert::{TryFrom, TryInto};
+use std::ffi::CStr;
+use std::io::{Error, ErrorKind, IoSlice};
+use std::ops::Deref;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::ptr::{null, null_mut, NonNull};
+use std::sync::Mutex;
+
+use libc::c_void;
+
 use super::generated::xproto::{QueryExtensionReply, Setup};
 use crate::connection::{
     BufWithFds, Connection, DiscardMode, EventAndSeqNumber, RequestConnection, RequestKind,
@@ -14,15 +25,6 @@ use crate::errors::{ConnectError, ConnectionError, ParseError, ReplyError, Reply
 use crate::extension_information::ExtensionInformation;
 use crate::utils::{CSlice, RawFdContainer};
 use crate::x11_utils::{GenericError, GenericEvent};
-use libc::c_void;
-use std::convert::{TryFrom, TryInto};
-use std::ffi::CStr;
-use std::io::{Error, ErrorKind, IoSlice};
-use std::ops::Deref;
-#[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
-use std::ptr::{null, null_mut, NonNull};
-use std::sync::Mutex;
 
 mod pending_errors;
 mod raw_ffi;

--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -1,9 +1,10 @@
 #[cfg(not(test))]
-use libc::c_void;
-use libc::{c_char, c_int, c_uint};
-#[cfg(not(test))]
 use std::io::IoSlice;
 use std::ptr::NonNull;
+
+#[cfg(not(test))]
+use libc::c_void;
+use libc::{c_char, c_int, c_uint};
 
 #[allow(non_camel_case_types)]
 #[repr(C)]


### PR DESCRIPTION
In some modules, imports from `std` were splitted from `x11rb` imports with an empty line. In other modules, imports from `std` and `x11rb` were mixed (although ordered by rustfmt).

This commit splits imports from `std` and `x11rb` in all modules.