### PR TITLE
Parse enums as their expected types

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -718,11 +718,6 @@ class Module(object):
                                              field_name, i, field_name, i)
                                     for n in range(field.type.size):
                                         parts.append("%s_%d[%d]" % (field_name, i, n))
-                        elif field.type.size == 1:
-                            if is_bool(field.type):
-                                parts.append("u8::from(input.%s)" % field_name)
-                            else:
-                                parts.append("input.%s" % field_name)
                         else:
                             self.out("let %s = input.%s.serialize();", field_name, field_name)
                             for i in range(field.type.size):

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -421,7 +421,13 @@ class Module(object):
                         # the members individually and then assemble that into the output.
                         field_name_bytes = self._to_rust_variable(field.field_name + "_bytes")
                         # First serialize the value itself...
-                        self.out("let %s = self.%s.serialize();", field_name_bytes, field_name)
+                        if not hasattr(field, "has_enum_type"):
+                            self.out("let %s = self.%s.serialize();", field_name_bytes, field_name)
+                        else:
+                            # Turn the enum into the right on-the-wire-type
+                            wire_field_type = self._to_complex_owned_rust_type(field)
+                            self.out("let %s = Into::<%s>::into(self.%s).serialize();",
+                                     field_name_bytes, wire_field_type, field_name)
                         # ...then copy to the output.
                         for i in range(field.type.size):
                             result_bytes.append("%s[%d]" % (field_name_bytes, i))
@@ -441,7 +447,12 @@ class Module(object):
                         self.out("bytes.extend_from_slice(&[0; %s]);", field.type.nmemb)
                     else:
                         field_name = self._to_rust_variable(field.field_name)
-                        self.out("self.%s.serialize_into(bytes);", field_name)
+                        if not hasattr(field, "has_enum_type"):
+                            self.out("self.%s.serialize_into(bytes);", field_name)
+                        else:
+                            wire_field_type = self._to_complex_owned_rust_type(field)
+                            self.out("Into::<%s>::into(self.%s).serialize_into(bytes);",
+                                     wire_field_type, field_name)
             self.out("}")
         self.out("}")
 
@@ -507,7 +518,11 @@ class Module(object):
                             source = field_name
                         else:
                             # Get the value of this field from "self".
-                            source = "self.%s" % field_name
+                            if not hasattr(field, "has_enum_type"):
+                                source = "self.%s" % field_name
+                            else:
+                                wire_field_type = self._to_complex_owned_rust_type(field)
+                                source = "Into::<%s>::into(self.%s)" % (wire_field_type, field_name)
                         self.out("%s.serialize_into(bytes);", source)
             self.out("}")
         self.out("}")
@@ -719,7 +734,14 @@ class Module(object):
                                     for n in range(field.type.size):
                                         parts.append("%s_%d[%d]" % (field_name, i, n))
                         else:
-                            self.out("let %s = input.%s.serialize();", field_name, field_name)
+                            if not hasattr(field, "has_enum_type"):
+                                self.out("let %s = input.%s.serialize();", field_name, field_name)
+                            else:
+                                # This field was interpreted as an enum. Turn it
+                                # back into something like u8.
+                                wire_field_type = self._to_complex_owned_rust_type(field)
+                                self.out("let %s = Into::<%s>::into(input.%s).serialize();",
+                                         field_name, wire_field_type, field_name)
                             for i in range(field.type.size):
                                 parts.append("%s[%d]" % (field_name, i))
 
@@ -834,6 +856,16 @@ class Module(object):
                 if not hasattr(field, 'is_length_field_for'):
                     parts.append(self._to_rust_variable(field.field_name))
 
+        # Handle turning things into enum instances where necessary. This needs
+        # to be down here, because the extra_try_parse_args handling above still
+        # needs the original wire type and not the enum.
+        # FIXME: Change the extra_try_parse_args handling so that this can be
+        # moved up into the above loop.
+        for field in fields:
+            if hasattr(field, "has_enum_type"):
+                field_name = self._to_rust_variable(field.field_name)
+                self.out("let %s = %s.try_into()?;", field_name, field_name)
+
         return parts
 
     def complex_type_struct(self, complex, name, parent_fields):
@@ -852,7 +884,24 @@ class Module(object):
             for field in complex.fields:
                 if field.visible or (not field.type.is_pad and not hasattr(field, "is_length_field_for")):
                     field_name = self._to_rust_variable(field.field_name)
-                    self.out("pub %s: %s,", field_name, self._to_complex_owned_rust_type(field))
+                    if field.enum is None:
+                        field_type = self._to_complex_owned_rust_type(field)
+                    else:
+                        enum = self.outer_module.get_type(field.enum)
+                        if enum.name != ('xcb', 'Gravity'):
+                            field_type = self._name(enum.name)
+                            field.has_enum_type = True
+                        else:
+                            # Cannot parse Gravity, because BitForget and
+                            # WinUnmap both have value 0. The context decides
+                            # which of the two types is meant. :-(
+                            # However, this only makes a difference for
+                            # GetWindowAttributesReply (fields bit_gravity and
+                            # win_gravity).
+                            # FIXME: Handle this as a special case so that the
+                            # enum can still be used.
+                            field_type = self._to_complex_owned_rust_type(field)
+                    self.out("pub %s: %s,", field_name, field_type)
         self.out("}")
 
     def complex_type(self, complex, name, impl_try_parse, parent_fields):

--- a/examples/list_fonts.rs
+++ b/examples/list_fonts.rs
@@ -6,15 +6,14 @@ use x11rb::xproto::{ConnectionExt, FontDraw};
 
 fn main() {
     let (conn, _) = x11rb::connect(None).unwrap();
-    let (ltr, rtl): (u8, u8) = (FontDraw::LeftToRight.into(), FontDraw::RightToLeft.into());
 
     println!("DIR  MIN  MAX EXIST DFLT PROP ASC DESC NAME");
     for reply in conn.list_fonts_with_info(u16::max_value(), b"*").unwrap() {
         let reply = reply.unwrap();
 
-        let dir = if reply.draw_direction == ltr {
+        let dir = if reply.draw_direction == FontDraw::LeftToRight {
             "-->"
-        } else if reply.draw_direction == rtl {
+        } else if reply.draw_direction == FontDraw::RightToLeft {
             "<--"
         } else {
             "???"

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -104,7 +104,7 @@ impl<'a, C: Connection> WMState<'a, C> {
                 continue;
             }
             let (attr, geom) = (attr.unwrap(), geom.unwrap());
-            if !attr.override_redirect && attr.map_state != MapState::Unmapped.into() {
+            if !attr.override_redirect && attr.map_state != MapState::Unmapped {
                 self.manage_window(win, &geom)?;
             }
         }

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -2572,14 +2572,14 @@ fn example11() -> Result<(), Box<dyn Error>> {
         setup.bitmap_format_scanline_unit
     );
     println!(
-        "Bitmap format bit order is {}",
+        "Bitmap format bit order is {:?}",
         setup.bitmap_format_bit_order
     );
     println!(
         "Bitmap format scanline pad is {}",
         setup.bitmap_format_scanline_pad
     );
-    println!("Image byte order is {}", setup.image_byte_order);
+    println!("Image byte order is {:?}", setup.image_byte_order);
 
     Ok(())
 }

--- a/src/generated/damage.rs
+++ b/src/generated/damage.rs
@@ -148,9 +148,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadDamageError {
 }
 impl From<&BadDamageError> for [u8; 32] {
     fn from(input: &BadDamageError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -391,6 +393,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NotifyEvent {
 }
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let level = input.level.serialize();
         let sequence = input.sequence.serialize();
         let drawable = input.drawable.serialize();
         let damage = input.damage.serialize();
@@ -398,7 +402,7 @@ impl From<&NotifyEvent> for [u8; 32] {
         let area = input.area.serialize();
         let geometry = input.geometry.serialize();
         [
-            input.response_type, input.level, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
+            response_type[0], level[0], sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
             damage[0], damage[1], damage[2], damage[3], timestamp[0], timestamp[1], timestamp[2], timestamp[3],
             area[0], area[1], area[2], area[3], area[4], area[5], area[6], area[7],
             geometry[0], geometry[1], geometry[2], geometry[3], geometry[4], geometry[5], geometry[6], geometry[7]

--- a/src/generated/damage.rs
+++ b/src/generated/damage.rs
@@ -353,7 +353,7 @@ pub const NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NotifyEvent {
     pub response_type: u8,
-    pub level: u8,
+    pub level: ReportLevel,
     pub sequence: u16,
     pub drawable: DRAWABLE,
     pub damage: DAMAGE,
@@ -371,6 +371,7 @@ impl NotifyEvent {
         let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
         let (area, remaining) = Rectangle::try_parse(remaining)?;
         let (geometry, remaining) = Rectangle::try_parse(remaining)?;
+        let level = level.try_into()?;
         let result = NotifyEvent { response_type, level, sequence, drawable, damage, timestamp, area, geometry };
         Ok((result, remaining))
     }
@@ -394,7 +395,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NotifyEvent {
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
         let response_type = input.response_type.serialize();
-        let level = input.level.serialize();
+        let level = Into::<u8>::into(input.level).serialize();
         let sequence = input.sequence.serialize();
         let drawable = input.drawable.serialize();
         let damage = input.damage.serialize();

--- a/src/generated/dpms.rs
+++ b/src/generated/dpms.rs
@@ -370,7 +370,7 @@ pub struct InfoReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub power_level: u16,
+    pub power_level: DPMSMode,
     pub state: bool,
 }
 impl InfoReply {
@@ -382,6 +382,7 @@ impl InfoReply {
         let (power_level, remaining) = u16::try_parse(remaining)?;
         let (state, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
+        let power_level = power_level.try_into()?;
         let result = InfoReply { response_type, sequence, length, power_level, state };
         Ok((result, remaining))
     }

--- a/src/generated/dri2.rs
+++ b/src/generated/dri2.rs
@@ -256,7 +256,7 @@ impl TryFrom<u32> for EventType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DRI2Buffer {
-    pub attachment: u32,
+    pub attachment: Attachment,
     pub name: u32,
     pub pitch: u32,
     pub cpp: u32,
@@ -269,6 +269,7 @@ impl TryParse for DRI2Buffer {
         let (pitch, remaining) = u32::try_parse(remaining)?;
         let (cpp, remaining) = u32::try_parse(remaining)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
+        let attachment = attachment.try_into()?;
         let result = DRI2Buffer { attachment, name, pitch, cpp, flags };
         Ok((result, remaining))
     }
@@ -282,7 +283,7 @@ impl TryFrom<&[u8]> for DRI2Buffer {
 impl Serialize for DRI2Buffer {
     type Bytes = [u8; 20];
     fn serialize(&self) -> Self::Bytes {
-        let attachment_bytes = self.attachment.serialize();
+        let attachment_bytes = Into::<u32>::into(self.attachment).serialize();
         let name_bytes = self.name.serialize();
         let pitch_bytes = self.pitch.serialize();
         let cpp_bytes = self.cpp.serialize();
@@ -312,7 +313,7 @@ impl Serialize for DRI2Buffer {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(20);
-        self.attachment.serialize_into(bytes);
+        Into::<u32>::into(self.attachment).serialize_into(bytes);
         self.name.serialize_into(bytes);
         self.pitch.serialize_into(bytes);
         self.cpp.serialize_into(bytes);
@@ -322,13 +323,14 @@ impl Serialize for DRI2Buffer {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AttachFormat {
-    pub attachment: u32,
+    pub attachment: Attachment,
     pub format: u32,
 }
 impl TryParse for AttachFormat {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (attachment, remaining) = u32::try_parse(remaining)?;
         let (format, remaining) = u32::try_parse(remaining)?;
+        let attachment = attachment.try_into()?;
         let result = AttachFormat { attachment, format };
         Ok((result, remaining))
     }
@@ -342,7 +344,7 @@ impl TryFrom<&[u8]> for AttachFormat {
 impl Serialize for AttachFormat {
     type Bytes = [u8; 8];
     fn serialize(&self) -> Self::Bytes {
-        let attachment_bytes = self.attachment.serialize();
+        let attachment_bytes = Into::<u32>::into(self.attachment).serialize();
         let format_bytes = self.format.serialize();
         [
             attachment_bytes[0],
@@ -357,7 +359,7 @@ impl Serialize for AttachFormat {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
-        self.attachment.serialize_into(bytes);
+        Into::<u32>::into(self.attachment).serialize_into(bytes);
         self.format.serialize_into(bytes);
     }
 }
@@ -1165,7 +1167,7 @@ pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 0;
 pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event_type: u16,
+    pub event_type: EventType,
     pub drawable: DRAWABLE,
     pub ust_hi: u32,
     pub ust_lo: u32,
@@ -1186,6 +1188,7 @@ impl BufferSwapCompleteEvent {
         let (msc_hi, remaining) = u32::try_parse(remaining)?;
         let (msc_lo, remaining) = u32::try_parse(remaining)?;
         let (sbc, remaining) = u32::try_parse(remaining)?;
+        let event_type = event_type.try_into()?;
         let result = BufferSwapCompleteEvent { response_type, sequence, event_type, drawable, ust_hi, ust_lo, msc_hi, msc_lo, sbc };
         Ok((result, remaining))
     }
@@ -1210,7 +1213,7 @@ impl From<&BufferSwapCompleteEvent> for [u8; 32] {
     fn from(input: &BufferSwapCompleteEvent) -> Self {
         let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
-        let event_type = input.event_type.serialize();
+        let event_type = Into::<u16>::into(input.event_type).serialize();
         let drawable = input.drawable.serialize();
         let ust_hi = input.ust_hi.serialize();
         let ust_lo = input.ust_lo.serialize();

--- a/src/generated/dri2.rs
+++ b/src/generated/dri2.rs
@@ -1208,6 +1208,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for BufferSwapCompleteEvent {
 }
 impl From<&BufferSwapCompleteEvent> for [u8; 32] {
     fn from(input: &BufferSwapCompleteEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event_type = input.event_type.serialize();
         let drawable = input.drawable.serialize();
@@ -1217,7 +1218,7 @@ impl From<&BufferSwapCompleteEvent> for [u8; 32] {
         let msc_lo = input.msc_lo.serialize();
         let sbc = input.sbc.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event_type[0], event_type[1], 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], event_type[0], event_type[1], 0, 0,
             drawable[0], drawable[1], drawable[2], drawable[3], ust_hi[0], ust_hi[1], ust_hi[2], ust_hi[3],
             ust_lo[0], ust_lo[1], ust_lo[2], ust_lo[3], msc_hi[0], msc_hi[1], msc_hi[2], msc_hi[3],
             msc_lo[0], msc_lo[1], msc_lo[2], msc_lo[3], sbc[0], sbc[1], sbc[2], sbc[3]
@@ -1266,10 +1267,11 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for InvalidateBuffersEvent {
 }
 impl From<&InvalidateBuffersEvent> for [u8; 32] {
     fn from(input: &InvalidateBuffersEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let drawable = input.drawable.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
+            response_type[0], 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/glx.rs
+++ b/src/generated/glx.rs
@@ -95,12 +95,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for GenericError {
 }
 impl From<&GenericError> for [u8; 32] {
     fn from(input: &GenericError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -154,12 +157,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadContextErro
 }
 impl From<&BadContextError> for [u8; 32] {
     fn from(input: &BadContextError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -213,12 +219,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadContextStat
 }
 impl From<&BadContextStateError> for [u8; 32] {
     fn from(input: &BadContextStateError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -272,12 +281,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadDrawableErr
 }
 impl From<&BadDrawableError> for [u8; 32] {
     fn from(input: &BadDrawableError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -331,12 +343,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadPixmapError
 }
 impl From<&BadPixmapError> for [u8; 32] {
     fn from(input: &BadPixmapError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -390,12 +405,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadContextTagE
 }
 impl From<&BadContextTagError> for [u8; 32] {
     fn from(input: &BadContextTagError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -449,12 +467,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadCurrentWind
 }
 impl From<&BadCurrentWindowError> for [u8; 32] {
     fn from(input: &BadCurrentWindowError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -508,12 +529,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadRenderReque
 }
 impl From<&BadRenderRequestError> for [u8; 32] {
     fn from(input: &BadRenderRequestError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -567,12 +591,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadLargeReques
 }
 impl From<&BadLargeRequestError> for [u8; 32] {
     fn from(input: &BadLargeRequestError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -626,12 +653,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for UnsupportedPri
 }
 impl From<&UnsupportedPrivateRequestError> for [u8; 32] {
     fn from(input: &UnsupportedPrivateRequestError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -685,12 +715,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadFBConfigErr
 }
 impl From<&BadFBConfigError> for [u8; 32] {
     fn from(input: &BadFBConfigError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -744,12 +777,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadPbufferErro
 }
 impl From<&BadPbufferError> for [u8; 32] {
     fn from(input: &BadPbufferError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -803,12 +839,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadCurrentDraw
 }
 impl From<&BadCurrentDrawableError> for [u8; 32] {
     fn from(input: &BadCurrentDrawableError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -862,12 +901,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for BadWindowError
 }
 impl From<&BadWindowError> for [u8; 32] {
     fn from(input: &BadWindowError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -921,12 +963,15 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericError<B>> for GLXBadProfileA
 }
 impl From<&GLXBadProfileARBError> for [u8; 32] {
     fn from(input: &GLXBadProfileARBError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -993,6 +1038,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for PbufferClobberEvent {
 }
 impl From<&PbufferClobberEvent> for [u8; 32] {
     fn from(input: &PbufferClobberEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event_type = input.event_type.serialize();
         let draw_type = input.draw_type.serialize();
@@ -1005,7 +1051,7 @@ impl From<&PbufferClobberEvent> for [u8; 32] {
         let height = input.height.serialize();
         let count = input.count.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event_type[0], event_type[1], draw_type[0], draw_type[1],
+            response_type[0], 0, sequence[0], sequence[1], event_type[0], event_type[1], draw_type[0], draw_type[1],
             drawable[0], drawable[1], drawable[2], drawable[3], b_mask[0], b_mask[1], b_mask[2], b_mask[3],
             aux_buffer[0], aux_buffer[1], x[0], x[1], y[0], y[1], width[0], width[1],
             height[0], height[1], count[0], count[1], 0, 0, 0, 0
@@ -1067,6 +1113,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for BufferSwapCompleteEvent {
 }
 impl From<&BufferSwapCompleteEvent> for [u8; 32] {
     fn from(input: &BufferSwapCompleteEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event_type = input.event_type.serialize();
         let drawable = input.drawable.serialize();
@@ -1076,7 +1123,7 @@ impl From<&BufferSwapCompleteEvent> for [u8; 32] {
         let msc_lo = input.msc_lo.serialize();
         let sbc = input.sbc.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event_type[0], event_type[1], 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], event_type[0], event_type[1], 0, 0,
             drawable[0], drawable[1], drawable[2], drawable[3], ust_hi[0], ust_hi[1], ust_hi[2], ust_hi[3],
             ust_lo[0], ust_lo[1], ust_lo[2], ust_lo[3], msc_hi[0], msc_hi[1], msc_hi[2], msc_hi[3],
             msc_lo[0], msc_lo[1], msc_lo[2], msc_lo[3], sbc[0], sbc[1], sbc[2], sbc[3]

--- a/src/generated/present.rs
+++ b/src/generated/present.rs
@@ -943,8 +943,8 @@ pub struct CompleteNotifyEvent {
     pub sequence: u16,
     pub length: u32,
     pub event_type: u16,
-    pub kind: u8,
-    pub mode: u8,
+    pub kind: CompleteKind,
+    pub mode: CompleteMode,
     pub event: EVENT,
     pub window: WINDOW,
     pub serial: u32,
@@ -965,6 +965,8 @@ impl CompleteNotifyEvent {
         let (serial, remaining) = u32::try_parse(remaining)?;
         let (ust, remaining) = u64::try_parse(remaining)?;
         let (msc, remaining) = u64::try_parse(remaining)?;
+        let kind = kind.try_into()?;
+        let mode = mode.try_into()?;
         let result = CompleteNotifyEvent { response_type, extension, sequence, length, event_type, kind, mode, event, window, serial, ust, msc };
         Ok((result, remaining))
     }

--- a/src/generated/present.rs
+++ b/src/generated/present.rs
@@ -851,12 +851,14 @@ impl<B: AsRef<[u8]>> From<&crate::x11_utils::GenericEvent<B>> for GenericEvent {
 }
 impl From<&GenericEvent> for [u8; 32] {
     fn from(input: &GenericEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let extension = input.extension.serialize();
         let sequence = input.sequence.serialize();
         let length = input.length.serialize();
         let evtype = input.evtype.serialize();
         let event = input.event.serialize();
         [
-            input.response_type, input.extension, sequence[0], sequence[1], length[0], length[1], length[2], length[3],
+            response_type[0], extension[0], sequence[0], sequence[1], length[0], length[1], length[2], length[3],
             evtype[0], evtype[1], 0, 0, event[0], event[1], event[2], event[3],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/randr.rs
+++ b/src/generated/randr.rs
@@ -84,9 +84,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadOutputError {
 }
 impl From<&BadOutputError> for [u8; 32] {
     fn from(input: &BadOutputError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -134,9 +136,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadCrtcError {
 }
 impl From<&BadCrtcError> for [u8; 32] {
     fn from(input: &BadCrtcError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -184,9 +188,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadModeError {
 }
 impl From<&BadModeError> for [u8; 32] {
     fn from(input: &BadModeError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -234,9 +240,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadProviderError {
 }
 impl From<&BadProviderError> for [u8; 32] {
     fn from(input: &BadProviderError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -3238,6 +3246,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ScreenChangeNotifyEvent {
 }
 impl From<&ScreenChangeNotifyEvent> for [u8; 32] {
     fn from(input: &ScreenChangeNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let rotation = input.rotation.serialize();
         let sequence = input.sequence.serialize();
         let timestamp = input.timestamp.serialize();
         let config_timestamp = input.config_timestamp.serialize();
@@ -3250,7 +3260,7 @@ impl From<&ScreenChangeNotifyEvent> for [u8; 32] {
         let mwidth = input.mwidth.serialize();
         let mheight = input.mheight.serialize();
         [
-            input.response_type, input.rotation, sequence[0], sequence[1], timestamp[0], timestamp[1], timestamp[2], timestamp[3],
+            response_type[0], rotation[0], sequence[0], sequence[1], timestamp[0], timestamp[1], timestamp[2], timestamp[3],
             config_timestamp[0], config_timestamp[1], config_timestamp[2], config_timestamp[3], root[0], root[1], root[2], root[3],
             request_window[0], request_window[1], request_window[2], request_window[3], size_id[0], size_id[1], subpixel_order[0], subpixel_order[1],
             width[0], width[1], height[0], height[1], mwidth[0], mwidth[1], mheight[0], mheight[1]
@@ -4311,10 +4321,12 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NotifyEvent {
 }
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let sub_code = input.sub_code.serialize();
         let sequence = input.sequence.serialize();
         let u = input.u.serialize();
         [
-            input.response_type, input.sub_code, sequence[0], sequence[1], u[0], u[1], u[2], u[3],
+            response_type[0], sub_code[0], sequence[0], sequence[1], u[0], u[1], u[2], u[3],
             u[4], u[5], u[6], u[7], u[8], u[9], u[10], u[11],
             u[12], u[13], u[14], u[15], u[16], u[17], u[18], u[19],
             u[20], u[21], u[22], u[23], u[24], u[25], u[26], u[27]

--- a/src/generated/record.rs
+++ b/src/generated/record.rs
@@ -445,10 +445,12 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadContextError {
 }
 impl From<&BadContextError> for [u8; 32] {
     fn from(input: &BadContextError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let invalid_record = input.invalid_record.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], invalid_record[0], invalid_record[1], invalid_record[2], invalid_record[3],
+            response_type[0], error_code[0], sequence[0], sequence[1], invalid_record[0], invalid_record[1], invalid_record[2], invalid_record[3],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/render.rs
+++ b/src/generated/render.rs
@@ -764,9 +764,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for PictFormatError {
 }
 impl From<&PictFormatError> for [u8; 32] {
     fn from(input: &PictFormatError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -814,9 +816,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for PictureError {
 }
 impl From<&PictureError> for [u8; 32] {
     fn from(input: &PictureError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -864,9 +868,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for PictOpError {
 }
 impl From<&PictOpError> for [u8; 32] {
     fn from(input: &PictOpError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -914,9 +920,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for GlyphSetError {
 }
 impl From<&GlyphSetError> for [u8; 32] {
     fn from(input: &GlyphSetError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -964,9 +972,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for GlyphError {
 }
 impl From<&GlyphError> for [u8; 32] {
     fn from(input: &GlyphError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/render.rs
+++ b/src/generated/render.rs
@@ -1066,7 +1066,7 @@ impl Serialize for Directformat {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pictforminfo {
     pub id: PICTFORMAT,
-    pub type_: u8,
+    pub type_: PictType,
     pub depth: u8,
     pub direct: Directformat,
     pub colormap: COLORMAP,
@@ -1079,6 +1079,7 @@ impl TryParse for Pictforminfo {
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (direct, remaining) = Directformat::try_parse(remaining)?;
         let (colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let type_ = type_.try_into()?;
         let result = Pictforminfo { id, type_, depth, direct, colormap };
         Ok((result, remaining))
     }
@@ -1093,7 +1094,7 @@ impl Serialize for Pictforminfo {
     type Bytes = [u8; 28];
     fn serialize(&self) -> Self::Bytes {
         let id_bytes = self.id.serialize();
-        let type_bytes = self.type_.serialize();
+        let type_bytes = Into::<u8>::into(self.type_).serialize();
         let depth_bytes = self.depth.serialize();
         let direct_bytes = self.direct.serialize();
         let colormap_bytes = self.colormap.serialize();
@@ -1131,7 +1132,7 @@ impl Serialize for Pictforminfo {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(28);
         self.id.serialize_into(bytes);
-        self.type_.serialize_into(bytes);
+        Into::<u8>::into(self.type_).serialize_into(bytes);
         self.depth.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
         self.direct.serialize_into(bytes);

--- a/src/generated/screensaver.rs
+++ b/src/generated/screensaver.rs
@@ -735,14 +735,18 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NotifyEvent {
 }
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let state = input.state.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
         let window = input.window.serialize();
+        let kind = input.kind.serialize();
+        let forced = input.forced.serialize();
         [
-            input.response_type, input.state, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], state[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], window[0], window[1], window[2], window[3],
-            input.kind, u8::from(input.forced), 0, 0, 0, 0, 0, 0,
+            kind[0], forced[0], 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
     }

--- a/src/generated/shape.rs
+++ b/src/generated/shape.rs
@@ -227,6 +227,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NotifyEvent {
 }
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let shape_kind = input.shape_kind.serialize();
         let sequence = input.sequence.serialize();
         let affected_window = input.affected_window.serialize();
         let extents_x = input.extents_x.serialize();
@@ -234,10 +236,11 @@ impl From<&NotifyEvent> for [u8; 32] {
         let extents_width = input.extents_width.serialize();
         let extents_height = input.extents_height.serialize();
         let server_time = input.server_time.serialize();
+        let shaped = input.shaped.serialize();
         [
-            input.response_type, input.shape_kind, sequence[0], sequence[1], affected_window[0], affected_window[1], affected_window[2], affected_window[3],
+            response_type[0], shape_kind[0], sequence[0], sequence[1], affected_window[0], affected_window[1], affected_window[2], affected_window[3],
             extents_x[0], extents_x[1], extents_y[0], extents_y[1], extents_width[0], extents_width[1], extents_height[0], extents_height[1],
-            server_time[0], server_time[1], server_time[2], server_time[3], u8::from(input.shaped), 0, 0, 0,
+            server_time[0], server_time[1], server_time[2], server_time[3], shaped[0], 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
     }

--- a/src/generated/shm.rs
+++ b/src/generated/shm.rs
@@ -84,14 +84,16 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CompletionEvent {
 }
 impl From<&CompletionEvent> for [u8; 32] {
     fn from(input: &CompletionEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let drawable = input.drawable.serialize();
         let minor_event = input.minor_event.serialize();
+        let major_event = input.major_event.serialize();
         let shmseg = input.shmseg.serialize();
         let offset = input.offset.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
-            minor_event[0], minor_event[1], input.major_event, 0, shmseg[0], shmseg[1], shmseg[2], shmseg[3],
+            response_type[0], 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
+            minor_event[0], minor_event[1], major_event[0], 0, shmseg[0], shmseg[1], shmseg[2], shmseg[3],
             offset[0], offset[1], offset[2], offset[3], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -145,12 +147,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadSegError {
 }
 impl From<&BadSegError> for [u8; 32] {
     fn from(input: &BadSegError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]

--- a/src/generated/sync.rs
+++ b/src/generated/sync.rs
@@ -565,12 +565,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for CounterError {
 }
 impl From<&CounterError> for [u8; 32] {
     fn from(input: &CounterError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_counter = input.bad_counter.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_counter[0], bad_counter[1], bad_counter[2], bad_counter[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, /* trailing padding */ 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_counter[0], bad_counter[1], bad_counter[2], bad_counter[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], /* trailing padding */ 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -623,12 +626,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for AlarmError {
 }
 impl From<&AlarmError> for [u8; 32] {
     fn from(input: &AlarmError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_alarm = input.bad_alarm.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_alarm[0], bad_alarm[1], bad_alarm[2], bad_alarm[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, /* trailing padding */ 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_alarm[0], bad_alarm[1], bad_alarm[2], bad_alarm[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], /* trailing padding */ 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -1593,17 +1599,20 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CounterNotifyEvent {
 }
 impl From<&CounterNotifyEvent> for [u8; 32] {
     fn from(input: &CounterNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let kind = input.kind.serialize();
         let sequence = input.sequence.serialize();
         let counter = input.counter.serialize();
         let wait_value = input.wait_value.serialize();
         let counter_value = input.counter_value.serialize();
         let timestamp = input.timestamp.serialize();
         let count = input.count.serialize();
+        let destroyed = input.destroyed.serialize();
         [
-            input.response_type, input.kind, sequence[0], sequence[1], counter[0], counter[1], counter[2], counter[3],
+            response_type[0], kind[0], sequence[0], sequence[1], counter[0], counter[1], counter[2], counter[3],
             wait_value[0], wait_value[1], wait_value[2], wait_value[3], wait_value[4], wait_value[5], wait_value[6], wait_value[7],
             counter_value[0], counter_value[1], counter_value[2], counter_value[3], counter_value[4], counter_value[5], counter_value[6], counter_value[7],
-            timestamp[0], timestamp[1], timestamp[2], timestamp[3], count[0], count[1], u8::from(input.destroyed), 0
+            timestamp[0], timestamp[1], timestamp[2], timestamp[3], count[0], count[1], destroyed[0], 0
         ]
     }
 }
@@ -1659,16 +1668,19 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for AlarmNotifyEvent {
 }
 impl From<&AlarmNotifyEvent> for [u8; 32] {
     fn from(input: &AlarmNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let kind = input.kind.serialize();
         let sequence = input.sequence.serialize();
         let alarm = input.alarm.serialize();
         let counter_value = input.counter_value.serialize();
         let alarm_value = input.alarm_value.serialize();
         let timestamp = input.timestamp.serialize();
+        let state = input.state.serialize();
         [
-            input.response_type, input.kind, sequence[0], sequence[1], alarm[0], alarm[1], alarm[2], alarm[3],
+            response_type[0], kind[0], sequence[0], sequence[1], alarm[0], alarm[1], alarm[2], alarm[3],
             counter_value[0], counter_value[1], counter_value[2], counter_value[3], counter_value[4], counter_value[5], counter_value[6], counter_value[7],
             alarm_value[0], alarm_value[1], alarm_value[2], alarm_value[3], alarm_value[4], alarm_value[5], alarm_value[6], alarm_value[7],
-            timestamp[0], timestamp[1], timestamp[2], timestamp[3], input.state, 0, 0, 0
+            timestamp[0], timestamp[1], timestamp[2], timestamp[3], state[0], 0, 0, 0
         ]
     }
 }

--- a/src/generated/xf86vidmode.rs
+++ b/src/generated/xf86vidmode.rs
@@ -1677,9 +1677,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadClockError {
 }
 impl From<&BadClockError> for [u8; 32] {
     fn from(input: &BadClockError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1727,9 +1729,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadHTimingsError {
 }
 impl From<&BadHTimingsError> for [u8; 32] {
     fn from(input: &BadHTimingsError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1777,9 +1781,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadVTimingsError {
 }
 impl From<&BadVTimingsError> for [u8; 32] {
     fn from(input: &BadVTimingsError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1827,9 +1833,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ModeUnsuitableError {
 }
 impl From<&ModeUnsuitableError> for [u8; 32] {
     fn from(input: &ModeUnsuitableError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1877,9 +1885,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ExtensionDisabledError {
 }
 impl From<&ExtensionDisabledError> for [u8; 32] {
     fn from(input: &ExtensionDisabledError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1927,9 +1937,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ClientNotLocalError {
 }
 impl From<&ClientNotLocalError> for [u8; 32] {
     fn from(input: &ClientNotLocalError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1977,9 +1989,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ZoomLockedError {
 }
 impl From<&ZoomLockedError> for [u8; 32] {
     fn from(input: &ZoomLockedError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/xfixes.rs
+++ b/src/generated/xfixes.rs
@@ -455,7 +455,7 @@ pub const SELECTION_NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
-    pub subtype: u8,
+    pub subtype: SelectionEvent,
     pub sequence: u16,
     pub window: WINDOW,
     pub owner: WINDOW,
@@ -474,6 +474,7 @@ impl SelectionNotifyEvent {
         let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
         let (selection_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let subtype = subtype.try_into()?;
         let result = SelectionNotifyEvent { response_type, subtype, sequence, window, owner, selection, timestamp, selection_timestamp };
         Ok((result, remaining))
     }
@@ -497,7 +498,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for SelectionNotifyEvent {
 impl From<&SelectionNotifyEvent> for [u8; 32] {
     fn from(input: &SelectionNotifyEvent) -> Self {
         let response_type = input.response_type.serialize();
-        let subtype = input.subtype.serialize();
+        let subtype = Into::<u8>::into(input.subtype).serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let owner = input.owner.serialize();
@@ -677,7 +678,7 @@ pub const CURSOR_NOTIFY_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CursorNotifyEvent {
     pub response_type: u8,
-    pub subtype: u8,
+    pub subtype: CursorNotify,
     pub sequence: u16,
     pub window: WINDOW,
     pub cursor_serial: u32,
@@ -694,6 +695,7 @@ impl CursorNotifyEvent {
         let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
         let (name, remaining) = ATOM::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let subtype = subtype.try_into()?;
         let result = CursorNotifyEvent { response_type, subtype, sequence, window, cursor_serial, timestamp, name };
         Ok((result, remaining))
     }
@@ -717,7 +719,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CursorNotifyEvent {
 impl From<&CursorNotifyEvent> for [u8; 32] {
     fn from(input: &CursorNotifyEvent) -> Self {
         let response_type = input.response_type.serialize();
-        let subtype = input.subtype.serialize();
+        let subtype = Into::<u8>::into(input.subtype).serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let cursor_serial = input.cursor_serial.serialize();

--- a/src/generated/xfixes.rs
+++ b/src/generated/xfixes.rs
@@ -496,6 +496,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for SelectionNotifyEvent {
 }
 impl From<&SelectionNotifyEvent> for [u8; 32] {
     fn from(input: &SelectionNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let subtype = input.subtype.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let owner = input.owner.serialize();
@@ -503,7 +505,7 @@ impl From<&SelectionNotifyEvent> for [u8; 32] {
         let timestamp = input.timestamp.serialize();
         let selection_timestamp = input.selection_timestamp.serialize();
         [
-            input.response_type, input.subtype, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            response_type[0], subtype[0], sequence[0], sequence[1], window[0], window[1], window[2], window[3],
             owner[0], owner[1], owner[2], owner[3], selection[0], selection[1], selection[2], selection[3],
             timestamp[0], timestamp[1], timestamp[2], timestamp[3], selection_timestamp[0], selection_timestamp[1], selection_timestamp[2], selection_timestamp[3],
             0, 0, 0, 0, 0, 0, 0, 0
@@ -714,13 +716,15 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CursorNotifyEvent {
 }
 impl From<&CursorNotifyEvent> for [u8; 32] {
     fn from(input: &CursorNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let subtype = input.subtype.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let cursor_serial = input.cursor_serial.serialize();
         let timestamp = input.timestamp.serialize();
         let name = input.name.serialize();
         [
-            input.response_type, input.subtype, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            response_type[0], subtype[0], sequence[0], sequence[1], window[0], window[1], window[2], window[3],
             cursor_serial[0], cursor_serial[1], cursor_serial[2], cursor_serial[3], timestamp[0], timestamp[1], timestamp[2], timestamp[3],
             name[0], name[1], name[2], name[3], 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -859,9 +863,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadRegionError {
 }
 impl From<&BadRegionError> for [u8; 32] {
     fn from(input: &BadRegionError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/xinput.rs
+++ b/src/generated/xinput.rs
@@ -10942,8 +10942,12 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceValuatorEvent {
 }
 impl From<&DeviceValuatorEvent> for [u8; 32] {
     fn from(input: &DeviceValuatorEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let device_id = input.device_id.serialize();
         let sequence = input.sequence.serialize();
         let device_state = input.device_state.serialize();
+        let num_valuators = input.num_valuators.serialize();
+        let first_valuator = input.first_valuator.serialize();
         let valuators_0 = input.valuators[0].serialize();
         let valuators_1 = input.valuators[1].serialize();
         let valuators_2 = input.valuators[2].serialize();
@@ -10951,7 +10955,7 @@ impl From<&DeviceValuatorEvent> for [u8; 32] {
         let valuators_4 = input.valuators[4].serialize();
         let valuators_5 = input.valuators[5].serialize();
         [
-            input.response_type, input.device_id, sequence[0], sequence[1], device_state[0], device_state[1], input.num_valuators, input.first_valuator,
+            response_type[0], device_id[0], sequence[0], sequence[1], device_state[0], device_state[1], num_valuators[0], first_valuator[0],
             valuators_0[0], valuators_0[1], valuators_0[2], valuators_0[3], valuators_1[0], valuators_1[1], valuators_1[2], valuators_1[3],
             valuators_2[0], valuators_2[1], valuators_2[2], valuators_2[3], valuators_3[0], valuators_3[1], valuators_3[2], valuators_3[3],
             valuators_4[0], valuators_4[1], valuators_4[2], valuators_4[3], valuators_5[0], valuators_5[1], valuators_5[2], valuators_5[3]
@@ -11081,6 +11085,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceKeyPressEvent {
 }
 impl From<&DeviceKeyPressEvent> for [u8; 32] {
     fn from(input: &DeviceKeyPressEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -11091,11 +11097,13 @@ impl From<&DeviceKeyPressEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), input.device_id
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], device_id[0]
         ]
     }
 }
@@ -11162,6 +11170,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceKeyReleaseEvent {
 }
 impl From<&DeviceKeyReleaseEvent> for [u8; 32] {
     fn from(input: &DeviceKeyReleaseEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -11172,11 +11182,13 @@ impl From<&DeviceKeyReleaseEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), input.device_id
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], device_id[0]
         ]
     }
 }
@@ -11243,6 +11255,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceButtonPressEvent {
 }
 impl From<&DeviceButtonPressEvent> for [u8; 32] {
     fn from(input: &DeviceButtonPressEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -11253,11 +11267,13 @@ impl From<&DeviceButtonPressEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), input.device_id
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], device_id[0]
         ]
     }
 }
@@ -11324,6 +11340,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceButtonReleaseEvent {
 }
 impl From<&DeviceButtonReleaseEvent> for [u8; 32] {
     fn from(input: &DeviceButtonReleaseEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -11334,11 +11352,13 @@ impl From<&DeviceButtonReleaseEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), input.device_id
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], device_id[0]
         ]
     }
 }
@@ -11405,6 +11425,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceMotionNotifyEvent {
 }
 impl From<&DeviceMotionNotifyEvent> for [u8; 32] {
     fn from(input: &DeviceMotionNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -11415,11 +11437,13 @@ impl From<&DeviceMotionNotifyEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), input.device_id
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], device_id[0]
         ]
     }
 }
@@ -11473,12 +11497,16 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceFocusInEvent {
 }
 impl From<&DeviceFocusInEvent> for [u8; 32] {
     fn from(input: &DeviceFocusInEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let window = input.window.serialize();
+        let mode = input.mode.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            window[0], window[1], window[2], window[3], input.mode, input.device_id, 0, 0,
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            window[0], window[1], window[2], window[3], mode[0], device_id[0], 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -11534,12 +11562,16 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceFocusOutEvent {
 }
 impl From<&DeviceFocusOutEvent> for [u8; 32] {
     fn from(input: &DeviceFocusOutEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let window = input.window.serialize();
+        let mode = input.mode.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            window[0], window[1], window[2], window[3], input.mode, input.device_id, 0, 0,
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            window[0], window[1], window[2], window[3], mode[0], device_id[0], 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -11608,6 +11640,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ProximityInEvent {
 }
 impl From<&ProximityInEvent> for [u8; 32] {
     fn from(input: &ProximityInEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -11618,11 +11652,13 @@ impl From<&ProximityInEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), input.device_id
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], device_id[0]
         ]
     }
 }
@@ -11689,6 +11725,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ProximityOutEvent {
 }
 impl From<&ProximityOutEvent> for [u8; 32] {
     fn from(input: &ProximityOutEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -11699,11 +11737,13 @@ impl From<&ProximityOutEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), input.device_id
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], device_id[0]
         ]
     }
 }
@@ -11861,14 +11901,20 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceStateNotifyEvent {
 }
 impl From<&DeviceStateNotifyEvent> for [u8; 32] {
     fn from(input: &DeviceStateNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let device_id = input.device_id.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let num_keys = input.num_keys.serialize();
+        let num_buttons = input.num_buttons.serialize();
+        let num_valuators = input.num_valuators.serialize();
+        let classes_reported = input.classes_reported.serialize();
         let valuators_0 = input.valuators[0].serialize();
         let valuators_1 = input.valuators[1].serialize();
         let valuators_2 = input.valuators[2].serialize();
         [
-            input.response_type, input.device_id, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.num_keys, input.num_buttons, input.num_valuators, input.classes_reported, input.buttons[0], input.buttons[1], input.buttons[2], input.buttons[3],
+            response_type[0], device_id[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            num_keys[0], num_buttons[0], num_valuators[0], classes_reported[0], input.buttons[0], input.buttons[1], input.buttons[2], input.buttons[3],
             input.keys[0], input.keys[1], input.keys[2], input.keys[3], valuators_0[0], valuators_0[1], valuators_0[2], valuators_0[3],
             valuators_1[0], valuators_1[1], valuators_1[2], valuators_1[3], valuators_2[0], valuators_2[1], valuators_2[2], valuators_2[3]
         ]
@@ -11925,10 +11971,15 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceMappingNotifyEvent {
 }
 impl From<&DeviceMappingNotifyEvent> for [u8; 32] {
     fn from(input: &DeviceMappingNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let device_id = input.device_id.serialize();
         let sequence = input.sequence.serialize();
+        let request = input.request.serialize();
+        let first_keycode = input.first_keycode.serialize();
+        let count = input.count.serialize();
         let time = input.time.serialize();
         [
-            input.response_type, input.device_id, sequence[0], sequence[1], input.request, input.first_keycode, input.count, 0,
+            response_type[0], device_id[0], sequence[0], sequence[1], request[0], first_keycode[0], count[0], 0,
             time[0], time[1], time[2], time[3], 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -12043,11 +12094,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ChangeDeviceNotifyEvent {
 }
 impl From<&ChangeDeviceNotifyEvent> for [u8; 32] {
     fn from(input: &ChangeDeviceNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let device_id = input.device_id.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let request = input.request.serialize();
         [
-            input.response_type, input.device_id, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.request, 0, 0, 0, 0, 0, 0, 0,
+            response_type[0], device_id[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            request[0], 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -12153,9 +12207,11 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceKeyStateNotifyEvent {
 }
 impl From<&DeviceKeyStateNotifyEvent> for [u8; 32] {
     fn from(input: &DeviceKeyStateNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let device_id = input.device_id.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.device_id, sequence[0], sequence[1], input.keys[0], input.keys[1], input.keys[2], input.keys[3],
+            response_type[0], device_id[0], sequence[0], sequence[1], input.keys[0], input.keys[1], input.keys[2], input.keys[3],
             input.keys[4], input.keys[5], input.keys[6], input.keys[7], input.keys[8], input.keys[9], input.keys[10], input.keys[11],
             input.keys[12], input.keys[13], input.keys[14], input.keys[15], input.keys[16], input.keys[17], input.keys[18], input.keys[19],
             input.keys[20], input.keys[21], input.keys[22], input.keys[23], input.keys[24], input.keys[25], input.keys[26], input.keys[27]
@@ -12262,9 +12318,11 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DeviceButtonStateNotifyEvent {
 }
 impl From<&DeviceButtonStateNotifyEvent> for [u8; 32] {
     fn from(input: &DeviceButtonStateNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let device_id = input.device_id.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.device_id, sequence[0], sequence[1], input.buttons[0], input.buttons[1], input.buttons[2], input.buttons[3],
+            response_type[0], device_id[0], sequence[0], sequence[1], input.buttons[0], input.buttons[1], input.buttons[2], input.buttons[3],
             input.buttons[4], input.buttons[5], input.buttons[6], input.buttons[7], input.buttons[8], input.buttons[9], input.buttons[10], input.buttons[11],
             input.buttons[12], input.buttons[13], input.buttons[14], input.buttons[15], input.buttons[16], input.buttons[17], input.buttons[18], input.buttons[19],
             input.buttons[20], input.buttons[21], input.buttons[22], input.buttons[23], input.buttons[24], input.buttons[25], input.buttons[26], input.buttons[27]
@@ -12394,12 +12452,15 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DevicePresenceNotifyEvent {
 }
 impl From<&DevicePresenceNotifyEvent> for [u8; 32] {
     fn from(input: &DevicePresenceNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let devchange = input.devchange.serialize();
+        let device_id = input.device_id.serialize();
         let control = input.control.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.devchange, input.device_id, control[0], control[1], 0, 0, 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            devchange[0], device_id[0], control[0], control[1], 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -12453,14 +12514,17 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DevicePropertyNotifyEvent {
 }
 impl From<&DevicePropertyNotifyEvent> for [u8; 32] {
     fn from(input: &DevicePropertyNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let state = input.state.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let property = input.property.serialize();
+        let device_id = input.device_id.serialize();
         [
-            input.response_type, input.state, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], state[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             property[0], property[1], property[2], property[3], 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, input.device_id
+            0, 0, 0, 0, 0, 0, 0, device_id[0]
         ]
     }
 }
@@ -15101,9 +15165,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for DeviceError {
 }
 impl From<&DeviceError> for [u8; 32] {
     fn from(input: &DeviceError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -15151,9 +15217,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for EventError {
 }
 impl From<&EventError> for [u8; 32] {
     fn from(input: &EventError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -15201,9 +15269,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ModeError {
 }
 impl From<&ModeError> for [u8; 32] {
     fn from(input: &ModeError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -15251,9 +15321,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for DeviceBusyError {
 }
 impl From<&DeviceBusyError> for [u8; 32] {
     fn from(input: &DeviceBusyError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -15301,9 +15373,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ClassError {
 }
 impl From<&ClassError> for [u8; 32] {
     fn from(input: &ClassError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/xkb.rs
+++ b/src/generated/xkb.rs
@@ -4164,12 +4164,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for KeyboardError {
 }
 impl From<&KeyboardError> for [u8; 32] {
     fn from(input: &KeyboardError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let value = input.value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], value[0], value[1], value[2], value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], value[0], value[1], value[2], value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -9378,12 +9381,22 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NewKeyboardNotifyEvent {
 }
 impl From<&NewKeyboardNotifyEvent> for [u8; 32] {
     fn from(input: &NewKeyboardNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let old_device_id = input.old_device_id.serialize();
+        let min_key_code = input.min_key_code.serialize();
+        let max_key_code = input.max_key_code.serialize();
+        let old_min_key_code = input.old_min_key_code.serialize();
+        let old_max_key_code = input.old_max_key_code.serialize();
+        let request_major = input.request_major.serialize();
+        let request_minor = input.request_minor.serialize();
         let changed = input.changed.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.old_device_id, input.min_key_code, input.max_key_code, input.old_min_key_code, input.old_max_key_code, input.request_major, input.request_minor,
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], old_device_id[0], min_key_code[0], max_key_code[0], old_min_key_code[0], old_max_key_code[0], request_major[0], request_minor[0],
             changed[0], changed[1], 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -9473,15 +9486,35 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for MapNotifyEvent {
 }
 impl From<&MapNotifyEvent> for [u8; 32] {
     fn from(input: &MapNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let ptr_btn_actions = input.ptr_btn_actions.serialize();
         let changed = input.changed.serialize();
+        let min_key_code = input.min_key_code.serialize();
+        let max_key_code = input.max_key_code.serialize();
+        let first_type = input.first_type.serialize();
+        let n_types = input.n_types.serialize();
+        let first_key_sym = input.first_key_sym.serialize();
+        let n_key_syms = input.n_key_syms.serialize();
+        let first_key_act = input.first_key_act.serialize();
+        let n_key_acts = input.n_key_acts.serialize();
+        let first_key_behavior = input.first_key_behavior.serialize();
+        let n_key_behavior = input.n_key_behavior.serialize();
+        let first_key_explicit = input.first_key_explicit.serialize();
+        let n_key_explicit = input.n_key_explicit.serialize();
+        let first_mod_map_key = input.first_mod_map_key.serialize();
+        let n_mod_map_keys = input.n_mod_map_keys.serialize();
+        let first_v_mod_map_key = input.first_v_mod_map_key.serialize();
+        let n_v_mod_map_keys = input.n_v_mod_map_keys.serialize();
         let virtual_mods = input.virtual_mods.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.ptr_btn_actions, changed[0], changed[1], input.min_key_code, input.max_key_code, input.first_type, input.n_types,
-            input.first_key_sym, input.n_key_syms, input.first_key_act, input.n_key_acts, input.first_key_behavior, input.n_key_behavior, input.first_key_explicit, input.n_key_explicit,
-            input.first_mod_map_key, input.n_mod_map_keys, input.first_v_mod_map_key, input.n_v_mod_map_keys, virtual_mods[0], virtual_mods[1], 0, 0
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], ptr_btn_actions[0], changed[0], changed[1], min_key_code[0], max_key_code[0], first_type[0], n_types[0],
+            first_key_sym[0], n_key_syms[0], first_key_act[0], n_key_acts[0], first_key_behavior[0], n_key_behavior[0], first_key_explicit[0], n_key_explicit[0],
+            first_mod_map_key[0], n_mod_map_keys[0], first_v_mod_map_key[0], n_v_mod_map_keys[0], virtual_mods[0], virtual_mods[1], 0, 0
         ]
     }
 }
@@ -9568,17 +9601,35 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for StateNotifyEvent {
 }
 impl From<&StateNotifyEvent> for [u8; 32] {
     fn from(input: &StateNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let mods = input.mods.serialize();
+        let base_mods = input.base_mods.serialize();
+        let latched_mods = input.latched_mods.serialize();
+        let locked_mods = input.locked_mods.serialize();
+        let group = input.group.serialize();
         let base_group = input.base_group.serialize();
         let latched_group = input.latched_group.serialize();
+        let locked_group = input.locked_group.serialize();
+        let compat_state = input.compat_state.serialize();
+        let grab_mods = input.grab_mods.serialize();
+        let compat_grab_mods = input.compat_grab_mods.serialize();
+        let lookup_mods = input.lookup_mods.serialize();
+        let compat_loockup_mods = input.compat_loockup_mods.serialize();
         let ptr_btn_state = input.ptr_btn_state.serialize();
         let changed = input.changed.serialize();
+        let keycode = input.keycode.serialize();
+        let event_type = input.event_type.serialize();
+        let request_major = input.request_major.serialize();
+        let request_minor = input.request_minor.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.mods, input.base_mods, input.latched_mods, input.locked_mods, input.group, base_group[0], base_group[1],
-            latched_group[0], latched_group[1], input.locked_group, input.compat_state, input.grab_mods, input.compat_grab_mods, input.lookup_mods, input.compat_loockup_mods,
-            ptr_btn_state[0], ptr_btn_state[1], changed[0], changed[1], input.keycode, input.event_type, input.request_major, input.request_minor
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], mods[0], base_mods[0], latched_mods[0], locked_mods[0], group[0], base_group[0], base_group[1],
+            latched_group[0], latched_group[1], locked_group[0], compat_state[0], grab_mods[0], compat_grab_mods[0], lookup_mods[0], compat_loockup_mods[0],
+            ptr_btn_state[0], ptr_btn_state[1], changed[0], changed[1], keycode[0], event_type[0], request_major[0], request_minor[0]
         ]
     }
 }
@@ -9645,16 +9696,24 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ControlsNotifyEvent {
 }
 impl From<&ControlsNotifyEvent> for [u8; 32] {
     fn from(input: &ControlsNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let num_groups = input.num_groups.serialize();
         let changed_controls = input.changed_controls.serialize();
         let enabled_controls = input.enabled_controls.serialize();
         let enabled_control_changes = input.enabled_control_changes.serialize();
+        let keycode = input.keycode.serialize();
+        let event_type = input.event_type.serialize();
+        let request_major = input.request_major.serialize();
+        let request_minor = input.request_minor.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.num_groups, 0, 0, changed_controls[0], changed_controls[1], changed_controls[2], changed_controls[3],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], num_groups[0], 0, 0, changed_controls[0], changed_controls[1], changed_controls[2], changed_controls[3],
             enabled_controls[0], enabled_controls[1], enabled_controls[2], enabled_controls[3], enabled_control_changes[0], enabled_control_changes[1], enabled_control_changes[2], enabled_control_changes[3],
-            input.keycode, input.event_type, input.request_major, input.request_minor, 0, 0, 0, 0
+            keycode[0], event_type[0], request_major[0], request_minor[0], 0, 0, 0, 0
         ]
     }
 }
@@ -9709,13 +9768,16 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for IndicatorStateNotifyEvent {
 }
 impl From<&IndicatorStateNotifyEvent> for [u8; 32] {
     fn from(input: &IndicatorStateNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
         let state = input.state.serialize();
         let state_changed = input.state_changed.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, 0, 0, 0, state[0], state[1], state[2], state[3],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], 0, 0, 0, state[0], state[1], state[2], state[3],
             state_changed[0], state_changed[1], state_changed[2], state_changed[3], 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -9772,13 +9834,16 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for IndicatorMapNotifyEvent {
 }
 impl From<&IndicatorMapNotifyEvent> for [u8; 32] {
     fn from(input: &IndicatorMapNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
         let state = input.state.serialize();
         let map_changed = input.map_changed.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, 0, 0, 0, state[0], state[1], state[2], state[3],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], 0, 0, 0, state[0], state[1], state[2], state[3],
             map_changed[0], map_changed[1], map_changed[2], map_changed[3], 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -9856,15 +9921,27 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NamesNotifyEvent {
 }
 impl From<&NamesNotifyEvent> for [u8; 32] {
     fn from(input: &NamesNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
         let changed = input.changed.serialize();
+        let first_type = input.first_type.serialize();
+        let n_types = input.n_types.serialize();
+        let first_level_name = input.first_level_name.serialize();
+        let n_level_names = input.n_level_names.serialize();
+        let n_radio_groups = input.n_radio_groups.serialize();
+        let n_key_aliases = input.n_key_aliases.serialize();
+        let changed_group_names = input.changed_group_names.serialize();
         let changed_virtual_mods = input.changed_virtual_mods.serialize();
+        let first_key = input.first_key.serialize();
+        let n_keys = input.n_keys.serialize();
         let changed_indicators = input.changed_indicators.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, 0, changed[0], changed[1], input.first_type, input.n_types, input.first_level_name, input.n_level_names,
-            0, input.n_radio_groups, input.n_key_aliases, input.changed_group_names, changed_virtual_mods[0], changed_virtual_mods[1], input.first_key, input.n_keys,
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], 0, changed[0], changed[1], first_type[0], n_types[0], first_level_name[0], n_level_names[0],
+            0, n_radio_groups[0], n_key_aliases[0], changed_group_names[0], changed_virtual_mods[0], changed_virtual_mods[1], first_key[0], n_keys[0],
             changed_indicators[0], changed_indicators[1], changed_indicators[2], changed_indicators[3], 0, 0, 0, 0
         ]
     }
@@ -9923,14 +10000,18 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CompatMapNotifyEvent {
 }
 impl From<&CompatMapNotifyEvent> for [u8; 32] {
     fn from(input: &CompatMapNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let changed_groups = input.changed_groups.serialize();
         let first_si = input.first_si.serialize();
         let n_si = input.n_si.serialize();
         let n_total_si = input.n_total_si.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.changed_groups, first_si[0], first_si[1], n_si[0], n_si[1], n_total_si[0], n_total_si[1],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], changed_groups[0], first_si[0], first_si[1], n_si[0], n_si[1], n_total_si[0], n_total_si[1],
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -9998,17 +10079,24 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for BellNotifyEvent {
 }
 impl From<&BellNotifyEvent> for [u8; 32] {
     fn from(input: &BellNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let bell_class = input.bell_class.serialize();
+        let bell_id = input.bell_id.serialize();
+        let percent = input.percent.serialize();
         let pitch = input.pitch.serialize();
         let duration = input.duration.serialize();
         let name = input.name.serialize();
         let window = input.window.serialize();
+        let event_only = input.event_only.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.bell_class, input.bell_id, input.percent, pitch[0], pitch[1], duration[0], duration[1],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], bell_class[0], bell_id[0], percent[0], pitch[0], pitch[1], duration[0], duration[1],
             name[0], name[1], name[2], name[3], window[0], window[1], window[2], window[3],
-            u8::from(input.event_only), 0, 0, 0, 0, 0, 0, 0
+            event_only[0], 0, 0, 0, 0, 0, 0, 0
         ]
     }
 }
@@ -10087,11 +10175,19 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ActionMessageEvent {
 }
 impl From<&ActionMessageEvent> for [u8; 32] {
     fn from(input: &ActionMessageEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let keycode = input.keycode.serialize();
+        let press = input.press.serialize();
+        let key_event_follows = input.key_event_follows.serialize();
+        let mods = input.mods.serialize();
+        let group = input.group.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.keycode, u8::from(input.press), u8::from(input.key_event_follows), input.mods, input.group, input.message[0], input.message[1],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], keycode[0], press[0], key_event_follows[0], mods[0], group[0], input.message[0], input.message[1],
             input.message[2], input.message[3], input.message[4], input.message[5], input.message[6], input.message[7], 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -10151,14 +10247,18 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for AccessXNotifyEvent {
 }
 impl From<&AccessXNotifyEvent> for [u8; 32] {
     fn from(input: &AccessXNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
+        let keycode = input.keycode.serialize();
         let detailt = input.detailt.serialize();
         let slow_keys_delay = input.slow_keys_delay.serialize();
         let debounce_delay = input.debounce_delay.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, input.keycode, detailt[0], detailt[1], slow_keys_delay[0], slow_keys_delay[1], debounce_delay[0], debounce_delay[1],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], keycode[0], detailt[0], detailt[1], slow_keys_delay[0], slow_keys_delay[1], debounce_delay[0], debounce_delay[1],
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -10229,20 +10329,25 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ExtensionDeviceNotifyEvent {
 }
 impl From<&ExtensionDeviceNotifyEvent> for [u8; 32] {
     fn from(input: &ExtensionDeviceNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let xkb_type = input.xkb_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
+        let device_id = input.device_id.serialize();
         let reason = input.reason.serialize();
         let led_class = input.led_class.serialize();
         let led_id = input.led_id.serialize();
         let leds_defined = input.leds_defined.serialize();
         let led_state = input.led_state.serialize();
+        let first_button = input.first_button.serialize();
+        let n_buttons = input.n_buttons.serialize();
         let supported = input.supported.serialize();
         let unsupported = input.unsupported.serialize();
         [
-            input.response_type, input.xkb_type, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
-            input.device_id, 0, reason[0], reason[1], led_class[0], led_class[1], led_id[0], led_id[1],
+            response_type[0], xkb_type[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            device_id[0], 0, reason[0], reason[1], led_class[0], led_class[1], led_id[0], led_id[1],
             leds_defined[0], leds_defined[1], leds_defined[2], leds_defined[3], led_state[0], led_state[1], led_state[2], led_state[3],
-            input.first_button, input.n_buttons, supported[0], supported[1], unsupported[0], unsupported[1], 0, 0
+            first_button[0], n_buttons[0], supported[0], supported[1], unsupported[0], unsupported[1], 0, 0
         ]
     }
 }

--- a/src/generated/xprint.rs
+++ b/src/generated/xprint.rs
@@ -1420,11 +1420,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NotifyEvent {
 }
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let context = input.context.serialize();
+        let cancel = input.cancel.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], context[0], context[1], context[2], context[3],
-            u8::from(input.cancel), /* trailing padding */ 0, 0, 0, 0, 0, 0, 0,
+            response_type[0], detail[0], sequence[0], sequence[1], context[0], context[1], context[2], context[3],
+            cancel[0], /* trailing padding */ 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -1473,10 +1476,12 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for AttributNotifyEvent {
 }
 impl From<&AttributNotifyEvent> for [u8; 32] {
     fn from(input: &AttributNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let context = input.context.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], context[0], context[1], context[2], context[3],
+            response_type[0], detail[0], sequence[0], sequence[1], context[0], context[1], context[2], context[3],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1524,9 +1529,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadContextError {
 }
 impl From<&BadContextError> for [u8; 32] {
     fn from(input: &BadContextError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1574,9 +1581,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadSequenceError {
 }
 impl From<&BadSequenceError> for [u8; 32] {
     fn from(input: &BadSequenceError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/generated/xproto.rs
+++ b/src/generated/xproto.rs
@@ -1328,6 +1328,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for KeyPressEvent {
 }
 impl From<&KeyPressEvent> for [u8; 32] {
     fn from(input: &KeyPressEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -1338,11 +1340,12 @@ impl From<&KeyPressEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), 0
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], 0
         ]
     }
 }
@@ -1433,6 +1436,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for KeyReleaseEvent {
 }
 impl From<&KeyReleaseEvent> for [u8; 32] {
     fn from(input: &KeyReleaseEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -1443,11 +1448,12 @@ impl From<&KeyReleaseEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), 0
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], 0
         ]
     }
 }
@@ -1597,6 +1603,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ButtonPressEvent {
 }
 impl From<&ButtonPressEvent> for [u8; 32] {
     fn from(input: &ButtonPressEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -1607,11 +1615,12 @@ impl From<&ButtonPressEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), 0
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], 0
         ]
     }
 }
@@ -1702,6 +1711,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ButtonReleaseEvent {
 }
 impl From<&ButtonReleaseEvent> for [u8; 32] {
     fn from(input: &ButtonReleaseEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -1712,11 +1723,12 @@ impl From<&ButtonReleaseEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), 0
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], 0
         ]
     }
 }
@@ -1869,6 +1881,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for MotionNotifyEvent {
 }
 impl From<&MotionNotifyEvent> for [u8; 32] {
     fn from(input: &MotionNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -1879,11 +1893,12 @@ impl From<&MotionNotifyEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let same_screen = input.same_screen.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], u8::from(input.same_screen), 0
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], same_screen[0], 0
         ]
     }
 }
@@ -2113,6 +2128,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for EnterNotifyEvent {
 }
 impl From<&EnterNotifyEvent> for [u8; 32] {
     fn from(input: &EnterNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -2123,11 +2140,13 @@ impl From<&EnterNotifyEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let mode = input.mode.serialize();
+        let same_screen_focus = input.same_screen_focus.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], input.mode, input.same_screen_focus
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], mode[0], same_screen_focus[0]
         ]
     }
 }
@@ -2209,6 +2228,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for LeaveNotifyEvent {
 }
 impl From<&LeaveNotifyEvent> for [u8; 32] {
     fn from(input: &LeaveNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let root = input.root.serialize();
@@ -2219,11 +2240,13 @@ impl From<&LeaveNotifyEvent> for [u8; 32] {
         let event_x = input.event_x.serialize();
         let event_y = input.event_y.serialize();
         let state = input.state.serialize();
+        let mode = input.mode.serialize();
+        let same_screen_focus = input.same_screen_focus.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], detail[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             root[0], root[1], root[2], root[3], event[0], event[1], event[2], event[3],
             child[0], child[1], child[2], child[3], root_x[0], root_x[1], root_y[0], root_y[1],
-            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], input.mode, input.same_screen_focus
+            event_x[0], event_x[1], event_y[0], event_y[1], state[0], state[1], mode[0], same_screen_focus[0]
         ]
     }
 }
@@ -2280,11 +2303,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for FocusInEvent {
 }
 impl From<&FocusInEvent> for [u8; 32] {
     fn from(input: &FocusInEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
+        let mode = input.mode.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
-            input.mode, 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], detail[0], sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            mode[0], 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -2343,11 +2369,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for FocusOutEvent {
 }
 impl From<&FocusOutEvent> for [u8; 32] {
     fn from(input: &FocusOutEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let detail = input.detail.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
+        let mode = input.mode.serialize();
         [
-            input.response_type, input.detail, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
-            input.mode, 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], detail[0], sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            mode[0], 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -2455,8 +2484,9 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for KeymapNotifyEvent {
 }
 impl From<&KeymapNotifyEvent> for [u8; 32] {
     fn from(input: &KeymapNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         [
-            input.response_type, input.keys[0], input.keys[1], input.keys[2], input.keys[3], input.keys[4], input.keys[5], input.keys[6],
+            response_type[0], input.keys[0], input.keys[1], input.keys[2], input.keys[3], input.keys[4], input.keys[5], input.keys[6],
             input.keys[7], input.keys[8], input.keys[9], input.keys[10], input.keys[11], input.keys[12], input.keys[13], input.keys[14],
             input.keys[15], input.keys[16], input.keys[17], input.keys[18], input.keys[19], input.keys[20], input.keys[21], input.keys[22],
             input.keys[23], input.keys[24], input.keys[25], input.keys[26], input.keys[27], input.keys[28], input.keys[29], input.keys[30]
@@ -2532,6 +2562,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ExposeEvent {
 }
 impl From<&ExposeEvent> for [u8; 32] {
     fn from(input: &ExposeEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let x = input.x.serialize();
@@ -2540,7 +2571,7 @@ impl From<&ExposeEvent> for [u8; 32] {
         let height = input.height.serialize();
         let count = input.count.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            response_type[0], 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
             x[0], x[1], y[0], y[1], width[0], width[1], height[0], height[1],
             count[0], count[1], 0, 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -2604,6 +2635,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for GraphicsExposureEvent {
 }
 impl From<&GraphicsExposureEvent> for [u8; 32] {
     fn from(input: &GraphicsExposureEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let drawable = input.drawable.serialize();
         let x = input.x.serialize();
@@ -2612,10 +2644,11 @@ impl From<&GraphicsExposureEvent> for [u8; 32] {
         let height = input.height.serialize();
         let minor_opcode = input.minor_opcode.serialize();
         let count = input.count.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
+            response_type[0], 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
             x[0], x[1], y[0], y[1], width[0], width[1], height[0], height[1],
-            minor_opcode[0], minor_opcode[1], count[0], count[1], input.major_opcode, 0, 0, 0,
+            minor_opcode[0], minor_opcode[1], count[0], count[1], major_opcode[0], 0, 0, 0,
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0
         ]
     }
@@ -2667,12 +2700,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NoExposureEvent {
 }
 impl From<&NoExposureEvent> for [u8; 32] {
     fn from(input: &NoExposureEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let drawable = input.drawable.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], drawable[0], drawable[1], drawable[2], drawable[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -2788,11 +2823,13 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for VisibilityNotifyEvent {
 }
 impl From<&VisibilityNotifyEvent> for [u8; 32] {
     fn from(input: &VisibilityNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
+        let state = input.state.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
-            input.state, 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            state[0], 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -2855,6 +2892,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CreateNotifyEvent {
 }
 impl From<&CreateNotifyEvent> for [u8; 32] {
     fn from(input: &CreateNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let parent = input.parent.serialize();
         let window = input.window.serialize();
@@ -2863,10 +2901,11 @@ impl From<&CreateNotifyEvent> for [u8; 32] {
         let width = input.width.serialize();
         let height = input.height.serialize();
         let border_width = input.border_width.serialize();
+        let override_redirect = input.override_redirect.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], parent[0], parent[1], parent[2], parent[3],
+            response_type[0], 0, sequence[0], sequence[1], parent[0], parent[1], parent[2], parent[3],
             window[0], window[1], window[2], window[3], x[0], x[1], y[0], y[1],
-            width[0], width[1], height[0], height[1], border_width[0], border_width[1], u8::from(input.override_redirect), 0,
+            width[0], width[1], height[0], height[1], border_width[0], border_width[1], override_redirect[0], 0,
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0
         ]
     }
@@ -2927,11 +2966,12 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for DestroyNotifyEvent {
 }
 impl From<&DestroyNotifyEvent> for [u8; 32] {
     fn from(input: &DestroyNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
             window[0], window[1], window[2], window[3], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -2999,12 +3039,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for UnmapNotifyEvent {
 }
 impl From<&UnmapNotifyEvent> for [u8; 32] {
     fn from(input: &UnmapNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
+        let from_configure = input.from_configure.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
-            window[0], window[1], window[2], window[3], u8::from(input.from_configure), 0, 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            window[0], window[1], window[2], window[3], from_configure[0], 0, 0, 0,
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -3070,12 +3112,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for MapNotifyEvent {
 }
 impl From<&MapNotifyEvent> for [u8; 32] {
     fn from(input: &MapNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
+        let override_redirect = input.override_redirect.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
-            window[0], window[1], window[2], window[3], u8::from(input.override_redirect), 0, 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            window[0], window[1], window[2], window[3], override_redirect[0], 0, 0, 0,
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -3136,11 +3180,12 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for MapRequestEvent {
 }
 impl From<&MapRequestEvent> for [u8; 32] {
     fn from(input: &MapRequestEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let parent = input.parent.serialize();
         let window = input.window.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], parent[0], parent[1], parent[2], parent[3],
+            response_type[0], 0, sequence[0], sequence[1], parent[0], parent[1], parent[2], parent[3],
             window[0], window[1], window[2], window[3], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -3200,16 +3245,18 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ReparentNotifyEvent {
 }
 impl From<&ReparentNotifyEvent> for [u8; 32] {
     fn from(input: &ReparentNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
         let parent = input.parent.serialize();
         let x = input.x.serialize();
         let y = input.y.serialize();
+        let override_redirect = input.override_redirect.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
             window[0], window[1], window[2], window[3], parent[0], parent[1], parent[2], parent[3],
-            x[0], x[1], y[0], y[1], u8::from(input.override_redirect), 0, 0, 0,
+            x[0], x[1], y[0], y[1], override_redirect[0], 0, 0, 0,
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0
         ]
     }
@@ -3296,6 +3343,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ConfigureNotifyEvent {
 }
 impl From<&ConfigureNotifyEvent> for [u8; 32] {
     fn from(input: &ConfigureNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
@@ -3305,11 +3353,12 @@ impl From<&ConfigureNotifyEvent> for [u8; 32] {
         let width = input.width.serialize();
         let height = input.height.serialize();
         let border_width = input.border_width.serialize();
+        let override_redirect = input.override_redirect.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
             window[0], window[1], window[2], window[3], above_sibling[0], above_sibling[1], above_sibling[2], above_sibling[3],
             x[0], x[1], y[0], y[1], width[0], width[1], height[0], height[1],
-            border_width[0], border_width[1], u8::from(input.override_redirect), 0, /* trailing padding */ 0, 0, 0, 0
+            border_width[0], border_width[1], override_redirect[0], 0, /* trailing padding */ 0, 0, 0, 0
         ]
     }
 }
@@ -3372,6 +3421,8 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ConfigureRequestEvent {
 }
 impl From<&ConfigureRequestEvent> for [u8; 32] {
     fn from(input: &ConfigureRequestEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let stack_mode = input.stack_mode.serialize();
         let sequence = input.sequence.serialize();
         let parent = input.parent.serialize();
         let window = input.window.serialize();
@@ -3383,7 +3434,7 @@ impl From<&ConfigureRequestEvent> for [u8; 32] {
         let border_width = input.border_width.serialize();
         let value_mask = input.value_mask.serialize();
         [
-            input.response_type, input.stack_mode, sequence[0], sequence[1], parent[0], parent[1], parent[2], parent[3],
+            response_type[0], stack_mode[0], sequence[0], sequence[1], parent[0], parent[1], parent[2], parent[3],
             window[0], window[1], window[2], window[3], sibling[0], sibling[1], sibling[2], sibling[3],
             x[0], x[1], y[0], y[1], width[0], width[1], height[0], height[1],
             border_width[0], border_width[1], value_mask[0], value_mask[1], /* trailing padding */ 0, 0, 0, 0
@@ -3438,13 +3489,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for GravityNotifyEvent {
 }
 impl From<&GravityNotifyEvent> for [u8; 32] {
     fn from(input: &GravityNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
         let x = input.x.serialize();
         let y = input.y.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
             window[0], window[1], window[2], window[3], x[0], x[1], y[0], y[1],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -3497,12 +3549,13 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ResizeRequestEvent {
 }
 impl From<&ResizeRequestEvent> for [u8; 32] {
     fn from(input: &ResizeRequestEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let width = input.width.serialize();
         let height = input.height.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            response_type[0], 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
             width[0], width[1], height[0], height[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -3638,13 +3691,15 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CirculateNotifyEvent {
 }
 impl From<&CirculateNotifyEvent> for [u8; 32] {
     fn from(input: &CirculateNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
+        let place = input.place.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
             window[0], window[1], window[2], window[3], 0, 0, 0, 0,
-            input.place, 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
+            place[0], 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
     }
@@ -3709,13 +3764,15 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for CirculateRequestEvent {
 }
 impl From<&CirculateRequestEvent> for [u8; 32] {
     fn from(input: &CirculateRequestEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let event = input.event.serialize();
         let window = input.window.serialize();
+        let place = input.place.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
+            response_type[0], 0, sequence[0], sequence[1], event[0], event[1], event[2], event[3],
             window[0], window[1], window[2], window[3], 0, 0, 0, 0,
-            input.place, 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
+            place[0], 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
     }
@@ -3843,14 +3900,16 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for PropertyNotifyEvent {
 }
 impl From<&PropertyNotifyEvent> for [u8; 32] {
     fn from(input: &PropertyNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let atom = input.atom.serialize();
         let time = input.time.serialize();
+        let state = input.state.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            response_type[0], 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
             atom[0], atom[1], atom[2], atom[3], time[0], time[1], time[2], time[3],
-            input.state, 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
+            state[0], 0, 0, 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
     }
@@ -3901,12 +3960,13 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for SelectionClearEvent {
 }
 impl From<&SelectionClearEvent> for [u8; 32] {
     fn from(input: &SelectionClearEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let owner = input.owner.serialize();
         let selection = input.selection.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             owner[0], owner[1], owner[2], owner[3], selection[0], selection[1], selection[2], selection[3],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -4200,6 +4260,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for SelectionRequestEvent {
 }
 impl From<&SelectionRequestEvent> for [u8; 32] {
     fn from(input: &SelectionRequestEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let owner = input.owner.serialize();
@@ -4208,7 +4269,7 @@ impl From<&SelectionRequestEvent> for [u8; 32] {
         let target = input.target.serialize();
         let property = input.property.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             owner[0], owner[1], owner[2], owner[3], requestor[0], requestor[1], requestor[2], requestor[3],
             selection[0], selection[1], selection[2], selection[3], target[0], target[1], target[2], target[3],
             property[0], property[1], property[2], property[3], /* trailing padding */ 0, 0, 0, 0
@@ -4265,6 +4326,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for SelectionNotifyEvent {
 }
 impl From<&SelectionNotifyEvent> for [u8; 32] {
     fn from(input: &SelectionNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let requestor = input.requestor.serialize();
@@ -4272,7 +4334,7 @@ impl From<&SelectionNotifyEvent> for [u8; 32] {
         let target = input.target.serialize();
         let property = input.property.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             requestor[0], requestor[1], requestor[2], requestor[3], selection[0], selection[1], selection[2], selection[3],
             target[0], target[1], target[2], target[3], property[0], property[1], property[2], property[3],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0
@@ -4469,12 +4531,15 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ColormapNotifyEvent {
 }
 impl From<&ColormapNotifyEvent> for [u8; 32] {
     fn from(input: &ColormapNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let colormap = input.colormap.serialize();
+        let new = input.new.serialize();
+        let state = input.state.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
-            colormap[0], colormap[1], colormap[2], colormap[3], u8::from(input.new), input.state, 0, 0,
+            response_type[0], 0, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            colormap[0], colormap[1], colormap[2], colormap[3], new[0], state[0], 0, 0,
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -4739,12 +4804,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for ClientMessageEvent {
 }
 impl From<&ClientMessageEvent> for [u8; 32] {
     fn from(input: &ClientMessageEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let format = input.format.serialize();
         let sequence = input.sequence.serialize();
         let window = input.window.serialize();
         let type_ = input.type_.serialize();
         let data = input.data.serialize();
         [
-            input.response_type, input.format, sequence[0], sequence[1], window[0], window[1], window[2], window[3],
+            response_type[0], format[0], sequence[0], sequence[1], window[0], window[1], window[2], window[3],
             type_[0], type_[1], type_[2], type_[3], data[0], data[1], data[2], data[3],
             data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11],
             data[12], data[13], data[14], data[15], data[16], data[17], data[18], data[19]
@@ -4870,9 +4937,13 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for MappingNotifyEvent {
 }
 impl From<&MappingNotifyEvent> for [u8; 32] {
     fn from(input: &MappingNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
+        let request = input.request.serialize();
+        let first_keycode = input.first_keycode.serialize();
+        let count = input.count.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], input.request, input.first_keycode, input.count, 0,
+            response_type[0], 0, sequence[0], sequence[1], request[0], first_keycode[0], count[0], 0,
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -4976,12 +5047,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for RequestError {
 }
 impl From<&RequestError> for [u8; 32] {
     fn from(input: &RequestError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5035,12 +5109,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ValueError {
 }
 impl From<&ValueError> for [u8; 32] {
     fn from(input: &ValueError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5094,12 +5171,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for WindowError {
 }
 impl From<&WindowError> for [u8; 32] {
     fn from(input: &WindowError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5153,12 +5233,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for PixmapError {
 }
 impl From<&PixmapError> for [u8; 32] {
     fn from(input: &PixmapError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5212,12 +5295,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for AtomError {
 }
 impl From<&AtomError> for [u8; 32] {
     fn from(input: &AtomError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5271,12 +5357,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for CursorError {
 }
 impl From<&CursorError> for [u8; 32] {
     fn from(input: &CursorError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5330,12 +5419,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for FontError {
 }
 impl From<&FontError> for [u8; 32] {
     fn from(input: &FontError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5389,12 +5481,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for MatchError {
 }
 impl From<&MatchError> for [u8; 32] {
     fn from(input: &MatchError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5448,12 +5543,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for DrawableError {
 }
 impl From<&DrawableError> for [u8; 32] {
     fn from(input: &DrawableError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5507,12 +5605,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for AccessError {
 }
 impl From<&AccessError> for [u8; 32] {
     fn from(input: &AccessError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5566,12 +5667,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for AllocError {
 }
 impl From<&AllocError> for [u8; 32] {
     fn from(input: &AllocError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5625,12 +5729,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ColormapError {
 }
 impl From<&ColormapError> for [u8; 32] {
     fn from(input: &ColormapError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5684,12 +5791,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for GContextError {
 }
 impl From<&GContextError> for [u8; 32] {
     fn from(input: &GContextError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5743,12 +5853,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for IDChoiceError {
 }
 impl From<&IDChoiceError> for [u8; 32] {
     fn from(input: &IDChoiceError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5802,12 +5915,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for NameError {
 }
 impl From<&NameError> for [u8; 32] {
     fn from(input: &NameError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5861,12 +5977,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for LengthError {
 }
 impl From<&LengthError> for [u8; 32] {
     fn from(input: &LengthError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]
@@ -5920,12 +6039,15 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for ImplementationError {
 }
 impl From<&ImplementationError> for [u8; 32] {
     fn from(input: &ImplementationError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         let bad_value = input.bad_value.serialize();
         let minor_opcode = input.minor_opcode.serialize();
+        let major_opcode = input.major_opcode.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
-            minor_opcode[0], minor_opcode[1], input.major_opcode, 0, /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], bad_value[0], bad_value[1], bad_value[2], bad_value[3],
+            minor_opcode[0], minor_opcode[1], major_opcode[0], 0, /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         ]

--- a/src/generated/xv.rs
+++ b/src/generated/xv.rs
@@ -807,8 +807,8 @@ impl Serialize for AttributeInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ImageFormatInfo {
     pub id: u32,
-    pub type_: u8,
-    pub byte_order: u8,
+    pub type_: ImageFormatInfoType,
+    pub byte_order: ImageOrder,
     pub guid: [u8; 16],
     pub bpp: u8,
     pub num_planes: u8,
@@ -816,7 +816,7 @@ pub struct ImageFormatInfo {
     pub red_mask: u32,
     pub green_mask: u32,
     pub blue_mask: u32,
-    pub format: u8,
+    pub format: ImageFormatInfoFormat,
     pub y_sample_bits: u32,
     pub u_sample_bits: u32,
     pub v_sample_bits: u32,
@@ -827,7 +827,7 @@ pub struct ImageFormatInfo {
     pub vvert_u_period: u32,
     pub vvert_v_period: u32,
     pub vcomp_order: [u8; 32],
-    pub vscanline_order: u8,
+    pub vscanline_order: ScanlineOrder,
 }
 impl TryParse for ImageFormatInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -956,6 +956,10 @@ impl TryParse for ImageFormatInfo {
         ];
         let (vscanline_order, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
+        let type_ = type_.try_into()?;
+        let byte_order = byte_order.try_into()?;
+        let format = format.try_into()?;
+        let vscanline_order = vscanline_order.try_into()?;
         let result = ImageFormatInfo { id, type_, byte_order, guid, bpp, num_planes, depth, red_mask, green_mask, blue_mask, format, y_sample_bits, u_sample_bits, v_sample_bits, vhorz_y_period, vhorz_u_period, vhorz_v_period, vvert_y_period, vvert_u_period, vvert_v_period, vcomp_order, vscanline_order };
         Ok((result, remaining))
     }
@@ -970,15 +974,15 @@ impl Serialize for ImageFormatInfo {
     type Bytes = [u8; 128];
     fn serialize(&self) -> Self::Bytes {
         let id_bytes = self.id.serialize();
-        let type_bytes = self.type_.serialize();
-        let byte_order_bytes = self.byte_order.serialize();
+        let type_bytes = Into::<u8>::into(self.type_).serialize();
+        let byte_order_bytes = Into::<u8>::into(self.byte_order).serialize();
         let bpp_bytes = self.bpp.serialize();
         let num_planes_bytes = self.num_planes.serialize();
         let depth_bytes = self.depth.serialize();
         let red_mask_bytes = self.red_mask.serialize();
         let green_mask_bytes = self.green_mask.serialize();
         let blue_mask_bytes = self.blue_mask.serialize();
-        let format_bytes = self.format.serialize();
+        let format_bytes = Into::<u8>::into(self.format).serialize();
         let y_sample_bits_bytes = self.y_sample_bits.serialize();
         let u_sample_bits_bytes = self.u_sample_bits.serialize();
         let v_sample_bits_bytes = self.v_sample_bits.serialize();
@@ -988,7 +992,7 @@ impl Serialize for ImageFormatInfo {
         let vvert_y_period_bytes = self.vvert_y_period.serialize();
         let vvert_u_period_bytes = self.vvert_u_period.serialize();
         let vvert_v_period_bytes = self.vvert_v_period.serialize();
-        let vscanline_order_bytes = self.vscanline_order.serialize();
+        let vscanline_order_bytes = Into::<u8>::into(self.vscanline_order).serialize();
         [
             id_bytes[0],
             id_bytes[1],
@@ -1123,8 +1127,8 @@ impl Serialize for ImageFormatInfo {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(128);
         self.id.serialize_into(bytes);
-        self.type_.serialize_into(bytes);
-        self.byte_order.serialize_into(bytes);
+        Into::<u8>::into(self.type_).serialize_into(bytes);
+        Into::<u8>::into(self.byte_order).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
         self.guid.serialize_into(bytes);
         self.bpp.serialize_into(bytes);
@@ -1135,7 +1139,7 @@ impl Serialize for ImageFormatInfo {
         self.red_mask.serialize_into(bytes);
         self.green_mask.serialize_into(bytes);
         self.blue_mask.serialize_into(bytes);
-        self.format.serialize_into(bytes);
+        Into::<u8>::into(self.format).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 3]);
         self.y_sample_bits.serialize_into(bytes);
         self.u_sample_bits.serialize_into(bytes);
@@ -1147,7 +1151,7 @@ impl Serialize for ImageFormatInfo {
         self.vvert_u_period.serialize_into(bytes);
         self.vvert_v_period.serialize_into(bytes);
         self.vcomp_order.serialize_into(bytes);
-        self.vscanline_order.serialize_into(bytes);
+        Into::<u8>::into(self.vscanline_order).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 11]);
     }
 }
@@ -1313,7 +1317,7 @@ pub const VIDEO_NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoNotifyEvent {
     pub response_type: u8,
-    pub reason: u8,
+    pub reason: VideoNotifyReason,
     pub sequence: u16,
     pub time: TIMESTAMP,
     pub drawable: DRAWABLE,
@@ -1327,6 +1331,7 @@ impl VideoNotifyEvent {
         let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
         let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
         let (port, remaining) = PORT::try_parse(remaining)?;
+        let reason = reason.try_into()?;
         let result = VideoNotifyEvent { response_type, reason, sequence, time, drawable, port };
         Ok((result, remaining))
     }
@@ -1350,7 +1355,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for VideoNotifyEvent {
 impl From<&VideoNotifyEvent> for [u8; 32] {
     fn from(input: &VideoNotifyEvent) -> Self {
         let response_type = input.response_type.serialize();
-        let reason = input.reason.serialize();
+        let reason = Into::<u8>::into(input.reason).serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let drawable = input.drawable.serialize();
@@ -1611,7 +1616,7 @@ where Conn: RequestConnection + ?Sized
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrabPortReply {
     pub response_type: u8,
-    pub result: u8,
+    pub result: GrabPortStatus,
     pub sequence: u16,
     pub length: u32,
 }
@@ -1621,6 +1626,7 @@ impl GrabPortReply {
         let (result, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
+        let result = result.try_into()?;
         let result = GrabPortReply { response_type, result, sequence, length };
         Ok((result, remaining))
     }

--- a/src/generated/xv.rs
+++ b/src/generated/xv.rs
@@ -1187,9 +1187,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadPortError {
 }
 impl From<&BadPortError> for [u8; 32] {
     fn from(input: &BadPortError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1237,9 +1239,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadEncodingError {
 }
 impl From<&BadEncodingError> for [u8; 32] {
     fn from(input: &BadEncodingError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1287,9 +1291,11 @@ impl<B: AsRef<[u8]>> From<&GenericError<B>> for BadControlError {
 }
 impl From<&BadControlError> for [u8; 32] {
     fn from(input: &BadControlError) -> Self {
+        let response_type = input.response_type.serialize();
+        let error_code = input.error_code.serialize();
         let sequence = input.sequence.serialize();
         [
-            input.response_type, input.error_code, sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
+            response_type[0], error_code[0], sequence[0], sequence[1], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1343,12 +1349,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for VideoNotifyEvent {
 }
 impl From<&VideoNotifyEvent> for [u8; 32] {
     fn from(input: &VideoNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
+        let reason = input.reason.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let drawable = input.drawable.serialize();
         let port = input.port.serialize();
         [
-            input.response_type, input.reason, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], reason[0], sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             drawable[0], drawable[1], drawable[2], drawable[3], port[0], port[1], port[2], port[3],
             /* trailing padding */ 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -1403,13 +1411,14 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for PortNotifyEvent {
 }
 impl From<&PortNotifyEvent> for [u8; 32] {
     fn from(input: &PortNotifyEvent) -> Self {
+        let response_type = input.response_type.serialize();
         let sequence = input.sequence.serialize();
         let time = input.time.serialize();
         let port = input.port.serialize();
         let attribute = input.attribute.serialize();
         let value = input.value.serialize();
         [
-            input.response_type, 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
+            response_type[0], 0, sequence[0], sequence[1], time[0], time[1], time[2], time[3],
             port[0], port[1], port[2], port[3], attribute[0], attribute[1], attribute[2], attribute[3],
             value[0], value[1], value[2], value[3], /* trailing padding */ 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -424,7 +424,7 @@ mod test {
     use crate::connection::RequestKind;
     use crate::errors::ConnectError;
     use crate::x11_utils::Serialize;
-    use crate::xproto::{Setup, SetupAuthenticate, SetupFailed};
+    use crate::xproto::{ImageOrder, Setup, SetupAuthenticate, SetupFailed};
 
     #[test]
     fn read_setup_success() {
@@ -438,8 +438,8 @@ mod test {
             resource_id_mask: 0,
             motion_buffer_size: 0,
             maximum_request_length: 0,
-            image_byte_order: 0,
-            bitmap_format_bit_order: 0,
+            image_byte_order: ImageOrder::LSBFirst,
+            bitmap_format_bit_order: ImageOrder::LSBFirst,
             bitmap_format_scanline_unit: 0,
             bitmap_format_scanline_pad: 0,
             min_keycode: 0,

--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -128,7 +128,7 @@ mod mock {
 
     use super::{iovec, xcb_connection_t, xcb_protocol_request_t, xcb_void_cookie_t};
     use crate::x11_utils::Serialize;
-    use crate::xproto::Setup;
+    use crate::xproto::{ImageOrder, Setup};
 
     #[repr(C)]
     struct ConnectionMock {
@@ -157,8 +157,8 @@ mod mock {
             resource_id_mask: 0,
             motion_buffer_size: 0,
             maximum_request_length: 0,
-            image_byte_order: 0,
-            bitmap_format_bit_order: 0,
+            image_byte_order: ImageOrder::LSBFirst,
+            bitmap_format_bit_order: ImageOrder::LSBFirst,
             bitmap_format_scanline_unit: 0,
             bitmap_format_scanline_pad: 0,
             min_keycode: 0,

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -63,7 +63,9 @@ mod fake_stream {
     use x11rb::connection::SequenceNumber;
     use x11rb::errors::ConnectError;
     use x11rb::rust_connection::RustConnection;
-    use x11rb::xproto::{Setup, CLIENT_MESSAGE_EVENT, GET_INPUT_FOCUS_REQUEST, SEND_EVENT_REQUEST};
+    use x11rb::xproto::{
+        ImageOrder, Setup, CLIENT_MESSAGE_EVENT, GET_INPUT_FOCUS_REQUEST, SEND_EVENT_REQUEST,
+    };
 
     /// Create a new `RustConnection` connected to a fake stream
     pub(crate) fn connect() -> Result<RustConnection<FakeStreamRead, FakeStreamWrite>, ConnectError>
@@ -78,8 +80,8 @@ mod fake_stream {
             resource_id_mask: 0xff,
             motion_buffer_size: 0,
             maximum_request_length: 0,
-            image_byte_order: 0,
-            bitmap_format_bit_order: 0,
+            image_byte_order: ImageOrder::LSBFirst,
+            bitmap_format_bit_order: ImageOrder::LSBFirst,
             bitmap_format_scanline_unit: 0,
             bitmap_format_scanline_pad: 0,
             min_keycode: 0,

--- a/tests/parsing_tests.rs
+++ b/tests/parsing_tests.rs
@@ -1,6 +1,6 @@
 use x11rb::errors::ParseError;
 use x11rb::x11_utils::TryParse;
-use x11rb::xproto::Setup;
+use x11rb::xproto::{Setup, VisualClass};
 
 fn get_setup_data() -> Vec<u8> {
     let mut s = Vec::new();
@@ -124,7 +124,7 @@ fn parse_setup() -> Result<(), ParseError> {
     assert_eq!(1, depth.visuals.len());
     let visual = &depth.visuals[0];
     assert_eq!(80, visual.visual_id);
-    assert_eq!(2, visual.class);
+    assert_eq!(VisualClass::StaticColor, visual.class);
     assert_eq!(4, visual.bits_per_rgb_value);
     assert_eq!(81, visual.colormap_entries);
     assert_eq!(82, visual.red_mask);


### PR DESCRIPTION
This:
- removes the unused `xproto` feature (unrelated to this PR, but I just noticed it)
- removes a special case in the code generator to simplify the later commit (does not cause any API difference)
- fixes a bug in xcb-proto (and this is why this PR is a draft): https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/merge_requests/7
- fixes https://github.com/psychon/x11rb/issues/263 by parsing enums instead of providing their values only as nubers

This last commit is "where all the fun is". It causes tons of changes to the API, but I think it is for the better.

TODO: Wait for the patch to xcb-proto to be merged and then update our vendored copy of xcb-proto.

@andrewshadura Sorry that it took so long and thanks again for suggesting this.