### PR TITLE
Code generator: Skip write if content is correct

### DIFF
--- a/code_generator_helpers/output.py
+++ b/code_generator_helpers/output.py
@@ -66,10 +66,20 @@ class Output(object):
             self("%s", line)
 
     def write_file(self, filename):
+        expected = "".join([line.rstrip() + '\n' for line in self._lines])
+
+        # First read the file to check if it already has the right content
+        try:
+            with open(filename, 'r') as target:
+                content = target.read()
+                if content == expected:
+                    return
+        except IOError:
+            # Well, okay... just try to write the file
+            pass
+
         with open(filename, 'w') as target:
-            for line in self._lines:
-                target.write(line.rstrip())
-                target.write('\n')
+            target.write(expected)
 
     def __bool__(self):
         return bool(self._lines)


### PR DESCRIPTION
This commit makes the code generator not overwrite its output files with
content that they already have.

The effect of this is that the time of last modification of the file
does not change, thus cargo does not rebuild the code. This has a lot
impact on build times. The idea is to make working on the code generator
less time consuming.

Signed-off-by: Uli Schlachter <psychon@znc.in>