### PR TITLE
Remove the `vendor-xcb-proto` feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ matrix:
 addons:
   apt:
     packages:
-      - xcb-proto
-      - python-xcbgen
-      - pkg-config
       - pycodestyle
       - xvfb
 
@@ -38,10 +35,9 @@ install:
 script:
   # Check the code generator against python 2 and 3. Both versions should
   # produce identical output.
-  - PYDIR="$(pkg-config --variable=pythondir xcb-proto)"
-  - PROTO="$(pkg-config --variable=xcbincludedir xcb-proto)"
-  - echo $PYDIR
-  - echo $PROTO
+  - XCB_PROTO_DIR="xcbproto-1.13-6-ge79f6b0"
+  - PYDIR="$XCB_PROTO_DIR"
+  - PROTO="$XCB_PROTO_DIR/src"
   - mkdir /tmp/py2 /tmp/py3
   - python3 rs_code_generator.py -p "$PYDIR" -i "$PROTO" -o /tmp/py3 generated
   - python2 rs_code_generator.py -p "$PYDIR" -i "$PROTO" -o /tmp/py2 generated
@@ -65,7 +61,7 @@ script:
   # Enable the 'all-extensions' feature or Cargo will complain
   - run_examples --features all-extensions
 
-  - cargo build --verbose --all-targets --no-default-features --features "vendor-xcb-proto all-extensions"
+  - cargo build --verbose --all-targets --no-default-features --features all-extensions
 
   # Run the examples as 'integration tests'. This time using RustConnection.
-  - run_examples --no-default-features --features "vendor-xcb-proto all-extensions libc"
+  - run_examples --no-default-features --features "all-extensions libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,10 @@ keywords = ["xcb", "X11"]
 libc = { version = "0.2", optional = true }
 gethostname = "0.2.1"
 
-[build-dependencies]
-pkg-config = "0.3"
-
 [features]
 default = [
-    "vendor-xcb-proto",
     "allow-unsafe-code",
 ]
-
-# Enable use of the vendored copy of xcb-proto. Without this feature, pkg-config
-# is used to find it instead. Without this feature, no stable API can be
-# guaranteed, because the protocol description can differ.
-vendor-xcb-proto = []
 
 # Without this feature, all uses of `unsafe` in the crate are forbidden via
 # #![deny(unsafe_code)]. This has the effect of disabling the XCB FFI bindings.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,8 @@ document](doc/comparison.md).
 This crate uses a code generator that is implemented in Python. As such, you
 need to have Python available to build this crate.
 
-The code generator uses the X11 XML description from `xcb-proto`. When the
-`vendor-xcb-proto` is enabled, which it is by default, a copy of xcb-proto that
-comes with the source code is used.
-
-When that feature is disabled, `pkg-config` is used to find `xcb-proto`.  In a
-nutshell, if you can run `pkg-config --modversion xcb-proto` successfully, you
-should be fine. On Debian, the necessary packages are called `pkg-config`,
-`xcb-proto`, and `python-xcbgen`. I hope that other distros use similarly
-obvious naming.
+The code generator uses the X11 XML description from `xcb-proto`. A copy of
+xcb-proto that comes with the source code is used.
 
 
 ## Does this support async/await
@@ -39,8 +32,6 @@ of sending multiple requests and only afterwards wait for the replies.
 
 The following features are enabled by default:
 
-* `vendor-xcb-proto`: Use our own copy of `xcb-proto`. Without this feature,
-  `pkg-config` is used to find `xcb-proto`.
 * `allow-unsafe-code`: Without this feature, `forbid(unsafe_code)` forbids all
   unsafe code. With this feature, `XCBConnection` and FD passing become
   available.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ install:
 build: false
 test_script:
   # We do not have libxcb and thus cannot build XCBConnection
-  - cargo build --verbose --all-targets --no-default-features --features "vendor-xcb-proto all-extensions"
-  - cargo test --verbose --no-default-features --features "vendor-xcb-proto all-extensions"
+  - cargo build --verbose --all-targets --no-default-features --features all-extensions
+  - cargo test --verbose --no-default-features --features all-extensions
 
   # Start an X11 server in the background
   - ps: $Server = Start-Process -PassThru -FilePath C:\cygwin\bin\Xvfb.exe -ArgumentList "-listen tcp :0"
@@ -22,14 +22,14 @@ test_script:
   - set "X11RB_EXAMPLE_TIMEOUT=1"
 
   # FIXME: Can this list be automated? somehow?
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example check_unchecked_requests
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example generic_events
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example hypnomoire
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example list_fonts
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example simple_window
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example simple_window_manager
-  #- cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example tutorial
-  - cargo run --verbose --no-default-features --features "vendor-xcb-proto all-extensions" --example xeyes
+  - cargo run --verbose --no-default-features --features all-extensions --example check_unchecked_requests
+  - cargo run --verbose --no-default-features --features all-extensions --example generic_events
+  - cargo run --verbose --no-default-features --features all-extensions --example hypnomoire
+  - cargo run --verbose --no-default-features --features all-extensions --example list_fonts
+  - cargo run --verbose --no-default-features --features all-extensions --example simple_window
+  - cargo run --verbose --no-default-features --features all-extensions --example simple_window_manager
+  #- cargo run --verbose --no-default-features --features all-extensions --example tutorial
+  - cargo run --verbose --no-default-features --features all-extensions --example xeyes
 
 on_finish:
   - ps: Stop-Process -Id $Server.Id

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate pkg_config;
-
 use std::env;
 use std::ffi::OsStr;
 use std::fs::{create_dir, read_dir};
@@ -17,14 +15,6 @@ fn create_dir_if_not_exist(dir: &PathBuf) -> Result<()> {
     result
 }
 
-#[cfg(not(feature = "vendor-xcb-proto"))]
-fn get_paths() -> (PathBuf, PathBuf) {
-    let pythondir = pkg_config::get_variable("xcb-proto", "pythondir").unwrap();
-    let includedir = pkg_config::get_variable("xcb-proto", "xcbincludedir").unwrap();
-    (pythondir.into(), includedir.into())
-}
-
-#[cfg(feature = "vendor-xcb-proto")]
 fn get_paths() -> (PathBuf, PathBuf) {
     let dir = Path::new("xcbproto-1.13-6-ge79f6b0");
     let pythondir = dir.to_path_buf();

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,9 @@
+# Version 0.5.0 (2020-XX-XX)
+
+Breaking changes:
+* The `vendor-xcb-proto` feature flag is no longer available. The included
+  xcb-proto is now always used.
+
 # Version 0.4.0 (2020-03-08)
 
 New features:

--- a/src/extension_information.rs
+++ b/src/extension_information.rs
@@ -71,9 +71,7 @@ impl ExtensionInformation {
                         ReplyError::X11Error(_) => ConnectionError::UnknownError,
                     })?;
                 // If the extension is not present, we return None, else we box it
-                #[allow(trivial_numeric_casts)]
-                let present = info.present as u8;
-                if present != 0 {
+                if info.present {
                     *entry = CheckState::Present(info);
                     Ok(Some(info))
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,6 @@
 //! `all-extensions` feature to just enable, well, all extensions.
 //!
 //! Additionally, the following flags are enabled by default:
-//! * `vendor-xcb-proto`: Use a copy of `xcb-proto` that comes with x11rb. Without this flag,
-//!   `pkg-config` is used to find `xcb-proto` on the host system.
 //! * `allow-unsafe-code`: Enable features that require `unsafe`. Without this flag,
 //!   `x11rb::xcb_ffi::XCBConnection` and some support code for it are unavailable.
 

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -186,13 +186,11 @@ mod test {
             &self,
             _extension_name: &'static str,
         ) -> Result<Option<QueryExtensionReply>, ConnectionError> {
-            #[allow(trivial_casts, clippy::unnecessary_cast)]
-            let present = true as _;
             Ok(self.0.as_ref().map(|_| QueryExtensionReply {
                 response_type: 1,
                 sequence: 0,
                 length: 0,
-                present,
+                present: true,
                 major_opcode: 127,
                 first_event: 0,
                 first_error: 0,


### PR DESCRIPTION
Now, the included copy of xcb-proto is used always.

Resolves https://github.com/psychon/x11rb/issues/272.

Makes https://github.com/psychon/x11rb/issues/115 irrelevant.

Tiny step towards https://github.com/psychon/x11rb/issues/190.