### PR TITLE
Remove 'xproto' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ all-extensions = [
     "xinput",
     "xkb",
     "xprint",
-    "xproto",
     "xselinux",
     "xtest",
     "xv",
@@ -78,7 +77,6 @@ xinerama = []
 xinput = ["xfixes"]
 xkb = []
 xprint = []
-xproto = []
 xselinux = []
 xtest = []
 xv = ["shm"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! `composite`, `damage`, `dpms`, `dri2`, `dri3`, `glx`, `present`, `randr`, `record`, `render`,
 //! `res`, `screensaver`, `shape`, `shm`, `sync`, `xevie`, `xf86dri`, `xf86vidmode`, `xfixes`,
-//! `xinerama`, `xinput`, `xkb`, `xprint`, `xproto`, `xselinux`, `xtest`, `xv`, `xvmc`.
+//! `xinerama`, `xinput`, `xkb`, `xprint`, `xselinux`, `xtest`, `xv`, `xvmc`.
 //!
 //! If you want to take the "I do not want to think about this"-approach, you can enable the
 //! `all-extensions` feature to just enable, well, all extensions.


### PR DESCRIPTION
The feature flag 'xproto' is unused and does not actually do anything.

Signed-off-by: Uli Schlachter <psychon@znc.in>

This is split of from #299