### PR TITLE
Move an #[allow(clippy::...)] down to where it is needed

### DIFF
--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -2,8 +2,6 @@
 //!
 //! This module is only available when the `allow-unsafe-code` feature is enabled.
 
-#![allow(clippy::cast_ptr_alignment)] // FIXME: Remove this
-
 use std::convert::{TryFrom, TryInto};
 use std::ffi::CStr;
 use std::io::{Error, ErrorKind, IoSlice};
@@ -428,7 +426,8 @@ impl RequestConnection for XCBConnection {
         // Get a pointer to the array of integers where libxcb saved the FD numbers.
         // libxcb saves the list of FDs after the data of the reply. Since the reply's
         // length is encoded in "number of 4 bytes block", the following pointer is aligned
-        // correctly (if malloc() returned an alloced chunk, which it does).
+        // correctly (if malloc() returned an aligned chunk, which it does).
+        #[allow(clippy::cast_ptr_alignment)]
         let fd_ptr = (unsafe { buffer.as_ptr().add(buffer.len()) }) as *const RawFd;
 
         // The number of FDs is in the second byte (= buffer[1]) in all replies.

--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -186,6 +186,8 @@ mod mock {
     }
 
     pub(crate) unsafe fn xcb_connection_has_error(c: *const xcb_connection_t) -> c_int {
+        // The pointer is suitable aligned since our xcb_connect() mock above created it
+        #[allow(clippy::cast_ptr_alignment)]
         (*(c as *const ConnectionMock)).error
     }
 
@@ -254,6 +256,8 @@ mod mock {
     }
 
     pub(crate) unsafe fn xcb_get_setup(c: *const xcb_connection_t) -> *const u8 {
+        // The pointer is suitable aligned since our xcb_connect() mock above created it
+        #[allow(clippy::cast_ptr_alignment)]
         (*(c as *const ConnectionMock)).setup.as_ptr()
     }
 


### PR DESCRIPTION
It is better to only allow the specific instance that has a comment
explaining what is going on, instead of just blanket-allowing it for the
whole module.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

Hm... I think libxcb has an alignment bug on systems where `int` has 64 bits. Although it might be lucky and the position where it saved FDs is actually aligned to a 8 byte boundary and so no mis-alignment occurs... Anyway, out `unsafe` block is still fine as long as libxcb works. If this `unsafe` block breaks, then libxcb has a problem and must change ABI / API.