### PR TITLE
Split blocks of capital letters in snake-case names

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1342,9 +1342,13 @@ class Module(object):
     def _lower_snake_name(self, name):
         """Convert a name tuple to a lowercase snake name. MonitorInfo is turned
         into monitor_info."""
+
         name = self._name(name)
-        name = re.sub('([a-z0-9])([A-Z])', '\\1_\\2', name)
-        return name.lower()
+        # Based on _cname_re from libxcb's c_client.py
+        pattern = re.compile('([A-Z][a-z0-9]+|[A-Z]+(?![a-z0-9])|[a-z0-9]+)')
+        split = pattern.finditer(name)
+        name_parts = [match.group(0) for match in split]
+        return '_'.join(name_parts).lower()
 
     def _upper_snake_name(self, name):
         """Convert a name tuple to a uppercase snake name. MonitorInfo is turned

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -50,7 +50,7 @@ impl IDAllocator {
                 return Err(ReplyOrIdError::IdsExhausted);
             }
             // Send an XC-MISC GetXIDRange request.
-            let xidrange = conn.xc_misc_get_xidrange()?.reply()?;
+            let xidrange = conn.xc_misc_get_xid_range()?.reply()?;
             let (start, count) = (xidrange.start_id, xidrange.count);
             // Apparently (0, 1) is how the server signals "I am out of IDs".
             // The second case avoids an underflow below and should never happen.


### PR DESCRIPTION
For example, `xiquery_version` becomes `xi_query_version`, or `get_xidrange` (from XC-MISC) becomes `get_xid_range`.

Of course, this is a breaking change.