### PR TITLE
Clean up hack in code generator

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -1190,14 +1190,13 @@ class Module(object):
             self.out("}")
         self.out("}")
 
-    def _generate_aux(self, name, request, switch, mask_field, request_function_name):
+    def _generate_aux(self, name, request, switch, mask_field_name, mask_field_type, request_function_name):
         if switch.type.bitcases[0].type.is_case:
             self._emit_switch_type(switch.type, name, [], False)
             self._emit_switch_serialize(name, switch.type)
             self.out("impl %s {", name)
             with Indent(self.out):
-                self.out("fn %s(&self) -> %s {",
-                         mask_field.field_name, self._field_type(mask_field))
+                self.out("fn %s(&self) -> %s {", mask_field_name, mask_field_type)
                 with Indent(self.out):
                     self.out("match self {")
                     with Indent(self.out):
@@ -1237,7 +1236,7 @@ class Module(object):
             self.out.indent("Default::default()")
             self.out("}")
 
-            self.out("fn value_mask(&self) -> %s {", self._field_type(mask_field))
+            self.out("fn value_mask(&self) -> %s {", mask_field_type)
             with Indent(self.out):
                 self.out("let mut mask = 0;")
                 for case in switch.type.bitcases:
@@ -1250,7 +1249,7 @@ class Module(object):
                         field = case.only_field
                         field_name = self._aux_field_name(field)
                     self.out("if self.%s.is_some() {", field_name)
-                    self.out.indent("mask |= Into::<%s>::into(%s::%s);", self._field_type(mask_field),
+                    self.out.indent("mask |= Into::<%s>::into(%s::%s);", mask_field_type,
                                     enum_name, ename_to_rust(expr.lenfield_name))
                     self.out("}")
                 self.out("mask")

--- a/code_generator_helpers/request.py
+++ b/code_generator_helpers/request.py
@@ -48,15 +48,15 @@ def handle_switches(module, obj, name, function_name):
         # Hide it from the API and "connect" it to the switch
         mask_field.visible = False
         mask_field.lenfield_for_switch = switch
+
+        mask_field_name = mask_field.field_name
+        mask_field_type = module._field_type(mask_field)
     else:
         # Well, this case is complicated. We handle it as a special case.
-        from collections import namedtuple
-        from xcbgen.xtypes import tcard16
+        mask_field_name = "This should be unused so cause a compiler error if used"
+        mask_field_type = "u16"
 
-        assert name == ('xcb', 'xkb', 'SelectEvents')
-        mask_field = namedtuple('FakeField', 'type field_type')(tcard16, ('uint16_t',))
-
-    module._generate_aux(aux_name, obj, switch, mask_field, function_name)
+    module._generate_aux(aux_name, obj, switch, mask_field_name, mask_field_type, function_name)
     return aux_name
 
 


### PR DESCRIPTION
Instead of trying to invent a Field instance to send to _generate_aux(),
_generate_aux() now gets the necessary parts of Field as arguments.

Signed-off-by: Uli Schlachter <psychon@znc.in>