### PR TITLE
Simplify parsing code

### DIFF
--- a/src/generated/bigreq.rs
+++ b/src/generated/bigreq.rs
@@ -62,17 +62,12 @@ pub struct EnableReply {
     pub maximum_request_length: u32,
 }
 impl EnableReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (maximum_request_length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (maximum_request_length, remaining) = u32::try_parse(remaining)?;
         let result = EnableReply { response_type, sequence, length, maximum_request_length };
         Ok((result, remaining))
     }

--- a/src/generated/composite.rs
+++ b/src/generated/composite.rs
@@ -143,20 +143,14 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -384,18 +378,13 @@ pub struct GetOverlayWindowReply {
     pub overlay_win: WINDOW,
 }
 impl GetOverlayWindowReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (overlay_win, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (overlay_win, remaining) = WINDOW::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = GetOverlayWindowReply { response_type, sequence, length, overlay_win };
         Ok((result, remaining))
     }

--- a/src/generated/damage.rs
+++ b/src/generated/damage.rs
@@ -122,14 +122,10 @@ pub struct BadDamageError {
     pub sequence: u16,
 }
 impl BadDamageError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadDamageError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -205,20 +201,14 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -370,24 +360,15 @@ pub struct NotifyEvent {
     pub geometry: Rectangle,
 }
 impl NotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (level, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (damage, new_remaining) = DAMAGE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (area, new_remaining) = Rectangle::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (geometry, new_remaining) = Rectangle::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (level, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (damage, remaining) = DAMAGE::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (area, remaining) = Rectangle::try_parse(remaining)?;
+        let (geometry, remaining) = Rectangle::try_parse(remaining)?;
         let result = NotifyEvent { response_type, level, sequence, drawable, damage, timestamp, area, geometry };
         Ok((result, remaining))
     }

--- a/src/generated/dpms.rs
+++ b/src/generated/dpms.rs
@@ -69,19 +69,13 @@ pub struct GetVersionReply {
     pub server_minor_version: u16,
 }
 impl GetVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major_version, remaining) = u16::try_parse(remaining)?;
+        let (server_minor_version, remaining) = u16::try_parse(remaining)?;
         let result = GetVersionReply { response_type, sequence, length, server_major_version, server_minor_version };
         Ok((result, remaining))
     }
@@ -120,18 +114,13 @@ pub struct CapableReply {
     pub capable: bool,
 }
 impl CapableReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (capable, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (capable, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = CapableReply { response_type, sequence, length, capable };
         Ok((result, remaining))
     }
@@ -172,22 +161,15 @@ pub struct GetTimeoutsReply {
     pub off_timeout: u16,
 }
 impl GetTimeoutsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (standby_timeout, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (suspend_timeout, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (off_timeout, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (standby_timeout, remaining) = u16::try_parse(remaining)?;
+        let (suspend_timeout, remaining) = u16::try_parse(remaining)?;
+        let (off_timeout, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let result = GetTimeoutsReply { response_type, sequence, length, standby_timeout, suspend_timeout, off_timeout };
         Ok((result, remaining))
     }
@@ -392,20 +374,14 @@ pub struct InfoReply {
     pub state: bool,
 }
 impl InfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (power_level, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (power_level, remaining) = u16::try_parse(remaining)?;
+        let (state, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = InfoReply { response_type, sequence, length, power_level, state };
         Ok((result, remaining))
     }

--- a/src/generated/dri2.rs
+++ b/src/generated/dri2.rs
@@ -263,18 +263,12 @@ pub struct DRI2Buffer {
     pub flags: u32,
 }
 impl TryParse for DRI2Buffer {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (attachment, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pitch, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cpp, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (attachment, remaining) = u32::try_parse(remaining)?;
+        let (name, remaining) = u32::try_parse(remaining)?;
+        let (pitch, remaining) = u32::try_parse(remaining)?;
+        let (cpp, remaining) = u32::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
         let result = DRI2Buffer { attachment, name, pitch, cpp, flags };
         Ok((result, remaining))
     }
@@ -332,12 +326,9 @@ pub struct AttachFormat {
     pub format: u32,
 }
 impl TryParse for AttachFormat {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (attachment, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (attachment, remaining) = u32::try_parse(remaining)?;
+        let (format, remaining) = u32::try_parse(remaining)?;
         let result = AttachFormat { attachment, format };
         Ok((result, remaining))
     }
@@ -409,19 +400,13 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -473,26 +458,17 @@ pub struct ConnectReply {
     pub device_name: Vec<u8>,
 }
 impl ConnectReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (driver_name_length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_name_length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (driver_name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, driver_name_length as usize)?;
-        remaining = new_remaining;
-        let (alignment_pad, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((driver_name_length as usize) + (3)) & (!(3))) - (driver_name_length as usize))?;
-        remaining = new_remaining;
-        let (device_name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, device_name_length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (driver_name_length, remaining) = u32::try_parse(remaining)?;
+        let (device_name_length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (driver_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, driver_name_length as usize)?;
+        let (alignment_pad, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((driver_name_length as usize) + (3)) & (!(3))) - (driver_name_length as usize))?;
+        let (device_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, device_name_length as usize)?;
         let result = ConnectReply { response_type, sequence, length, driver_name, alignment_pad, device_name };
         Ok((result, remaining))
     }
@@ -541,17 +517,12 @@ pub struct AuthenticateReply {
     pub authenticated: u32,
 }
 impl AuthenticateReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (authenticated, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (authenticated, remaining) = u32::try_parse(remaining)?;
         let result = AuthenticateReply { response_type, sequence, length, authenticated };
         Ok((result, remaining))
     }
@@ -656,24 +627,16 @@ pub struct GetBuffersReply {
     pub buffers: Vec<DRI2Buffer>,
 }
 impl GetBuffersReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (buffers, new_remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u32::try_parse(remaining)?;
+        let (height, remaining) = u32::try_parse(remaining)?;
+        let (count, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count as usize)?;
         let result = GetBuffersReply { response_type, sequence, length, width, height, buffers };
         Ok((result, remaining))
     }
@@ -731,15 +694,11 @@ pub struct CopyRegionReply {
     pub length: u32,
 }
 impl CopyRegionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = CopyRegionReply { response_type, sequence, length };
         Ok((result, remaining))
     }
@@ -794,24 +753,16 @@ pub struct GetBuffersWithFormatReply {
     pub buffers: Vec<DRI2Buffer>,
 }
 impl GetBuffersWithFormatReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (buffers, new_remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u32::try_parse(remaining)?;
+        let (height, remaining) = u32::try_parse(remaining)?;
+        let (count, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count as usize)?;
         let result = GetBuffersWithFormatReply { response_type, sequence, length, width, height, buffers };
         Ok((result, remaining))
     }
@@ -886,19 +837,13 @@ pub struct SwapBuffersReply {
     pub swap_lo: u32,
 }
 impl SwapBuffersReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (swap_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (swap_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (swap_hi, remaining) = u32::try_parse(remaining)?;
+        let (swap_lo, remaining) = u32::try_parse(remaining)?;
         let result = SwapBuffersReply { response_type, sequence, length, swap_hi, swap_lo };
         Ok((result, remaining))
     }
@@ -947,27 +892,17 @@ pub struct GetMSCReply {
     pub sbc_lo: u32,
 }
 impl GetMSCReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ust_hi, remaining) = u32::try_parse(remaining)?;
+        let (ust_lo, remaining) = u32::try_parse(remaining)?;
+        let (msc_hi, remaining) = u32::try_parse(remaining)?;
+        let (msc_lo, remaining) = u32::try_parse(remaining)?;
+        let (sbc_hi, remaining) = u32::try_parse(remaining)?;
+        let (sbc_lo, remaining) = u32::try_parse(remaining)?;
         let result = GetMSCReply { response_type, sequence, length, ust_hi, ust_lo, msc_hi, msc_lo, sbc_hi, sbc_lo };
         Ok((result, remaining))
     }
@@ -1046,27 +981,17 @@ pub struct WaitMSCReply {
     pub sbc_lo: u32,
 }
 impl WaitMSCReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ust_hi, remaining) = u32::try_parse(remaining)?;
+        let (ust_lo, remaining) = u32::try_parse(remaining)?;
+        let (msc_hi, remaining) = u32::try_parse(remaining)?;
+        let (msc_lo, remaining) = u32::try_parse(remaining)?;
+        let (sbc_hi, remaining) = u32::try_parse(remaining)?;
+        let (sbc_lo, remaining) = u32::try_parse(remaining)?;
         let result = WaitMSCReply { response_type, sequence, length, ust_hi, ust_lo, msc_hi, msc_lo, sbc_hi, sbc_lo };
         Ok((result, remaining))
     }
@@ -1125,27 +1050,17 @@ pub struct WaitSBCReply {
     pub sbc_lo: u32,
 }
 impl WaitSBCReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ust_hi, remaining) = u32::try_parse(remaining)?;
+        let (ust_lo, remaining) = u32::try_parse(remaining)?;
+        let (msc_hi, remaining) = u32::try_parse(remaining)?;
+        let (msc_lo, remaining) = u32::try_parse(remaining)?;
+        let (sbc_hi, remaining) = u32::try_parse(remaining)?;
+        let (sbc_lo, remaining) = u32::try_parse(remaining)?;
         let result = WaitSBCReply { response_type, sequence, length, ust_hi, ust_lo, msc_hi, msc_lo, sbc_hi, sbc_lo };
         Ok((result, remaining))
     }
@@ -1226,20 +1141,13 @@ pub struct GetParamReply {
     pub value_lo: u32,
 }
 impl GetParamReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (is_param_recognized, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (is_param_recognized, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (value_hi, remaining) = u32::try_parse(remaining)?;
+        let (value_lo, remaining) = u32::try_parse(remaining)?;
         let result = GetParamReply { response_type, is_param_recognized, sequence, length, value_hi, value_lo };
         Ok((result, remaining))
     }
@@ -1266,28 +1174,18 @@ pub struct BufferSwapCompleteEvent {
     pub sbc: u32,
 }
 impl BufferSwapCompleteEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (ust_hi, remaining) = u32::try_parse(remaining)?;
+        let (ust_lo, remaining) = u32::try_parse(remaining)?;
+        let (msc_hi, remaining) = u32::try_parse(remaining)?;
+        let (msc_lo, remaining) = u32::try_parse(remaining)?;
+        let (sbc, remaining) = u32::try_parse(remaining)?;
         let result = BufferSwapCompleteEvent { response_type, sequence, event_type, drawable, ust_hi, ust_lo, msc_hi, msc_lo, sbc };
         Ok((result, remaining))
     }
@@ -1341,15 +1239,11 @@ pub struct InvalidateBuffersEvent {
     pub drawable: DRAWABLE,
 }
 impl InvalidateBuffersEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
         let result = InvalidateBuffersEvent { response_type, sequence, drawable };
         Ok((result, remaining))
     }

--- a/src/generated/dri3.rs
+++ b/src/generated/dri3.rs
@@ -75,19 +75,13 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -137,19 +131,14 @@ pub struct OpenReply {
     pub device_fd: RawFdContainer,
 }
 impl OpenReply {
-    fn try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nfd, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (nfd, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         if fds.is_empty() { return Err(ParseError::ParseError) }
         let device_fd = fds.remove(0);
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = OpenReply { response_type, nfd, sequence, length, device_fd };
         Ok((result, remaining))
     }
@@ -250,31 +239,20 @@ pub struct BufferFromPixmapReply {
     pub pixmap_fd: RawFdContainer,
 }
 impl BufferFromPixmapReply {
-    fn try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nfd, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (stride, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bpp, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (nfd, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (size, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (stride, remaining) = u16::try_parse(remaining)?;
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let (bpp, remaining) = u8::try_parse(remaining)?;
         if fds.is_empty() { return Err(ParseError::ParseError) }
         let pixmap_fd = fds.remove(0);
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let result = BufferFromPixmapReply { response_type, nfd, sequence, length, size, width, height, stride, depth, bpp, pixmap_fd };
         Ok((result, remaining))
     }
@@ -361,19 +339,14 @@ pub struct FDFromFenceReply {
     pub fence_fd: RawFdContainer,
 }
 impl FDFromFenceReply {
-    fn try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nfd, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (nfd, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         if fds.is_empty() { return Err(ParseError::ParseError) }
         let fence_fd = fds.remove(0);
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = FDFromFenceReply { response_type, nfd, sequence, length, fence_fd };
         Ok((result, remaining))
     }
@@ -425,24 +398,16 @@ pub struct GetSupportedModifiersReply {
     pub screen_modifiers: Vec<u64>,
 }
 impl GetSupportedModifiersReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_window_modifiers, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_screen_modifiers, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (window_modifiers, new_remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_window_modifiers as usize)?;
-        remaining = new_remaining;
-        let (screen_modifiers, new_remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_screen_modifiers as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_window_modifiers, remaining) = u32::try_parse(remaining)?;
+        let (num_screen_modifiers, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (window_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_window_modifiers as usize)?;
+        let (screen_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_screen_modifiers as usize)?;
         let result = GetSupportedModifiersReply { response_type, sequence, length, window_modifiers, screen_modifiers };
         Ok((result, remaining))
     }
@@ -591,32 +556,20 @@ pub struct BuffersFromPixmapReply {
     pub buffers: Vec<RawFdContainer>,
 }
 impl BuffersFromPixmapReply {
-    fn try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nfd, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (modifier, new_remaining) = u64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bpp, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(6..).ok_or(ParseError::ParseError)?;
-        let (strides, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd as usize)?;
-        remaining = new_remaining;
-        let (offsets, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd as usize)?;
-        remaining = new_remaining;
+    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (nfd, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (modifier, remaining) = u64::try_parse(remaining)?;
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let (bpp, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(6..).ok_or(ParseError::ParseError)?;
+        let (strides, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd as usize)?;
+        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd as usize)?;
         let fds_len = nfd as usize;
         if fds.len() < fds_len { return Err(ParseError::ParseError) }
         let mut buffers = fds.split_off(fds_len);

--- a/src/generated/ge.rs
+++ b/src/generated/ge.rs
@@ -69,20 +69,14 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u16::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }

--- a/src/generated/glx.rs
+++ b/src/generated/glx.rs
@@ -65,21 +65,14 @@ pub struct GenericError {
     pub major_opcode: u8,
 }
 impl GenericError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = GenericError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -131,21 +124,14 @@ pub struct BadContextError {
     pub major_opcode: u8,
 }
 impl BadContextError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadContextError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -197,21 +183,14 @@ pub struct BadContextStateError {
     pub major_opcode: u8,
 }
 impl BadContextStateError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadContextStateError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -263,21 +242,14 @@ pub struct BadDrawableError {
     pub major_opcode: u8,
 }
 impl BadDrawableError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadDrawableError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -329,21 +301,14 @@ pub struct BadPixmapError {
     pub major_opcode: u8,
 }
 impl BadPixmapError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadPixmapError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -395,21 +360,14 @@ pub struct BadContextTagError {
     pub major_opcode: u8,
 }
 impl BadContextTagError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadContextTagError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -461,21 +419,14 @@ pub struct BadCurrentWindowError {
     pub major_opcode: u8,
 }
 impl BadCurrentWindowError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadCurrentWindowError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -527,21 +478,14 @@ pub struct BadRenderRequestError {
     pub major_opcode: u8,
 }
 impl BadRenderRequestError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadRenderRequestError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -593,21 +537,14 @@ pub struct BadLargeRequestError {
     pub major_opcode: u8,
 }
 impl BadLargeRequestError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadLargeRequestError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -659,21 +596,14 @@ pub struct UnsupportedPrivateRequestError {
     pub major_opcode: u8,
 }
 impl UnsupportedPrivateRequestError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = UnsupportedPrivateRequestError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -725,21 +655,14 @@ pub struct BadFBConfigError {
     pub major_opcode: u8,
 }
 impl BadFBConfigError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadFBConfigError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -791,21 +714,14 @@ pub struct BadPbufferError {
     pub major_opcode: u8,
 }
 impl BadPbufferError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadPbufferError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -857,21 +773,14 @@ pub struct BadCurrentDrawableError {
     pub major_opcode: u8,
 }
 impl BadCurrentDrawableError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadCurrentDrawableError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -923,21 +832,14 @@ pub struct BadWindowError {
     pub major_opcode: u8,
 }
 impl BadWindowError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = BadWindowError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -989,21 +891,14 @@ pub struct GLXBadProfileARBError {
     pub major_opcode: u8,
 }
 impl GLXBadProfileARBError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = GLXBadProfileARBError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -1061,34 +956,21 @@ pub struct PbufferClobberEvent {
     pub count: u16,
 }
 impl PbufferClobberEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (draw_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (b_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (aux_buffer, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (draw_type, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (b_mask, remaining) = u32::try_parse(remaining)?;
+        let (aux_buffer, remaining) = u16::try_parse(remaining)?;
+        let (x, remaining) = u16::try_parse(remaining)?;
+        let (y, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = PbufferClobberEvent { response_type, sequence, event_type, draw_type, drawable, b_mask, aux_buffer, x, y, width, height, count };
         Ok((result, remaining))
     }
@@ -1151,28 +1033,18 @@ pub struct BufferSwapCompleteEvent {
     pub sbc: u32,
 }
 impl BufferSwapCompleteEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_hi, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc_lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sbc, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (ust_hi, remaining) = u32::try_parse(remaining)?;
+        let (ust_lo, remaining) = u32::try_parse(remaining)?;
+        let (msc_hi, remaining) = u32::try_parse(remaining)?;
+        let (msc_lo, remaining) = u32::try_parse(remaining)?;
+        let (sbc, remaining) = u32::try_parse(remaining)?;
         let result = BufferSwapCompleteEvent { response_type, sequence, event_type, drawable, ust_hi, ust_lo, msc_hi, msc_lo, sbc };
         Ok((result, remaining))
     }
@@ -1489,18 +1361,13 @@ pub struct MakeCurrentReply {
     pub context_tag: ContextTag,
 }
 impl MakeCurrentReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_tag, new_remaining) = ContextTag::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_tag, remaining) = ContextTag::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = MakeCurrentReply { response_type, sequence, length, context_tag };
         Ok((result, remaining))
     }
@@ -1544,18 +1411,13 @@ pub struct IsDirectReply {
     pub is_direct: bool,
 }
 impl IsDirectReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (is_direct, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (is_direct, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = IsDirectReply { response_type, sequence, length, is_direct };
         Ok((result, remaining))
     }
@@ -1605,20 +1467,14 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -1956,22 +1812,15 @@ pub struct GetVisualConfigsReply {
     pub property_list: Vec<u32>,
 }
 impl GetVisualConfigsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_visuals, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_properties, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (property_list, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_visuals, remaining) = u32::try_parse(remaining)?;
+        let (num_properties, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (property_list, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = GetVisualConfigsReply { response_type, sequence, num_visuals, num_properties, property_list };
         Ok((result, remaining))
     }
@@ -2082,65 +1931,36 @@ pub struct VendorPrivateWithReplyReply {
     pub data2: Vec<u8>,
 }
 impl VendorPrivateWithReplyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (retval, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data1_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (retval, remaining) = u32::try_parse(remaining)?;
+        let (data1_0, remaining) = u8::try_parse(remaining)?;
+        let (data1_1, remaining) = u8::try_parse(remaining)?;
+        let (data1_2, remaining) = u8::try_parse(remaining)?;
+        let (data1_3, remaining) = u8::try_parse(remaining)?;
+        let (data1_4, remaining) = u8::try_parse(remaining)?;
+        let (data1_5, remaining) = u8::try_parse(remaining)?;
+        let (data1_6, remaining) = u8::try_parse(remaining)?;
+        let (data1_7, remaining) = u8::try_parse(remaining)?;
+        let (data1_8, remaining) = u8::try_parse(remaining)?;
+        let (data1_9, remaining) = u8::try_parse(remaining)?;
+        let (data1_10, remaining) = u8::try_parse(remaining)?;
+        let (data1_11, remaining) = u8::try_parse(remaining)?;
+        let (data1_12, remaining) = u8::try_parse(remaining)?;
+        let (data1_13, remaining) = u8::try_parse(remaining)?;
+        let (data1_14, remaining) = u8::try_parse(remaining)?;
+        let (data1_15, remaining) = u8::try_parse(remaining)?;
+        let (data1_16, remaining) = u8::try_parse(remaining)?;
+        let (data1_17, remaining) = u8::try_parse(remaining)?;
+        let (data1_18, remaining) = u8::try_parse(remaining)?;
+        let (data1_19, remaining) = u8::try_parse(remaining)?;
+        let (data1_20, remaining) = u8::try_parse(remaining)?;
+        let (data1_21, remaining) = u8::try_parse(remaining)?;
+        let (data1_22, remaining) = u8::try_parse(remaining)?;
+        let (data1_23, remaining) = u8::try_parse(remaining)?;
         let data1 = [
             data1_0,
             data1_1,
@@ -2167,8 +1987,7 @@ impl VendorPrivateWithReplyReply {
             data1_22,
             data1_23,
         ];
-        let (data2, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+        let (data2, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = VendorPrivateWithReplyReply { response_type, sequence, retval, data1, data2 };
         Ok((result, remaining))
     }
@@ -2212,19 +2031,14 @@ pub struct QueryExtensionsStringReply {
     pub n: u32,
 }
 impl QueryExtensionsStringReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = QueryExtensionsStringReply { response_type, sequence, length, n };
         Ok((result, remaining))
     }
@@ -2273,21 +2087,15 @@ pub struct QueryServerStringReply {
     pub string: Vec<u8>,
 }
 impl QueryServerStringReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (str_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (string, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, str_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (str_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, str_len as usize)?;
         let result = QueryServerStringReply { response_type, sequence, length, string };
         Ok((result, remaining))
     }
@@ -2371,22 +2179,15 @@ pub struct GetFBConfigsReply {
     pub property_list: Vec<u32>,
 }
 impl GetFBConfigsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_fb_configs, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_properties, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (property_list, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_fb_configs, remaining) = u32::try_parse(remaining)?;
+        let (num_properties, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (property_list, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = GetFBConfigsReply { response_type, sequence, num_fb_configs, num_properties, property_list };
         Ok((result, remaining))
     }
@@ -2556,20 +2357,14 @@ pub struct QueryContextReply {
     pub attribs: Vec<u32>,
 }
 impl QueryContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_attribs, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attribs, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, (num_attribs as usize) * (2))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_attribs, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (num_attribs as usize) * (2))?;
         let result = QueryContextReply { response_type, sequence, length, attribs };
         Ok((result, remaining))
     }
@@ -2628,18 +2423,13 @@ pub struct MakeContextCurrentReply {
     pub context_tag: ContextTag,
 }
 impl MakeContextCurrentReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_tag, new_remaining) = ContextTag::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_tag, remaining) = ContextTag::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = MakeContextCurrentReply { response_type, sequence, length, context_tag };
         Ok((result, remaining))
     }
@@ -2754,20 +2544,14 @@ pub struct GetDrawableAttributesReply {
     pub attribs: Vec<u32>,
 }
 impl GetDrawableAttributesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_attribs, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attribs, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, (num_attribs as usize) * (2))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_attribs, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (num_attribs as usize) * (2))?;
         let result = GetDrawableAttributesReply { response_type, sequence, length, attribs };
         Ok((result, remaining))
     }
@@ -3189,17 +2973,12 @@ pub struct GenListsReply {
     pub ret_val: u32,
 }
 impl GenListsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ret_val, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ret_val, remaining) = u32::try_parse(remaining)?;
         let result = GenListsReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -3315,24 +3094,16 @@ pub struct RenderModeReply {
     pub data: Vec<u32>,
 }
 impl RenderModeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ret_val, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (new_mode, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ret_val, remaining) = u32::try_parse(remaining)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (new_mode, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
         let result = RenderModeReply { response_type, sequence, length, ret_val, new_mode, data };
         Ok((result, remaining))
     }
@@ -3425,15 +3196,11 @@ pub struct FinishReply {
     pub length: u32,
 }
 impl FinishReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = FinishReply { response_type, sequence, length };
         Ok((result, remaining))
     }
@@ -3582,18 +3349,13 @@ pub struct ReadPixelsReply {
     pub data: Vec<u8>,
 }
 impl ReadPixelsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = ReadPixelsReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -3643,23 +3405,16 @@ pub struct GetBooleanvReply {
     pub data: Vec<u8>,
 }
 impl GetBooleanvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(15..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n as usize)?;
         let result = GetBooleanvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -3707,18 +3462,13 @@ pub struct GetClipPlaneReply {
     pub data: Vec<FLOAT64>,
 }
 impl GetClipPlaneReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, (length as usize) / (2))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, (length as usize) / (2))?;
         let result = GetClipPlaneReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -3768,23 +3518,16 @@ pub struct GetDoublevReply {
     pub data: Vec<FLOAT64>,
 }
 impl GetDoublevReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT64::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT64::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
         let result = GetDoublevReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -3828,17 +3571,12 @@ pub struct GetErrorReply {
     pub error: i32,
 }
 impl GetErrorReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (error, remaining) = i32::try_parse(remaining)?;
         let result = GetErrorReply { response_type, sequence, length, error };
         Ok((result, remaining))
     }
@@ -3888,23 +3626,16 @@ pub struct GetFloatvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetFloatvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetFloatvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -3954,23 +3685,16 @@ pub struct GetIntegervReply {
     pub data: Vec<i32>,
 }
 impl GetIntegervReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetIntegervReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4025,23 +3749,16 @@ pub struct GetLightfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetLightfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetLightfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4096,23 +3813,16 @@ pub struct GetLightivReply {
     pub data: Vec<i32>,
 }
 impl GetLightivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetLightivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4167,23 +3877,16 @@ pub struct GetMapdvReply {
     pub data: Vec<FLOAT64>,
 }
 impl GetMapdvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT64::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT64::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
         let result = GetMapdvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4238,23 +3941,16 @@ pub struct GetMapfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetMapfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetMapfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4309,23 +4005,16 @@ pub struct GetMapivReply {
     pub data: Vec<i32>,
 }
 impl GetMapivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetMapivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4380,23 +4069,16 @@ pub struct GetMaterialfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetMaterialfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetMaterialfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4451,23 +4133,16 @@ pub struct GetMaterialivReply {
     pub data: Vec<i32>,
 }
 impl GetMaterialivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetMaterialivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4517,23 +4192,16 @@ pub struct GetPixelMapfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetPixelMapfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetPixelMapfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4583,23 +4251,16 @@ pub struct GetPixelMapuivReply {
     pub data: Vec<u32>,
 }
 impl GetPixelMapuivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
         let result = GetPixelMapuivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4649,23 +4310,16 @@ pub struct GetPixelMapusvReply {
     pub data: Vec<u16>,
 }
 impl GetPixelMapusvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u16>(remaining, n as usize)?;
         let result = GetPixelMapusvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4713,18 +4367,13 @@ pub struct GetPolygonStippleReply {
     pub data: Vec<u8>,
 }
 impl GetPolygonStippleReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetPolygonStippleReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -4773,21 +4422,15 @@ pub struct GetStringReply {
     pub string: Vec<u8>,
 }
 impl GetStringReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (string, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n as usize)?;
         let result = GetStringReply { response_type, sequence, length, string };
         Ok((result, remaining))
     }
@@ -4842,23 +4485,16 @@ pub struct GetTexEnvfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetTexEnvfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetTexEnvfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4913,23 +4549,16 @@ pub struct GetTexEnvivReply {
     pub data: Vec<i32>,
 }
 impl GetTexEnvivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetTexEnvivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4984,23 +4613,16 @@ pub struct GetTexGendvReply {
     pub data: Vec<FLOAT64>,
 }
 impl GetTexGendvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT64::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT64::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
         let result = GetTexGendvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5055,23 +4677,16 @@ pub struct GetTexGenfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetTexGenfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetTexGenfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5126,23 +4741,16 @@ pub struct GetTexGenivReply {
     pub data: Vec<i32>,
 }
 impl GetTexGenivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetTexGenivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5213,25 +4821,17 @@ pub struct GetTexImageReply {
     pub data: Vec<u8>,
 }
 impl GetTexImageReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (width, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depth, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (width, remaining) = i32::try_parse(remaining)?;
+        let (height, remaining) = i32::try_parse(remaining)?;
+        let (depth, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetTexImageReply { response_type, sequence, width, height, depth, data };
         Ok((result, remaining))
     }
@@ -5286,23 +4886,16 @@ pub struct GetTexParameterfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetTexParameterfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetTexParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5357,23 +4950,16 @@ pub struct GetTexParameterivReply {
     pub data: Vec<i32>,
 }
 impl GetTexParameterivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetTexParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5433,23 +5019,16 @@ pub struct GetTexLevelParameterfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetTexLevelParameterfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetTexLevelParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5509,23 +5088,16 @@ pub struct GetTexLevelParameterivReply {
     pub data: Vec<i32>,
 }
 impl GetTexLevelParameterivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetTexLevelParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5574,17 +5146,12 @@ pub struct IsEnabledReply {
     pub ret_val: BOOL32,
 }
 impl IsEnabledReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ret_val, new_remaining) = BOOL32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
         let result = IsEnabledReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -5633,17 +5200,12 @@ pub struct IsListReply {
     pub ret_val: BOOL32,
 }
 impl IsListReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ret_val, new_remaining) = BOOL32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
         let result = IsListReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -5722,20 +5284,14 @@ pub struct AreTexturesResidentReply {
     pub data: Vec<u8>,
 }
 impl AreTexturesResidentReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ret_val, new_remaining) = BOOL32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = AreTexturesResidentReply { response_type, sequence, ret_val, data };
         Ok((result, remaining))
     }
@@ -5818,18 +5374,13 @@ pub struct GenTexturesReply {
     pub data: Vec<u32>,
 }
 impl GenTexturesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = GenTexturesReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -5878,17 +5429,12 @@ pub struct IsTextureReply {
     pub ret_val: BOOL32,
 }
 impl IsTextureReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ret_val, new_remaining) = BOOL32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
         let result = IsTextureReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -5952,21 +5498,15 @@ pub struct GetColorTableReply {
     pub data: Vec<u8>,
 }
 impl GetColorTableReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (width, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (width, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetColorTableReply { response_type, sequence, width, data };
         Ok((result, remaining))
     }
@@ -6021,23 +5561,16 @@ pub struct GetColorTableParameterfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetColorTableParameterfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetColorTableParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6092,23 +5625,16 @@ pub struct GetColorTableParameterivReply {
     pub data: Vec<i32>,
 }
 impl GetColorTableParameterivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetColorTableParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6173,23 +5699,16 @@ pub struct GetConvolutionFilterReply {
     pub data: Vec<u8>,
 }
 impl GetConvolutionFilterReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (width, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (width, remaining) = i32::try_parse(remaining)?;
+        let (height, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetConvolutionFilterReply { response_type, sequence, width, height, data };
         Ok((result, remaining))
     }
@@ -6244,23 +5763,16 @@ pub struct GetConvolutionParameterfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetConvolutionParameterfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetConvolutionParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6315,23 +5827,16 @@ pub struct GetConvolutionParameterivReply {
     pub data: Vec<i32>,
 }
 impl GetConvolutionParameterivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetConvolutionParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6396,23 +5901,16 @@ pub struct GetSeparableFilterReply {
     pub rows_and_cols: Vec<u8>,
 }
 impl GetSeparableFilterReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (row_w, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (col_h, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (rows_and_cols, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (row_w, remaining) = i32::try_parse(remaining)?;
+        let (col_h, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (rows_and_cols, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetSeparableFilterReply { response_type, sequence, row_w, col_h, rows_and_cols };
         Ok((result, remaining))
     }
@@ -6477,21 +5975,15 @@ pub struct GetHistogramReply {
     pub data: Vec<u8>,
 }
 impl GetHistogramReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (width, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (width, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetHistogramReply { response_type, sequence, width, data };
         Ok((result, remaining))
     }
@@ -6546,23 +6038,16 @@ pub struct GetHistogramParameterfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetHistogramParameterfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetHistogramParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6617,23 +6102,16 @@ pub struct GetHistogramParameterivReply {
     pub data: Vec<i32>,
 }
 impl GetHistogramParameterivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetHistogramParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6697,18 +6175,13 @@ pub struct GetMinmaxReply {
     pub data: Vec<u8>,
 }
 impl GetMinmaxReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetMinmaxReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -6763,23 +6236,16 @@ pub struct GetMinmaxParameterfvReply {
     pub data: Vec<FLOAT32>,
 }
 impl GetMinmaxParameterfvReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = FLOAT32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
         let result = GetMinmaxParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6834,23 +6300,16 @@ pub struct GetMinmaxParameterivReply {
     pub data: Vec<i32>,
 }
 impl GetMinmaxParameterivReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetMinmaxParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6904,21 +6363,15 @@ pub struct GetCompressedTexImageARBReply {
     pub data: Vec<u8>,
 }
 impl GetCompressedTexImageARBReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (size, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (size, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetCompressedTexImageARBReply { response_type, sequence, size, data };
         Ok((result, remaining))
     }
@@ -7001,18 +6454,13 @@ pub struct GenQueriesARBReply {
     pub data: Vec<u32>,
 }
 impl GenQueriesARBReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = GenQueriesARBReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -7061,17 +6509,12 @@ pub struct IsQueryARBReply {
     pub ret_val: BOOL32,
 }
 impl IsQueryARBReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ret_val, new_remaining) = BOOL32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
         let result = IsQueryARBReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -7126,23 +6569,16 @@ pub struct GetQueryivARBReply {
     pub data: Vec<i32>,
 }
 impl GetQueryivARBReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetQueryivARBReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -7197,23 +6633,16 @@ pub struct GetQueryObjectivARBReply {
     pub data: Vec<i32>,
 }
 impl GetQueryObjectivARBReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = i32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
         let result = GetQueryObjectivARBReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -7268,23 +6697,16 @@ pub struct GetQueryObjectuivARBReply {
     pub data: Vec<u32>,
 }
 impl GetQueryObjectuivARBReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (n, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (datum, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (n, remaining) = u32::try_parse(remaining)?;
+        let (datum, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
         let result = GetQueryObjectuivARBReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }

--- a/src/generated/present.rs
+++ b/src/generated/present.rs
@@ -464,12 +464,9 @@ pub struct Notify {
     pub serial: u32,
 }
 impl TryParse for Notify {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (serial, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (serial, remaining) = u32::try_parse(remaining)?;
         let result = Notify { window, serial };
         Ok((result, remaining))
     }
@@ -541,19 +538,13 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -801,17 +792,12 @@ pub struct QueryCapabilitiesReply {
     pub capabilities: u32,
 }
 impl QueryCapabilitiesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (capabilities, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (capabilities, remaining) = u32::try_parse(remaining)?;
         let result = QueryCapabilitiesReply { response_type, sequence, length, capabilities };
         Ok((result, remaining))
     }
@@ -835,21 +821,14 @@ pub struct GenericEvent {
     pub event: EVENT,
 }
 impl GenericEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (evtype, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (event, new_remaining) = EVENT::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (evtype, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = EVENT::try_parse(remaining)?;
         let result = GenericEvent { response_type, extension, sequence, length, evtype, event };
         Ok((result, remaining))
     }
@@ -912,41 +891,24 @@ pub struct ConfigureNotifyEvent {
     pub pixmap_flags: u32,
 }
 impl ConfigureNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (event, new_remaining) = EVENT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (off_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (off_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixmap_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixmap_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixmap_flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = EVENT::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (off_x, remaining) = i16::try_parse(remaining)?;
+        let (off_y, remaining) = i16::try_parse(remaining)?;
+        let (pixmap_width, remaining) = u16::try_parse(remaining)?;
+        let (pixmap_height, remaining) = u16::try_parse(remaining)?;
+        let (pixmap_flags, remaining) = u32::try_parse(remaining)?;
         let result = ConfigureNotifyEvent { response_type, extension, sequence, length, event_type, event, window, x, y, width, height, off_x, off_y, pixmap_width, pixmap_height, pixmap_flags };
         Ok((result, remaining))
     }
@@ -988,32 +950,19 @@ pub struct CompleteNotifyEvent {
     pub msc: u64,
 }
 impl CompleteNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kind, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = EVENT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (serial, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ust, new_remaining) = u64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (msc, new_remaining) = u64::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (event, remaining) = EVENT::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (serial, remaining) = u32::try_parse(remaining)?;
+        let (ust, remaining) = u64::try_parse(remaining)?;
+        let (msc, remaining) = u64::try_parse(remaining)?;
         let result = CompleteNotifyEvent { response_type, extension, sequence, length, event_type, kind, mode, event, window, serial, ust, msc };
         Ok((result, remaining))
     }
@@ -1053,29 +1002,18 @@ pub struct IdleNotifyEvent {
     pub idle_fence: sync::FENCE,
 }
 impl IdleNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (event, new_remaining) = EVENT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (serial, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixmap, new_remaining) = PIXMAP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (idle_fence, new_remaining) = sync::FENCE::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = EVENT::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (serial, remaining) = u32::try_parse(remaining)?;
+        let (pixmap, remaining) = PIXMAP::try_parse(remaining)?;
+        let (idle_fence, remaining) = sync::FENCE::try_parse(remaining)?;
         let result = IdleNotifyEvent { response_type, extension, sequence, length, event_type, event, window, serial, pixmap, idle_fence };
         Ok((result, remaining))
     }
@@ -1130,58 +1068,34 @@ pub struct RedirectNotifyEvent {
     pub notifies: Vec<Notify>,
 }
 impl RedirectNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (update_window, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (event, new_remaining) = EVENT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixmap, new_remaining) = PIXMAP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (serial, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valid_region, new_remaining) = xfixes::REGION::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (update_region, new_remaining) = xfixes::REGION::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valid_rect, new_remaining) = Rectangle::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (update_rect, new_remaining) = Rectangle::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x_off, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y_off, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (target_crtc, new_remaining) = randr::CRTC::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (wait_fence, new_remaining) = sync::FENCE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (idle_fence, new_remaining) = sync::FENCE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (options, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (target_msc, new_remaining) = u64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (divisor, new_remaining) = u64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (remainder, new_remaining) = u64::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (update_window, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = EVENT::try_parse(remaining)?;
+        let (event_window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (pixmap, remaining) = PIXMAP::try_parse(remaining)?;
+        let (serial, remaining) = u32::try_parse(remaining)?;
+        let (valid_region, remaining) = xfixes::REGION::try_parse(remaining)?;
+        let (update_region, remaining) = xfixes::REGION::try_parse(remaining)?;
+        let (valid_rect, remaining) = Rectangle::try_parse(remaining)?;
+        let (update_rect, remaining) = Rectangle::try_parse(remaining)?;
+        let (x_off, remaining) = i16::try_parse(remaining)?;
+        let (y_off, remaining) = i16::try_parse(remaining)?;
+        let (target_crtc, remaining) = randr::CRTC::try_parse(remaining)?;
+        let (wait_fence, remaining) = sync::FENCE::try_parse(remaining)?;
+        let (idle_fence, remaining) = sync::FENCE::try_parse(remaining)?;
+        let (options, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (target_msc, remaining) = u64::try_parse(remaining)?;
+        let (divisor, remaining) = u64::try_parse(remaining)?;
+        let (remainder, remaining) = u64::try_parse(remaining)?;
+        let mut remaining = remaining;
         // Length is 'everything left in the input'
         let mut notifies = Vec::new();
         while !remaining.is_empty() {

--- a/src/generated/randr.rs
+++ b/src/generated/randr.rs
@@ -58,14 +58,10 @@ pub struct BadOutputError {
     pub sequence: u16,
 }
 impl BadOutputError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadOutputError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -112,14 +108,10 @@ pub struct BadCrtcError {
     pub sequence: u16,
 }
 impl BadCrtcError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadCrtcError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -166,14 +158,10 @@ pub struct BadModeError {
     pub sequence: u16,
 }
 impl BadModeError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadModeError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -220,14 +208,10 @@ pub struct BadProviderError {
     pub sequence: u16,
 }
 impl BadProviderError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadProviderError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -348,16 +332,11 @@ pub struct ScreenSize {
     pub mheight: u16,
 }
 impl TryParse for ScreenSize {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mwidth, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mheight, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (mwidth, remaining) = u16::try_parse(remaining)?;
+        let (mheight, remaining) = u16::try_parse(remaining)?;
         let result = ScreenSize { width, height, mwidth, mheight };
         Ok((result, remaining))
     }
@@ -400,12 +379,9 @@ pub struct RefreshRates {
     pub rates: Vec<u16>,
 }
 impl TryParse for RefreshRates {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (n_rates, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rates, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, n_rates as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (n_rates, remaining) = u16::try_parse(remaining)?;
+        let (rates, remaining) = crate::x11_utils::parse_list::<u16>(remaining, n_rates as usize)?;
         let result = RefreshRates { rates };
         Ok((result, remaining))
     }
@@ -469,20 +445,14 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -619,25 +589,16 @@ pub struct SetScreenConfigReply {
     pub subpixel_order: u16,
 }
 impl SetScreenConfigReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (new_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (config_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subpixel_order, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(10..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (new_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (subpixel_order, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
         let result = SetScreenConfigReply { response_type, status, sequence, length, new_timestamp, config_timestamp, root, subpixel_order };
         Ok((result, remaining))
     }
@@ -801,37 +762,22 @@ pub struct GetScreenInfoReply {
     pub rates: Vec<RefreshRates>,
 }
 impl GetScreenInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotations, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (config_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_sizes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rate, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_info, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (sizes, new_remaining) = crate::x11_utils::parse_list::<ScreenSize>(remaining, n_sizes as usize)?;
-        remaining = new_remaining;
-        let (rates, new_remaining) = crate::x11_utils::parse_list::<RefreshRates>(remaining, (n_info as usize) - (n_sizes as usize))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (rotations, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (n_sizes, remaining) = u16::try_parse(remaining)?;
+        let (size_id, remaining) = u16::try_parse(remaining)?;
+        let (rotation, remaining) = u16::try_parse(remaining)?;
+        let (rate, remaining) = u16::try_parse(remaining)?;
+        let (n_info, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (sizes, remaining) = crate::x11_utils::parse_list::<ScreenSize>(remaining, n_sizes as usize)?;
+        let (rates, remaining) = crate::x11_utils::parse_list::<RefreshRates>(remaining, (n_info as usize) - (n_sizes as usize))?;
         let result = GetScreenInfoReply { response_type, rotations, sequence, length, root, timestamp, config_timestamp, size_id, rotation, rate, n_info, sizes, rates };
         Ok((result, remaining))
     }
@@ -878,24 +824,16 @@ pub struct GetScreenSizeRangeReply {
     pub max_height: u16,
 }
 impl GetScreenSizeRangeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (min_width, remaining) = u16::try_parse(remaining)?;
+        let (min_height, remaining) = u16::try_parse(remaining)?;
+        let (max_width, remaining) = u16::try_parse(remaining)?;
+        let (max_height, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = GetScreenSizeRangeReply { response_type, sequence, length, min_width, min_height, max_width, max_height };
         Ok((result, remaining))
     }
@@ -1048,34 +986,20 @@ pub struct ModeInfo {
     pub mode_flags: u32,
 }
 impl TryParse for ModeInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (id, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dot_clock, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hsync_start, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hsync_end, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (htotal, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hskew, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vsync_start, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vsync_end, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vtotal, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode_flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (id, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (dot_clock, remaining) = u32::try_parse(remaining)?;
+        let (hsync_start, remaining) = u16::try_parse(remaining)?;
+        let (hsync_end, remaining) = u16::try_parse(remaining)?;
+        let (htotal, remaining) = u16::try_parse(remaining)?;
+        let (hskew, remaining) = u16::try_parse(remaining)?;
+        let (vsync_start, remaining) = u16::try_parse(remaining)?;
+        let (vsync_end, remaining) = u16::try_parse(remaining)?;
+        let (vtotal, remaining) = u16::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let (mode_flags, remaining) = u32::try_parse(remaining)?;
         let result = ModeInfo { id, width, height, dot_clock, hsync_start, hsync_end, htotal, hskew, vsync_start, vsync_end, vtotal, name_len, mode_flags };
         Ok((result, remaining))
     }
@@ -1192,36 +1116,22 @@ pub struct GetScreenResourcesReply {
     pub names: Vec<u8>,
 }
 impl GetScreenResourcesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (config_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_crtcs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_outputs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_modes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (names_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (crtcs, new_remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        remaining = new_remaining;
-        let (outputs, new_remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
-        remaining = new_remaining;
-        let (modes, new_remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
-        remaining = new_remaining;
-        let (names, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (num_crtcs, remaining) = u16::try_parse(remaining)?;
+        let (num_outputs, remaining) = u16::try_parse(remaining)?;
+        let (num_modes, remaining) = u16::try_parse(remaining)?;
+        let (names_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
+        let (modes, remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
         let result = GetScreenResourcesReply { response_type, sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
         Ok((result, remaining))
     }
@@ -1346,46 +1256,26 @@ pub struct GetOutputInfoReply {
     pub name: Vec<u8>,
 }
 impl GetOutputInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (crtc, new_remaining) = CRTC::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mm_width, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mm_height, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (connection, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subpixel_order, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_crtcs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_modes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_preferred, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_clones, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (crtcs, new_remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        remaining = new_remaining;
-        let (modes, new_remaining) = crate::x11_utils::parse_list::<MODE>(remaining, num_modes as usize)?;
-        remaining = new_remaining;
-        let (clones, new_remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_clones as usize)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (crtc, remaining) = CRTC::try_parse(remaining)?;
+        let (mm_width, remaining) = u32::try_parse(remaining)?;
+        let (mm_height, remaining) = u32::try_parse(remaining)?;
+        let (connection, remaining) = u8::try_parse(remaining)?;
+        let (subpixel_order, remaining) = u8::try_parse(remaining)?;
+        let (num_crtcs, remaining) = u16::try_parse(remaining)?;
+        let (num_modes, remaining) = u16::try_parse(remaining)?;
+        let (num_preferred, remaining) = u16::try_parse(remaining)?;
+        let (num_clones, remaining) = u16::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
+        let (modes, remaining) = crate::x11_utils::parse_list::<MODE>(remaining, num_modes as usize)?;
+        let (clones, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_clones as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         let result = GetOutputInfoReply { response_type, status, sequence, length, timestamp, crtc, mm_width, mm_height, connection, subpixel_order, num_preferred, crtcs, modes, clones, name };
         Ok((result, remaining))
     }
@@ -1429,20 +1319,14 @@ pub struct ListOutputPropertiesReply {
     pub atoms: Vec<ATOM>,
 }
 impl ListOutputPropertiesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_atoms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_atoms, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
         let result = ListOutputPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -1493,24 +1377,16 @@ pub struct QueryOutputPropertyReply {
     pub valid_values: Vec<i32>,
 }
 impl QueryOutputPropertyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pending, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (range, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (immutable, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
-        let (valid_values, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (pending, remaining) = bool::try_parse(remaining)?;
+        let (range, remaining) = bool::try_parse(remaining)?;
+        let (immutable, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
+        let (valid_values, remaining) = crate::x11_utils::parse_list::<i32>(remaining, length as usize)?;
         let result = QueryOutputPropertyReply { response_type, sequence, pending, range, immutable, valid_values };
         Ok((result, remaining))
     }
@@ -1705,25 +1581,16 @@ pub struct GetOutputPropertyReply {
     pub data: Vec<u8>,
 }
 impl GetOutputPropertyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes_after, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_items, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (num_items as usize) * ((format as usize) / (8)))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (format, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (bytes_after, remaining) = u32::try_parse(remaining)?;
+        let (num_items, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (num_items as usize) * ((format as usize) / (8)))?;
         let result = GetOutputPropertyReply { response_type, format, sequence, length, type_, bytes_after, num_items, data };
         Ok((result, remaining))
     }
@@ -1803,18 +1670,13 @@ pub struct CreateModeReply {
     pub mode: MODE,
 }
 impl CreateModeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = MODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = CreateModeReply { response_type, sequence, length, mode };
         Ok((result, remaining))
     }
@@ -1958,40 +1820,23 @@ pub struct GetCrtcInfoReply {
     pub possible: Vec<OUTPUT>,
 }
 impl GetCrtcInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = MODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotations, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_outputs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_possible_outputs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (outputs, new_remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
-        remaining = new_remaining;
-        let (possible, new_remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_possible_outputs as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let (rotation, remaining) = u16::try_parse(remaining)?;
+        let (rotations, remaining) = u16::try_parse(remaining)?;
+        let (num_outputs, remaining) = u16::try_parse(remaining)?;
+        let (num_possible_outputs, remaining) = u16::try_parse(remaining)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
+        let (possible, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_possible_outputs as usize)?;
         let result = GetCrtcInfoReply { response_type, status, sequence, length, timestamp, x, y, width, height, mode, rotation, rotations, outputs, possible };
         Ok((result, remaining))
     }
@@ -2066,19 +1911,13 @@ pub struct SetCrtcConfigReply {
     pub timestamp: TIMESTAMP,
 }
 impl SetCrtcConfigReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = SetCrtcConfigReply { response_type, status, sequence, length, timestamp };
         Ok((result, remaining))
     }
@@ -2122,18 +1961,13 @@ pub struct GetCrtcGammaSizeReply {
     pub size: u16,
 }
 impl GetCrtcGammaSizeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (size, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
         let result = GetCrtcGammaSizeReply { response_type, sequence, length, size };
         Ok((result, remaining))
     }
@@ -2180,24 +2014,16 @@ pub struct GetCrtcGammaReply {
     pub blue: Vec<u16>,
 }
 impl GetCrtcGammaReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (red, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, size as usize)?;
-        remaining = new_remaining;
-        let (green, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, size as usize)?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, size as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (size, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (red, remaining) = crate::x11_utils::parse_list::<u16>(remaining, size as usize)?;
+        let (green, remaining) = crate::x11_utils::parse_list::<u16>(remaining, size as usize)?;
+        let (blue, remaining) = crate::x11_utils::parse_list::<u16>(remaining, size as usize)?;
         let result = GetCrtcGammaReply { response_type, sequence, length, size, red, green, blue };
         Ok((result, remaining))
     }
@@ -2287,36 +2113,22 @@ pub struct GetScreenResourcesCurrentReply {
     pub names: Vec<u8>,
 }
 impl GetScreenResourcesCurrentReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (config_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_crtcs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_outputs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_modes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (names_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (crtcs, new_remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        remaining = new_remaining;
-        let (outputs, new_remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
-        remaining = new_remaining;
-        let (modes, new_remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
-        remaining = new_remaining;
-        let (names, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (num_crtcs, remaining) = u16::try_parse(remaining)?;
+        let (num_outputs, remaining) = u16::try_parse(remaining)?;
+        let (num_modes, remaining) = u16::try_parse(remaining)?;
+        let (names_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
+        let (modes, remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
         let result = GetScreenResourcesCurrentReply { response_type, sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
         Ok((result, remaining))
     }
@@ -2510,47 +2322,33 @@ pub struct GetCrtcTransformReply {
     pub current_params: Vec<render::FIXED>,
 }
 impl GetCrtcTransformReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pending_transform, new_remaining) = render::Transform::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (has_transforms, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (current_transform, new_remaining) = render::Transform::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (pending_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pending_nparams, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (current_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (current_nparams, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pending_filter_name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, pending_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (pending_transform, remaining) = render::Transform::try_parse(remaining)?;
+        let (has_transforms, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (current_transform, remaining) = render::Transform::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (pending_len, remaining) = u16::try_parse(remaining)?;
+        let (pending_nparams, remaining) = u16::try_parse(remaining)?;
+        let (current_len, remaining) = u16::try_parse(remaining)?;
+        let (current_nparams, remaining) = u16::try_parse(remaining)?;
+        let (pending_filter_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, pending_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (pending_params, new_remaining) = crate::x11_utils::parse_list::<render::FIXED>(remaining, pending_nparams as usize)?;
-        remaining = new_remaining;
-        let (current_filter_name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, current_len as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (pending_params, remaining) = crate::x11_utils::parse_list::<render::FIXED>(remaining, pending_nparams as usize)?;
+        let (current_filter_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, current_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (current_params, new_remaining) = crate::x11_utils::parse_list::<render::FIXED>(remaining, current_nparams as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (current_params, remaining) = crate::x11_utils::parse_list::<render::FIXED>(remaining, current_nparams as usize)?;
         let result = GetCrtcTransformReply { response_type, sequence, length, pending_transform, has_transforms, current_transform, pending_filter_name, pending_params, current_filter_name, current_params };
         Ok((result, remaining))
     }
@@ -2607,42 +2405,24 @@ pub struct GetPanningReply {
     pub border_bottom: i16,
 }
 impl GetPanningReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (left, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (top, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (track_left, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (track_top, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (track_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (track_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_left, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_top, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_right, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_bottom, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (left, remaining) = u16::try_parse(remaining)?;
+        let (top, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (track_left, remaining) = u16::try_parse(remaining)?;
+        let (track_top, remaining) = u16::try_parse(remaining)?;
+        let (track_width, remaining) = u16::try_parse(remaining)?;
+        let (track_height, remaining) = u16::try_parse(remaining)?;
+        let (border_left, remaining) = i16::try_parse(remaining)?;
+        let (border_top, remaining) = i16::try_parse(remaining)?;
+        let (border_right, remaining) = i16::try_parse(remaining)?;
+        let (border_bottom, remaining) = i16::try_parse(remaining)?;
         let result = GetPanningReply { response_type, status, sequence, length, timestamp, left, top, width, height, track_left, track_top, track_width, track_height, border_left, border_top, border_right, border_bottom };
         Ok((result, remaining))
     }
@@ -2728,18 +2508,12 @@ pub struct SetPanningReply {
     pub timestamp: TIMESTAMP,
 }
 impl SetPanningReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
         let result = SetPanningReply { response_type, status, sequence, length, timestamp };
         Ok((result, remaining))
     }
@@ -2813,17 +2587,12 @@ pub struct GetOutputPrimaryReply {
     pub output: OUTPUT,
 }
 impl GetOutputPrimaryReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (output, new_remaining) = OUTPUT::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (output, remaining) = OUTPUT::try_parse(remaining)?;
         let result = GetOutputPrimaryReply { response_type, sequence, length, output };
         Ok((result, remaining))
     }
@@ -2868,22 +2637,15 @@ pub struct GetProvidersReply {
     pub providers: Vec<PROVIDER>,
 }
 impl GetProvidersReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_providers, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
-        let (providers, new_remaining) = crate::x11_utils::parse_list::<PROVIDER>(remaining, num_providers as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (num_providers, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
+        let (providers, remaining) = crate::x11_utils::parse_list::<PROVIDER>(remaining, num_providers as usize)?;
         let result = GetProvidersReply { response_type, sequence, length, timestamp, providers };
         Ok((result, remaining))
     }
@@ -3009,39 +2771,23 @@ pub struct GetProviderInfoReply {
     pub name: Vec<u8>,
 }
 impl GetProviderInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (capabilities, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_crtcs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_outputs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_associated_providers, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (crtcs, new_remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        remaining = new_remaining;
-        let (outputs, new_remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
-        remaining = new_remaining;
-        let (associated_providers, new_remaining) = crate::x11_utils::parse_list::<PROVIDER>(remaining, num_associated_providers as usize)?;
-        remaining = new_remaining;
-        let (associated_capability, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_associated_providers as usize)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (capabilities, remaining) = u32::try_parse(remaining)?;
+        let (num_crtcs, remaining) = u16::try_parse(remaining)?;
+        let (num_outputs, remaining) = u16::try_parse(remaining)?;
+        let (num_associated_providers, remaining) = u16::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
+        let (associated_providers, remaining) = crate::x11_utils::parse_list::<PROVIDER>(remaining, num_associated_providers as usize)?;
+        let (associated_capability, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_associated_providers as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         let result = GetProviderInfoReply { response_type, status, sequence, length, timestamp, capabilities, num_associated_providers, crtcs, outputs, associated_providers, associated_capability, name };
         Ok((result, remaining))
     }
@@ -3155,20 +2901,14 @@ pub struct ListProviderPropertiesReply {
     pub atoms: Vec<ATOM>,
 }
 impl ListProviderPropertiesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_atoms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_atoms, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
         let result = ListProviderPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -3219,24 +2959,16 @@ pub struct QueryProviderPropertyReply {
     pub valid_values: Vec<i32>,
 }
 impl QueryProviderPropertyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pending, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (range, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (immutable, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
-        let (valid_values, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (pending, remaining) = bool::try_parse(remaining)?;
+        let (range, remaining) = bool::try_parse(remaining)?;
+        let (immutable, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
+        let (valid_values, remaining) = crate::x11_utils::parse_list::<i32>(remaining, length as usize)?;
         let result = QueryProviderPropertyReply { response_type, sequence, pending, range, immutable, valid_values };
         Ok((result, remaining))
     }
@@ -3430,25 +3162,16 @@ pub struct GetProviderPropertyReply {
     pub data: Vec<u8>,
 }
 impl GetProviderPropertyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes_after, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_items, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (num_items as usize) * ((format as usize) / (8)))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (format, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (bytes_after, remaining) = u32::try_parse(remaining)?;
+        let (num_items, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (num_items as usize) * ((format as usize) / (8)))?;
         let result = GetProviderPropertyReply { response_type, format, sequence, length, type_, bytes_after, num_items, data };
         Ok((result, remaining))
     }
@@ -3479,34 +3202,20 @@ pub struct ScreenChangeNotifyEvent {
     pub mheight: u16,
 }
 impl ScreenChangeNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (config_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request_window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subpixel_order, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mwidth, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mheight, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (rotation, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (request_window, remaining) = WINDOW::try_parse(remaining)?;
+        let (size_id, remaining) = u16::try_parse(remaining)?;
+        let (subpixel_order, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (mwidth, remaining) = u16::try_parse(remaining)?;
+        let (mheight, remaining) = u16::try_parse(remaining)?;
         let result = ScreenChangeNotifyEvent { response_type, rotation, sequence, timestamp, config_timestamp, root, request_window, size_id, subpixel_order, width, height, mwidth, mheight };
         Ok((result, remaining))
     }
@@ -3644,27 +3353,17 @@ pub struct CrtcChange {
     pub height: u16,
 }
 impl TryParse for CrtcChange {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (crtc, new_remaining) = CRTC::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = MODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (crtc, remaining) = CRTC::try_parse(remaining)?;
+        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let (rotation, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
         let result = CrtcChange { timestamp, window, crtc, mode, rotation, x, y, width, height };
         Ok((result, remaining))
     }
@@ -3746,26 +3445,16 @@ pub struct OutputChange {
     pub subpixel_order: u8,
 }
 impl TryParse for OutputChange {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (config_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (output, new_remaining) = OUTPUT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (crtc, new_remaining) = CRTC::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = MODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (connection, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subpixel_order, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (output, remaining) = OUTPUT::try_parse(remaining)?;
+        let (crtc, remaining) = CRTC::try_parse(remaining)?;
+        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let (rotation, remaining) = u16::try_parse(remaining)?;
+        let (connection, remaining) = u8::try_parse(remaining)?;
+        let (subpixel_order, remaining) = u8::try_parse(remaining)?;
         let result = OutputChange { timestamp, config_timestamp, window, output, crtc, mode, rotation, connection, subpixel_order };
         Ok((result, remaining))
     }
@@ -3842,19 +3531,13 @@ pub struct OutputProperty {
     pub status: u8,
 }
 impl TryParse for OutputProperty {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (output, new_remaining) = OUTPUT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (atom, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(11..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (output, remaining) = OUTPUT::try_parse(remaining)?;
+        let (atom, remaining) = ATOM::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let result = OutputProperty { window, output, atom, timestamp, status };
         Ok((result, remaining))
     }
@@ -3922,15 +3605,11 @@ pub struct ProviderChange {
     pub provider: PROVIDER,
 }
 impl TryParse for ProviderChange {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (provider, new_remaining) = PROVIDER::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (provider, remaining) = PROVIDER::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = ProviderChange { timestamp, window, provider };
         Ok((result, remaining))
     }
@@ -3996,19 +3675,13 @@ pub struct ProviderProperty {
     pub state: u8,
 }
 impl TryParse for ProviderProperty {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (provider, new_remaining) = PROVIDER::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (atom, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(11..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (provider, remaining) = PROVIDER::try_parse(remaining)?;
+        let (atom, remaining) = ATOM::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let result = ProviderProperty { window, provider, atom, timestamp, state };
         Ok((result, remaining))
     }
@@ -4075,13 +3748,10 @@ pub struct ResourceChange {
     pub window: WINDOW,
 }
 impl TryParse for ResourceChange {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = ResourceChange { timestamp, window };
         Ok((result, remaining))
     }
@@ -4150,30 +3820,18 @@ pub struct MonitorInfo {
     pub outputs: Vec<OUTPUT>,
 }
 impl TryParse for MonitorInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (primary, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (automatic, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_output, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width_in_millimeters, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height_in_millimeters, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (outputs, new_remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, n_output as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (primary, remaining) = bool::try_parse(remaining)?;
+        let (automatic, remaining) = bool::try_parse(remaining)?;
+        let (n_output, remaining) = u16::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (width_in_millimeters, remaining) = u32::try_parse(remaining)?;
+        let (height_in_millimeters, remaining) = u32::try_parse(remaining)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, n_output as usize)?;
         let result = MonitorInfo { name, primary, automatic, x, y, width, height, width_in_millimeters, height_in_millimeters, outputs };
         Ok((result, remaining))
     }
@@ -4247,24 +3905,16 @@ pub struct GetMonitorsReply {
     pub monitors: Vec<MonitorInfo>,
 }
 impl GetMonitorsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_monitors, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_outputs, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (monitors, new_remaining) = crate::x11_utils::parse_list::<MonitorInfo>(remaining, n_monitors as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (n_monitors, remaining) = u32::try_parse(remaining)?;
+        let (n_outputs, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (monitors, remaining) = crate::x11_utils::parse_list::<MonitorInfo>(remaining, n_monitors as usize)?;
         let result = GetMonitorsReply { response_type, sequence, length, timestamp, n_outputs, monitors };
         Ok((result, remaining))
     }
@@ -4387,19 +4037,14 @@ pub struct CreateLeaseReply {
     pub master_fd: RawFdContainer,
 }
 impl CreateLeaseReply {
-    fn try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nfd, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (nfd, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         if fds.is_empty() { return Err(ParseError::ParseError) }
         let master_fd = fds.remove(0);
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = CreateLeaseReply { response_type, nfd, sequence, length, master_fd };
         Ok((result, remaining))
     }
@@ -4450,17 +4095,12 @@ pub struct LeaseNotify {
     pub created: u8,
 }
 impl TryParse for LeaseNotify {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (lease, new_remaining) = LEASE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (created, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(15..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (lease, remaining) = LEASE::try_parse(remaining)?;
+        let (created, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
         let result = LeaseNotify { timestamp, window, lease, created };
         Ok((result, remaining))
     }
@@ -4523,70 +4163,56 @@ impl Serialize for LeaseNotify {
 pub struct NotifyData([u8; 28]);
 impl NotifyData {
     pub fn as_cc(&self) -> CrtcChange {
-        fn do_the_parse(value: &[u8]) -> Result<CrtcChange, ParseError> {
-            let mut remaining = value;
-            let (cc, new_remaining) = CrtcChange::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<CrtcChange, ParseError> {
+            let (cc, remaining) = CrtcChange::try_parse(remaining)?;
             let _ = remaining;
             Ok(cc)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_oc(&self) -> OutputChange {
-        fn do_the_parse(value: &[u8]) -> Result<OutputChange, ParseError> {
-            let mut remaining = value;
-            let (oc, new_remaining) = OutputChange::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<OutputChange, ParseError> {
+            let (oc, remaining) = OutputChange::try_parse(remaining)?;
             let _ = remaining;
             Ok(oc)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_op(&self) -> OutputProperty {
-        fn do_the_parse(value: &[u8]) -> Result<OutputProperty, ParseError> {
-            let mut remaining = value;
-            let (op, new_remaining) = OutputProperty::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<OutputProperty, ParseError> {
+            let (op, remaining) = OutputProperty::try_parse(remaining)?;
             let _ = remaining;
             Ok(op)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_pc(&self) -> ProviderChange {
-        fn do_the_parse(value: &[u8]) -> Result<ProviderChange, ParseError> {
-            let mut remaining = value;
-            let (pc, new_remaining) = ProviderChange::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<ProviderChange, ParseError> {
+            let (pc, remaining) = ProviderChange::try_parse(remaining)?;
             let _ = remaining;
             Ok(pc)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_pp(&self) -> ProviderProperty {
-        fn do_the_parse(value: &[u8]) -> Result<ProviderProperty, ParseError> {
-            let mut remaining = value;
-            let (pp, new_remaining) = ProviderProperty::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<ProviderProperty, ParseError> {
+            let (pp, remaining) = ProviderProperty::try_parse(remaining)?;
             let _ = remaining;
             Ok(pp)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_rc(&self) -> ResourceChange {
-        fn do_the_parse(value: &[u8]) -> Result<ResourceChange, ParseError> {
-            let mut remaining = value;
-            let (rc, new_remaining) = ResourceChange::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<ResourceChange, ParseError> {
+            let (rc, remaining) = ResourceChange::try_parse(remaining)?;
             let _ = remaining;
             Ok(rc)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_lc(&self) -> LeaseNotify {
-        fn do_the_parse(value: &[u8]) -> Result<LeaseNotify, ParseError> {
-            let mut remaining = value;
-            let (lc, new_remaining) = LeaseNotify::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<LeaseNotify, ParseError> {
+            let (lc, remaining) = LeaseNotify::try_parse(remaining)?;
             let _ = remaining;
             Ok(lc)
         }
@@ -4658,16 +4284,11 @@ pub struct NotifyEvent {
     pub u: NotifyData,
 }
 impl NotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sub_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (u, new_remaining) = NotifyData::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (sub_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (u, remaining) = NotifyData::try_parse(remaining)?;
         let result = NotifyEvent { response_type, sub_code, sequence, u };
         Ok((result, remaining))
     }

--- a/src/generated/record.rs
+++ b/src/generated/record.rs
@@ -43,12 +43,9 @@ pub struct Range8 {
     pub last: u8,
 }
 impl TryParse for Range8 {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (first, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (last, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (first, remaining) = u8::try_parse(remaining)?;
+        let (last, remaining) = u8::try_parse(remaining)?;
         let result = Range8 { first, last };
         Ok((result, remaining))
     }
@@ -82,12 +79,9 @@ pub struct Range16 {
     pub last: u16,
 }
 impl TryParse for Range16 {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (first, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (last, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (first, remaining) = u16::try_parse(remaining)?;
+        let (last, remaining) = u16::try_parse(remaining)?;
         let result = Range16 { first, last };
         Ok((result, remaining))
     }
@@ -123,12 +117,9 @@ pub struct ExtRange {
     pub minor: Range16,
 }
 impl TryParse for ExtRange {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (major, new_remaining) = Range8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor, new_remaining) = Range16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (major, remaining) = Range8::try_parse(remaining)?;
+        let (minor, remaining) = Range16::try_parse(remaining)?;
         let result = ExtRange { major, minor };
         Ok((result, remaining))
     }
@@ -173,26 +164,16 @@ pub struct Range {
     pub client_died: bool,
 }
 impl TryParse for Range {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (core_requests, new_remaining) = Range8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (core_replies, new_remaining) = Range8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ext_requests, new_remaining) = ExtRange::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ext_replies, new_remaining) = ExtRange::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (delivered_events, new_remaining) = Range8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_events, new_remaining) = Range8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (errors, new_remaining) = Range8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (client_started, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (client_died, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (core_requests, remaining) = Range8::try_parse(remaining)?;
+        let (core_replies, remaining) = Range8::try_parse(remaining)?;
+        let (ext_requests, remaining) = ExtRange::try_parse(remaining)?;
+        let (ext_replies, remaining) = ExtRange::try_parse(remaining)?;
+        let (delivered_events, remaining) = Range8::try_parse(remaining)?;
+        let (device_events, remaining) = Range8::try_parse(remaining)?;
+        let (errors, remaining) = Range8::try_parse(remaining)?;
+        let (client_started, remaining) = bool::try_parse(remaining)?;
+        let (client_died, remaining) = bool::try_parse(remaining)?;
         let result = Range { core_requests, core_replies, ext_requests, ext_replies, delivered_events, device_events, errors, client_started, client_died };
         Ok((result, remaining))
     }
@@ -397,14 +378,10 @@ pub struct ClientInfo {
     pub ranges: Vec<Range>,
 }
 impl TryParse for ClientInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (client_resource, new_remaining) = ClientSpec::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_ranges, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ranges, new_remaining) = crate::x11_utils::parse_list::<Range>(remaining, num_ranges as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (client_resource, remaining) = ClientSpec::try_parse(remaining)?;
+        let (num_ranges, remaining) = u32::try_parse(remaining)?;
+        let (ranges, remaining) = crate::x11_utils::parse_list::<Range>(remaining, num_ranges as usize)?;
         let result = ClientInfo { client_resource, ranges };
         Ok((result, remaining))
     }
@@ -441,16 +418,11 @@ pub struct BadContextError {
     pub invalid_record: u32,
 }
 impl BadContextError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (invalid_record, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (invalid_record, remaining) = u32::try_parse(remaining)?;
         let result = BadContextError { response_type, error_code, sequence, invalid_record };
         Ok((result, remaining))
     }
@@ -523,19 +495,13 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u16::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -712,24 +678,16 @@ pub struct GetContextReply {
     pub intercepted_clients: Vec<ClientInfo>,
 }
 impl GetContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enabled, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (element_header, new_remaining) = ElementHeader::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (num_intercepted_clients, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (intercepted_clients, new_remaining) = crate::x11_utils::parse_list::<ClientInfo>(remaining, num_intercepted_clients as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (enabled, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (element_header, remaining) = ElementHeader::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (num_intercepted_clients, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (intercepted_clients, remaining) = crate::x11_utils::parse_list::<ClientInfo>(remaining, num_intercepted_clients as usize)?;
         let result = GetContextReply { response_type, enabled, sequence, length, element_header, intercepted_clients };
         Ok((result, remaining))
     }
@@ -778,30 +736,19 @@ pub struct EnableContextReply {
     pub data: Vec<u8>,
 }
 impl EnableContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (category, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (element_header, new_remaining) = ElementHeader::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (client_swapped, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (xid_base, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_time, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rec_sequence_num, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (category, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (element_header, remaining) = ElementHeader::try_parse(remaining)?;
+        let (client_swapped, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (xid_base, remaining) = u32::try_parse(remaining)?;
+        let (server_time, remaining) = u32::try_parse(remaining)?;
+        let (rec_sequence_num, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = EnableContextReply { response_type, category, sequence, element_header, client_swapped, xid_base, server_time, rec_sequence_num, data };
         Ok((result, remaining))
     }

--- a/src/generated/render.rs
+++ b/src/generated/render.rs
@@ -738,14 +738,10 @@ pub struct PictFormatError {
     pub sequence: u16,
 }
 impl PictFormatError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = PictFormatError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -792,14 +788,10 @@ pub struct PictureError {
     pub sequence: u16,
 }
 impl PictureError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = PictureError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -846,14 +838,10 @@ pub struct PictOpError {
     pub sequence: u16,
 }
 impl PictOpError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = PictOpError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -900,14 +888,10 @@ pub struct GlyphSetError {
     pub sequence: u16,
 }
 impl GlyphSetError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = GlyphSetError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -954,14 +938,10 @@ pub struct GlyphError {
     pub sequence: u16,
 }
 impl GlyphError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = GlyphError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -1011,24 +991,15 @@ pub struct Directformat {
     pub alpha_mask: u16,
 }
 impl TryParse for Directformat {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (red_shift, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (red_mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green_shift, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green_mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue_shift, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue_mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alpha_shift, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alpha_mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (red_shift, remaining) = u16::try_parse(remaining)?;
+        let (red_mask, remaining) = u16::try_parse(remaining)?;
+        let (green_shift, remaining) = u16::try_parse(remaining)?;
+        let (green_mask, remaining) = u16::try_parse(remaining)?;
+        let (blue_shift, remaining) = u16::try_parse(remaining)?;
+        let (blue_mask, remaining) = u16::try_parse(remaining)?;
+        let (alpha_shift, remaining) = u16::try_parse(remaining)?;
+        let (alpha_mask, remaining) = u16::try_parse(remaining)?;
         let result = Directformat { red_shift, red_mask, green_shift, green_mask, blue_shift, blue_mask, alpha_shift, alpha_mask };
         Ok((result, remaining))
     }
@@ -1091,19 +1062,13 @@ pub struct Pictforminfo {
     pub colormap: COLORMAP,
 }
 impl TryParse for Pictforminfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (id, new_remaining) = PICTFORMAT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (direct, new_remaining) = Directformat::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (colormap, new_remaining) = COLORMAP::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (id, remaining) = PICTFORMAT::try_parse(remaining)?;
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (direct, remaining) = Directformat::try_parse(remaining)?;
+        let (colormap, remaining) = COLORMAP::try_parse(remaining)?;
         let result = Pictforminfo { id, type_, depth, direct, colormap };
         Ok((result, remaining))
     }
@@ -1170,12 +1135,9 @@ pub struct Pictvisual {
     pub format: PICTFORMAT,
 }
 impl TryParse for Pictvisual {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (visual, new_remaining) = VISUALID::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = PICTFORMAT::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (format, remaining) = PICTFORMAT::try_parse(remaining)?;
         let result = Pictvisual { visual, format };
         Ok((result, remaining))
     }
@@ -1215,16 +1177,12 @@ pub struct Pictdepth {
     pub visuals: Vec<Pictvisual>,
 }
 impl TryParse for Pictdepth {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (num_visuals, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (visuals, new_remaining) = crate::x11_utils::parse_list::<Pictvisual>(remaining, num_visuals as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (num_visuals, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (visuals, remaining) = crate::x11_utils::parse_list::<Pictvisual>(remaining, num_visuals as usize)?;
         let result = Pictdepth { depth, visuals };
         Ok((result, remaining))
     }
@@ -1259,14 +1217,10 @@ pub struct Pictscreen {
     pub depths: Vec<Pictdepth>,
 }
 impl TryParse for Pictscreen {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (num_depths, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (fallback, new_remaining) = PICTFORMAT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depths, new_remaining) = crate::x11_utils::parse_list::<Pictdepth>(remaining, num_depths as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (num_depths, remaining) = u32::try_parse(remaining)?;
+        let (fallback, remaining) = PICTFORMAT::try_parse(remaining)?;
+        let (depths, remaining) = crate::x11_utils::parse_list::<Pictdepth>(remaining, num_depths as usize)?;
         let result = Pictscreen { fallback, depths };
         Ok((result, remaining))
     }
@@ -1302,18 +1256,12 @@ pub struct Indexvalue {
     pub alpha: u16,
 }
 impl TryParse for Indexvalue {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (pixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alpha, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (pixel, remaining) = u32::try_parse(remaining)?;
+        let (red, remaining) = u16::try_parse(remaining)?;
+        let (green, remaining) = u16::try_parse(remaining)?;
+        let (blue, remaining) = u16::try_parse(remaining)?;
+        let (alpha, remaining) = u16::try_parse(remaining)?;
         let result = Indexvalue { pixel, red, green, blue, alpha };
         Ok((result, remaining))
     }
@@ -1365,16 +1313,11 @@ pub struct Color {
     pub alpha: u16,
 }
 impl TryParse for Color {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alpha, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (red, remaining) = u16::try_parse(remaining)?;
+        let (green, remaining) = u16::try_parse(remaining)?;
+        let (blue, remaining) = u16::try_parse(remaining)?;
+        let (alpha, remaining) = u16::try_parse(remaining)?;
         let result = Color { red, green, blue, alpha };
         Ok((result, remaining))
     }
@@ -1418,12 +1361,9 @@ pub struct Pointfix {
     pub y: FIXED,
 }
 impl TryParse for Pointfix {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (x, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (x, remaining) = FIXED::try_parse(remaining)?;
+        let (y, remaining) = FIXED::try_parse(remaining)?;
         let result = Pointfix { x, y };
         Ok((result, remaining))
     }
@@ -1463,12 +1403,9 @@ pub struct Linefix {
     pub p2: Pointfix,
 }
 impl TryParse for Linefix {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (p1, new_remaining) = Pointfix::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (p2, new_remaining) = Pointfix::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (p1, remaining) = Pointfix::try_parse(remaining)?;
+        let (p2, remaining) = Pointfix::try_parse(remaining)?;
         let result = Linefix { p1, p2 };
         Ok((result, remaining))
     }
@@ -1517,14 +1454,10 @@ pub struct Triangle {
     pub p3: Pointfix,
 }
 impl TryParse for Triangle {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (p1, new_remaining) = Pointfix::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (p2, new_remaining) = Pointfix::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (p3, new_remaining) = Pointfix::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (p1, remaining) = Pointfix::try_parse(remaining)?;
+        let (p2, remaining) = Pointfix::try_parse(remaining)?;
+        let (p3, remaining) = Pointfix::try_parse(remaining)?;
         let result = Triangle { p1, p2, p3 };
         Ok((result, remaining))
     }
@@ -1584,16 +1517,11 @@ pub struct Trapezoid {
     pub right: Linefix,
 }
 impl TryParse for Trapezoid {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (top, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bottom, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (left, new_remaining) = Linefix::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (right, new_remaining) = Linefix::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (top, remaining) = FIXED::try_parse(remaining)?;
+        let (bottom, remaining) = FIXED::try_parse(remaining)?;
+        let (left, remaining) = Linefix::try_parse(remaining)?;
+        let (right, remaining) = Linefix::try_parse(remaining)?;
         let result = Trapezoid { top, bottom, left, right };
         Ok((result, remaining))
     }
@@ -1673,20 +1601,13 @@ pub struct Glyphinfo {
     pub y_off: i16,
 }
 impl TryParse for Glyphinfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x_off, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y_off, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (x_off, remaining) = i16::try_parse(remaining)?;
+        let (y_off, remaining) = i16::try_parse(remaining)?;
         let result = Glyphinfo { width, height, x, y, x_off, y_off };
         Ok((result, remaining))
     }
@@ -1770,20 +1691,14 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -1826,32 +1741,20 @@ pub struct QueryPictFormatsReply {
     pub subpixels: Vec<u32>,
 }
 impl QueryPictFormatsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_formats, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_screens, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_depths, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_visuals, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_subpixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (formats, new_remaining) = crate::x11_utils::parse_list::<Pictforminfo>(remaining, num_formats as usize)?;
-        remaining = new_remaining;
-        let (screens, new_remaining) = crate::x11_utils::parse_list::<Pictscreen>(remaining, num_screens as usize)?;
-        remaining = new_remaining;
-        let (subpixels, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_subpixel as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_formats, remaining) = u32::try_parse(remaining)?;
+        let (num_screens, remaining) = u32::try_parse(remaining)?;
+        let (num_depths, remaining) = u32::try_parse(remaining)?;
+        let (num_visuals, remaining) = u32::try_parse(remaining)?;
+        let (num_subpixel, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (formats, remaining) = crate::x11_utils::parse_list::<Pictforminfo>(remaining, num_formats as usize)?;
+        let (screens, remaining) = crate::x11_utils::parse_list::<Pictscreen>(remaining, num_screens as usize)?;
+        let (subpixels, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_subpixel as usize)?;
         let result = QueryPictFormatsReply { response_type, sequence, length, num_depths, num_visuals, formats, screens, subpixels };
         Ok((result, remaining))
     }
@@ -1895,20 +1798,14 @@ pub struct QueryPictIndexValuesReply {
     pub values: Vec<Indexvalue>,
 }
 impl QueryPictIndexValuesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (values, new_remaining) = crate::x11_utils::parse_list::<Indexvalue>(remaining, num_values as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_values, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (values, remaining) = crate::x11_utils::parse_list::<Indexvalue>(remaining, num_values as usize)?;
         let result = QueryPictIndexValuesReply { response_type, sequence, length, values };
         Ok((result, remaining))
     }
@@ -3100,26 +2997,16 @@ pub struct Transform {
     pub matrix33: FIXED,
 }
 impl TryParse for Transform {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (matrix11, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix12, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix13, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix21, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix22, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix23, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix31, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix32, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (matrix33, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (matrix11, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix12, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix13, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix21, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix22, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix23, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix31, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix32, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix33, remaining) = FIXED::try_parse(remaining)?;
         let result = Transform { matrix11, matrix12, matrix13, matrix21, matrix22, matrix23, matrix31, matrix32, matrix33 };
         Ok((result, remaining))
     }
@@ -3290,24 +3177,16 @@ pub struct QueryFiltersReply {
     pub filters: Vec<Str>,
 }
 impl QueryFiltersReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_aliases, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_filters, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (aliases, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_aliases as usize)?;
-        remaining = new_remaining;
-        let (filters, new_remaining) = crate::x11_utils::parse_list::<Str>(remaining, num_filters as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_aliases, remaining) = u32::try_parse(remaining)?;
+        let (num_filters, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (aliases, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_aliases as usize)?;
+        let (filters, remaining) = crate::x11_utils::parse_list::<Str>(remaining, num_filters as usize)?;
         let result = QueryFiltersReply { response_type, sequence, length, aliases, filters };
         Ok((result, remaining))
     }
@@ -3363,12 +3242,9 @@ pub struct Animcursorelt {
     pub delay: u32,
 }
 impl TryParse for Animcursorelt {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (cursor, new_remaining) = CURSOR::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (delay, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (cursor, remaining) = CURSOR::try_parse(remaining)?;
+        let (delay, remaining) = u32::try_parse(remaining)?;
         let result = Animcursorelt { cursor, delay };
         Ok((result, remaining))
     }
@@ -3438,14 +3314,10 @@ pub struct Spanfix {
     pub y: FIXED,
 }
 impl TryParse for Spanfix {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (l, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (r, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = FIXED::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (l, remaining) = FIXED::try_parse(remaining)?;
+        let (r, remaining) = FIXED::try_parse(remaining)?;
+        let (y, remaining) = FIXED::try_parse(remaining)?;
         let result = Spanfix { l, r, y };
         Ok((result, remaining))
     }
@@ -3491,12 +3363,9 @@ pub struct Trap {
     pub bot: Spanfix,
 }
 impl TryParse for Trap {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (top, new_remaining) = Spanfix::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bot, new_remaining) = Spanfix::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (top, remaining) = Spanfix::try_parse(remaining)?;
+        let (bot, remaining) = Spanfix::try_parse(remaining)?;
         let result = Trap { top, bot };
         Ok((result, remaining))
     }

--- a/src/generated/res.rs
+++ b/src/generated/res.rs
@@ -43,12 +43,9 @@ pub struct Client {
     pub resource_mask: u32,
 }
 impl TryParse for Client {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (resource_base, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resource_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (resource_base, remaining) = u32::try_parse(remaining)?;
+        let (resource_mask, remaining) = u32::try_parse(remaining)?;
         let result = Client { resource_base, resource_mask };
         Ok((result, remaining))
     }
@@ -88,12 +85,9 @@ pub struct Type {
     pub count: u32,
 }
 impl TryParse for Type {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (resource_type, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (resource_type, remaining) = ATOM::try_parse(remaining)?;
+        let (count, remaining) = u32::try_parse(remaining)?;
         let result = Type { resource_type, count };
         Ok((result, remaining))
     }
@@ -196,12 +190,9 @@ pub struct ClientIdSpec {
     pub mask: u32,
 }
 impl TryParse for ClientIdSpec {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (client, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (client, remaining) = u32::try_parse(remaining)?;
+        let (mask, remaining) = u32::try_parse(remaining)?;
         let result = ClientIdSpec { client, mask };
         Ok((result, remaining))
     }
@@ -241,14 +232,10 @@ pub struct ClientIdValue {
     pub value: Vec<u32>,
 }
 impl TryParse for ClientIdValue {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (spec, new_remaining) = ClientIdSpec::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, (length as usize) / (4))?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (spec, remaining) = ClientIdSpec::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (value, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (length as usize) / (4))?;
         let result = ClientIdValue { spec, value };
         Ok((result, remaining))
     }
@@ -282,12 +269,9 @@ pub struct ResourceIdSpec {
     pub type_: u32,
 }
 impl TryParse for ResourceIdSpec {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (resource, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (resource, remaining) = u32::try_parse(remaining)?;
+        let (type_, remaining) = u32::try_parse(remaining)?;
         let result = ResourceIdSpec { resource, type_ };
         Ok((result, remaining))
     }
@@ -329,16 +313,11 @@ pub struct ResourceSizeSpec {
     pub use_count: u32,
 }
 impl TryParse for ResourceSizeSpec {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (spec, new_remaining) = ResourceIdSpec::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ref_count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (use_count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (spec, remaining) = ResourceIdSpec::try_parse(remaining)?;
+        let (bytes, remaining) = u32::try_parse(remaining)?;
+        let (ref_count, remaining) = u32::try_parse(remaining)?;
+        let (use_count, remaining) = u32::try_parse(remaining)?;
         let result = ResourceSizeSpec { spec, bytes, ref_count, use_count };
         Ok((result, remaining))
     }
@@ -394,14 +373,10 @@ pub struct ResourceSizeValue {
     pub cross_references: Vec<ResourceSizeSpec>,
 }
 impl TryParse for ResourceSizeValue {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (size, new_remaining) = ResourceSizeSpec::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_cross_references, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cross_references, new_remaining) = crate::x11_utils::parse_list::<ResourceSizeSpec>(remaining, num_cross_references as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (size, remaining) = ResourceSizeSpec::try_parse(remaining)?;
+        let (num_cross_references, remaining) = u32::try_parse(remaining)?;
+        let (cross_references, remaining) = crate::x11_utils::parse_list::<ResourceSizeSpec>(remaining, num_cross_references as usize)?;
         let result = ResourceSizeValue { size, cross_references };
         Ok((result, remaining))
     }
@@ -462,19 +437,13 @@ pub struct QueryVersionReply {
     pub server_minor: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major, remaining) = u16::try_parse(remaining)?;
+        let (server_minor, remaining) = u16::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, server_major, server_minor };
         Ok((result, remaining))
     }
@@ -513,20 +482,14 @@ pub struct QueryClientsReply {
     pub clients: Vec<Client>,
 }
 impl QueryClientsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_clients, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (clients, new_remaining) = crate::x11_utils::parse_list::<Client>(remaining, num_clients as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_clients, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (clients, remaining) = crate::x11_utils::parse_list::<Client>(remaining, num_clients as usize)?;
         let result = QueryClientsReply { response_type, sequence, length, clients };
         Ok((result, remaining))
     }
@@ -570,20 +533,14 @@ pub struct QueryClientResourcesReply {
     pub types: Vec<Type>,
 }
 impl QueryClientResourcesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_types, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (types, new_remaining) = crate::x11_utils::parse_list::<Type>(remaining, num_types as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_types, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (types, remaining) = crate::x11_utils::parse_list::<Type>(remaining, num_types as usize)?;
         let result = QueryClientResourcesReply { response_type, sequence, length, types };
         Ok((result, remaining))
     }
@@ -628,19 +585,13 @@ pub struct QueryClientPixmapBytesReply {
     pub bytes_overflow: u32,
 }
 impl QueryClientPixmapBytesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes_overflow, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (bytes, remaining) = u32::try_parse(remaining)?;
+        let (bytes_overflow, remaining) = u32::try_parse(remaining)?;
         let result = QueryClientPixmapBytesReply { response_type, sequence, length, bytes, bytes_overflow };
         Ok((result, remaining))
     }
@@ -689,20 +640,14 @@ pub struct QueryClientIdsReply {
     pub ids: Vec<ClientIdValue>,
 }
 impl QueryClientIdsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_ids, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (ids, new_remaining) = crate::x11_utils::parse_list::<ClientIdValue>(remaining, num_ids as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_ids, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (ids, remaining) = crate::x11_utils::parse_list::<ClientIdValue>(remaining, num_ids as usize)?;
         let result = QueryClientIdsReply { response_type, sequence, length, ids };
         Ok((result, remaining))
     }
@@ -756,20 +701,14 @@ pub struct QueryResourceBytesReply {
     pub sizes: Vec<ResourceSizeValue>,
 }
 impl QueryResourceBytesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_sizes, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (sizes, new_remaining) = crate::x11_utils::parse_list::<ResourceSizeValue>(remaining, num_sizes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_sizes, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (sizes, remaining) = crate::x11_utils::parse_list::<ResourceSizeValue>(remaining, num_sizes as usize)?;
         let result = QueryResourceBytesReply { response_type, sequence, length, sizes };
         Ok((result, remaining))
     }

--- a/src/generated/screensaver.rs
+++ b/src/generated/screensaver.rs
@@ -267,20 +267,14 @@ pub struct QueryVersionReply {
     pub server_minor_version: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major_version, remaining) = u16::try_parse(remaining)?;
+        let (server_minor_version, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, server_major_version, server_minor_version };
         Ok((result, remaining))
     }
@@ -329,27 +323,17 @@ pub struct QueryInfoReply {
     pub kind: u8,
 }
 impl QueryInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (saver_window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ms_until_server, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ms_since_user_input, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kind, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(7..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (saver_window, remaining) = WINDOW::try_parse(remaining)?;
+        let (ms_until_server, remaining) = u32::try_parse(remaining)?;
+        let (ms_since_user_input, remaining) = u32::try_parse(remaining)?;
+        let (event_mask, remaining) = u32::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
         let result = QueryInfoReply { response_type, state, sequence, length, saver_window, ms_until_server, ms_since_user_input, event_mask, kind };
         Ok((result, remaining))
     }
@@ -719,25 +703,16 @@ pub struct NotifyEvent {
     pub forced: bool,
 }
 impl NotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kind, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (forced, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(14..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let (forced, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
         let result = NotifyEvent { response_type, state, sequence, time, root, window, kind, forced };
         Ok((result, remaining))
     }

--- a/src/generated/shape.rs
+++ b/src/generated/shape.rs
@@ -193,29 +193,18 @@ pub struct NotifyEvent {
     pub shaped: bool,
 }
 impl NotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (shape_kind, new_remaining) = KIND::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (affected_window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extents_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extents_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extents_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extents_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (shaped, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(11..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (shape_kind, remaining) = KIND::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (affected_window, remaining) = WINDOW::try_parse(remaining)?;
+        let (extents_x, remaining) = i16::try_parse(remaining)?;
+        let (extents_y, remaining) = i16::try_parse(remaining)?;
+        let (extents_width, remaining) = u16::try_parse(remaining)?;
+        let (extents_height, remaining) = u16::try_parse(remaining)?;
+        let (server_time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (shaped, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let result = NotifyEvent { response_type, shape_kind, sequence, affected_window, extents_x, extents_y, extents_width, extents_height, server_time, shaped };
         Ok((result, remaining))
     }
@@ -287,19 +276,13 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u16::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -524,36 +507,22 @@ pub struct QueryExtentsReply {
     pub clip_shape_extents_height: u16,
 }
 impl QueryExtentsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bounding_shaped, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (clip_shaped, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (bounding_shape_extents_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bounding_shape_extents_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bounding_shape_extents_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bounding_shape_extents_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (clip_shape_extents_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (clip_shape_extents_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (clip_shape_extents_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (clip_shape_extents_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (bounding_shaped, remaining) = bool::try_parse(remaining)?;
+        let (clip_shaped, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (bounding_shape_extents_x, remaining) = i16::try_parse(remaining)?;
+        let (bounding_shape_extents_y, remaining) = i16::try_parse(remaining)?;
+        let (bounding_shape_extents_width, remaining) = u16::try_parse(remaining)?;
+        let (bounding_shape_extents_height, remaining) = u16::try_parse(remaining)?;
+        let (clip_shape_extents_x, remaining) = i16::try_parse(remaining)?;
+        let (clip_shape_extents_y, remaining) = i16::try_parse(remaining)?;
+        let (clip_shape_extents_width, remaining) = u16::try_parse(remaining)?;
+        let (clip_shape_extents_height, remaining) = u16::try_parse(remaining)?;
         let result = QueryExtentsReply { response_type, sequence, length, bounding_shaped, clip_shaped, bounding_shape_extents_x, bounding_shape_extents_y, bounding_shape_extents_width, bounding_shape_extents_height, clip_shape_extents_x, clip_shape_extents_y, clip_shape_extents_width, clip_shape_extents_height };
         Ok((result, remaining))
     }
@@ -627,16 +596,11 @@ pub struct InputSelectedReply {
     pub length: u32,
 }
 impl InputSelectedReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enabled, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (enabled, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = InputSelectedReply { response_type, enabled, sequence, length };
         Ok((result, remaining))
     }
@@ -687,21 +651,14 @@ pub struct GetRectanglesReply {
     pub rectangles: Vec<Rectangle>,
 }
 impl GetRectanglesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ordering, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rectangles_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (rectangles, new_remaining) = crate::x11_utils::parse_list::<Rectangle>(remaining, rectangles_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (ordering, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (rectangles_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<Rectangle>(remaining, rectangles_len as usize)?;
         let result = GetRectanglesReply { response_type, ordering, sequence, length, rectangles };
         Ok((result, remaining))
     }

--- a/src/generated/shm.rs
+++ b/src/generated/shm.rs
@@ -52,24 +52,16 @@ pub struct CompletionEvent {
     pub offset: u32,
 }
 impl CompletionEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_event, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_event, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (shmseg, new_remaining) = SEG::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (minor_event, remaining) = u16::try_parse(remaining)?;
+        let (major_event, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (shmseg, remaining) = SEG::try_parse(remaining)?;
+        let (offset, remaining) = u32::try_parse(remaining)?;
         let result = CompletionEvent { response_type, sequence, drawable, minor_event, major_event, shmseg, offset };
         Ok((result, remaining))
     }
@@ -123,21 +115,14 @@ pub struct BadSegError {
     pub major_opcode: u8,
 }
 impl BadSegError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = BadSegError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -209,27 +194,17 @@ pub struct QueryVersionReply {
     pub pixmap_format: u8,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (shared_pixmaps, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (uid, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (gid, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixmap_format, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(15..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (shared_pixmaps, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u16::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
+        let (uid, remaining) = u16::try_parse(remaining)?;
+        let (gid, remaining) = u16::try_parse(remaining)?;
+        let (pixmap_format, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, shared_pixmaps, sequence, length, major_version, minor_version, uid, gid, pixmap_format };
         Ok((result, remaining))
     }
@@ -438,20 +413,13 @@ pub struct GetImageReply {
     pub size: u32,
 }
 impl GetImageReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual, new_remaining) = VISUALID::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (size, remaining) = u32::try_parse(remaining)?;
         let result = GetImageReply { response_type, depth, sequence, length, visual, size };
         Ok((result, remaining))
     }
@@ -588,19 +556,14 @@ pub struct CreateSegmentReply {
     pub shm_fd: RawFdContainer,
 }
 impl CreateSegmentReply {
-    fn try_parse_fd<'a>(value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nfd, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (nfd, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         if fds.is_empty() { return Err(ParseError::ParseError) }
         let shm_fd = fds.remove(0);
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = CreateSegmentReply { response_type, nfd, sequence, length, shm_fd };
         Ok((result, remaining))
     }

--- a/src/generated/sync.rs
+++ b/src/generated/sync.rs
@@ -319,12 +319,9 @@ pub struct Int64 {
     pub lo: u32,
 }
 impl TryParse for Int64 {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (hi, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (lo, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (hi, remaining) = i32::try_parse(remaining)?;
+        let (lo, remaining) = u32::try_parse(remaining)?;
         let result = Int64 { hi, lo };
         Ok((result, remaining))
     }
@@ -365,20 +362,16 @@ pub struct Systemcounter {
     pub name: Vec<u8>,
 }
 impl TryParse for Systemcounter {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (counter, new_remaining) = COUNTER::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resolution, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (counter, remaining) = COUNTER::try_parse(remaining)?;
+        let (resolution, remaining) = Int64::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = Systemcounter { counter, resolution, name };
         Ok((result, remaining))
     }
@@ -415,16 +408,11 @@ pub struct Trigger {
     pub test_type: u32,
 }
 impl TryParse for Trigger {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (counter, new_remaining) = COUNTER::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (wait_type, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (wait_value, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (test_type, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (counter, remaining) = COUNTER::try_parse(remaining)?;
+        let (wait_type, remaining) = u32::try_parse(remaining)?;
+        let (wait_value, remaining) = Int64::try_parse(remaining)?;
+        let (test_type, remaining) = u32::try_parse(remaining)?;
         let result = Trigger { counter, wait_type, wait_value, test_type };
         Ok((result, remaining))
     }
@@ -480,12 +468,9 @@ pub struct Waitcondition {
     pub event_threshold: Int64,
 }
 impl TryParse for Waitcondition {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (trigger, new_remaining) = Trigger::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_threshold, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (trigger, remaining) = Trigger::try_parse(remaining)?;
+        let (event_threshold, remaining) = Int64::try_parse(remaining)?;
         let result = Waitcondition { trigger, event_threshold };
         Ok((result, remaining))
     }
@@ -551,20 +536,13 @@ pub struct CounterError {
     pub major_opcode: u8,
 }
 impl CounterError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_counter, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_counter, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
         let result = CounterError { response_type, error_code, sequence, bad_counter, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -616,20 +594,13 @@ pub struct AlarmError {
     pub major_opcode: u8,
 }
 impl AlarmError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_alarm, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_alarm, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
         let result = AlarmError { response_type, error_code, sequence, bad_alarm, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -703,20 +674,14 @@ pub struct InitializeReply {
     pub minor_version: u8,
 }
 impl InitializeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u8::try_parse(remaining)?;
+        let (minor_version, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
         let result = InitializeReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -755,20 +720,14 @@ pub struct ListSystemCountersReply {
     pub counters: Vec<Systemcounter>,
 }
 impl ListSystemCountersReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (counters_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (counters, new_remaining) = crate::x11_utils::parse_list::<Systemcounter>(remaining, counters_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (counters_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (counters, remaining) = crate::x11_utils::parse_list::<Systemcounter>(remaining, counters_len as usize)?;
         let result = ListSystemCountersReply { response_type, sequence, length, counters };
         Ok((result, remaining))
     }
@@ -871,17 +830,12 @@ pub struct QueryCounterReply {
     pub counter_value: Int64,
 }
 impl QueryCounterReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (counter_value, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (counter_value, remaining) = Int64::try_parse(remaining)?;
         let result = QueryCounterReply { response_type, sequence, length, counter_value };
         Ok((result, remaining))
     }
@@ -1307,24 +1261,16 @@ pub struct QueryAlarmReply {
     pub state: u8,
 }
 impl QueryAlarmReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (trigger, new_remaining) = Trigger::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (delta, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (events, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (trigger, remaining) = Trigger::try_parse(remaining)?;
+        let (delta, remaining) = Int64::try_parse(remaining)?;
+        let (events, remaining) = bool::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = QueryAlarmReply { response_type, sequence, length, trigger, delta, events, state };
         Ok((result, remaining))
     }
@@ -1398,17 +1344,12 @@ pub struct GetPriorityReply {
     pub priority: i32,
 }
 impl GetPriorityReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (priority, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (priority, remaining) = i32::try_parse(remaining)?;
         let result = GetPriorityReply { response_type, sequence, length, priority };
         Ok((result, remaining))
     }
@@ -1562,18 +1503,13 @@ pub struct QueryFenceReply {
     pub triggered: bool,
 }
 impl QueryFenceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (triggered, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (triggered, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = QueryFenceReply { response_type, sequence, length, triggered };
         Ok((result, remaining))
     }
@@ -1624,27 +1560,17 @@ pub struct CounterNotifyEvent {
     pub destroyed: bool,
 }
 impl CounterNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kind, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (counter, new_remaining) = COUNTER::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (wait_value, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (counter_value, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (destroyed, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (counter, remaining) = COUNTER::try_parse(remaining)?;
+        let (wait_value, remaining) = Int64::try_parse(remaining)?;
+        let (counter_value, remaining) = Int64::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let (destroyed, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = CounterNotifyEvent { response_type, kind, sequence, counter, wait_value, counter_value, timestamp, count, destroyed };
         Ok((result, remaining))
     }
@@ -1701,25 +1627,16 @@ pub struct AlarmNotifyEvent {
     pub state: u8,
 }
 impl AlarmNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kind, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alarm, new_remaining) = ALARM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (counter_value, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alarm_value, new_remaining) = Int64::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (alarm, remaining) = ALARM::try_parse(remaining)?;
+        let (counter_value, remaining) = Int64::try_parse(remaining)?;
+        let (alarm_value, remaining) = Int64::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = AlarmNotifyEvent { response_type, kind, sequence, alarm, counter_value, alarm_value, timestamp, state };
         Ok((result, remaining))
     }

--- a/src/generated/xc_misc.rs
+++ b/src/generated/xc_misc.rs
@@ -69,19 +69,13 @@ pub struct GetVersionReply {
     pub server_minor_version: u16,
 }
 impl GetVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major_version, remaining) = u16::try_parse(remaining)?;
+        let (server_minor_version, remaining) = u16::try_parse(remaining)?;
         let result = GetVersionReply { response_type, sequence, length, server_major_version, server_minor_version };
         Ok((result, remaining))
     }
@@ -121,19 +115,13 @@ pub struct GetXIDRangeReply {
     pub count: u32,
 }
 impl GetXIDRangeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (start_id, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (start_id, remaining) = u32::try_parse(remaining)?;
+        let (count, remaining) = u32::try_parse(remaining)?;
         let result = GetXIDRangeReply { response_type, sequence, length, start_id, count };
         Ok((result, remaining))
     }
@@ -177,20 +165,14 @@ pub struct GetXIDListReply {
     pub ids: Vec<u32>,
 }
 impl GetXIDListReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ids_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (ids, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, ids_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (ids_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (ids, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ids_len as usize)?;
         let result = GetXIDListReply { response_type, sequence, length, ids };
         Ok((result, remaining))
     }

--- a/src/generated/xevie.rs
+++ b/src/generated/xevie.rs
@@ -69,20 +69,14 @@ pub struct QueryVersionReply {
     pub server_minor_version: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major_version, remaining) = u16::try_parse(remaining)?;
+        let (server_minor_version, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, server_major_version, server_minor_version };
         Ok((result, remaining))
     }
@@ -125,16 +119,12 @@ pub struct StartReply {
     pub length: u32,
 }
 impl StartReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = StartReply { response_type, sequence, length };
         Ok((result, remaining))
     }
@@ -177,16 +167,12 @@ pub struct EndReply {
     pub length: u32,
 }
 impl EndReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = EndReply { response_type, sequence, length };
         Ok((result, remaining))
     }
@@ -264,9 +250,8 @@ impl TryFrom<u32> for Datatype {
 pub struct Event {
 }
 impl TryParse for Event {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        remaining = &remaining.get(32..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = remaining.get(32..).ok_or(ParseError::ParseError)?;
         let result = Event {  };
         Ok((result, remaining))
     }
@@ -449,16 +434,12 @@ pub struct SendReply {
     pub length: u32,
 }
 impl SendReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = SendReply { response_type, sequence, length };
         Ok((result, remaining))
     }
@@ -501,16 +482,12 @@ pub struct SelectInputReply {
     pub length: u32,
 }
 impl SelectInputReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
         let result = SelectInputReply { response_type, sequence, length };
         Ok((result, remaining))
     }

--- a/src/generated/xf86dri.rs
+++ b/src/generated/xf86dri.rs
@@ -43,16 +43,11 @@ pub struct DrmClipRect {
     pub x3: i16,
 }
 impl TryParse for DrmClipRect {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (x1, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y1, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x2, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x3, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (x1, remaining) = i16::try_parse(remaining)?;
+        let (y1, remaining) = i16::try_parse(remaining)?;
+        let (x2, remaining) = i16::try_parse(remaining)?;
+        let (x3, remaining) = i16::try_parse(remaining)?;
         let result = DrmClipRect { x1, y1, x2, x3 };
         Ok((result, remaining))
     }
@@ -119,21 +114,14 @@ pub struct QueryVersionReply {
     pub dri_minor_patch: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dri_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dri_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dri_minor_patch, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (dri_major_version, remaining) = u16::try_parse(remaining)?;
+        let (dri_minor_version, remaining) = u16::try_parse(remaining)?;
+        let (dri_minor_patch, remaining) = u32::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, dri_major_version, dri_minor_version, dri_minor_patch };
         Ok((result, remaining))
     }
@@ -177,17 +165,12 @@ pub struct QueryDirectRenderingCapableReply {
     pub is_capable: bool,
 }
 impl QueryDirectRenderingCapableReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (is_capable, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (is_capable, remaining) = bool::try_parse(remaining)?;
         let result = QueryDirectRenderingCapableReply { response_type, sequence, length, is_capable };
         Ok((result, remaining))
     }
@@ -233,24 +216,16 @@ pub struct OpenConnectionReply {
     pub bus_id: Vec<u8>,
 }
 impl OpenConnectionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sarea_handle_low, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sarea_handle_high, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bus_id_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (bus_id, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, bus_id_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (sarea_handle_low, remaining) = u32::try_parse(remaining)?;
+        let (sarea_handle_high, remaining) = u32::try_parse(remaining)?;
+        let (bus_id_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (bus_id, remaining) = crate::x11_utils::parse_list::<u8>(remaining, bus_id_len as usize)?;
         let result = OpenConnectionReply { response_type, sequence, length, sarea_handle_low, sarea_handle_high, bus_id };
         Ok((result, remaining))
     }
@@ -322,26 +297,17 @@ pub struct GetClientDriverNameReply {
     pub client_driver_name: Vec<u8>,
 }
 impl GetClientDriverNameReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (client_driver_major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (client_driver_minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (client_driver_patch_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (client_driver_name_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (client_driver_name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, client_driver_name_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (client_driver_major_version, remaining) = u32::try_parse(remaining)?;
+        let (client_driver_minor_version, remaining) = u32::try_parse(remaining)?;
+        let (client_driver_patch_version, remaining) = u32::try_parse(remaining)?;
+        let (client_driver_name_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (client_driver_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, client_driver_name_len as usize)?;
         let result = GetClientDriverNameReply { response_type, sequence, length, client_driver_major_version, client_driver_minor_version, client_driver_patch_version, client_driver_name };
         Ok((result, remaining))
     }
@@ -395,17 +361,12 @@ pub struct CreateContextReply {
     pub hw_context: u32,
 }
 impl CreateContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hw_context, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (hw_context, remaining) = u32::try_parse(remaining)?;
         let result = CreateContextReply { response_type, sequence, length, hw_context };
         Ok((result, remaining))
     }
@@ -484,17 +445,12 @@ pub struct CreateDrawableReply {
     pub hw_drawable_handle: u32,
 }
 impl CreateDrawableReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hw_drawable_handle, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (hw_drawable_handle, remaining) = u32::try_parse(remaining)?;
         let result = CreateDrawableReply { response_type, sequence, length, hw_drawable_handle };
         Ok((result, remaining))
     }
@@ -582,39 +538,23 @@ pub struct GetDrawableInfoReply {
     pub back_clip_rects: Vec<DrmClipRect>,
 }
 impl GetDrawableInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable_table_index, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable_table_stamp, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable_origin_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable_origin_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable_size_w, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable_size_h, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_clip_rects, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (back_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (back_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_back_clip_rects, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (clip_rects, new_remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_clip_rects as usize)?;
-        remaining = new_remaining;
-        let (back_clip_rects, new_remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_back_clip_rects as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (drawable_table_index, remaining) = u32::try_parse(remaining)?;
+        let (drawable_table_stamp, remaining) = u32::try_parse(remaining)?;
+        let (drawable_origin_x, remaining) = i16::try_parse(remaining)?;
+        let (drawable_origin_y, remaining) = i16::try_parse(remaining)?;
+        let (drawable_size_w, remaining) = i16::try_parse(remaining)?;
+        let (drawable_size_h, remaining) = i16::try_parse(remaining)?;
+        let (num_clip_rects, remaining) = u32::try_parse(remaining)?;
+        let (back_x, remaining) = i16::try_parse(remaining)?;
+        let (back_y, remaining) = i16::try_parse(remaining)?;
+        let (num_back_clip_rects, remaining) = u32::try_parse(remaining)?;
+        let (clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_clip_rects as usize)?;
+        let (back_clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_back_clip_rects as usize)?;
         let result = GetDrawableInfoReply { response_type, sequence, length, drawable_table_index, drawable_table_stamp, drawable_origin_x, drawable_origin_y, drawable_size_w, drawable_size_h, back_x, back_y, clip_rects, back_clip_rects };
         Ok((result, remaining))
     }
@@ -663,29 +603,18 @@ pub struct GetDeviceInfoReply {
     pub device_private: Vec<u32>,
 }
 impl GetDeviceInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (framebuffer_handle_low, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (framebuffer_handle_high, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (framebuffer_origin_offset, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (framebuffer_size, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (framebuffer_stride, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_private_size, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_private, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, device_private_size as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (framebuffer_handle_low, remaining) = u32::try_parse(remaining)?;
+        let (framebuffer_handle_high, remaining) = u32::try_parse(remaining)?;
+        let (framebuffer_origin_offset, remaining) = u32::try_parse(remaining)?;
+        let (framebuffer_size, remaining) = u32::try_parse(remaining)?;
+        let (framebuffer_stride, remaining) = u32::try_parse(remaining)?;
+        let (device_private_size, remaining) = u32::try_parse(remaining)?;
+        let (device_private, remaining) = crate::x11_utils::parse_list::<u32>(remaining, device_private_size as usize)?;
         let result = GetDeviceInfoReply { response_type, sequence, length, framebuffer_handle_low, framebuffer_handle_high, framebuffer_origin_offset, framebuffer_size, framebuffer_stride, device_private };
         Ok((result, remaining))
     }
@@ -734,17 +663,12 @@ pub struct AuthConnectionReply {
     pub authenticated: u32,
 }
 impl AuthConnectionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (authenticated, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (authenticated, remaining) = u32::try_parse(remaining)?;
         let result = AuthConnectionReply { response_type, sequence, length, authenticated };
         Ok((result, remaining))
     }

--- a/src/generated/xf86vidmode.rs
+++ b/src/generated/xf86vidmode.rs
@@ -258,34 +258,21 @@ pub struct ModeInfo {
     pub privsize: u32,
 }
 impl TryParse for ModeInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (dotclock, new_remaining) = DOTCLOCK::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hdisplay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hsyncstart, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hsyncend, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (htotal, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hskew, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vdisplay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vsyncstart, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vsyncend, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vtotal, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (privsize, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (dotclock, remaining) = DOTCLOCK::try_parse(remaining)?;
+        let (hdisplay, remaining) = u16::try_parse(remaining)?;
+        let (hsyncstart, remaining) = u16::try_parse(remaining)?;
+        let (hsyncend, remaining) = u16::try_parse(remaining)?;
+        let (htotal, remaining) = u16::try_parse(remaining)?;
+        let (hskew, remaining) = u32::try_parse(remaining)?;
+        let (vdisplay, remaining) = u16::try_parse(remaining)?;
+        let (vsyncstart, remaining) = u16::try_parse(remaining)?;
+        let (vsyncend, remaining) = u16::try_parse(remaining)?;
+        let (vtotal, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (privsize, remaining) = u32::try_parse(remaining)?;
         let result = ModeInfo { dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, privsize };
         Ok((result, remaining))
     }
@@ -409,19 +396,13 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u16::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -476,43 +457,26 @@ pub struct GetModeLineReply {
     pub private: Vec<u8>,
 }
 impl GetModeLineReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dotclock, new_remaining) = DOTCLOCK::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hdisplay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hsyncstart, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hsyncend, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (htotal, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hskew, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vdisplay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vsyncstart, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vsyncend, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vtotal, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (privsize, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (private, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, privsize as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (dotclock, remaining) = DOTCLOCK::try_parse(remaining)?;
+        let (hdisplay, remaining) = u16::try_parse(remaining)?;
+        let (hsyncstart, remaining) = u16::try_parse(remaining)?;
+        let (hsyncend, remaining) = u16::try_parse(remaining)?;
+        let (htotal, remaining) = u16::try_parse(remaining)?;
+        let (hskew, remaining) = u16::try_parse(remaining)?;
+        let (vdisplay, remaining) = u16::try_parse(remaining)?;
+        let (vsyncstart, remaining) = u16::try_parse(remaining)?;
+        let (vsyncend, remaining) = u16::try_parse(remaining)?;
+        let (vtotal, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (privsize, remaining) = u32::try_parse(remaining)?;
+        let (private, remaining) = crate::x11_utils::parse_list::<u8>(remaining, privsize as usize)?;
         let result = GetModeLineReply { response_type, sequence, length, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private };
         Ok((result, remaining))
     }
@@ -666,34 +630,21 @@ pub struct GetMonitorReply {
     pub model: Vec<u8>,
 }
 impl GetMonitorReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vendor_length, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (model_length, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_hsync, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_vsync, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (hsync, new_remaining) = crate::x11_utils::parse_list::<SYNCRANGE>(remaining, num_hsync as usize)?;
-        remaining = new_remaining;
-        let (vsync, new_remaining) = crate::x11_utils::parse_list::<SYNCRANGE>(remaining, num_vsync as usize)?;
-        remaining = new_remaining;
-        let (vendor, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_length as usize)?;
-        remaining = new_remaining;
-        let (alignment_pad, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((vendor_length as usize) + (3)) & (!(3))) - (vendor_length as usize))?;
-        remaining = new_remaining;
-        let (model, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, model_length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (vendor_length, remaining) = u8::try_parse(remaining)?;
+        let (model_length, remaining) = u8::try_parse(remaining)?;
+        let (num_hsync, remaining) = u8::try_parse(remaining)?;
+        let (num_vsync, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (hsync, remaining) = crate::x11_utils::parse_list::<SYNCRANGE>(remaining, num_hsync as usize)?;
+        let (vsync, remaining) = crate::x11_utils::parse_list::<SYNCRANGE>(remaining, num_vsync as usize)?;
+        let (vendor, remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_length as usize)?;
+        let (alignment_pad, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((vendor_length as usize) + (3)) & (!(3))) - (vendor_length as usize))?;
+        let (model, remaining) = crate::x11_utils::parse_list::<u8>(remaining, model_length as usize)?;
         let result = GetMonitorReply { response_type, sequence, length, hsync, vsync, vendor, alignment_pad, model };
         Ok((result, remaining))
     }
@@ -763,20 +714,14 @@ pub struct GetAllModeLinesReply {
     pub modeinfo: Vec<ModeInfo>,
 }
 impl GetAllModeLinesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (modecount, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (modeinfo, new_remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, modecount as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (modecount, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (modeinfo, remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, modecount as usize)?;
         let result = GetAllModeLinesReply { response_type, sequence, length, modeinfo };
         Ok((result, remaining))
     }
@@ -1101,18 +1046,13 @@ pub struct ValidateModeLineReply {
     pub status: u32,
 }
 impl ValidateModeLineReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = ValidateModeLineReply { response_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -1242,20 +1182,14 @@ pub struct GetViewPortReply {
     pub y: u32,
 }
 impl GetViewPortReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (x, remaining) = u32::try_parse(remaining)?;
+        let (y, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = GetViewPortReply { response_type, sequence, length, x, y };
         Ok((result, remaining))
     }
@@ -1337,24 +1271,16 @@ pub struct GetDotClocksReply {
     pub clock: Vec<u32>,
 }
 impl GetDotClocksReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (clocks, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (maxclocks, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (clock, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((1) - ((flags as usize) & (1))) * (clocks as usize))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (clocks, remaining) = u32::try_parse(remaining)?;
+        let (maxclocks, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (clock, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((1) - ((flags as usize) & (1))) * (clocks as usize))?;
         let result = GetDotClocksReply { response_type, sequence, length, flags, clocks, maxclocks, clock };
         Ok((result, remaining))
     }
@@ -1502,22 +1428,15 @@ pub struct GetGammaReply {
     pub blue: u32,
 }
 impl GetGammaReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (red, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (red, remaining) = u32::try_parse(remaining)?;
+        let (green, remaining) = u32::try_parse(remaining)?;
+        let (blue, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let result = GetGammaReply { response_type, sequence, length, red, green, blue };
         Ok((result, remaining))
     }
@@ -1565,24 +1484,16 @@ pub struct GetGammaRampReply {
     pub blue: Vec<u16>,
 }
 impl GetGammaRampReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (red, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, ((size as usize) + (1)) & (!(1)))?;
-        remaining = new_remaining;
-        let (green, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, ((size as usize) + (1)) & (!(1)))?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, ((size as usize) + (1)) & (!(1)))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (size, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (red, remaining) = crate::x11_utils::parse_list::<u16>(remaining, ((size as usize) + (1)) & (!(1)))?;
+        let (green, remaining) = crate::x11_utils::parse_list::<u16>(remaining, ((size as usize) + (1)) & (!(1)))?;
+        let (blue, remaining) = crate::x11_utils::parse_list::<u16>(remaining, ((size as usize) + (1)) & (!(1)))?;
         let result = GetGammaRampReply { response_type, sequence, length, size, red, green, blue };
         Ok((result, remaining))
     }
@@ -1663,18 +1574,13 @@ pub struct GetGammaRampSizeReply {
     pub size: u16,
 }
 impl GetGammaRampSizeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (size, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (size, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
         let result = GetGammaRampSizeReply { response_type, sequence, length, size };
         Ok((result, remaining))
     }
@@ -1718,18 +1624,13 @@ pub struct GetPermissionsReply {
     pub permissions: u32,
 }
 impl GetPermissionsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (permissions, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (permissions, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = GetPermissionsReply { response_type, sequence, length, permissions };
         Ok((result, remaining))
     }
@@ -1750,14 +1651,10 @@ pub struct BadClockError {
     pub sequence: u16,
 }
 impl BadClockError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadClockError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -1804,14 +1701,10 @@ pub struct BadHTimingsError {
     pub sequence: u16,
 }
 impl BadHTimingsError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadHTimingsError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -1858,14 +1751,10 @@ pub struct BadVTimingsError {
     pub sequence: u16,
 }
 impl BadVTimingsError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadVTimingsError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -1912,14 +1801,10 @@ pub struct ModeUnsuitableError {
     pub sequence: u16,
 }
 impl ModeUnsuitableError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = ModeUnsuitableError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -1966,14 +1851,10 @@ pub struct ExtensionDisabledError {
     pub sequence: u16,
 }
 impl ExtensionDisabledError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = ExtensionDisabledError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -2020,14 +1901,10 @@ pub struct ClientNotLocalError {
     pub sequence: u16,
 }
 impl ClientNotLocalError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = ClientNotLocalError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -2074,14 +1951,10 @@ pub struct ZoomLockedError {
     pub sequence: u16,
 }
 impl ZoomLockedError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = ZoomLockedError { response_type, error_code, sequence };
         Ok((result, remaining))
     }

--- a/src/generated/xfixes.rs
+++ b/src/generated/xfixes.rs
@@ -79,20 +79,14 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = QueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -470,25 +464,16 @@ pub struct SelectionNotifyEvent {
     pub selection_timestamp: TIMESTAMP,
 }
 impl SelectionNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subtype, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (owner, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (selection, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (selection_timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (subtype, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (owner, remaining) = WINDOW::try_parse(remaining)?;
+        let (selection, remaining) = ATOM::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (selection_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let result = SelectionNotifyEvent { response_type, subtype, sequence, window, owner, selection, timestamp, selection_timestamp };
         Ok((result, remaining))
     }
@@ -698,23 +683,15 @@ pub struct CursorNotifyEvent {
     pub name: ATOM,
 }
 impl CursorNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subtype, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cursor_serial, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timestamp, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (subtype, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (cursor_serial, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let result = CursorNotifyEvent { response_type, subtype, sequence, window, cursor_serial, timestamp, name };
         Ok((result, remaining))
     }
@@ -820,32 +797,20 @@ pub struct GetCursorImageReply {
     pub cursor_image: Vec<u32>,
 }
 impl GetCursorImageReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xhot, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (yhot, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cursor_serial, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (cursor_image, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (xhot, remaining) = u16::try_parse(remaining)?;
+        let (yhot, remaining) = u16::try_parse(remaining)?;
+        let (cursor_serial, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
         let result = GetCursorImageReply { response_type, sequence, length, x, y, width, height, xhot, yhot, cursor_serial, cursor_image };
         Ok((result, remaining))
     }
@@ -868,14 +833,10 @@ pub struct BadRegionError {
     pub sequence: u16,
 }
 impl BadRegionError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadRegionError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -1448,20 +1409,14 @@ pub struct FetchRegionReply {
     pub rectangles: Vec<Rectangle>,
 }
 impl FetchRegionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extents, new_remaining) = Rectangle::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (rectangles, new_remaining) = crate::x11_utils::parse_list::<Rectangle>(remaining, (length as usize) / (2))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (extents, remaining) = Rectangle::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<Rectangle>(remaining, (length as usize) / (2))?;
         let result = FetchRegionReply { response_type, sequence, extents, rectangles };
         Ok((result, remaining))
     }
@@ -1654,22 +1609,15 @@ pub struct GetCursorNameReply {
     pub name: Vec<u8>,
 }
 impl GetCursorNameReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (atom, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nbytes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (atom, remaining) = ATOM::try_parse(remaining)?;
+        let (nbytes, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
         let result = GetCursorNameReply { response_type, sequence, length, atom, name };
         Ok((result, remaining))
     }
@@ -1717,38 +1665,23 @@ pub struct GetCursorImageAndNameReply {
     pub name: Vec<u8>,
 }
 impl GetCursorImageAndNameReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xhot, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (yhot, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cursor_serial, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cursor_atom, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (nbytes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (cursor_image, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (xhot, remaining) = u16::try_parse(remaining)?;
+        let (yhot, remaining) = u16::try_parse(remaining)?;
+        let (cursor_serial, remaining) = u32::try_parse(remaining)?;
+        let (cursor_atom, remaining) = ATOM::try_parse(remaining)?;
+        let (nbytes, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
         let result = GetCursorImageAndNameReply { response_type, sequence, length, x, y, width, height, xhot, yhot, cursor_serial, cursor_atom, cursor_image, name };
         Ok((result, remaining))
     }

--- a/src/generated/xinerama.rs
+++ b/src/generated/xinerama.rs
@@ -45,16 +45,11 @@ pub struct ScreenInfo {
     pub height: u16,
 }
 impl TryParse for ScreenInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (x_org, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y_org, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (x_org, remaining) = i16::try_parse(remaining)?;
+        let (y_org, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
         let result = ScreenInfo { x_org, y_org, width, height };
         Ok((result, remaining))
     }
@@ -126,19 +121,13 @@ pub struct QueryVersionReply {
     pub minor: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major, remaining) = u16::try_parse(remaining)?;
+        let (minor, remaining) = u16::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major, minor };
         Ok((result, remaining))
     }
@@ -183,18 +172,12 @@ pub struct GetStateReply {
     pub window: WINDOW,
 }
 impl GetStateReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
         let result = GetStateReply { response_type, state, sequence, length, window };
         Ok((result, remaining))
     }
@@ -239,18 +222,12 @@ pub struct GetScreenCountReply {
     pub window: WINDOW,
 }
 impl GetScreenCountReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (screen_count, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (screen_count, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
         let result = GetScreenCountReply { response_type, screen_count, sequence, length, window };
         Ok((result, remaining))
     }
@@ -302,23 +279,15 @@ pub struct GetScreenSizeReply {
     pub screen: u32,
 }
 impl GetScreenSizeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (screen, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u32::try_parse(remaining)?;
+        let (height, remaining) = u32::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (screen, remaining) = u32::try_parse(remaining)?;
         let result = GetScreenSizeReply { response_type, sequence, length, width, height, window, screen };
         Ok((result, remaining))
     }
@@ -357,17 +326,12 @@ pub struct IsActiveReply {
     pub state: u32,
 }
 impl IsActiveReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (state, remaining) = u32::try_parse(remaining)?;
         let result = IsActiveReply { response_type, sequence, length, state };
         Ok((result, remaining))
     }
@@ -406,20 +370,14 @@ pub struct QueryScreensReply {
     pub screen_info: Vec<ScreenInfo>,
 }
 impl QueryScreensReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (number, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (screen_info, new_remaining) = crate::x11_utils::parse_list::<ScreenInfo>(remaining, number as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (number, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (screen_info, remaining) = crate::x11_utils::parse_list::<ScreenInfo>(remaining, number as usize)?;
         let result = QueryScreensReply { response_type, sequence, length, screen_info };
         Ok((result, remaining))
     }

--- a/src/generated/xinput.rs
+++ b/src/generated/xinput.rs
@@ -57,12 +57,9 @@ pub struct Fp3232 {
     pub frac: u32,
 }
 impl TryParse for Fp3232 {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (integral, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (frac, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (integral, remaining) = i32::try_parse(remaining)?;
+        let (frac, remaining) = u32::try_parse(remaining)?;
         let result = Fp3232 { integral, frac };
         Ok((result, remaining))
     }
@@ -135,23 +132,15 @@ pub struct GetExtensionVersionReply {
     pub present: bool,
 }
 impl GetExtensionVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (present, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(19..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major, remaining) = u16::try_parse(remaining)?;
+        let (server_minor, remaining) = u16::try_parse(remaining)?;
+        let (present, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(19..).ok_or(ParseError::ParseError)?;
         let result = GetExtensionVersionReply { response_type, xi_reply_type, sequence, length, server_major, server_minor, present };
         Ok((result, remaining))
     }
@@ -381,17 +370,12 @@ pub struct DeviceInfo {
     pub device_use: u8,
 }
 impl TryParse for DeviceInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (device_type, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_class_info, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_use, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (device_type, remaining) = ATOM::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (num_class_info, remaining) = u8::try_parse(remaining)?;
+        let (device_use, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = DeviceInfo { device_type, device_id, num_class_info, device_use };
         Ok((result, remaining))
     }
@@ -439,19 +423,13 @@ pub struct KeyInfo {
     pub num_keys: u16,
 }
 impl TryParse for KeyInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_keycode, new_remaining) = KeyCode::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_keycode, new_remaining) = KeyCode::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_keys, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (min_keycode, remaining) = KeyCode::try_parse(remaining)?;
+        let (max_keycode, remaining) = KeyCode::try_parse(remaining)?;
+        let (num_keys, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = KeyInfo { class_id, len, min_keycode, max_keycode, num_keys };
         Ok((result, remaining))
     }
@@ -499,14 +477,10 @@ pub struct ButtonInfo {
     pub num_buttons: u16,
 }
 impl TryParse for ButtonInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_buttons, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (num_buttons, remaining) = u16::try_parse(remaining)?;
         let result = ButtonInfo { class_id, len, num_buttons };
         Ok((result, remaining))
     }
@@ -545,14 +519,10 @@ pub struct AxisInfo {
     pub maximum: i32,
 }
 impl TryParse for AxisInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (resolution, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minimum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (maximum, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (resolution, remaining) = u32::try_parse(remaining)?;
+        let (minimum, remaining) = i32::try_parse(remaining)?;
+        let (maximum, remaining) = i32::try_parse(remaining)?;
         let result = AxisInfo { resolution, minimum, maximum };
         Ok((result, remaining))
     }
@@ -601,20 +571,13 @@ pub struct ValuatorInfo {
     pub axes: Vec<AxisInfo>,
 }
 impl TryParse for ValuatorInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (axes_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (motion_size, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (axes, new_remaining) = crate::x11_utils::parse_list::<AxisInfo>(remaining, axes_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (axes_len, remaining) = u8::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (motion_size, remaining) = u32::try_parse(remaining)?;
+        let (axes, remaining) = crate::x11_utils::parse_list::<AxisInfo>(remaining, axes_len as usize)?;
         let result = ValuatorInfo { class_id, len, mode, motion_size, axes };
         Ok((result, remaining))
     }
@@ -651,15 +614,11 @@ pub struct InputInfoInfoKey {
     pub num_keys: u16,
 }
 impl TryParse for InputInfoInfoKey {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (min_keycode, new_remaining) = KeyCode::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_keycode, new_remaining) = KeyCode::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_keys, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (min_keycode, remaining) = KeyCode::try_parse(remaining)?;
+        let (max_keycode, remaining) = KeyCode::try_parse(remaining)?;
+        let (num_keys, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = InputInfoInfoKey { min_keycode, max_keycode, num_keys };
         Ok((result, remaining))
     }
@@ -700,16 +659,11 @@ pub struct InputInfoInfoValuator {
     pub axes: Vec<AxisInfo>,
 }
 impl TryParse for InputInfoInfoValuator {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (axes_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (motion_size, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (axes, new_remaining) = crate::x11_utils::parse_list::<AxisInfo>(remaining, axes_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (axes_len, remaining) = u8::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (motion_size, remaining) = u32::try_parse(remaining)?;
+        let (axes, remaining) = crate::x11_utils::parse_list::<AxisInfo>(remaining, axes_len as usize)?;
         let result = InputInfoInfoValuator { mode, motion_size, axes };
         Ok((result, remaining))
     }
@@ -744,29 +698,30 @@ pub enum InputInfoInfo {
 }
 impl InputInfoInfo {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if class_id == Into::<u8>::into(InputClass::Key) {
-            let (key, new_remaining) = InputInfoInfoKey::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (key, new_remaining) = InputInfoInfoKey::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputInfoInfo::Key(key));
         }
         if class_id == Into::<u8>::into(InputClass::Button) {
-            let (num_buttons, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (num_buttons, remaining) = u16::try_parse(remaining)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputInfoInfo::NumButtons(num_buttons));
         }
         if class_id == Into::<u8>::into(InputClass::Valuator) {
-            let (valuator, new_remaining) = InputInfoInfoValuator::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (valuator, new_remaining) = InputInfoInfoValuator::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputInfoInfo::Valuator(valuator));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_key(&self) -> Option<&InputInfoInfoKey> {
@@ -812,14 +767,10 @@ pub struct InputInfo {
     pub info: InputInfoInfo,
 }
 impl TryParse for InputInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (info, new_remaining) = InputInfoInfo::try_parse(remaining, class_id)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (info, remaining) = InputInfoInfo::try_parse(remaining, class_id)?;
         let result = InputInfo { class_id, len, info };
         Ok((result, remaining))
     }
@@ -850,12 +801,9 @@ pub struct DeviceName {
     pub string: Vec<u8>,
 }
 impl TryParse for DeviceName {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (string, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, len as usize)?;
         let result = DeviceName { string };
         Ok((result, remaining))
     }
@@ -912,29 +860,21 @@ pub struct ListInputDevicesReply {
     pub names: Vec<Str>,
 }
 impl ListInputDevicesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (devices_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (devices, new_remaining) = crate::x11_utils::parse_list::<DeviceInfo>(remaining, devices_len as usize)?;
-        remaining = new_remaining;
-        let (infos, new_remaining) = crate::x11_utils::parse_list::<InputInfo>(remaining, devices.iter().map(|x| TryInto::<usize>::try_into(x.num_class_info).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (names, new_remaining) = crate::x11_utils::parse_list::<Str>(remaining, devices_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (devices_len, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let (devices, remaining) = crate::x11_utils::parse_list::<DeviceInfo>(remaining, devices_len as usize)?;
+        let (infos, remaining) = crate::x11_utils::parse_list::<InputInfo>(remaining, devices.iter().map(|x| TryInto::<usize>::try_into(x.num_class_info).unwrap()).sum())?;
+        let (names, remaining) = crate::x11_utils::parse_list::<Str>(remaining, devices_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = ListInputDevicesReply { response_type, xi_reply_type, sequence, length, devices_len, devices, infos, names };
         Ok((result, remaining))
     }
@@ -954,12 +894,9 @@ pub struct InputClassInfo {
     pub event_type_base: EventTypeBase,
 }
 impl TryParse for InputClassInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type_base, new_remaining) = EventTypeBase::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (event_type_base, remaining) = EventTypeBase::try_parse(remaining)?;
         let result = InputClassInfo { class_id, event_type_base };
         Ok((result, remaining))
     }
@@ -1020,25 +957,19 @@ pub struct OpenDeviceReply {
     pub class_info: Vec<InputClassInfo>,
 }
 impl OpenDeviceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_classes, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (class_info, new_remaining) = crate::x11_utils::parse_list::<InputClassInfo>(remaining, num_classes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_classes, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let (class_info, remaining) = crate::x11_utils::parse_list::<InputClassInfo>(remaining, num_classes as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = OpenDeviceReply { response_type, xi_reply_type, sequence, length, class_info };
         Ok((result, remaining))
     }
@@ -1110,19 +1041,13 @@ pub struct SetDeviceModeReply {
     pub status: u8,
 }
 impl SetDeviceModeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = SetDeviceModeReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -1203,25 +1128,16 @@ pub struct GetSelectedExtensionEventsReply {
     pub all_classes: Vec<EventClass>,
 }
 impl GetSelectedExtensionEventsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_this_classes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_all_classes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (this_classes, new_remaining) = crate::x11_utils::parse_list::<EventClass>(remaining, num_this_classes as usize)?;
-        remaining = new_remaining;
-        let (all_classes, new_remaining) = crate::x11_utils::parse_list::<EventClass>(remaining, num_all_classes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_this_classes, remaining) = u16::try_parse(remaining)?;
+        let (num_all_classes, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (this_classes, remaining) = crate::x11_utils::parse_list::<EventClass>(remaining, num_this_classes as usize)?;
+        let (all_classes, remaining) = crate::x11_utils::parse_list::<EventClass>(remaining, num_all_classes as usize)?;
         let result = GetSelectedExtensionEventsReply { response_type, xi_reply_type, sequence, length, this_classes, all_classes };
         Ok((result, remaining))
     }
@@ -1365,21 +1281,14 @@ pub struct GetDeviceDontPropagateListReply {
     pub classes: Vec<EventClass>,
 }
 impl GetDeviceDontPropagateListReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_classes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (classes, new_remaining) = crate::x11_utils::parse_list::<EventClass>(remaining, num_classes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_classes, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (classes, remaining) = crate::x11_utils::parse_list::<EventClass>(remaining, num_classes as usize)?;
         let result = GetDeviceDontPropagateListReply { response_type, xi_reply_type, sequence, length, classes };
         Ok((result, remaining))
     }
@@ -1397,12 +1306,9 @@ pub struct DeviceTimeCoord {
     pub axisvalues: Vec<i32>,
 }
 impl DeviceTimeCoord {
-    pub fn try_parse(value: &[u8], num_axes: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_axes as usize)?;
-        remaining = new_remaining;
+    pub fn try_parse(remaining: &[u8], num_axes: u8) -> Result<(Self, &[u8]), ParseError> {
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_axes as usize)?;
         let result = DeviceTimeCoord { time, axisvalues };
         Ok((result, remaining))
     }
@@ -1469,23 +1375,16 @@ pub struct GetDeviceMotionEventsReply {
     pub events: Vec<DeviceTimeCoord>,
 }
 impl GetDeviceMotionEventsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_events, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_axes, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_events, remaining) = u32::try_parse(remaining)?;
+        let (num_axes, remaining) = u8::try_parse(remaining)?;
+        let (device_mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
+        let mut remaining = remaining;
         let list_length = num_events as usize;
         let mut events = Vec::with_capacity(list_length);
         for _ in 0..list_length {
@@ -1537,19 +1436,13 @@ pub struct ChangeKeyboardDeviceReply {
     pub status: u8,
 }
 impl ChangeKeyboardDeviceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = ChangeKeyboardDeviceReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -1596,19 +1489,13 @@ pub struct ChangePointerDeviceReply {
     pub status: u8,
 }
 impl ChangePointerDeviceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = ChangePointerDeviceReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -1678,19 +1565,13 @@ pub struct GrabDeviceReply {
     pub status: u8,
 }
 impl GrabDeviceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = GrabDeviceReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -2110,23 +1991,15 @@ pub struct GetDeviceFocusReply {
     pub revert_to: u8,
 }
 impl GetDeviceFocusReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (focus, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (revert_to, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(15..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (focus, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (revert_to, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
         let result = GetDeviceFocusReply { response_type, xi_reply_type, sequence, length, focus, time, revert_to };
         Ok((result, remaining))
     }
@@ -2264,93 +2137,50 @@ pub struct KbdFeedbackState {
     pub auto_repeats: [u8; 32],
 }
 impl TryParse for KbdFeedbackState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pitch, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (duration, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (global_auto_repeat, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (click, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (percent, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (auto_repeats_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (pitch, remaining) = u16::try_parse(remaining)?;
+        let (duration, remaining) = u16::try_parse(remaining)?;
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
+        let (global_auto_repeat, remaining) = bool::try_parse(remaining)?;
+        let (click, remaining) = u8::try_parse(remaining)?;
+        let (percent, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (auto_repeats_0, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_1, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_2, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_3, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_4, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_5, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_6, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_7, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_8, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_9, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_10, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_11, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_12, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_13, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_14, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_15, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_16, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_17, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_18, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_19, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_20, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_21, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_22, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_23, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_24, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_25, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_26, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_27, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_28, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_29, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_30, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_31, remaining) = u8::try_parse(remaining)?;
         let auto_repeats = [
             auto_repeats_0,
             auto_repeats_1,
@@ -2490,21 +2320,14 @@ pub struct PtrFeedbackState {
     pub threshold: u16,
 }
 impl TryParse for PtrFeedbackState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (accel_num, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (accel_denom, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (threshold, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (accel_num, remaining) = u16::try_parse(remaining)?;
+        let (accel_denom, remaining) = u16::try_parse(remaining)?;
+        let (threshold, remaining) = u16::try_parse(remaining)?;
         let result = PtrFeedbackState { class_id, feedback_id, len, accel_num, accel_denom, threshold };
         Ok((result, remaining))
     }
@@ -2561,20 +2384,13 @@ pub struct IntegerFeedbackState {
     pub max_value: i32,
 }
 impl TryParse for IntegerFeedbackState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resolution, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_value, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_value, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (resolution, remaining) = u32::try_parse(remaining)?;
+        let (min_value, remaining) = i32::try_parse(remaining)?;
+        let (max_value, remaining) = i32::try_parse(remaining)?;
         let result = IntegerFeedbackState { class_id, feedback_id, len, resolution, min_value, max_value };
         Ok((result, remaining))
     }
@@ -2633,20 +2449,13 @@ pub struct StringFeedbackState {
     pub keysyms: Vec<KEYSYM>,
 }
 impl TryParse for StringFeedbackState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_symbols, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_keysyms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keysyms, new_remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (max_symbols, remaining) = u16::try_parse(remaining)?;
+        let (num_keysyms, remaining) = u16::try_parse(remaining)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
         let result = StringFeedbackState { class_id, feedback_id, len, max_symbols, keysyms };
         Ok((result, remaining))
     }
@@ -2686,21 +2495,14 @@ pub struct BellFeedbackState {
     pub duration: u16,
 }
 impl TryParse for BellFeedbackState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (percent, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (pitch, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (duration, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (percent, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (pitch, remaining) = u16::try_parse(remaining)?;
+        let (duration, remaining) = u16::try_parse(remaining)?;
         let result = BellFeedbackState { class_id, feedback_id, len, percent, pitch, duration };
         Ok((result, remaining))
     }
@@ -2756,18 +2558,12 @@ pub struct LedFeedbackState {
     pub led_values: u32,
 }
 impl TryParse for LedFeedbackState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
         let result = LedFeedbackState { class_id, feedback_id, len, led_mask, led_values };
         Ok((result, remaining))
     }
@@ -2823,87 +2619,47 @@ pub struct FeedbackStateDataKeyboard {
     pub auto_repeats: [u8; 32],
 }
 impl TryParse for FeedbackStateDataKeyboard {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (pitch, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (duration, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (global_auto_repeat, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (click, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (percent, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (auto_repeats_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (pitch, remaining) = u16::try_parse(remaining)?;
+        let (duration, remaining) = u16::try_parse(remaining)?;
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
+        let (global_auto_repeat, remaining) = bool::try_parse(remaining)?;
+        let (click, remaining) = u8::try_parse(remaining)?;
+        let (percent, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (auto_repeats_0, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_1, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_2, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_3, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_4, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_5, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_6, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_7, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_8, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_9, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_10, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_11, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_12, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_13, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_14, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_15, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_16, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_17, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_18, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_19, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_20, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_21, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_22, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_23, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_24, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_25, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_26, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_27, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_28, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_29, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_30, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_31, remaining) = u8::try_parse(remaining)?;
         let auto_repeats = [
             auto_repeats_0,
             auto_repeats_1,
@@ -3029,15 +2785,11 @@ pub struct FeedbackStateDataPointer {
     pub threshold: u16,
 }
 impl TryParse for FeedbackStateDataPointer {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (accel_num, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (accel_denom, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (threshold, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (accel_num, remaining) = u16::try_parse(remaining)?;
+        let (accel_denom, remaining) = u16::try_parse(remaining)?;
+        let (threshold, remaining) = u16::try_parse(remaining)?;
         let result = FeedbackStateDataPointer { accel_num, accel_denom, threshold };
         Ok((result, remaining))
     }
@@ -3079,14 +2831,10 @@ pub struct FeedbackStateDataString {
     pub keysyms: Vec<KEYSYM>,
 }
 impl TryParse for FeedbackStateDataString {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (max_symbols, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_keysyms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keysyms, new_remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (max_symbols, remaining) = u16::try_parse(remaining)?;
+        let (num_keysyms, remaining) = u16::try_parse(remaining)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
         let result = FeedbackStateDataString { max_symbols, keysyms };
         Ok((result, remaining))
     }
@@ -3119,14 +2867,10 @@ pub struct FeedbackStateDataInteger {
     pub max_value: i32,
 }
 impl TryParse for FeedbackStateDataInteger {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (resolution, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_value, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_value, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (resolution, remaining) = u32::try_parse(remaining)?;
+        let (min_value, remaining) = i32::try_parse(remaining)?;
+        let (max_value, remaining) = i32::try_parse(remaining)?;
         let result = FeedbackStateDataInteger { resolution, min_value, max_value };
         Ok((result, remaining))
     }
@@ -3171,12 +2915,9 @@ pub struct FeedbackStateDataLed {
     pub led_values: u32,
 }
 impl TryParse for FeedbackStateDataLed {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
         let result = FeedbackStateDataLed { led_mask, led_values };
         Ok((result, remaining))
     }
@@ -3216,15 +2957,11 @@ pub struct FeedbackStateDataBell {
     pub duration: u16,
 }
 impl TryParse for FeedbackStateDataBell {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (percent, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (pitch, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (duration, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (percent, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (pitch, remaining) = u16::try_parse(remaining)?;
+        let (duration, remaining) = u16::try_parse(remaining)?;
         let result = FeedbackStateDataBell { percent, pitch, duration };
         Ok((result, remaining))
     }
@@ -3271,47 +3008,47 @@ pub enum FeedbackStateData {
 }
 impl FeedbackStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if class_id == Into::<u8>::into(FeedbackClass::Keyboard) {
-            let (keyboard, new_remaining) = FeedbackStateDataKeyboard::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (keyboard, new_remaining) = FeedbackStateDataKeyboard::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Keyboard(keyboard));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Pointer) {
-            let (pointer, new_remaining) = FeedbackStateDataPointer::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (pointer, new_remaining) = FeedbackStateDataPointer::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Pointer(pointer));
         }
         if class_id == Into::<u8>::into(FeedbackClass::String) {
-            let (string, new_remaining) = FeedbackStateDataString::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (string, new_remaining) = FeedbackStateDataString::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::String(string));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Integer) {
-            let (integer, new_remaining) = FeedbackStateDataInteger::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (integer, new_remaining) = FeedbackStateDataInteger::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Integer(integer));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Led) {
-            let (led, new_remaining) = FeedbackStateDataLed::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (led, new_remaining) = FeedbackStateDataLed::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Led(led));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Bell) {
-            let (bell, new_remaining) = FeedbackStateDataBell::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (bell, new_remaining) = FeedbackStateDataBell::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Bell(bell));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_keyboard(&self) -> Option<&FeedbackStateDataKeyboard> {
@@ -3382,16 +3119,11 @@ pub struct FeedbackState {
     pub data: FeedbackStateData,
 }
 impl TryParse for FeedbackState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = FeedbackStateData::try_parse(remaining, class_id)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (data, remaining) = FeedbackStateData::try_parse(remaining, class_id)?;
         let result = FeedbackState { class_id, feedback_id, len, data };
         Ok((result, remaining))
     }
@@ -3451,21 +3183,14 @@ pub struct GetFeedbackControlReply {
     pub feedbacks: Vec<FeedbackState>,
 }
 impl GetFeedbackControlReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_feedbacks, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (feedbacks, new_remaining) = crate::x11_utils::parse_list::<FeedbackState>(remaining, num_feedbacks as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_feedbacks, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (feedbacks, remaining) = crate::x11_utils::parse_list::<FeedbackState>(remaining, num_feedbacks as usize)?;
         let result = GetFeedbackControlReply { response_type, xi_reply_type, sequence, length, feedbacks };
         Ok((result, remaining))
     }
@@ -3492,30 +3217,18 @@ pub struct KbdFeedbackCtl {
     pub led_values: u32,
 }
 impl TryParse for KbdFeedbackCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (key, new_remaining) = KeyCode::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeat_mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (key_click_percent, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_percent, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_pitch, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_duration, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (key, remaining) = KeyCode::try_parse(remaining)?;
+        let (auto_repeat_mode, remaining) = u8::try_parse(remaining)?;
+        let (key_click_percent, remaining) = i8::try_parse(remaining)?;
+        let (bell_percent, remaining) = i8::try_parse(remaining)?;
+        let (bell_pitch, remaining) = i16::try_parse(remaining)?;
+        let (bell_duration, remaining) = i16::try_parse(remaining)?;
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
         let result = KbdFeedbackCtl { class_id, feedback_id, len, key, auto_repeat_mode, key_click_percent, bell_percent, bell_pitch, bell_duration, led_mask, led_values };
         Ok((result, remaining))
     }
@@ -3589,21 +3302,14 @@ pub struct PtrFeedbackCtl {
     pub threshold: i16,
 }
 impl TryParse for PtrFeedbackCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (num, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (denom, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (threshold, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (num, remaining) = i16::try_parse(remaining)?;
+        let (denom, remaining) = i16::try_parse(remaining)?;
+        let (threshold, remaining) = i16::try_parse(remaining)?;
         let result = PtrFeedbackCtl { class_id, feedback_id, len, num, denom, threshold };
         Ok((result, remaining))
     }
@@ -3658,16 +3364,11 @@ pub struct IntegerFeedbackCtl {
     pub int_to_display: i32,
 }
 impl TryParse for IntegerFeedbackCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (int_to_display, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (int_to_display, remaining) = i32::try_parse(remaining)?;
         let result = IntegerFeedbackCtl { class_id, feedback_id, len, int_to_display };
         Ok((result, remaining))
     }
@@ -3713,19 +3414,13 @@ pub struct StringFeedbackCtl {
     pub keysyms: Vec<KEYSYM>,
 }
 impl TryParse for StringFeedbackCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (num_keysyms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keysyms, new_remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (num_keysyms, remaining) = u16::try_parse(remaining)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
         let result = StringFeedbackCtl { class_id, feedback_id, len, keysyms };
         Ok((result, remaining))
     }
@@ -3765,21 +3460,14 @@ pub struct BellFeedbackCtl {
     pub duration: i16,
 }
 impl TryParse for BellFeedbackCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (percent, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (pitch, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (duration, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (percent, remaining) = i8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (pitch, remaining) = i16::try_parse(remaining)?;
+        let (duration, remaining) = i16::try_parse(remaining)?;
         let result = BellFeedbackCtl { class_id, feedback_id, len, percent, pitch, duration };
         Ok((result, remaining))
     }
@@ -3835,18 +3523,12 @@ pub struct LedFeedbackCtl {
     pub led_values: u32,
 }
 impl TryParse for LedFeedbackCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
         let result = LedFeedbackCtl { class_id, feedback_id, len, led_mask, led_values };
         Ok((result, remaining))
     }
@@ -3902,24 +3584,15 @@ pub struct FeedbackCtlDataKeyboard {
     pub led_values: u32,
 }
 impl TryParse for FeedbackCtlDataKeyboard {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (key, new_remaining) = KeyCode::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeat_mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (key_click_percent, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_percent, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_pitch, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_duration, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (key, remaining) = KeyCode::try_parse(remaining)?;
+        let (auto_repeat_mode, remaining) = u8::try_parse(remaining)?;
+        let (key_click_percent, remaining) = i8::try_parse(remaining)?;
+        let (bell_percent, remaining) = i8::try_parse(remaining)?;
+        let (bell_pitch, remaining) = i16::try_parse(remaining)?;
+        let (bell_duration, remaining) = i16::try_parse(remaining)?;
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
         let result = FeedbackCtlDataKeyboard { key, auto_repeat_mode, key_click_percent, bell_percent, bell_pitch, bell_duration, led_mask, led_values };
         Ok((result, remaining))
     }
@@ -3979,15 +3652,11 @@ pub struct FeedbackCtlDataPointer {
     pub threshold: i16,
 }
 impl TryParse for FeedbackCtlDataPointer {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (num, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (denom, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (threshold, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (num, remaining) = i16::try_parse(remaining)?;
+        let (denom, remaining) = i16::try_parse(remaining)?;
+        let (threshold, remaining) = i16::try_parse(remaining)?;
         let result = FeedbackCtlDataPointer { num, denom, threshold };
         Ok((result, remaining))
     }
@@ -4028,13 +3697,10 @@ pub struct FeedbackCtlDataString {
     pub keysyms: Vec<KEYSYM>,
 }
 impl TryParse for FeedbackCtlDataString {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (num_keysyms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keysyms, new_remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (num_keysyms, remaining) = u16::try_parse(remaining)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
         let result = FeedbackCtlDataString { keysyms };
         Ok((result, remaining))
     }
@@ -4066,12 +3732,9 @@ pub struct FeedbackCtlDataLed {
     pub led_values: u32,
 }
 impl TryParse for FeedbackCtlDataLed {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (led_values, remaining) = u32::try_parse(remaining)?;
         let result = FeedbackCtlDataLed { led_mask, led_values };
         Ok((result, remaining))
     }
@@ -4111,15 +3774,11 @@ pub struct FeedbackCtlDataBell {
     pub duration: i16,
 }
 impl TryParse for FeedbackCtlDataBell {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (percent, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (pitch, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (duration, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (percent, remaining) = i8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (pitch, remaining) = i16::try_parse(remaining)?;
+        let (duration, remaining) = i16::try_parse(remaining)?;
         let result = FeedbackCtlDataBell { percent, pitch, duration };
         Ok((result, remaining))
     }
@@ -4166,47 +3825,48 @@ pub enum FeedbackCtlData {
 }
 impl FeedbackCtlData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if class_id == Into::<u8>::into(FeedbackClass::Keyboard) {
-            let (keyboard, new_remaining) = FeedbackCtlDataKeyboard::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (keyboard, new_remaining) = FeedbackCtlDataKeyboard::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Keyboard(keyboard));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Pointer) {
-            let (pointer, new_remaining) = FeedbackCtlDataPointer::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (pointer, new_remaining) = FeedbackCtlDataPointer::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Pointer(pointer));
         }
         if class_id == Into::<u8>::into(FeedbackClass::String) {
-            let (string, new_remaining) = FeedbackCtlDataString::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (string, new_remaining) = FeedbackCtlDataString::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::String(string));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Integer) {
-            let (int_to_display, new_remaining) = i32::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (int_to_display, remaining) = i32::try_parse(remaining)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::IntToDisplay(int_to_display));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Led) {
-            let (led, new_remaining) = FeedbackCtlDataLed::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (led, new_remaining) = FeedbackCtlDataLed::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Led(led));
         }
         if class_id == Into::<u8>::into(FeedbackClass::Bell) {
-            let (bell, new_remaining) = FeedbackCtlDataBell::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (bell, new_remaining) = FeedbackCtlDataBell::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Bell(bell));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_keyboard(&self) -> Option<&FeedbackCtlDataKeyboard> {
@@ -4277,16 +3937,11 @@ pub struct FeedbackCtl {
     pub data: FeedbackCtlData,
 }
 impl TryParse for FeedbackCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (feedback_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = FeedbackCtlData::try_parse(remaining, class_id)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (feedback_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (data, remaining) = FeedbackCtlData::try_parse(remaining, class_id)?;
         let result = FeedbackCtl { class_id, feedback_id, len, data };
         Ok((result, remaining))
     }
@@ -4445,21 +4100,14 @@ pub struct GetDeviceKeyMappingReply {
     pub keysyms: Vec<KEYSYM>,
 }
 impl GetDeviceKeyMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keysyms_per_keycode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (keysyms, new_remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (keysyms_per_keycode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, length as usize)?;
         let result = GetDeviceKeyMappingReply { response_type, xi_reply_type, sequence, keysyms_per_keycode, keysyms };
         Ok((result, remaining))
     }
@@ -4537,21 +4185,14 @@ pub struct GetDeviceModifierMappingReply {
     pub keymaps: Vec<u8>,
 }
 impl GetDeviceModifierMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keycodes_per_modifier, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (keymaps, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (keycodes_per_modifier as usize) * (8))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (keycodes_per_modifier, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let (keymaps, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (keycodes_per_modifier as usize) * (8))?;
         let result = GetDeviceModifierMappingReply { response_type, xi_reply_type, sequence, length, keymaps };
         Ok((result, remaining))
     }
@@ -4602,19 +4243,13 @@ pub struct SetDeviceModifierMappingReply {
     pub status: u8,
 }
 impl SetDeviceModifierMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = SetDeviceModifierMappingReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -4659,25 +4294,19 @@ pub struct GetDeviceButtonMappingReply {
     pub map: Vec<u8>,
 }
 impl GetDeviceButtonMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_size, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (map, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, map_size as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (map_size, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let (map, remaining) = crate::x11_utils::parse_list::<u8>(remaining, map_size as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = GetDeviceButtonMappingReply { response_type, xi_reply_type, sequence, length, map };
         Ok((result, remaining))
     }
@@ -4727,19 +4356,13 @@ pub struct SetDeviceButtonMappingReply {
     pub status: u8,
 }
 impl SetDeviceButtonMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = SetDeviceButtonMappingReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -4759,79 +4382,43 @@ pub struct KeyState {
     pub keys: [u8; 32],
 }
 impl TryParse for KeyState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (keys_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (num_keys, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (keys_0, remaining) = u8::try_parse(remaining)?;
+        let (keys_1, remaining) = u8::try_parse(remaining)?;
+        let (keys_2, remaining) = u8::try_parse(remaining)?;
+        let (keys_3, remaining) = u8::try_parse(remaining)?;
+        let (keys_4, remaining) = u8::try_parse(remaining)?;
+        let (keys_5, remaining) = u8::try_parse(remaining)?;
+        let (keys_6, remaining) = u8::try_parse(remaining)?;
+        let (keys_7, remaining) = u8::try_parse(remaining)?;
+        let (keys_8, remaining) = u8::try_parse(remaining)?;
+        let (keys_9, remaining) = u8::try_parse(remaining)?;
+        let (keys_10, remaining) = u8::try_parse(remaining)?;
+        let (keys_11, remaining) = u8::try_parse(remaining)?;
+        let (keys_12, remaining) = u8::try_parse(remaining)?;
+        let (keys_13, remaining) = u8::try_parse(remaining)?;
+        let (keys_14, remaining) = u8::try_parse(remaining)?;
+        let (keys_15, remaining) = u8::try_parse(remaining)?;
+        let (keys_16, remaining) = u8::try_parse(remaining)?;
+        let (keys_17, remaining) = u8::try_parse(remaining)?;
+        let (keys_18, remaining) = u8::try_parse(remaining)?;
+        let (keys_19, remaining) = u8::try_parse(remaining)?;
+        let (keys_20, remaining) = u8::try_parse(remaining)?;
+        let (keys_21, remaining) = u8::try_parse(remaining)?;
+        let (keys_22, remaining) = u8::try_parse(remaining)?;
+        let (keys_23, remaining) = u8::try_parse(remaining)?;
+        let (keys_24, remaining) = u8::try_parse(remaining)?;
+        let (keys_25, remaining) = u8::try_parse(remaining)?;
+        let (keys_26, remaining) = u8::try_parse(remaining)?;
+        let (keys_27, remaining) = u8::try_parse(remaining)?;
+        let (keys_28, remaining) = u8::try_parse(remaining)?;
+        let (keys_29, remaining) = u8::try_parse(remaining)?;
+        let (keys_30, remaining) = u8::try_parse(remaining)?;
+        let (keys_31, remaining) = u8::try_parse(remaining)?;
         let keys = [
             keys_0,
             keys_1,
@@ -4939,79 +4526,43 @@ pub struct ButtonState {
     pub buttons: [u8; 32],
 }
 impl TryParse for ButtonState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_buttons, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (buttons_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (num_buttons, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (buttons_0, remaining) = u8::try_parse(remaining)?;
+        let (buttons_1, remaining) = u8::try_parse(remaining)?;
+        let (buttons_2, remaining) = u8::try_parse(remaining)?;
+        let (buttons_3, remaining) = u8::try_parse(remaining)?;
+        let (buttons_4, remaining) = u8::try_parse(remaining)?;
+        let (buttons_5, remaining) = u8::try_parse(remaining)?;
+        let (buttons_6, remaining) = u8::try_parse(remaining)?;
+        let (buttons_7, remaining) = u8::try_parse(remaining)?;
+        let (buttons_8, remaining) = u8::try_parse(remaining)?;
+        let (buttons_9, remaining) = u8::try_parse(remaining)?;
+        let (buttons_10, remaining) = u8::try_parse(remaining)?;
+        let (buttons_11, remaining) = u8::try_parse(remaining)?;
+        let (buttons_12, remaining) = u8::try_parse(remaining)?;
+        let (buttons_13, remaining) = u8::try_parse(remaining)?;
+        let (buttons_14, remaining) = u8::try_parse(remaining)?;
+        let (buttons_15, remaining) = u8::try_parse(remaining)?;
+        let (buttons_16, remaining) = u8::try_parse(remaining)?;
+        let (buttons_17, remaining) = u8::try_parse(remaining)?;
+        let (buttons_18, remaining) = u8::try_parse(remaining)?;
+        let (buttons_19, remaining) = u8::try_parse(remaining)?;
+        let (buttons_20, remaining) = u8::try_parse(remaining)?;
+        let (buttons_21, remaining) = u8::try_parse(remaining)?;
+        let (buttons_22, remaining) = u8::try_parse(remaining)?;
+        let (buttons_23, remaining) = u8::try_parse(remaining)?;
+        let (buttons_24, remaining) = u8::try_parse(remaining)?;
+        let (buttons_25, remaining) = u8::try_parse(remaining)?;
+        let (buttons_26, remaining) = u8::try_parse(remaining)?;
+        let (buttons_27, remaining) = u8::try_parse(remaining)?;
+        let (buttons_28, remaining) = u8::try_parse(remaining)?;
+        let (buttons_29, remaining) = u8::try_parse(remaining)?;
+        let (buttons_30, remaining) = u8::try_parse(remaining)?;
+        let (buttons_31, remaining) = u8::try_parse(remaining)?;
         let buttons = [
             buttons_0,
             buttons_1,
@@ -5182,18 +4733,12 @@ pub struct ValuatorState {
     pub valuators: Vec<i32>,
 }
 impl TryParse for ValuatorState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_valuators, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (valuators, remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_valuators as usize)?;
         let result = ValuatorState { class_id, len, mode, valuators };
         Ok((result, remaining))
     }
@@ -5228,75 +4773,41 @@ pub struct InputStateDataKey {
     pub keys: [u8; 32],
 }
 impl TryParse for InputStateDataKey {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (num_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (keys_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (num_keys, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (keys_0, remaining) = u8::try_parse(remaining)?;
+        let (keys_1, remaining) = u8::try_parse(remaining)?;
+        let (keys_2, remaining) = u8::try_parse(remaining)?;
+        let (keys_3, remaining) = u8::try_parse(remaining)?;
+        let (keys_4, remaining) = u8::try_parse(remaining)?;
+        let (keys_5, remaining) = u8::try_parse(remaining)?;
+        let (keys_6, remaining) = u8::try_parse(remaining)?;
+        let (keys_7, remaining) = u8::try_parse(remaining)?;
+        let (keys_8, remaining) = u8::try_parse(remaining)?;
+        let (keys_9, remaining) = u8::try_parse(remaining)?;
+        let (keys_10, remaining) = u8::try_parse(remaining)?;
+        let (keys_11, remaining) = u8::try_parse(remaining)?;
+        let (keys_12, remaining) = u8::try_parse(remaining)?;
+        let (keys_13, remaining) = u8::try_parse(remaining)?;
+        let (keys_14, remaining) = u8::try_parse(remaining)?;
+        let (keys_15, remaining) = u8::try_parse(remaining)?;
+        let (keys_16, remaining) = u8::try_parse(remaining)?;
+        let (keys_17, remaining) = u8::try_parse(remaining)?;
+        let (keys_18, remaining) = u8::try_parse(remaining)?;
+        let (keys_19, remaining) = u8::try_parse(remaining)?;
+        let (keys_20, remaining) = u8::try_parse(remaining)?;
+        let (keys_21, remaining) = u8::try_parse(remaining)?;
+        let (keys_22, remaining) = u8::try_parse(remaining)?;
+        let (keys_23, remaining) = u8::try_parse(remaining)?;
+        let (keys_24, remaining) = u8::try_parse(remaining)?;
+        let (keys_25, remaining) = u8::try_parse(remaining)?;
+        let (keys_26, remaining) = u8::try_parse(remaining)?;
+        let (keys_27, remaining) = u8::try_parse(remaining)?;
+        let (keys_28, remaining) = u8::try_parse(remaining)?;
+        let (keys_29, remaining) = u8::try_parse(remaining)?;
+        let (keys_30, remaining) = u8::try_parse(remaining)?;
+        let (keys_31, remaining) = u8::try_parse(remaining)?;
         let keys = [
             keys_0,
             keys_1,
@@ -5395,75 +4906,41 @@ pub struct InputStateDataButton {
     pub buttons: [u8; 32],
 }
 impl TryParse for InputStateDataButton {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (num_buttons, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (buttons_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (num_buttons, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (buttons_0, remaining) = u8::try_parse(remaining)?;
+        let (buttons_1, remaining) = u8::try_parse(remaining)?;
+        let (buttons_2, remaining) = u8::try_parse(remaining)?;
+        let (buttons_3, remaining) = u8::try_parse(remaining)?;
+        let (buttons_4, remaining) = u8::try_parse(remaining)?;
+        let (buttons_5, remaining) = u8::try_parse(remaining)?;
+        let (buttons_6, remaining) = u8::try_parse(remaining)?;
+        let (buttons_7, remaining) = u8::try_parse(remaining)?;
+        let (buttons_8, remaining) = u8::try_parse(remaining)?;
+        let (buttons_9, remaining) = u8::try_parse(remaining)?;
+        let (buttons_10, remaining) = u8::try_parse(remaining)?;
+        let (buttons_11, remaining) = u8::try_parse(remaining)?;
+        let (buttons_12, remaining) = u8::try_parse(remaining)?;
+        let (buttons_13, remaining) = u8::try_parse(remaining)?;
+        let (buttons_14, remaining) = u8::try_parse(remaining)?;
+        let (buttons_15, remaining) = u8::try_parse(remaining)?;
+        let (buttons_16, remaining) = u8::try_parse(remaining)?;
+        let (buttons_17, remaining) = u8::try_parse(remaining)?;
+        let (buttons_18, remaining) = u8::try_parse(remaining)?;
+        let (buttons_19, remaining) = u8::try_parse(remaining)?;
+        let (buttons_20, remaining) = u8::try_parse(remaining)?;
+        let (buttons_21, remaining) = u8::try_parse(remaining)?;
+        let (buttons_22, remaining) = u8::try_parse(remaining)?;
+        let (buttons_23, remaining) = u8::try_parse(remaining)?;
+        let (buttons_24, remaining) = u8::try_parse(remaining)?;
+        let (buttons_25, remaining) = u8::try_parse(remaining)?;
+        let (buttons_26, remaining) = u8::try_parse(remaining)?;
+        let (buttons_27, remaining) = u8::try_parse(remaining)?;
+        let (buttons_28, remaining) = u8::try_parse(remaining)?;
+        let (buttons_29, remaining) = u8::try_parse(remaining)?;
+        let (buttons_30, remaining) = u8::try_parse(remaining)?;
+        let (buttons_31, remaining) = u8::try_parse(remaining)?;
         let buttons = [
             buttons_0,
             buttons_1,
@@ -5562,14 +5039,10 @@ pub struct InputStateDataValuator {
     pub valuators: Vec<i32>,
 }
 impl TryParse for InputStateDataValuator {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (num_valuators, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators, new_remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (valuators, remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_valuators as usize)?;
         let result = InputStateDataValuator { mode, valuators };
         Ok((result, remaining))
     }
@@ -5603,29 +5076,29 @@ pub enum InputStateData {
 }
 impl InputStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if class_id == Into::<u8>::into(InputClass::Key) {
-            let (key, new_remaining) = InputStateDataKey::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (key, new_remaining) = InputStateDataKey::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputStateData::Key(key));
         }
         if class_id == Into::<u8>::into(InputClass::Button) {
-            let (button, new_remaining) = InputStateDataButton::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (button, new_remaining) = InputStateDataButton::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputStateData::Button(button));
         }
         if class_id == Into::<u8>::into(InputClass::Valuator) {
-            let (valuator, new_remaining) = InputStateDataValuator::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (valuator, new_remaining) = InputStateDataValuator::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputStateData::Valuator(valuator));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_key(&self) -> Option<&InputStateDataKey> {
@@ -5671,14 +5144,10 @@ pub struct InputState {
     pub data: InputStateData,
 }
 impl TryParse for InputState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (class_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = InputStateData::try_parse(remaining, class_id)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (class_id, remaining) = u8::try_parse(remaining)?;
+        let (len, remaining) = u8::try_parse(remaining)?;
+        let (data, remaining) = InputStateData::try_parse(remaining, class_id)?;
         let result = InputState { class_id, len, data };
         Ok((result, remaining))
     }
@@ -5737,21 +5206,14 @@ pub struct QueryDeviceStateReply {
     pub classes: Vec<InputState>,
 }
 impl QueryDeviceStateReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_classes, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (classes, new_remaining) = crate::x11_utils::parse_list::<InputState>(remaining, num_classes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_classes, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let (classes, remaining) = crate::x11_utils::parse_list::<InputState>(remaining, num_classes as usize)?;
         let result = QueryDeviceStateReply { response_type, xi_reply_type, sequence, length, classes };
         Ok((result, remaining))
     }
@@ -5831,19 +5293,13 @@ pub struct SetDeviceValuatorsReply {
     pub status: u8,
 }
 impl SetDeviceValuatorsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = SetDeviceValuatorsReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -5936,20 +5392,13 @@ pub struct DeviceResolutionState {
     pub resolution_max: Vec<u32>,
 }
 impl TryParse for DeviceResolutionState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_valuators, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resolution_values, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
-        let (resolution_min, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
-        let (resolution_max, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (num_valuators, remaining) = u32::try_parse(remaining)?;
+        let (resolution_values, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
+        let (resolution_min, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
+        let (resolution_max, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
         let result = DeviceResolutionState { control_id, len, num_valuators, resolution_values, resolution_min, resolution_max };
         Ok((result, remaining))
     }
@@ -5992,28 +5441,17 @@ pub struct DeviceAbsCalibState {
     pub button_threshold: u32,
 }
 impl TryParse for DeviceAbsCalibState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_threshold, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (min_x, remaining) = i32::try_parse(remaining)?;
+        let (max_x, remaining) = i32::try_parse(remaining)?;
+        let (min_y, remaining) = i32::try_parse(remaining)?;
+        let (max_y, remaining) = i32::try_parse(remaining)?;
+        let (flip_x, remaining) = u32::try_parse(remaining)?;
+        let (flip_y, remaining) = u32::try_parse(remaining)?;
+        let (rotation, remaining) = u32::try_parse(remaining)?;
+        let (button_threshold, remaining) = u32::try_parse(remaining)?;
         let result = DeviceAbsCalibState { control_id, len, min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
     }
@@ -6103,24 +5541,15 @@ pub struct DeviceAbsAreaState {
     pub following: u32,
 }
 impl TryParse for DeviceAbsAreaState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (screen, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (following, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (offset_x, remaining) = u32::try_parse(remaining)?;
+        let (offset_y, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u32::try_parse(remaining)?;
+        let (height, remaining) = u32::try_parse(remaining)?;
+        let (screen, remaining) = u32::try_parse(remaining)?;
+        let (following, remaining) = u32::try_parse(remaining)?;
         let result = DeviceAbsAreaState { control_id, len, offset_x, offset_y, width, height, screen, following };
         Ok((result, remaining))
     }
@@ -6194,17 +5623,12 @@ pub struct DeviceCoreState {
     pub iscore: u8,
 }
 impl TryParse for DeviceCoreState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (iscore, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (iscore, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = DeviceCoreState { control_id, len, status, iscore };
         Ok((result, remaining))
     }
@@ -6250,15 +5674,11 @@ pub struct DeviceEnableState {
     pub enable: u8,
 }
 impl TryParse for DeviceEnableState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enable, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (enable, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = DeviceEnableState { control_id, len, enable };
         Ok((result, remaining))
     }
@@ -6303,16 +5723,11 @@ pub struct DeviceStateDataResolution {
     pub resolution_max: Vec<u32>,
 }
 impl TryParse for DeviceStateDataResolution {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (num_valuators, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resolution_values, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
-        let (resolution_min, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
-        let (resolution_max, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (num_valuators, remaining) = u32::try_parse(remaining)?;
+        let (resolution_values, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
+        let (resolution_min, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
+        let (resolution_max, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
         let result = DeviceStateDataResolution { num_valuators, resolution_values, resolution_min, resolution_max };
         Ok((result, remaining))
     }
@@ -6350,24 +5765,15 @@ pub struct DeviceStateDataAbsCalib {
     pub button_threshold: u32,
 }
 impl TryParse for DeviceStateDataAbsCalib {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (min_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_threshold, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (min_x, remaining) = i32::try_parse(remaining)?;
+        let (max_x, remaining) = i32::try_parse(remaining)?;
+        let (min_y, remaining) = i32::try_parse(remaining)?;
+        let (max_y, remaining) = i32::try_parse(remaining)?;
+        let (flip_x, remaining) = u32::try_parse(remaining)?;
+        let (flip_y, remaining) = u32::try_parse(remaining)?;
+        let (rotation, remaining) = u32::try_parse(remaining)?;
+        let (button_threshold, remaining) = u32::try_parse(remaining)?;
         let result = DeviceStateDataAbsCalib { min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
     }
@@ -6442,13 +5848,10 @@ pub struct DeviceStateDataCore {
     pub iscore: u8,
 }
 impl TryParse for DeviceStateDataCore {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (iscore, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (iscore, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = DeviceStateDataCore { status, iscore };
         Ok((result, remaining))
     }
@@ -6488,20 +5891,13 @@ pub struct DeviceStateDataAbsArea {
     pub following: u32,
 }
 impl TryParse for DeviceStateDataAbsArea {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (offset_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (screen, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (following, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (offset_x, remaining) = u32::try_parse(remaining)?;
+        let (offset_y, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u32::try_parse(remaining)?;
+        let (height, remaining) = u32::try_parse(remaining)?;
+        let (screen, remaining) = u32::try_parse(remaining)?;
+        let (following, remaining) = u32::try_parse(remaining)?;
         let result = DeviceStateDataAbsArea { offset_x, offset_y, width, height, screen, following };
         Ok((result, remaining))
     }
@@ -6568,42 +5964,43 @@ pub enum DeviceStateData {
 }
 impl DeviceStateData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if control_id == Into::<u16>::into(DeviceControl::Resolution) {
-            let (resolution, new_remaining) = DeviceStateDataResolution::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (resolution, new_remaining) = DeviceStateDataResolution::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::Resolution(resolution));
         }
         if control_id == Into::<u16>::into(DeviceControl::Abscalib) {
-            let (abs_calib, new_remaining) = DeviceStateDataAbsCalib::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (abs_calib, new_remaining) = DeviceStateDataAbsCalib::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::AbsCalib(abs_calib));
         }
         if control_id == Into::<u16>::into(DeviceControl::Core) {
-            let (core, new_remaining) = DeviceStateDataCore::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (core, new_remaining) = DeviceStateDataCore::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::Core(core));
         }
         if control_id == Into::<u16>::into(DeviceControl::Enable) {
-            let (enable, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+            let remaining = outer_remaining;
+            let (enable, remaining) = u8::try_parse(remaining)?;
+            let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::Enable(enable));
         }
         if control_id == Into::<u16>::into(DeviceControl::Absarea) {
-            let (abs_area, new_remaining) = DeviceStateDataAbsArea::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (abs_area, new_remaining) = DeviceStateDataAbsArea::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::AbsArea(abs_area));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_resolution(&self) -> Option<&DeviceStateDataResolution> {
@@ -6665,14 +6062,10 @@ pub struct DeviceState {
     pub data: DeviceStateData,
 }
 impl TryParse for DeviceState {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = DeviceStateData::try_parse(remaining, control_id)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (data, remaining) = DeviceStateData::try_parse(remaining, control_id)?;
         let result = DeviceState { control_id, len, data };
         Ok((result, remaining))
     }
@@ -6734,21 +6127,14 @@ pub struct GetDeviceControlReply {
     pub control: DeviceState,
 }
 impl GetDeviceControlReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (control, new_remaining) = DeviceState::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let (control, remaining) = DeviceState::try_parse(remaining)?;
         let result = GetDeviceControlReply { response_type, xi_reply_type, sequence, length, status, control };
         Ok((result, remaining))
     }
@@ -6768,19 +6154,13 @@ pub struct DeviceResolutionCtl {
     pub resolution_values: Vec<u32>,
 }
 impl TryParse for DeviceResolutionCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_valuator, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_valuators, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (resolution_values, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (first_valuator, remaining) = u8::try_parse(remaining)?;
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (resolution_values, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
         let result = DeviceResolutionCtl { control_id, len, first_valuator, resolution_values };
         Ok((result, remaining))
     }
@@ -6824,28 +6204,17 @@ pub struct DeviceAbsCalibCtl {
     pub button_threshold: u32,
 }
 impl TryParse for DeviceAbsCalibCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_threshold, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (min_x, remaining) = i32::try_parse(remaining)?;
+        let (max_x, remaining) = i32::try_parse(remaining)?;
+        let (min_y, remaining) = i32::try_parse(remaining)?;
+        let (max_y, remaining) = i32::try_parse(remaining)?;
+        let (flip_x, remaining) = u32::try_parse(remaining)?;
+        let (flip_y, remaining) = u32::try_parse(remaining)?;
+        let (rotation, remaining) = u32::try_parse(remaining)?;
+        let (button_threshold, remaining) = u32::try_parse(remaining)?;
         let result = DeviceAbsCalibCtl { control_id, len, min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
     }
@@ -6935,24 +6304,15 @@ pub struct DeviceAbsAreaCtrl {
     pub following: u32,
 }
 impl TryParse for DeviceAbsAreaCtrl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (screen, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (following, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (offset_x, remaining) = u32::try_parse(remaining)?;
+        let (offset_y, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = i32::try_parse(remaining)?;
+        let (height, remaining) = i32::try_parse(remaining)?;
+        let (screen, remaining) = i32::try_parse(remaining)?;
+        let (following, remaining) = u32::try_parse(remaining)?;
         let result = DeviceAbsAreaCtrl { control_id, len, offset_x, offset_y, width, height, screen, following };
         Ok((result, remaining))
     }
@@ -7025,15 +6385,11 @@ pub struct DeviceCoreCtrl {
     pub status: u8,
 }
 impl TryParse for DeviceCoreCtrl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = DeviceCoreCtrl { control_id, len, status };
         Ok((result, remaining))
     }
@@ -7077,15 +6433,11 @@ pub struct DeviceEnableCtrl {
     pub enable: u8,
 }
 impl TryParse for DeviceEnableCtrl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enable, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (enable, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = DeviceEnableCtrl { control_id, len, enable };
         Ok((result, remaining))
     }
@@ -7128,15 +6480,11 @@ pub struct DeviceCtlDataResolution {
     pub resolution_values: Vec<u32>,
 }
 impl TryParse for DeviceCtlDataResolution {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (first_valuator, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_valuators, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (resolution_values, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (first_valuator, remaining) = u8::try_parse(remaining)?;
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (resolution_values, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators as usize)?;
         let result = DeviceCtlDataResolution { first_valuator, resolution_values };
         Ok((result, remaining))
     }
@@ -7175,24 +6523,15 @@ pub struct DeviceCtlDataAbsCalib {
     pub button_threshold: u32,
 }
 impl TryParse for DeviceCtlDataAbsCalib {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (min_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_x, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_y, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flip_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (rotation, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_threshold, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (min_x, remaining) = i32::try_parse(remaining)?;
+        let (max_x, remaining) = i32::try_parse(remaining)?;
+        let (min_y, remaining) = i32::try_parse(remaining)?;
+        let (max_y, remaining) = i32::try_parse(remaining)?;
+        let (flip_x, remaining) = u32::try_parse(remaining)?;
+        let (flip_y, remaining) = u32::try_parse(remaining)?;
+        let (rotation, remaining) = u32::try_parse(remaining)?;
+        let (button_threshold, remaining) = u32::try_parse(remaining)?;
         let result = DeviceCtlDataAbsCalib { min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
     }
@@ -7271,20 +6610,13 @@ pub struct DeviceCtlDataAbsArea {
     pub following: u32,
 }
 impl TryParse for DeviceCtlDataAbsArea {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (offset_x, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_y, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (screen, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (following, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (offset_x, remaining) = u32::try_parse(remaining)?;
+        let (offset_y, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = i32::try_parse(remaining)?;
+        let (height, remaining) = i32::try_parse(remaining)?;
+        let (screen, remaining) = i32::try_parse(remaining)?;
+        let (following, remaining) = u32::try_parse(remaining)?;
         let result = DeviceCtlDataAbsArea { offset_x, offset_y, width, height, screen, following };
         Ok((result, remaining))
     }
@@ -7351,43 +6683,45 @@ pub enum DeviceCtlData {
 }
 impl DeviceCtlData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if control_id == Into::<u16>::into(DeviceControl::Resolution) {
-            let (resolution, new_remaining) = DeviceCtlDataResolution::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (resolution, new_remaining) = DeviceCtlDataResolution::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::Resolution(resolution));
         }
         if control_id == Into::<u16>::into(DeviceControl::Abscalib) {
-            let (abs_calib, new_remaining) = DeviceCtlDataAbsCalib::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (abs_calib, new_remaining) = DeviceCtlDataAbsCalib::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::AbsCalib(abs_calib));
         }
         if control_id == Into::<u16>::into(DeviceControl::Core) {
-            let (status, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+            let remaining = outer_remaining;
+            let (status, remaining) = u8::try_parse(remaining)?;
+            let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::Status(status));
         }
         if control_id == Into::<u16>::into(DeviceControl::Enable) {
-            let (enable, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+            let remaining = outer_remaining;
+            let (enable, remaining) = u8::try_parse(remaining)?;
+            let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::Enable(enable));
         }
         if control_id == Into::<u16>::into(DeviceControl::Absarea) {
-            let (abs_area, new_remaining) = DeviceCtlDataAbsArea::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (abs_area, new_remaining) = DeviceCtlDataAbsArea::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::AbsArea(abs_area));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_resolution(&self) -> Option<&DeviceCtlDataResolution> {
@@ -7449,14 +6783,10 @@ pub struct DeviceCtl {
     pub data: DeviceCtlData,
 }
 impl TryParse for DeviceCtl {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (control_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = DeviceCtlData::try_parse(remaining, control_id)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (control_id, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (data, remaining) = DeviceCtlData::try_parse(remaining, control_id)?;
         let result = DeviceCtl { control_id, len, data };
         Ok((result, remaining))
     }
@@ -7521,19 +6851,13 @@ pub struct ChangeDeviceControlReply {
     pub status: u8,
 }
 impl ChangeDeviceControlReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = ChangeDeviceControlReply { response_type, xi_reply_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -7578,21 +6902,14 @@ pub struct ListDevicePropertiesReply {
     pub atoms: Vec<ATOM>,
 }
 impl ListDevicePropertiesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_atoms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_atoms, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
         let result = ListDevicePropertiesReply { response_type, xi_reply_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -7832,37 +7149,42 @@ pub enum GetDevicePropertyItems {
 }
 impl GetDevicePropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if format == Into::<u8>::into(PropertyFormat::M8Bits) {
-            let (data8, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, num_items as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let value = remaining;
+            let (data8, remaining) = crate::x11_utils::parse_list::<u8>(remaining, num_items as usize)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
-            remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(GetDevicePropertyItems::Data8(data8));
         }
         if format == Into::<u8>::into(PropertyFormat::M16Bits) {
-            let (data16, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let value = remaining;
+            let (data16, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items as usize)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
-            remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(GetDevicePropertyItems::Data16(data16));
         }
         if format == Into::<u8>::into(PropertyFormat::M32Bits) {
-            let (data32, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (data32, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items as usize)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(GetDevicePropertyItems::Data32(data32));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_data8(&self) -> Option<&Vec<u8>> {
@@ -7915,29 +7237,18 @@ pub struct GetDevicePropertyReply {
     pub items: GetDevicePropertyItems,
 }
 impl GetDevicePropertyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xi_reply_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes_after, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_items, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(10..).ok_or(ParseError::ParseError)?;
-        let (items, new_remaining) = GetDevicePropertyItems::try_parse(remaining, format, num_items)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (bytes_after, remaining) = u32::try_parse(remaining)?;
+        let (num_items, remaining) = u32::try_parse(remaining)?;
+        let (format, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
+        let (items, remaining) = GetDevicePropertyItems::try_parse(remaining, format, num_items)?;
         let result = GetDevicePropertyReply { response_type, xi_reply_type, sequence, length, type_, bytes_after, num_items, format, device_id, items };
         Ok((result, remaining))
     }
@@ -8019,16 +7330,11 @@ pub struct GroupInfo {
     pub effective: u8,
 }
 impl TryParse for GroupInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (base, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (latched, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (locked, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (effective, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (base, remaining) = u8::try_parse(remaining)?;
+        let (latched, remaining) = u8::try_parse(remaining)?;
+        let (locked, remaining) = u8::try_parse(remaining)?;
+        let (effective, remaining) = u8::try_parse(remaining)?;
         let result = GroupInfo { base, latched, locked, effective };
         Ok((result, remaining))
     }
@@ -8070,16 +7376,11 @@ pub struct ModifierInfo {
     pub effective: u32,
 }
 impl TryParse for ModifierInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (base, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (latched, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (locked, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (effective, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (base, remaining) = u32::try_parse(remaining)?;
+        let (latched, remaining) = u32::try_parse(remaining)?;
+        let (locked, remaining) = u32::try_parse(remaining)?;
+        let (effective, remaining) = u32::try_parse(remaining)?;
         let result = ModifierInfo { base, latched, locked, effective };
         Ok((result, remaining))
     }
@@ -8171,38 +7472,23 @@ pub struct XIQueryPointerReply {
     pub buttons: Vec<u32>,
 }
 impl XIQueryPointerReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (win_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (win_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (win_x, remaining) = FP1616::try_parse(remaining)?;
+        let (win_y, remaining) = FP1616::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
         let result = XIQueryPointerReply { response_type, sequence, length, root, child, root_x, root_y, win_x, win_y, same_screen, mods, group, buttons };
         Ok((result, remaining))
     }
@@ -8449,24 +7735,18 @@ pub struct AddMaster {
     pub name: Vec<u8>,
 }
 impl TryParse for AddMaster {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (send_core, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enable, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let (send_core, remaining) = bool::try_parse(remaining)?;
+        let (enable, remaining) = bool::try_parse(remaining)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = AddMaster { type_, len, send_core, enable, name };
         Ok((result, remaining))
     }
@@ -8507,21 +7787,14 @@ pub struct RemoveMaster {
     pub return_keyboard: DeviceId,
 }
 impl TryParse for RemoveMaster {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (return_mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (return_pointer, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (return_keyboard, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (return_mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (return_pointer, remaining) = DeviceId::try_parse(remaining)?;
+        let (return_keyboard, remaining) = DeviceId::try_parse(remaining)?;
         let result = RemoveMaster { type_, len, deviceid, return_mode, return_pointer, return_keyboard };
         Ok((result, remaining))
     }
@@ -8576,16 +7849,11 @@ pub struct AttachSlave {
     pub master: DeviceId,
 }
 impl TryParse for AttachSlave {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (master, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (master, remaining) = DeviceId::try_parse(remaining)?;
         let result = AttachSlave { type_, len, deviceid, master };
         Ok((result, remaining))
     }
@@ -8630,15 +7898,11 @@ pub struct DetachSlave {
     pub deviceid: DeviceId,
 }
 impl TryParse for DetachSlave {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = DetachSlave { type_, len, deviceid };
         Ok((result, remaining))
     }
@@ -8682,20 +7946,16 @@ pub struct HierarchyChangeDataAddMaster {
     pub name: Vec<u8>,
 }
 impl TryParse for HierarchyChangeDataAddMaster {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (send_core, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enable, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let (send_core, remaining) = bool::try_parse(remaining)?;
+        let (enable, remaining) = bool::try_parse(remaining)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = HierarchyChangeDataAddMaster { send_core, enable, name };
         Ok((result, remaining))
     }
@@ -8731,17 +7991,12 @@ pub struct HierarchyChangeDataRemoveMaster {
     pub return_keyboard: DeviceId,
 }
 impl TryParse for HierarchyChangeDataRemoveMaster {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (return_mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (return_pointer, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (return_keyboard, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (return_mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (return_pointer, remaining) = DeviceId::try_parse(remaining)?;
+        let (return_keyboard, remaining) = DeviceId::try_parse(remaining)?;
         let result = HierarchyChangeDataRemoveMaster { deviceid, return_mode, return_pointer, return_keyboard };
         Ok((result, remaining))
     }
@@ -8785,12 +8040,9 @@ pub struct HierarchyChangeDataAttachSlave {
     pub master: DeviceId,
 }
 impl TryParse for HierarchyChangeDataAttachSlave {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (master, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (master, remaining) = DeviceId::try_parse(remaining)?;
         let result = HierarchyChangeDataAttachSlave { deviceid, master };
         Ok((result, remaining))
     }
@@ -8828,36 +8080,37 @@ pub enum HierarchyChangeData {
 }
 impl HierarchyChangeData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if type_ == Into::<u16>::into(HierarchyChangeType::AddMaster) {
-            let (add_master, new_remaining) = HierarchyChangeDataAddMaster::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (add_master, new_remaining) = HierarchyChangeDataAddMaster::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(HierarchyChangeData::AddMaster(add_master));
         }
         if type_ == Into::<u16>::into(HierarchyChangeType::RemoveMaster) {
-            let (remove_master, new_remaining) = HierarchyChangeDataRemoveMaster::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (remove_master, new_remaining) = HierarchyChangeDataRemoveMaster::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(HierarchyChangeData::RemoveMaster(remove_master));
         }
         if type_ == Into::<u16>::into(HierarchyChangeType::AttachSlave) {
-            let (attach_slave, new_remaining) = HierarchyChangeDataAttachSlave::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (attach_slave, new_remaining) = HierarchyChangeDataAttachSlave::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(HierarchyChangeData::AttachSlave(attach_slave));
         }
         if type_ == Into::<u16>::into(HierarchyChangeType::DetachSlave) {
-            let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-            remaining = new_remaining;
-            remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+            let remaining = outer_remaining;
+            let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+            let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(HierarchyChangeData::Deviceid(deviceid));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_add_master(&self) -> Option<&HierarchyChangeDataAddMaster> {
@@ -8911,14 +8164,10 @@ pub struct HierarchyChange {
     pub data: HierarchyChangeData,
 }
 impl TryParse for HierarchyChange {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = HierarchyChangeData::try_parse(remaining, type_)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (data, remaining) = HierarchyChangeData::try_parse(remaining, type_)?;
         let result = HierarchyChange { type_, len, data };
         Ok((result, remaining))
     }
@@ -9037,21 +8286,15 @@ pub struct XIGetClientPointerReply {
     pub deviceid: DeviceId,
 }
 impl XIGetClientPointerReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (set, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (set, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = XIGetClientPointerReply { response_type, sequence, length, set, deviceid };
         Ok((result, remaining))
     }
@@ -9172,14 +8415,10 @@ pub struct EventMask {
     pub mask: Vec<u32>,
 }
 impl TryParse for EventMask {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, mask_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (mask_len, remaining) = u16::try_parse(remaining)?;
+        let (mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, mask_len as usize)?;
         let result = EventMask { deviceid, mask };
         Ok((result, remaining))
     }
@@ -9275,20 +8514,14 @@ pub struct XIQueryVersionReply {
     pub minor_version: u16,
 }
 impl XIQueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u16::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = XIQueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -9639,20 +8872,13 @@ pub struct ButtonClass {
     pub labels: Vec<ATOM>,
 }
 impl TryParse for ButtonClass {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_buttons, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((num_buttons as usize) + (31)) / (32))?;
-        remaining = new_remaining;
-        let (labels, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_buttons as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (num_buttons, remaining) = u16::try_parse(remaining)?;
+        let (state, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((num_buttons as usize) + (31)) / (32))?;
+        let (labels, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_buttons as usize)?;
         let result = ButtonClass { type_, len, sourceid, num_buttons, state, labels };
         Ok((result, remaining))
     }
@@ -9689,18 +8915,12 @@ pub struct KeyClass {
     pub keys: Vec<u32>,
 }
 impl TryParse for KeyClass {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_keys, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_keys as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (num_keys, remaining) = u16::try_parse(remaining)?;
+        let (keys, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_keys as usize)?;
         let result = KeyClass { type_, len, sourceid, keys };
         Ok((result, remaining))
     }
@@ -9740,23 +8960,15 @@ pub struct ScrollClass {
     pub increment: Fp3232,
 }
 impl TryParse for ScrollClass {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (number, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (scroll_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (increment, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (number, remaining) = u16::try_parse(remaining)?;
+        let (scroll_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (increment, remaining) = Fp3232::try_parse(remaining)?;
         let result = ScrollClass { type_, len, sourceid, number, scroll_type, flags, increment };
         Ok((result, remaining))
     }
@@ -9826,18 +9038,12 @@ pub struct TouchClass {
     pub num_touches: u8,
 }
 impl TryParse for TouchClass {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_touches, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (num_touches, remaining) = u8::try_parse(remaining)?;
         let result = TouchClass { type_, len, sourceid, mode, num_touches };
         Ok((result, remaining))
     }
@@ -9891,29 +9097,18 @@ pub struct ValuatorClass {
     pub mode: u8,
 }
 impl TryParse for ValuatorClass {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (number, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (label, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resolution, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (number, remaining) = u16::try_parse(remaining)?;
+        let (label, remaining) = ATOM::try_parse(remaining)?;
+        let (min, remaining) = Fp3232::try_parse(remaining)?;
+        let (max, remaining) = Fp3232::try_parse(remaining)?;
+        let (value, remaining) = Fp3232::try_parse(remaining)?;
+        let (resolution, remaining) = u32::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = ValuatorClass { type_, len, sourceid, number, label, min, max, value, resolution, mode };
         Ok((result, remaining))
     }
@@ -10005,12 +9200,9 @@ pub struct DeviceClassDataKey {
     pub keys: Vec<u32>,
 }
 impl TryParse for DeviceClassDataKey {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (num_keys, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_keys as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (num_keys, remaining) = u16::try_parse(remaining)?;
+        let (keys, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_keys as usize)?;
         let result = DeviceClassDataKey { keys };
         Ok((result, remaining))
     }
@@ -10042,14 +9234,10 @@ pub struct DeviceClassDataButton {
     pub labels: Vec<ATOM>,
 }
 impl TryParse for DeviceClassDataButton {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (num_buttons, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((num_buttons as usize) + (31)) / (32))?;
-        remaining = new_remaining;
-        let (labels, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_buttons as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (num_buttons, remaining) = u16::try_parse(remaining)?;
+        let (state, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((num_buttons as usize) + (31)) / (32))?;
+        let (labels, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_buttons as usize)?;
         let result = DeviceClassDataButton { num_buttons, state, labels };
         Ok((result, remaining))
     }
@@ -10085,23 +9273,15 @@ pub struct DeviceClassDataValuator {
     pub mode: u8,
 }
 impl TryParse for DeviceClassDataValuator {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (number, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (label, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resolution, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (number, remaining) = u16::try_parse(remaining)?;
+        let (label, remaining) = ATOM::try_parse(remaining)?;
+        let (min, remaining) = Fp3232::try_parse(remaining)?;
+        let (max, remaining) = Fp3232::try_parse(remaining)?;
+        let (value, remaining) = Fp3232::try_parse(remaining)?;
+        let (resolution, remaining) = u32::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = DeviceClassDataValuator { number, label, min, max, value, resolution, mode };
         Ok((result, remaining))
     }
@@ -10183,17 +9363,12 @@ pub struct DeviceClassDataScroll {
     pub increment: Fp3232,
 }
 impl TryParse for DeviceClassDataScroll {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (number, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (scroll_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (increment, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (number, remaining) = u16::try_parse(remaining)?;
+        let (scroll_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (increment, remaining) = Fp3232::try_parse(remaining)?;
         let result = DeviceClassDataScroll { number, scroll_type, flags, increment };
         Ok((result, remaining))
     }
@@ -10247,12 +9422,9 @@ pub struct DeviceClassDataTouch {
     pub num_touches: u8,
 }
 impl TryParse for DeviceClassDataTouch {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_touches, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (num_touches, remaining) = u8::try_parse(remaining)?;
         let result = DeviceClassDataTouch { mode, num_touches };
         Ok((result, remaining))
     }
@@ -10289,41 +9461,41 @@ pub enum DeviceClassData {
 }
 impl DeviceClassData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if type_ == Into::<u16>::into(DeviceClassType::Key) {
-            let (key, new_remaining) = DeviceClassDataKey::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (key, new_remaining) = DeviceClassDataKey::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Key(key));
         }
         if type_ == Into::<u16>::into(DeviceClassType::Button) {
-            let (button, new_remaining) = DeviceClassDataButton::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (button, new_remaining) = DeviceClassDataButton::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Button(button));
         }
         if type_ == Into::<u16>::into(DeviceClassType::Valuator) {
-            let (valuator, new_remaining) = DeviceClassDataValuator::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (valuator, new_remaining) = DeviceClassDataValuator::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Valuator(valuator));
         }
         if type_ == Into::<u16>::into(DeviceClassType::Scroll) {
-            let (scroll, new_remaining) = DeviceClassDataScroll::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (scroll, new_remaining) = DeviceClassDataScroll::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Scroll(scroll));
         }
         if type_ == Into::<u16>::into(DeviceClassType::Touch) {
-            let (touch, new_remaining) = DeviceClassDataTouch::try_parse(remaining)?;
-            remaining = new_remaining;
+            let (touch, new_remaining) = DeviceClassDataTouch::try_parse(outer_remaining)?;
+            outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Touch(touch));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_key(&self) -> Option<&DeviceClassDataKey> {
@@ -10386,16 +9558,11 @@ pub struct DeviceClass {
     pub data: DeviceClassData,
 }
 impl TryParse for DeviceClass {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = DeviceClassData::try_parse(remaining, type_)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (data, remaining) = DeviceClassData::try_parse(remaining, type_)?;
         let result = DeviceClass { type_, len, sourceid, data };
         Ok((result, remaining))
     }
@@ -10432,29 +9599,21 @@ pub struct XIDeviceInfo {
     pub classes: Vec<DeviceClass>,
 }
 impl TryParse for XIDeviceInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (attachment, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_classes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enabled, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (type_, remaining) = u16::try_parse(remaining)?;
+        let (attachment, remaining) = DeviceId::try_parse(remaining)?;
+        let (num_classes, remaining) = u16::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let (enabled, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (classes, new_remaining) = crate::x11_utils::parse_list::<DeviceClass>(remaining, num_classes as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (classes, remaining) = crate::x11_utils::parse_list::<DeviceClass>(remaining, num_classes as usize)?;
         let result = XIDeviceInfo { deviceid, type_, attachment, enabled, name, classes };
         Ok((result, remaining))
     }
@@ -10521,20 +9680,14 @@ pub struct XIQueryDeviceReply {
     pub infos: Vec<XIDeviceInfo>,
 }
 impl XIQueryDeviceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_infos, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (infos, new_remaining) = crate::x11_utils::parse_list::<XIDeviceInfo>(remaining, num_infos as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_infos, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (infos, remaining) = crate::x11_utils::parse_list::<XIDeviceInfo>(remaining, num_infos as usize)?;
         let result = XIQueryDeviceReply { response_type, sequence, length, infos };
         Ok((result, remaining))
     }
@@ -10613,18 +9766,13 @@ pub struct XIGetFocusReply {
     pub focus: WINDOW,
 }
 impl XIGetFocusReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (focus, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (focus, remaining) = WINDOW::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = XIGetFocusReply { response_type, sequence, length, focus };
         Ok((result, remaining))
     }
@@ -10761,18 +9909,13 @@ pub struct XIGrabDeviceReply {
     pub status: u8,
 }
 impl XIGrabDeviceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = XIGrabDeviceReply { response_type, sequence, length, status };
         Ok((result, remaining))
     }
@@ -11106,13 +10249,10 @@ pub struct GrabModifierInfo {
     pub status: u8,
 }
 impl TryParse for GrabModifierInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (modifiers, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (modifiers, remaining) = u32::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = GrabModifierInfo { modifiers, status };
         Ok((result, remaining))
     }
@@ -11225,20 +10365,14 @@ pub struct XIPassiveGrabDeviceReply {
     pub modifiers: Vec<GrabModifierInfo>,
 }
 impl XIPassiveGrabDeviceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_modifiers, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (modifiers, new_remaining) = crate::x11_utils::parse_list::<GrabModifierInfo>(remaining, num_modifiers as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_modifiers, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (modifiers, remaining) = crate::x11_utils::parse_list::<GrabModifierInfo>(remaining, num_modifiers as usize)?;
         let result = XIPassiveGrabDeviceReply { response_type, sequence, length, modifiers };
         Ok((result, remaining))
     }
@@ -11329,20 +10463,14 @@ pub struct XIListPropertiesReply {
     pub properties: Vec<ATOM>,
 }
 impl XIListPropertiesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_properties, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (properties, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_properties as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_properties, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_properties as usize)?;
         let result = XIListPropertiesReply { response_type, sequence, length, properties };
         Ok((result, remaining))
     }
@@ -11517,37 +10645,42 @@ pub enum XIGetPropertyItems {
 }
 impl XIGetPropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let mut parse_result = None;
         if format == Into::<u8>::into(PropertyFormat::M8Bits) {
-            let (data8, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, num_items as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let value = remaining;
+            let (data8, remaining) = crate::x11_utils::parse_list::<u8>(remaining, num_items as usize)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
-            remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(XIGetPropertyItems::Data8(data8));
         }
         if format == Into::<u8>::into(PropertyFormat::M16Bits) {
-            let (data16, new_remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let value = remaining;
+            let (data16, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items as usize)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
-            remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(XIGetPropertyItems::Data16(data16));
         }
         if format == Into::<u8>::into(PropertyFormat::M32Bits) {
-            let (data32, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (data32, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items as usize)?;
+            outer_remaining = remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(XIGetPropertyItems::Data32(data32));
         }
         match parse_result {
             None => Err(ParseError::ParseError),
-            Some(result) => Ok((result, remaining))
+            Some(result) => Ok((result, outer_remaining))
         }
     }
     pub fn as_data8(&self) -> Option<&Vec<u8>> {
@@ -11598,26 +10731,17 @@ pub struct XIGetPropertyReply {
     pub items: XIGetPropertyItems,
 }
 impl XIGetPropertyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes_after, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_items, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(11..).ok_or(ParseError::ParseError)?;
-        let (items, new_remaining) = XIGetPropertyItems::try_parse(remaining, format, num_items)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (bytes_after, remaining) = u32::try_parse(remaining)?;
+        let (num_items, remaining) = u32::try_parse(remaining)?;
+        let (format, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
+        let (items, remaining) = XIGetPropertyItems::try_parse(remaining, format, num_items)?;
         let result = XIGetPropertyReply { response_type, sequence, length, type_, bytes_after, num_items, format, items };
         Ok((result, remaining))
     }
@@ -11661,20 +10785,14 @@ pub struct XIGetSelectedEventsReply {
     pub masks: Vec<EventMask>,
 }
 impl XIGetSelectedEventsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_masks, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (masks, new_remaining) = crate::x11_utils::parse_list::<EventMask>(remaining, num_masks as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num_masks, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (masks, remaining) = crate::x11_utils::parse_list::<EventMask>(remaining, num_masks as usize)?;
         let result = XIGetSelectedEventsReply { response_type, sequence, length, masks };
         Ok((result, remaining))
     }
@@ -11693,15 +10811,11 @@ pub struct BarrierReleasePointerInfo {
     pub eventid: u32,
 }
 impl TryParse for BarrierReleasePointerInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (barrier, new_remaining) = xfixes::BARRIER::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (eventid, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (barrier, remaining) = xfixes::BARRIER::try_parse(remaining)?;
+        let (eventid, remaining) = u32::try_parse(remaining)?;
         let result = BarrierReleasePointerInfo { deviceid, barrier, eventid };
         Ok((result, remaining))
     }
@@ -11785,32 +10899,19 @@ pub struct DeviceValuatorEvent {
     pub valuators: [i32; 6],
 }
 impl DeviceValuatorEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_valuators, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_valuator, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_0, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_1, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_2, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_3, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_4, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_5, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (device_state, remaining) = u16::try_parse(remaining)?;
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let (first_valuator, remaining) = u8::try_parse(remaining)?;
+        let (valuators_0, remaining) = i32::try_parse(remaining)?;
+        let (valuators_1, remaining) = i32::try_parse(remaining)?;
+        let (valuators_2, remaining) = i32::try_parse(remaining)?;
+        let (valuators_3, remaining) = i32::try_parse(remaining)?;
+        let (valuators_4, remaining) = i32::try_parse(remaining)?;
+        let (valuators_5, remaining) = i32::try_parse(remaining)?;
         let valuators = [
             valuators_0,
             valuators_1,
@@ -11943,36 +11044,21 @@ pub struct DeviceKeyPressEvent {
     pub device_id: u8,
 }
 impl DeviceKeyPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = DeviceKeyPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
         Ok((result, remaining))
     }
@@ -12039,36 +11125,21 @@ pub struct DeviceKeyReleaseEvent {
     pub device_id: u8,
 }
 impl DeviceKeyReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = DeviceKeyReleaseEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
         Ok((result, remaining))
     }
@@ -12135,36 +11206,21 @@ pub struct DeviceButtonPressEvent {
     pub device_id: u8,
 }
 impl DeviceButtonPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = DeviceButtonPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
         Ok((result, remaining))
     }
@@ -12231,36 +11287,21 @@ pub struct DeviceButtonReleaseEvent {
     pub device_id: u8,
 }
 impl DeviceButtonReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = DeviceButtonReleaseEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
         Ok((result, remaining))
     }
@@ -12327,36 +11368,21 @@ pub struct DeviceMotionNotifyEvent {
     pub device_id: u8,
 }
 impl DeviceMotionNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = DeviceMotionNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
         Ok((result, remaining))
     }
@@ -12416,23 +11442,15 @@ pub struct DeviceFocusInEvent {
     pub device_id: u8,
 }
 impl DeviceFocusInEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let result = DeviceFocusInEvent { response_type, detail, sequence, time, window, mode, device_id };
         Ok((result, remaining))
     }
@@ -12485,23 +11503,15 @@ pub struct DeviceFocusOutEvent {
     pub device_id: u8,
 }
 impl DeviceFocusOutEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let result = DeviceFocusOutEvent { response_type, detail, sequence, time, window, mode, device_id };
         Ok((result, remaining))
     }
@@ -12561,36 +11571,21 @@ pub struct ProximityInEvent {
     pub device_id: u8,
 }
 impl ProximityInEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = ProximityInEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
         Ok((result, remaining))
     }
@@ -12657,36 +11652,21 @@ pub struct ProximityOutEvent {
     pub device_id: u8,
 }
 impl ProximityOutEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = ProximityOutEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
         Ok((result, remaining))
     }
@@ -12822,58 +11802,38 @@ pub struct DeviceStateNotifyEvent {
     pub valuators: [u32; 3],
 }
 impl DeviceStateNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_buttons, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_valuators, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (classes_reported, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (num_keys, remaining) = u8::try_parse(remaining)?;
+        let (num_buttons, remaining) = u8::try_parse(remaining)?;
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let (classes_reported, remaining) = u8::try_parse(remaining)?;
+        let (buttons_0, remaining) = u8::try_parse(remaining)?;
+        let (buttons_1, remaining) = u8::try_parse(remaining)?;
+        let (buttons_2, remaining) = u8::try_parse(remaining)?;
+        let (buttons_3, remaining) = u8::try_parse(remaining)?;
         let buttons = [
             buttons_0,
             buttons_1,
             buttons_2,
             buttons_3,
         ];
-        let (keys_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+        let (keys_0, remaining) = u8::try_parse(remaining)?;
+        let (keys_1, remaining) = u8::try_parse(remaining)?;
+        let (keys_2, remaining) = u8::try_parse(remaining)?;
+        let (keys_3, remaining) = u8::try_parse(remaining)?;
         let keys = [
             keys_0,
             keys_1,
             keys_2,
             keys_3,
         ];
-        let (valuators_0, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_1, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_2, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+        let (valuators_0, remaining) = u32::try_parse(remaining)?;
+        let (valuators_1, remaining) = u32::try_parse(remaining)?;
+        let (valuators_2, remaining) = u32::try_parse(remaining)?;
         let valuators = [
             valuators_0,
             valuators_1,
@@ -12933,24 +11893,16 @@ pub struct DeviceMappingNotifyEvent {
     pub time: TIMESTAMP,
 }
 impl DeviceMappingNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_keycode, new_remaining) = KeyCode::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (request, remaining) = u8::try_parse(remaining)?;
+        let (first_keycode, remaining) = KeyCode::try_parse(remaining)?;
+        let (count, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = DeviceMappingNotifyEvent { response_type, device_id, sequence, request, first_keycode, count, time };
         Ok((result, remaining))
     }
@@ -13062,19 +12014,13 @@ pub struct ChangeDeviceNotifyEvent {
     pub request: u8,
 }
 impl ChangeDeviceNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(23..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (request, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let result = ChangeDeviceNotifyEvent { response_type, device_id, sequence, time, request };
         Ok((result, remaining))
     }
@@ -13123,70 +12069,38 @@ pub struct DeviceKeyStateNotifyEvent {
     pub keys: [u8; 28],
 }
 impl DeviceKeyStateNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (keys_0, remaining) = u8::try_parse(remaining)?;
+        let (keys_1, remaining) = u8::try_parse(remaining)?;
+        let (keys_2, remaining) = u8::try_parse(remaining)?;
+        let (keys_3, remaining) = u8::try_parse(remaining)?;
+        let (keys_4, remaining) = u8::try_parse(remaining)?;
+        let (keys_5, remaining) = u8::try_parse(remaining)?;
+        let (keys_6, remaining) = u8::try_parse(remaining)?;
+        let (keys_7, remaining) = u8::try_parse(remaining)?;
+        let (keys_8, remaining) = u8::try_parse(remaining)?;
+        let (keys_9, remaining) = u8::try_parse(remaining)?;
+        let (keys_10, remaining) = u8::try_parse(remaining)?;
+        let (keys_11, remaining) = u8::try_parse(remaining)?;
+        let (keys_12, remaining) = u8::try_parse(remaining)?;
+        let (keys_13, remaining) = u8::try_parse(remaining)?;
+        let (keys_14, remaining) = u8::try_parse(remaining)?;
+        let (keys_15, remaining) = u8::try_parse(remaining)?;
+        let (keys_16, remaining) = u8::try_parse(remaining)?;
+        let (keys_17, remaining) = u8::try_parse(remaining)?;
+        let (keys_18, remaining) = u8::try_parse(remaining)?;
+        let (keys_19, remaining) = u8::try_parse(remaining)?;
+        let (keys_20, remaining) = u8::try_parse(remaining)?;
+        let (keys_21, remaining) = u8::try_parse(remaining)?;
+        let (keys_22, remaining) = u8::try_parse(remaining)?;
+        let (keys_23, remaining) = u8::try_parse(remaining)?;
+        let (keys_24, remaining) = u8::try_parse(remaining)?;
+        let (keys_25, remaining) = u8::try_parse(remaining)?;
+        let (keys_26, remaining) = u8::try_parse(remaining)?;
+        let (keys_27, remaining) = u8::try_parse(remaining)?;
         let keys = [
             keys_0,
             keys_1,
@@ -13264,70 +12178,38 @@ pub struct DeviceButtonStateNotifyEvent {
     pub buttons: [u8; 28],
 }
 impl DeviceButtonStateNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (buttons_0, remaining) = u8::try_parse(remaining)?;
+        let (buttons_1, remaining) = u8::try_parse(remaining)?;
+        let (buttons_2, remaining) = u8::try_parse(remaining)?;
+        let (buttons_3, remaining) = u8::try_parse(remaining)?;
+        let (buttons_4, remaining) = u8::try_parse(remaining)?;
+        let (buttons_5, remaining) = u8::try_parse(remaining)?;
+        let (buttons_6, remaining) = u8::try_parse(remaining)?;
+        let (buttons_7, remaining) = u8::try_parse(remaining)?;
+        let (buttons_8, remaining) = u8::try_parse(remaining)?;
+        let (buttons_9, remaining) = u8::try_parse(remaining)?;
+        let (buttons_10, remaining) = u8::try_parse(remaining)?;
+        let (buttons_11, remaining) = u8::try_parse(remaining)?;
+        let (buttons_12, remaining) = u8::try_parse(remaining)?;
+        let (buttons_13, remaining) = u8::try_parse(remaining)?;
+        let (buttons_14, remaining) = u8::try_parse(remaining)?;
+        let (buttons_15, remaining) = u8::try_parse(remaining)?;
+        let (buttons_16, remaining) = u8::try_parse(remaining)?;
+        let (buttons_17, remaining) = u8::try_parse(remaining)?;
+        let (buttons_18, remaining) = u8::try_parse(remaining)?;
+        let (buttons_19, remaining) = u8::try_parse(remaining)?;
+        let (buttons_20, remaining) = u8::try_parse(remaining)?;
+        let (buttons_21, remaining) = u8::try_parse(remaining)?;
+        let (buttons_22, remaining) = u8::try_parse(remaining)?;
+        let (buttons_23, remaining) = u8::try_parse(remaining)?;
+        let (buttons_24, remaining) = u8::try_parse(remaining)?;
+        let (buttons_25, remaining) = u8::try_parse(remaining)?;
+        let (buttons_26, remaining) = u8::try_parse(remaining)?;
+        let (buttons_27, remaining) = u8::try_parse(remaining)?;
         let buttons = [
             buttons_0,
             buttons_1,
@@ -13481,22 +12363,15 @@ pub struct DevicePresenceNotifyEvent {
     pub control: u16,
 }
 impl DevicePresenceNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (devchange, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (control, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (devchange, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (control, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = DevicePresenceNotifyEvent { response_type, sequence, time, devchange, device_id, control };
         Ok((result, remaining))
     }
@@ -13548,21 +12423,14 @@ pub struct DevicePropertyNotifyEvent {
     pub device_id: u8,
 }
 impl DevicePropertyNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (property, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(19..).ok_or(ParseError::ParseError)?;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (property, remaining) = ATOM::try_parse(remaining)?;
+        let remaining = remaining.get(19..).ok_or(ParseError::ParseError)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = DevicePropertyNotifyEvent { response_type, state, sequence, time, property, device_id };
         Ok((result, remaining))
     }
@@ -13680,31 +12548,19 @@ pub struct DeviceChangedEvent {
     pub classes: Vec<DeviceClass>,
 }
 impl DeviceChangedEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_classes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (reason, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(11..).ok_or(ParseError::ParseError)?;
-        let (classes, new_remaining) = crate::x11_utils::parse_list::<DeviceClass>(remaining, num_classes as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (num_classes, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (reason, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
+        let (classes, remaining) = crate::x11_utils::parse_list::<DeviceClass>(remaining, num_classes as usize)?;
         let result = DeviceChangedEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, reason, classes };
         Ok((result, remaining))
     }
@@ -13784,57 +12640,32 @@ pub struct KeyPressEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl KeyPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = KeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -13886,57 +12717,32 @@ pub struct KeyReleaseEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl KeyReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = KeyReleaseEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -14016,57 +12822,32 @@ pub struct ButtonPressEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl ButtonPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = ButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -14118,57 +12899,32 @@ pub struct ButtonReleaseEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl ButtonReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = ButtonReleaseEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -14220,57 +12976,32 @@ pub struct MotionEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl MotionEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = MotionEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -14476,54 +13207,30 @@ pub struct EnterEvent {
     pub buttons: Vec<u32>,
 }
 impl EnterEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (focus, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (focus, remaining) = bool::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
         let result = EnterEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, mode, detail, root, event, child, root_x, root_y, event_x, event_y, same_screen, focus, mods, group, buttons };
         Ok((result, remaining))
     }
@@ -14575,54 +13282,30 @@ pub struct LeaveEvent {
     pub buttons: Vec<u32>,
 }
 impl LeaveEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (focus, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (focus, remaining) = bool::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
         let result = LeaveEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, mode, detail, root, event, child, root_x, root_y, event_x, event_y, same_screen, focus, mods, group, buttons };
         Ok((result, remaining))
     }
@@ -14674,54 +13357,30 @@ pub struct FocusInEvent {
     pub buttons: Vec<u32>,
 }
 impl FocusInEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (focus, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (focus, remaining) = bool::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
         let result = FocusInEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, mode, detail, root, event, child, root_x, root_y, event_x, event_y, same_screen, focus, mods, group, buttons };
         Ok((result, remaining))
     }
@@ -14773,54 +13432,30 @@ pub struct FocusOutEvent {
     pub buttons: Vec<u32>,
 }
 impl FocusOutEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (focus, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (focus, remaining) = bool::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
         let result = FocusOutEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, mode, detail, root, event, child, root_x, root_y, event_x, event_y, same_screen, focus, mods, group, buttons };
         Ok((result, remaining))
     }
@@ -14934,19 +13569,13 @@ pub struct HierarchyInfo {
     pub flags: u32,
 }
 impl TryParse for HierarchyInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (attachment, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enabled, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (attachment, remaining) = DeviceId::try_parse(remaining)?;
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (enabled, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
         let result = HierarchyInfo { deviceid, attachment, type_, enabled, flags };
         Ok((result, remaining))
     }
@@ -15006,29 +13635,18 @@ pub struct HierarchyEvent {
     pub infos: Vec<HierarchyInfo>,
 }
 impl HierarchyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_infos, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(10..).ok_or(ParseError::ParseError)?;
-        let (infos, new_remaining) = crate::x11_utils::parse_list::<HierarchyInfo>(remaining, num_infos as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (num_infos, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
+        let (infos, remaining) = crate::x11_utils::parse_list::<HierarchyInfo>(remaining, num_infos as usize)?;
         let result = HierarchyEvent { response_type, extension, sequence, length, event_type, deviceid, time, flags, infos };
         Ok((result, remaining))
     }
@@ -15132,27 +13750,17 @@ pub struct PropertyEvent {
     pub what: u8,
 }
 impl PropertyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (property, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (what, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(11..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (property, remaining) = ATOM::try_parse(remaining)?;
+        let (what, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let result = PropertyEvent { response_type, extension, sequence, length, event_type, deviceid, time, property, what };
         Ok((result, remaining))
     }
@@ -15195,37 +13803,22 @@ pub struct RawKeyPressEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawKeyPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawKeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -15268,37 +13861,22 @@ pub struct RawKeyReleaseEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawKeyReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawKeyReleaseEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -15341,37 +13919,22 @@ pub struct RawButtonPressEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawButtonPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -15414,37 +13977,22 @@ pub struct RawButtonReleaseEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawButtonReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawButtonReleaseEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -15487,37 +14035,22 @@ pub struct RawMotionEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawMotionEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawMotionEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -15600,57 +14133,32 @@ pub struct TouchBeginEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl TouchBeginEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = TouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -15702,57 +14210,32 @@ pub struct TouchUpdateEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl TouchUpdateEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = TouchUpdateEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -15804,57 +14287,32 @@ pub struct TouchEndEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl TouchEndEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (buttons_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = ModifierInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = GroupInfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
-        remaining = new_remaining;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (event_x, remaining) = FP1616::try_parse(remaining)?;
+        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len as usize)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = TouchEndEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         Ok((result, remaining))
     }
@@ -15956,36 +14414,22 @@ pub struct TouchOwnershipEvent {
     pub flags: u32,
 }
 impl TouchOwnershipEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (touchid, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (touchid, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let result = TouchOwnershipEvent { response_type, extension, sequence, length, event_type, deviceid, time, touchid, root, event, child, sourceid, flags };
         Ok((result, remaining))
     }
@@ -16028,37 +14472,22 @@ pub struct RawTouchBeginEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawTouchBeginEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawTouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -16101,37 +14530,22 @@ pub struct RawTouchUpdateEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawTouchUpdateEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawTouchUpdateEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -16174,37 +14588,22 @@ pub struct RawTouchEndEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl RawTouchEndEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (valuators_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (valuator_mask, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
-        remaining = new_remaining;
-        let (axisvalues, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
-        let (axisvalues_raw, new_remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len as usize)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().map(|x| TryInto::<usize>::try_into(x.count_ones()).unwrap()).sum())?;
         let result = RawTouchEndEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         Ok((result, remaining))
     }
@@ -16315,45 +14714,26 @@ pub struct BarrierHitEvent {
     pub dy: Fp3232,
 }
 impl BarrierHitEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (eventid, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (barrier, new_remaining) = xfixes::BARRIER::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dtime, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dx, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dy, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (eventid, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (barrier, remaining) = xfixes::BARRIER::try_parse(remaining)?;
+        let (dtime, remaining) = u32::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (dx, remaining) = Fp3232::try_parse(remaining)?;
+        let (dy, remaining) = Fp3232::try_parse(remaining)?;
         let result = BarrierHitEvent { response_type, extension, sequence, length, event_type, deviceid, time, eventid, root, event, barrier, dtime, flags, sourceid, root_x, root_y, dx, dy };
         Ok((result, remaining))
     }
@@ -16401,45 +14781,26 @@ pub struct BarrierLeaveEvent {
     pub dy: Fp3232,
 }
 impl BarrierLeaveEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (deviceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (eventid, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (barrier, new_remaining) = xfixes::BARRIER::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dtime, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sourceid, new_remaining) = DeviceId::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (root_x, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = FP1616::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dx, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dy, new_remaining) = Fp3232::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (eventid, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (barrier, remaining) = xfixes::BARRIER::try_parse(remaining)?;
+        let (dtime, remaining) = u32::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (root_x, remaining) = FP1616::try_parse(remaining)?;
+        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (dx, remaining) = Fp3232::try_parse(remaining)?;
+        let (dy, remaining) = Fp3232::try_parse(remaining)?;
         let result = BarrierLeaveEvent { response_type, extension, sequence, length, event_type, deviceid, time, eventid, root, event, barrier, dtime, flags, sourceid, root_x, root_y, dx, dy };
         Ok((result, remaining))
     }
@@ -16467,128 +14828,128 @@ impl<B: AsRef<[u8]>> TryFrom<&GenericEvent<B>> for BarrierLeaveEvent {
 pub struct EventForSend([u8; 32]);
 impl EventForSend {
     pub fn as_device_valuator(&self) -> DeviceValuatorEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceValuatorEvent, ParseError> {
-            let (event, remaining) = DeviceValuatorEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceValuatorEvent, ParseError> {
+            let (event, remaining) = DeviceValuatorEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_key_press(&self) -> DeviceKeyPressEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceKeyPressEvent, ParseError> {
-            let (event, remaining) = DeviceKeyPressEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceKeyPressEvent, ParseError> {
+            let (event, remaining) = DeviceKeyPressEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_key_release(&self) -> DeviceKeyReleaseEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceKeyReleaseEvent, ParseError> {
-            let (event, remaining) = DeviceKeyReleaseEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceKeyReleaseEvent, ParseError> {
+            let (event, remaining) = DeviceKeyReleaseEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_button_press(&self) -> DeviceButtonPressEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceButtonPressEvent, ParseError> {
-            let (event, remaining) = DeviceButtonPressEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceButtonPressEvent, ParseError> {
+            let (event, remaining) = DeviceButtonPressEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_button_release(&self) -> DeviceButtonReleaseEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceButtonReleaseEvent, ParseError> {
-            let (event, remaining) = DeviceButtonReleaseEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceButtonReleaseEvent, ParseError> {
+            let (event, remaining) = DeviceButtonReleaseEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_motion_notify(&self) -> DeviceMotionNotifyEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceMotionNotifyEvent, ParseError> {
-            let (event, remaining) = DeviceMotionNotifyEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceMotionNotifyEvent, ParseError> {
+            let (event, remaining) = DeviceMotionNotifyEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_focus_in(&self) -> DeviceFocusInEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceFocusInEvent, ParseError> {
-            let (event, remaining) = DeviceFocusInEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceFocusInEvent, ParseError> {
+            let (event, remaining) = DeviceFocusInEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_focus_out(&self) -> DeviceFocusOutEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceFocusOutEvent, ParseError> {
-            let (event, remaining) = DeviceFocusOutEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceFocusOutEvent, ParseError> {
+            let (event, remaining) = DeviceFocusOutEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_proximity_in(&self) -> ProximityInEvent {
-        fn do_the_parse(value: &[u8]) -> Result<ProximityInEvent, ParseError> {
-            let (event, remaining) = ProximityInEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<ProximityInEvent, ParseError> {
+            let (event, remaining) = ProximityInEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_proximity_out(&self) -> ProximityOutEvent {
-        fn do_the_parse(value: &[u8]) -> Result<ProximityOutEvent, ParseError> {
-            let (event, remaining) = ProximityOutEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<ProximityOutEvent, ParseError> {
+            let (event, remaining) = ProximityOutEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_state_notify(&self) -> DeviceStateNotifyEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceStateNotifyEvent, ParseError> {
-            let (event, remaining) = DeviceStateNotifyEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceStateNotifyEvent, ParseError> {
+            let (event, remaining) = DeviceStateNotifyEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_mapping_notify(&self) -> DeviceMappingNotifyEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceMappingNotifyEvent, ParseError> {
-            let (event, remaining) = DeviceMappingNotifyEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceMappingNotifyEvent, ParseError> {
+            let (event, remaining) = DeviceMappingNotifyEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_change_device_notify(&self) -> ChangeDeviceNotifyEvent {
-        fn do_the_parse(value: &[u8]) -> Result<ChangeDeviceNotifyEvent, ParseError> {
-            let (event, remaining) = ChangeDeviceNotifyEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<ChangeDeviceNotifyEvent, ParseError> {
+            let (event, remaining) = ChangeDeviceNotifyEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_key_state_notify(&self) -> DeviceKeyStateNotifyEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceKeyStateNotifyEvent, ParseError> {
-            let (event, remaining) = DeviceKeyStateNotifyEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceKeyStateNotifyEvent, ParseError> {
+            let (event, remaining) = DeviceKeyStateNotifyEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_button_state_notify(&self) -> DeviceButtonStateNotifyEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DeviceButtonStateNotifyEvent, ParseError> {
-            let (event, remaining) = DeviceButtonStateNotifyEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DeviceButtonStateNotifyEvent, ParseError> {
+            let (event, remaining) = DeviceButtonStateNotifyEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_device_presence_notify(&self) -> DevicePresenceNotifyEvent {
-        fn do_the_parse(value: &[u8]) -> Result<DevicePresenceNotifyEvent, ParseError> {
-            let (event, remaining) = DevicePresenceNotifyEvent::try_parse(value)?;
+        fn do_the_parse(remaining: &[u8]) -> Result<DevicePresenceNotifyEvent, ParseError> {
+            let (event, remaining) = DevicePresenceNotifyEvent::try_parse(remaining)?;
             let _ = remaining;
             Ok(event)
         }
@@ -16714,14 +15075,10 @@ pub struct DeviceError {
     pub sequence: u16,
 }
 impl DeviceError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = DeviceError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -16768,14 +15125,10 @@ pub struct EventError {
     pub sequence: u16,
 }
 impl EventError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = EventError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -16822,14 +15175,10 @@ pub struct ModeError {
     pub sequence: u16,
 }
 impl ModeError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = ModeError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -16876,14 +15225,10 @@ pub struct DeviceBusyError {
     pub sequence: u16,
 }
 impl DeviceBusyError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = DeviceBusyError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -16930,14 +15275,10 @@ pub struct ClassError {
     pub sequence: u16,
 }
 impl ClassError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = ClassError { response_type, error_code, sequence };
         Ok((result, remaining))
     }

--- a/src/generated/xkb.rs
+++ b/src/generated/xkb.rs
@@ -2053,24 +2053,15 @@ pub struct IndicatorMap {
     pub ctrls: u32,
 }
 impl TryParse for IndicatorMap {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (which_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (which_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ctrls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (which_groups, remaining) = u8::try_parse(remaining)?;
+        let (groups, remaining) = u8::try_parse(remaining)?;
+        let (which_mods, remaining) = u8::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (vmods, remaining) = u16::try_parse(remaining)?;
+        let (ctrls, remaining) = u32::try_parse(remaining)?;
         let result = IndicatorMap { flags, which_groups, groups, which_mods, mods, real_mods, vmods, ctrls };
         Ok((result, remaining))
     }
@@ -2498,14 +2489,10 @@ pub struct ModDef {
     pub vmods: u16,
 }
 impl TryParse for ModDef {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (mask, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (vmods, remaining) = u16::try_parse(remaining)?;
         let result = ModDef { mask, real_mods, vmods };
         Ok((result, remaining))
     }
@@ -2542,16 +2529,11 @@ pub struct KeyName {
     pub name: [u8; 4],
 }
 impl TryParse for KeyName {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (name_0, remaining) = u8::try_parse(remaining)?;
+        let (name_1, remaining) = u8::try_parse(remaining)?;
+        let (name_2, remaining) = u8::try_parse(remaining)?;
+        let (name_3, remaining) = u8::try_parse(remaining)?;
         let name = [
             name_0,
             name_1,
@@ -2590,30 +2572,21 @@ pub struct KeyAlias {
     pub alias: [u8; 4],
 }
 impl TryParse for KeyAlias {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (real_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (real_0, remaining) = u8::try_parse(remaining)?;
+        let (real_1, remaining) = u8::try_parse(remaining)?;
+        let (real_2, remaining) = u8::try_parse(remaining)?;
+        let (real_3, remaining) = u8::try_parse(remaining)?;
         let real = [
             real_0,
             real_1,
             real_2,
             real_3,
         ];
-        let (alias_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alias_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alias_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (alias_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+        let (alias_0, remaining) = u8::try_parse(remaining)?;
+        let (alias_1, remaining) = u8::try_parse(remaining)?;
+        let (alias_2, remaining) = u8::try_parse(remaining)?;
+        let (alias_3, remaining) = u8::try_parse(remaining)?;
         let alias = [
             alias_0,
             alias_1,
@@ -2657,14 +2630,10 @@ pub struct CountedString16 {
     pub alignment_pad: Vec<u8>,
 }
 impl TryParse for CountedString16 {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (length, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (string, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, length as usize)?;
-        remaining = new_remaining;
-        let (alignment_pad, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((length as usize) + (5)) & (!(3))) - ((length as usize) + (2)))?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (length, remaining) = u16::try_parse(remaining)?;
+        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, length as usize)?;
+        let (alignment_pad, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((length as usize) + (5)) & (!(3))) - ((length as usize) + (2)))?;
         let result = CountedString16 { string, alignment_pad };
         Ok((result, remaining))
     }
@@ -2700,19 +2669,13 @@ pub struct KTMapEntry {
     pub mods_vmods: u16,
 }
 impl TryParse for KTMapEntry {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (active, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods_mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (level, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods_vmods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (active, remaining) = bool::try_parse(remaining)?;
+        let (mods_mask, remaining) = u8::try_parse(remaining)?;
+        let (level, remaining) = u8::try_parse(remaining)?;
+        let (mods_mods, remaining) = u8::try_parse(remaining)?;
+        let (mods_vmods, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = KTMapEntry { active, mods_mask, level, mods_mods, mods_vmods };
         Ok((result, remaining))
     }
@@ -2764,25 +2727,16 @@ pub struct KeyType {
     pub preserve: Vec<ModDef>,
 }
 impl TryParse for KeyType {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (mods_mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods_vmods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_levels, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_map_entries, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (has_preserve, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (map, new_remaining) = crate::x11_utils::parse_list::<KTMapEntry>(remaining, n_map_entries as usize)?;
-        remaining = new_remaining;
-        let (preserve, new_remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, (has_preserve as usize) * (n_map_entries as usize))?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (mods_mask, remaining) = u8::try_parse(remaining)?;
+        let (mods_mods, remaining) = u8::try_parse(remaining)?;
+        let (mods_vmods, remaining) = u16::try_parse(remaining)?;
+        let (num_levels, remaining) = u8::try_parse(remaining)?;
+        let (n_map_entries, remaining) = u8::try_parse(remaining)?;
+        let (has_preserve, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (map, remaining) = crate::x11_utils::parse_list::<KTMapEntry>(remaining, n_map_entries as usize)?;
+        let (preserve, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, (has_preserve as usize) * (n_map_entries as usize))?;
         let result = KeyType { mods_mask, mods_mods, mods_vmods, num_levels, has_preserve, map, preserve };
         Ok((result, remaining))
     }
@@ -2823,30 +2777,21 @@ pub struct KeySymMap {
     pub syms: Vec<KEYSYM>,
 }
 impl TryParse for KeySymMap {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (kt_index_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kt_index_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kt_index_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (kt_index_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (kt_index_0, remaining) = u8::try_parse(remaining)?;
+        let (kt_index_1, remaining) = u8::try_parse(remaining)?;
+        let (kt_index_2, remaining) = u8::try_parse(remaining)?;
+        let (kt_index_3, remaining) = u8::try_parse(remaining)?;
         let kt_index = [
             kt_index_0,
             kt_index_1,
             kt_index_2,
             kt_index_3,
         ];
-        let (group_info, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_syms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (syms, new_remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, n_syms as usize)?;
-        remaining = new_remaining;
+        let (group_info, remaining) = u8::try_parse(remaining)?;
+        let (width, remaining) = u8::try_parse(remaining)?;
+        let (n_syms, remaining) = u16::try_parse(remaining)?;
+        let (syms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, n_syms as usize)?;
         let result = KeySymMap { kt_index, group_info, width, syms };
         Ok((result, remaining))
     }
@@ -2881,12 +2826,9 @@ pub struct CommonBehavior {
     pub data: u8,
 }
 impl TryParse for CommonBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (data, remaining) = u8::try_parse(remaining)?;
         let result = CommonBehavior { type_, data };
         Ok((result, remaining))
     }
@@ -2919,11 +2861,9 @@ pub struct DefaultBehavior {
     pub type_: u8,
 }
 impl TryParse for DefaultBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = DefaultBehavior { type_ };
         Ok((result, remaining))
     }
@@ -2955,11 +2895,9 @@ pub struct LockBehavior {
     pub type_: u8,
 }
 impl TryParse for LockBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = LockBehavior { type_ };
         Ok((result, remaining))
     }
@@ -2992,12 +2930,9 @@ pub struct RadioGroupBehavior {
     pub group: u8,
 }
 impl TryParse for RadioGroupBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = u8::try_parse(remaining)?;
         let result = RadioGroupBehavior { type_, group };
         Ok((result, remaining))
     }
@@ -3031,12 +2966,9 @@ pub struct OverlayBehavior {
     pub key: KEYCODE,
 }
 impl TryParse for OverlayBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (key, remaining) = KEYCODE::try_parse(remaining)?;
         let result = OverlayBehavior { type_, key };
         Ok((result, remaining))
     }
@@ -3069,11 +3001,9 @@ pub struct PermamentLockBehavior {
     pub type_: u8,
 }
 impl TryParse for PermamentLockBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = PermamentLockBehavior { type_ };
         Ok((result, remaining))
     }
@@ -3106,12 +3036,9 @@ pub struct PermamentRadioGroupBehavior {
     pub group: u8,
 }
 impl TryParse for PermamentRadioGroupBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = u8::try_parse(remaining)?;
         let result = PermamentRadioGroupBehavior { type_, group };
         Ok((result, remaining))
     }
@@ -3145,12 +3072,9 @@ pub struct PermamentOverlayBehavior {
     pub key: KEYCODE,
 }
 impl TryParse for PermamentOverlayBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (key, remaining) = KEYCODE::try_parse(remaining)?;
         let result = PermamentOverlayBehavior { type_, key };
         Ok((result, remaining))
     }
@@ -3182,110 +3106,88 @@ impl Serialize for PermamentOverlayBehavior {
 pub struct Behavior([u8; 2]);
 impl Behavior {
     pub fn as_common(&self) -> CommonBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<CommonBehavior, ParseError> {
-            let mut remaining = value;
-            let (common, new_remaining) = CommonBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<CommonBehavior, ParseError> {
+            let (common, remaining) = CommonBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(common)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_default(&self) -> DefaultBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<DefaultBehavior, ParseError> {
-            let mut remaining = value;
-            let (default, new_remaining) = DefaultBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<DefaultBehavior, ParseError> {
+            let (default, remaining) = DefaultBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(default)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_lock(&self) -> LockBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<LockBehavior, ParseError> {
-            let mut remaining = value;
-            let (lock, new_remaining) = LockBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<LockBehavior, ParseError> {
+            let (lock, remaining) = LockBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(lock)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_radio_group(&self) -> RadioGroupBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<RadioGroupBehavior, ParseError> {
-            let mut remaining = value;
-            let (radio_group, new_remaining) = RadioGroupBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<RadioGroupBehavior, ParseError> {
+            let (radio_group, remaining) = RadioGroupBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(radio_group)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_overlay1(&self) -> OverlayBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<OverlayBehavior, ParseError> {
-            let mut remaining = value;
-            let (overlay1, new_remaining) = OverlayBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<OverlayBehavior, ParseError> {
+            let (overlay1, remaining) = OverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(overlay1)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_overlay2(&self) -> OverlayBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<OverlayBehavior, ParseError> {
-            let mut remaining = value;
-            let (overlay2, new_remaining) = OverlayBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<OverlayBehavior, ParseError> {
+            let (overlay2, remaining) = OverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(overlay2)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_permament_lock(&self) -> PermamentLockBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<PermamentLockBehavior, ParseError> {
-            let mut remaining = value;
-            let (permament_lock, new_remaining) = PermamentLockBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<PermamentLockBehavior, ParseError> {
+            let (permament_lock, remaining) = PermamentLockBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(permament_lock)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_permament_radio_group(&self) -> PermamentRadioGroupBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<PermamentRadioGroupBehavior, ParseError> {
-            let mut remaining = value;
-            let (permament_radio_group, new_remaining) = PermamentRadioGroupBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<PermamentRadioGroupBehavior, ParseError> {
+            let (permament_radio_group, remaining) = PermamentRadioGroupBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(permament_radio_group)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_permament_overlay1(&self) -> PermamentOverlayBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<PermamentOverlayBehavior, ParseError> {
-            let mut remaining = value;
-            let (permament_overlay1, new_remaining) = PermamentOverlayBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<PermamentOverlayBehavior, ParseError> {
+            let (permament_overlay1, remaining) = PermamentOverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(permament_overlay1)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_permament_overlay2(&self) -> PermamentOverlayBehavior {
-        fn do_the_parse(value: &[u8]) -> Result<PermamentOverlayBehavior, ParseError> {
-            let mut remaining = value;
-            let (permament_overlay2, new_remaining) = PermamentOverlayBehavior::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<PermamentOverlayBehavior, ParseError> {
+            let (permament_overlay2, remaining) = PermamentOverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
             Ok(permament_overlay2)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_type(&self) -> u8 {
-        fn do_the_parse(value: &[u8]) -> Result<u8, ParseError> {
-            let mut remaining = value;
-            let (type_, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<u8, ParseError> {
+            let (type_, remaining) = u8::try_parse(remaining)?;
             let _ = remaining;
             Ok(type_)
         }
@@ -3430,13 +3332,10 @@ pub struct SetBehavior {
     pub behavior: Behavior,
 }
 impl TryParse for SetBehavior {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (behavior, new_remaining) = Behavior::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (behavior, remaining) = Behavior::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = SetBehavior { keycode, behavior };
         Ok((result, remaining))
     }
@@ -3473,12 +3372,9 @@ pub struct SetExplicit {
     pub explicit: u8,
 }
 impl TryParse for SetExplicit {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (explicit, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (explicit, remaining) = u8::try_parse(remaining)?;
         let result = SetExplicit { keycode, explicit };
         Ok((result, remaining))
     }
@@ -3512,12 +3408,9 @@ pub struct KeyModMap {
     pub mods: u8,
 }
 impl TryParse for KeyModMap {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
         let result = KeyModMap { keycode, mods };
         Ok((result, remaining))
     }
@@ -3551,13 +3444,10 @@ pub struct KeyVModMap {
     pub vmods: u16,
 }
 impl TryParse for KeyVModMap {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (vmods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (vmods, remaining) = u16::try_parse(remaining)?;
         let result = KeyVModMap { keycode, vmods };
         Ok((result, remaining))
     }
@@ -3595,14 +3485,10 @@ pub struct KTSetMapEntry {
     pub virtual_mods: u16,
 }
 impl TryParse for KTSetMapEntry {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (level, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (virtual_mods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (level, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let result = KTSetMapEntry { level, real_mods, virtual_mods };
         Ok((result, remaining))
     }
@@ -3645,25 +3531,16 @@ pub struct SetKeyType {
     pub preserve_entries: Vec<KTSetMapEntry>,
 }
 impl TryParse for SetKeyType {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (virtual_mods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_levels, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_map_entries, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (preserve, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (entries, new_remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, n_map_entries as usize)?;
-        remaining = new_remaining;
-        let (preserve_entries, new_remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, (preserve as usize) * (n_map_entries as usize))?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (mask, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let (num_levels, remaining) = u8::try_parse(remaining)?;
+        let (n_map_entries, remaining) = u8::try_parse(remaining)?;
+        let (preserve, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, n_map_entries as usize)?;
+        let (preserve_entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, (preserve as usize) * (n_map_entries as usize))?;
         let result = SetKeyType { mask, real_mods, virtual_mods, num_levels, preserve, entries, preserve_entries };
         Ok((result, remaining))
     }
@@ -3704,15 +3581,11 @@ pub struct Outline {
     pub points: Vec<Point>,
 }
 impl TryParse for Outline {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (n_points, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (corner_radius, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (points, new_remaining) = crate::x11_utils::parse_list::<Point>(remaining, n_points as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (n_points, remaining) = u8::try_parse(remaining)?;
+        let (corner_radius, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (points, remaining) = crate::x11_utils::parse_list::<Point>(remaining, n_points as usize)?;
         let result = Outline { corner_radius, points };
         Ok((result, remaining))
     }
@@ -3748,19 +3621,13 @@ pub struct Shape {
     pub outlines: Vec<Outline>,
 }
 impl TryParse for Shape {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_outlines, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (primary_ndx, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (approx_ndx, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (outlines, new_remaining) = crate::x11_utils::parse_list::<Outline>(remaining, n_outlines as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (n_outlines, remaining) = u8::try_parse(remaining)?;
+        let (primary_ndx, remaining) = u8::try_parse(remaining)?;
+        let (approx_ndx, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (outlines, remaining) = crate::x11_utils::parse_list::<Outline>(remaining, n_outlines as usize)?;
         let result = Shape { name, primary_ndx, approx_ndx, outlines };
         Ok((result, remaining))
     }
@@ -3798,28 +3665,20 @@ pub struct Key {
     pub color_ndx: u8,
 }
 impl TryParse for Key {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name_0, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_1, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_2, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_3, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (name_0, remaining) = STRING8::try_parse(remaining)?;
+        let (name_1, remaining) = STRING8::try_parse(remaining)?;
+        let (name_2, remaining) = STRING8::try_parse(remaining)?;
+        let (name_3, remaining) = STRING8::try_parse(remaining)?;
         let name = [
             name_0,
             name_1,
             name_2,
             name_3,
         ];
-        let (gap, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (shape_ndx, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (color_ndx, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+        let (gap, remaining) = i16::try_parse(remaining)?;
+        let (shape_ndx, remaining) = u8::try_parse(remaining)?;
+        let (color_ndx, remaining) = u8::try_parse(remaining)?;
         let result = Key { name, gap, shape_ndx, color_ndx };
         Ok((result, remaining))
     }
@@ -3862,30 +3721,21 @@ pub struct OverlayKey {
     pub under: [STRING8; 4],
 }
 impl TryParse for OverlayKey {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (over_0, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (over_1, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (over_2, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (over_3, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (over_0, remaining) = STRING8::try_parse(remaining)?;
+        let (over_1, remaining) = STRING8::try_parse(remaining)?;
+        let (over_2, remaining) = STRING8::try_parse(remaining)?;
+        let (over_3, remaining) = STRING8::try_parse(remaining)?;
         let over = [
             over_0,
             over_1,
             over_2,
             over_3,
         ];
-        let (under_0, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (under_1, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (under_2, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (under_3, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
+        let (under_0, remaining) = STRING8::try_parse(remaining)?;
+        let (under_1, remaining) = STRING8::try_parse(remaining)?;
+        let (under_2, remaining) = STRING8::try_parse(remaining)?;
+        let (under_3, remaining) = STRING8::try_parse(remaining)?;
         let under = [
             under_0,
             under_1,
@@ -3929,15 +3779,11 @@ pub struct OverlayRow {
     pub keys: Vec<OverlayKey>,
 }
 impl TryParse for OverlayRow {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (row_under, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (keys, new_remaining) = crate::x11_utils::parse_list::<OverlayKey>(remaining, n_keys as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (row_under, remaining) = u8::try_parse(remaining)?;
+        let (n_keys, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (keys, remaining) = crate::x11_utils::parse_list::<OverlayKey>(remaining, n_keys as usize)?;
         let result = OverlayRow { row_under, keys };
         Ok((result, remaining))
     }
@@ -3971,15 +3817,11 @@ pub struct Overlay {
     pub rows: Vec<OverlayRow>,
 }
 impl TryParse for Overlay {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_rows, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (rows, new_remaining) = crate::x11_utils::parse_list::<OverlayRow>(remaining, n_rows as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (n_rows, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (rows, remaining) = crate::x11_utils::parse_list::<OverlayRow>(remaining, n_rows as usize)?;
         let result = Overlay { name, rows };
         Ok((result, remaining))
     }
@@ -4015,19 +3857,13 @@ pub struct Row {
     pub keys: Vec<Key>,
 }
 impl TryParse for Row {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (top, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (left, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vertical, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (keys, new_remaining) = crate::x11_utils::parse_list::<Key>(remaining, n_keys as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (top, remaining) = i16::try_parse(remaining)?;
+        let (left, remaining) = i16::try_parse(remaining)?;
+        let (n_keys, remaining) = u8::try_parse(remaining)?;
+        let (vertical, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (keys, remaining) = crate::x11_utils::parse_list::<Key>(remaining, n_keys as usize)?;
         let result = Row { top, left, vertical, keys };
         Ok((result, remaining))
     }
@@ -4134,18 +3970,15 @@ pub struct Listing {
     pub string: Vec<STRING8>,
 }
 impl TryParse for Listing {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (flags, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (string, new_remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, length as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (flags, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u16::try_parse(remaining)?;
+        let (string, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, length as usize)?;
         // Align offset to multiple of 2
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (2 - (offset % 2)) % 2;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = Listing { flags, string };
         Ok((result, remaining))
     }
@@ -4185,24 +4018,15 @@ pub struct DeviceLedInfo {
     pub maps: Vec<IndicatorMap>,
 }
 impl TryParse for DeviceLedInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (led_class, new_remaining) = LedClassSpec::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_id, new_remaining) = IDSpec::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (names_present, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (maps_present, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (phys_indicators, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (names, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(names_present.count_ones()).unwrap())?;
-        remaining = new_remaining;
-        let (maps, new_remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, TryInto::<usize>::try_into(maps_present.count_ones()).unwrap())?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (led_class, remaining) = LedClassSpec::try_parse(remaining)?;
+        let (led_id, remaining) = IDSpec::try_parse(remaining)?;
+        let (names_present, remaining) = u32::try_parse(remaining)?;
+        let (maps_present, remaining) = u32::try_parse(remaining)?;
+        let (phys_indicators, remaining) = u32::try_parse(remaining)?;
+        let (state, remaining) = u32::try_parse(remaining)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(names_present.count_ones()).unwrap())?;
+        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, TryInto::<usize>::try_into(maps_present.count_ones()).unwrap())?;
         let result = DeviceLedInfo { led_class, led_id, names_present, maps_present, phys_indicators, state, names, maps };
         Ok((result, remaining))
     }
@@ -4310,21 +4134,14 @@ pub struct KeyboardError {
     pub major_opcode: u8,
 }
 impl KeyboardError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(21..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(21..).ok_or(ParseError::ParseError)?;
         let result = KeyboardError { response_type, error_code, sequence, value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -4532,11 +4349,9 @@ pub struct SANoAction {
     pub type_: u8,
 }
 impl TryParse for SANoAction {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(7..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
         let result = SANoAction { type_ };
         Ok((result, remaining))
     }
@@ -4579,21 +4394,14 @@ pub struct SASetMods {
     pub vmods_low: u8,
 }
 impl TryParse for SASetMods {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (mask, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (vmods_high, remaining) = u8::try_parse(remaining)?;
+        let (vmods_low, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = SASetMods { type_, flags, mask, real_mods, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -4646,21 +4454,14 @@ pub struct SALatchMods {
     pub vmods_low: u8,
 }
 impl TryParse for SALatchMods {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (mask, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (vmods_high, remaining) = u8::try_parse(remaining)?;
+        let (vmods_low, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = SALatchMods { type_, flags, mask, real_mods, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -4713,21 +4514,14 @@ pub struct SALockMods {
     pub vmods_low: u8,
 }
 impl TryParse for SALockMods {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (mask, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (vmods_high, remaining) = u8::try_parse(remaining)?;
+        let (vmods_low, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = SALockMods { type_, flags, mask, real_mods, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -4777,15 +4571,11 @@ pub struct SASetGroup {
     pub group: i8,
 }
 impl TryParse for SASetGroup {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(5..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = i8::try_parse(remaining)?;
+        let remaining = remaining.get(5..).ok_or(ParseError::ParseError)?;
         let result = SASetGroup { type_, flags, group };
         Ok((result, remaining))
     }
@@ -4829,15 +4619,11 @@ pub struct SALatchGroup {
     pub group: i8,
 }
 impl TryParse for SALatchGroup {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(5..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = i8::try_parse(remaining)?;
+        let remaining = remaining.get(5..).ok_or(ParseError::ParseError)?;
         let result = SALatchGroup { type_, flags, group };
         Ok((result, remaining))
     }
@@ -4881,15 +4667,11 @@ pub struct SALockGroup {
     pub group: i8,
 }
 impl TryParse for SALockGroup {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(5..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = i8::try_parse(remaining)?;
+        let remaining = remaining.get(5..).ok_or(ParseError::ParseError)?;
         let result = SALockGroup { type_, flags, group };
         Ok((result, remaining))
     }
@@ -5002,21 +4784,14 @@ pub struct SAMovePtr {
     pub y_low: u8,
 }
 impl TryParse for SAMovePtr {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x_high, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y_high, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (x_high, remaining) = i8::try_parse(remaining)?;
+        let (x_low, remaining) = u8::try_parse(remaining)?;
+        let (y_high, remaining) = i8::try_parse(remaining)?;
+        let (y_low, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = SAMovePtr { type_, flags, x_high, x_low, y_high, y_low };
         Ok((result, remaining))
     }
@@ -5067,17 +4842,12 @@ pub struct SAPtrBtn {
     pub button: u8,
 }
 impl TryParse for SAPtrBtn {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (count, remaining) = u8::try_parse(remaining)?;
+        let (button, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = SAPtrBtn { type_, flags, count, button };
         Ok((result, remaining))
     }
@@ -5123,16 +4893,12 @@ pub struct SALockPtrBtn {
     pub button: u8,
 }
 impl TryParse for SALockPtrBtn {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (button, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (button, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = SALockPtrBtn { type_, flags, button };
         Ok((result, remaining))
     }
@@ -5241,17 +5007,12 @@ pub struct SASetPtrDflt {
     pub value: i8,
 }
 impl TryParse for SASetPtrDflt {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (affect, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (affect, remaining) = u8::try_parse(remaining)?;
+        let (value, remaining) = i8::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = SASetPtrDflt { type_, flags, affect, value };
         Ok((result, remaining))
     }
@@ -5417,24 +5178,15 @@ pub struct SAIsoLock {
     pub vmods_low: u8,
 }
 impl TryParse for SAIsoLock {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (affect, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (mask, remaining) = u8::try_parse(remaining)?;
+        let (real_mods, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = i8::try_parse(remaining)?;
+        let (affect, remaining) = u8::try_parse(remaining)?;
+        let (vmods_high, remaining) = u8::try_parse(remaining)?;
+        let (vmods_low, remaining) = u8::try_parse(remaining)?;
         let result = SAIsoLock { type_, flags, mask, real_mods, group, affect, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -5485,11 +5237,9 @@ pub struct SATerminate {
     pub type_: u8,
 }
 impl TryParse for SATerminate {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(7..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
         let result = SATerminate { type_ };
         Ok((result, remaining))
     }
@@ -5592,15 +5342,11 @@ pub struct SASwitchScreen {
     pub new_screen: i8,
 }
 impl TryParse for SASwitchScreen {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (new_screen, new_remaining) = i8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(5..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (new_screen, remaining) = i8::try_parse(remaining)?;
+        let remaining = remaining.get(5..).ok_or(ParseError::ParseError)?;
         let result = SASwitchScreen { type_, flags, new_screen };
         Ok((result, remaining))
     }
@@ -5797,16 +5543,12 @@ pub struct SASetControls {
     pub bool_ctrls_low: u8,
 }
 impl TryParse for SASetControls {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (bool_ctrls_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bool_ctrls_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (bool_ctrls_high, remaining) = u8::try_parse(remaining)?;
+        let (bool_ctrls_low, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = SASetControls { type_, bool_ctrls_high, bool_ctrls_low };
         Ok((result, remaining))
     }
@@ -5851,16 +5593,12 @@ pub struct SALockControls {
     pub bool_ctrls_low: u8,
 }
 impl TryParse for SALockControls {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (bool_ctrls_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bool_ctrls_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (bool_ctrls_high, remaining) = u8::try_parse(remaining)?;
+        let (bool_ctrls_low, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = SALockControls { type_, bool_ctrls_high, bool_ctrls_low };
         Ok((result, remaining))
     }
@@ -5971,24 +5709,15 @@ pub struct SAActionMessage {
     pub message: [u8; 6],
 }
 impl TryParse for SAActionMessage {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (message_0, remaining) = u8::try_parse(remaining)?;
+        let (message_1, remaining) = u8::try_parse(remaining)?;
+        let (message_2, remaining) = u8::try_parse(remaining)?;
+        let (message_3, remaining) = u8::try_parse(remaining)?;
+        let (message_4, remaining) = u8::try_parse(remaining)?;
+        let (message_5, remaining) = u8::try_parse(remaining)?;
         let message = [
             message_0,
             message_1,
@@ -6043,24 +5772,15 @@ pub struct SARedirectKey {
     pub vmods_low: u8,
 }
 impl TryParse for SARedirectKey {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (newkey, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_modifiers, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_mask_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_mask_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_high, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vmods_low, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (newkey, remaining) = KEYCODE::try_parse(remaining)?;
+        let (mask, remaining) = u8::try_parse(remaining)?;
+        let (real_modifiers, remaining) = u8::try_parse(remaining)?;
+        let (vmods_mask_high, remaining) = u8::try_parse(remaining)?;
+        let (vmods_mask_low, remaining) = u8::try_parse(remaining)?;
+        let (vmods_high, remaining) = u8::try_parse(remaining)?;
+        let (vmods_low, remaining) = u8::try_parse(remaining)?;
         let result = SARedirectKey { type_, newkey, mask, real_modifiers, vmods_mask_high, vmods_mask_low, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -6115,19 +5835,13 @@ pub struct SADeviceBtn {
     pub device: u8,
 }
 impl TryParse for SADeviceBtn {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (button, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (count, remaining) = u8::try_parse(remaining)?;
+        let (button, remaining) = u8::try_parse(remaining)?;
+        let (device, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = SADeviceBtn { type_, flags, count, button, device };
         Ok((result, remaining))
     }
@@ -6239,18 +5953,13 @@ pub struct SALockDeviceBtn {
     pub device: u8,
 }
 impl TryParse for SALockDeviceBtn {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (button, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (button, remaining) = u8::try_parse(remaining)?;
+        let (device, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = SALockDeviceBtn { type_, flags, button, device };
         Ok((result, remaining))
     }
@@ -6376,24 +6085,15 @@ pub struct SADeviceValuator {
     pub val2value: u8,
 }
 impl TryParse for SADeviceValuator {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (val1what, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (val1index, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (val1value, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (val2what, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (val2index, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (val2value, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (device, remaining) = u8::try_parse(remaining)?;
+        let (val1what, remaining) = u8::try_parse(remaining)?;
+        let (val1index, remaining) = u8::try_parse(remaining)?;
+        let (val1value, remaining) = u8::try_parse(remaining)?;
+        let (val2what, remaining) = u8::try_parse(remaining)?;
+        let (val2index, remaining) = u8::try_parse(remaining)?;
+        let (val2value, remaining) = u8::try_parse(remaining)?;
         let result = SADeviceValuator { type_, device, val1what, val1index, val1value, val2what, val2index, val2value };
         Ok((result, remaining))
     }
@@ -6445,24 +6145,15 @@ pub struct SIAction {
     pub data: [u8; 7],
 }
 impl TryParse for SIAction {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (type_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (type_, remaining) = u8::try_parse(remaining)?;
+        let (data_0, remaining) = u8::try_parse(remaining)?;
+        let (data_1, remaining) = u8::try_parse(remaining)?;
+        let (data_2, remaining) = u8::try_parse(remaining)?;
+        let (data_3, remaining) = u8::try_parse(remaining)?;
+        let (data_4, remaining) = u8::try_parse(remaining)?;
+        let (data_5, remaining) = u8::try_parse(remaining)?;
+        let (data_6, remaining) = u8::try_parse(remaining)?;
         let data = [
             data_0,
             data_1,
@@ -6514,20 +6205,13 @@ pub struct SymInterpret {
     pub action: SIAction,
 }
 impl TryParse for SymInterpret {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (sym, new_remaining) = KEYSYM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (match_, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (virtual_mod, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (action, new_remaining) = SIAction::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (sym, remaining) = KEYSYM::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
+        let (match_, remaining) = u8::try_parse(remaining)?;
+        let (virtual_mod, remaining) = u8::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let (action, remaining) = SIAction::try_parse(remaining)?;
         let result = SymInterpret { sym, mods, match_, virtual_mod, flags, action };
         Ok((result, remaining))
     }
@@ -6581,220 +6265,176 @@ impl Serialize for SymInterpret {
 pub struct Action([u8; 8]);
 impl Action {
     pub fn as_noaction(&self) -> SANoAction {
-        fn do_the_parse(value: &[u8]) -> Result<SANoAction, ParseError> {
-            let mut remaining = value;
-            let (noaction, new_remaining) = SANoAction::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SANoAction, ParseError> {
+            let (noaction, remaining) = SANoAction::try_parse(remaining)?;
             let _ = remaining;
             Ok(noaction)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_setmods(&self) -> SASetMods {
-        fn do_the_parse(value: &[u8]) -> Result<SASetMods, ParseError> {
-            let mut remaining = value;
-            let (setmods, new_remaining) = SASetMods::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SASetMods, ParseError> {
+            let (setmods, remaining) = SASetMods::try_parse(remaining)?;
             let _ = remaining;
             Ok(setmods)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_latchmods(&self) -> SALatchMods {
-        fn do_the_parse(value: &[u8]) -> Result<SALatchMods, ParseError> {
-            let mut remaining = value;
-            let (latchmods, new_remaining) = SALatchMods::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SALatchMods, ParseError> {
+            let (latchmods, remaining) = SALatchMods::try_parse(remaining)?;
             let _ = remaining;
             Ok(latchmods)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_lockmods(&self) -> SALockMods {
-        fn do_the_parse(value: &[u8]) -> Result<SALockMods, ParseError> {
-            let mut remaining = value;
-            let (lockmods, new_remaining) = SALockMods::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SALockMods, ParseError> {
+            let (lockmods, remaining) = SALockMods::try_parse(remaining)?;
             let _ = remaining;
             Ok(lockmods)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_setgroup(&self) -> SASetGroup {
-        fn do_the_parse(value: &[u8]) -> Result<SASetGroup, ParseError> {
-            let mut remaining = value;
-            let (setgroup, new_remaining) = SASetGroup::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SASetGroup, ParseError> {
+            let (setgroup, remaining) = SASetGroup::try_parse(remaining)?;
             let _ = remaining;
             Ok(setgroup)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_latchgroup(&self) -> SALatchGroup {
-        fn do_the_parse(value: &[u8]) -> Result<SALatchGroup, ParseError> {
-            let mut remaining = value;
-            let (latchgroup, new_remaining) = SALatchGroup::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SALatchGroup, ParseError> {
+            let (latchgroup, remaining) = SALatchGroup::try_parse(remaining)?;
             let _ = remaining;
             Ok(latchgroup)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_lockgroup(&self) -> SALockGroup {
-        fn do_the_parse(value: &[u8]) -> Result<SALockGroup, ParseError> {
-            let mut remaining = value;
-            let (lockgroup, new_remaining) = SALockGroup::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SALockGroup, ParseError> {
+            let (lockgroup, remaining) = SALockGroup::try_parse(remaining)?;
             let _ = remaining;
             Ok(lockgroup)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_moveptr(&self) -> SAMovePtr {
-        fn do_the_parse(value: &[u8]) -> Result<SAMovePtr, ParseError> {
-            let mut remaining = value;
-            let (moveptr, new_remaining) = SAMovePtr::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SAMovePtr, ParseError> {
+            let (moveptr, remaining) = SAMovePtr::try_parse(remaining)?;
             let _ = remaining;
             Ok(moveptr)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_ptrbtn(&self) -> SAPtrBtn {
-        fn do_the_parse(value: &[u8]) -> Result<SAPtrBtn, ParseError> {
-            let mut remaining = value;
-            let (ptrbtn, new_remaining) = SAPtrBtn::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SAPtrBtn, ParseError> {
+            let (ptrbtn, remaining) = SAPtrBtn::try_parse(remaining)?;
             let _ = remaining;
             Ok(ptrbtn)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_lockptrbtn(&self) -> SALockPtrBtn {
-        fn do_the_parse(value: &[u8]) -> Result<SALockPtrBtn, ParseError> {
-            let mut remaining = value;
-            let (lockptrbtn, new_remaining) = SALockPtrBtn::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SALockPtrBtn, ParseError> {
+            let (lockptrbtn, remaining) = SALockPtrBtn::try_parse(remaining)?;
             let _ = remaining;
             Ok(lockptrbtn)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_setptrdflt(&self) -> SASetPtrDflt {
-        fn do_the_parse(value: &[u8]) -> Result<SASetPtrDflt, ParseError> {
-            let mut remaining = value;
-            let (setptrdflt, new_remaining) = SASetPtrDflt::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SASetPtrDflt, ParseError> {
+            let (setptrdflt, remaining) = SASetPtrDflt::try_parse(remaining)?;
             let _ = remaining;
             Ok(setptrdflt)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_isolock(&self) -> SAIsoLock {
-        fn do_the_parse(value: &[u8]) -> Result<SAIsoLock, ParseError> {
-            let mut remaining = value;
-            let (isolock, new_remaining) = SAIsoLock::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SAIsoLock, ParseError> {
+            let (isolock, remaining) = SAIsoLock::try_parse(remaining)?;
             let _ = remaining;
             Ok(isolock)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_terminate(&self) -> SATerminate {
-        fn do_the_parse(value: &[u8]) -> Result<SATerminate, ParseError> {
-            let mut remaining = value;
-            let (terminate, new_remaining) = SATerminate::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SATerminate, ParseError> {
+            let (terminate, remaining) = SATerminate::try_parse(remaining)?;
             let _ = remaining;
             Ok(terminate)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_switchscreen(&self) -> SASwitchScreen {
-        fn do_the_parse(value: &[u8]) -> Result<SASwitchScreen, ParseError> {
-            let mut remaining = value;
-            let (switchscreen, new_remaining) = SASwitchScreen::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SASwitchScreen, ParseError> {
+            let (switchscreen, remaining) = SASwitchScreen::try_parse(remaining)?;
             let _ = remaining;
             Ok(switchscreen)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_setcontrols(&self) -> SASetControls {
-        fn do_the_parse(value: &[u8]) -> Result<SASetControls, ParseError> {
-            let mut remaining = value;
-            let (setcontrols, new_remaining) = SASetControls::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SASetControls, ParseError> {
+            let (setcontrols, remaining) = SASetControls::try_parse(remaining)?;
             let _ = remaining;
             Ok(setcontrols)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_lockcontrols(&self) -> SALockControls {
-        fn do_the_parse(value: &[u8]) -> Result<SALockControls, ParseError> {
-            let mut remaining = value;
-            let (lockcontrols, new_remaining) = SALockControls::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SALockControls, ParseError> {
+            let (lockcontrols, remaining) = SALockControls::try_parse(remaining)?;
             let _ = remaining;
             Ok(lockcontrols)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_message(&self) -> SAActionMessage {
-        fn do_the_parse(value: &[u8]) -> Result<SAActionMessage, ParseError> {
-            let mut remaining = value;
-            let (message, new_remaining) = SAActionMessage::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SAActionMessage, ParseError> {
+            let (message, remaining) = SAActionMessage::try_parse(remaining)?;
             let _ = remaining;
             Ok(message)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_redirect(&self) -> SARedirectKey {
-        fn do_the_parse(value: &[u8]) -> Result<SARedirectKey, ParseError> {
-            let mut remaining = value;
-            let (redirect, new_remaining) = SARedirectKey::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SARedirectKey, ParseError> {
+            let (redirect, remaining) = SARedirectKey::try_parse(remaining)?;
             let _ = remaining;
             Ok(redirect)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_devbtn(&self) -> SADeviceBtn {
-        fn do_the_parse(value: &[u8]) -> Result<SADeviceBtn, ParseError> {
-            let mut remaining = value;
-            let (devbtn, new_remaining) = SADeviceBtn::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SADeviceBtn, ParseError> {
+            let (devbtn, remaining) = SADeviceBtn::try_parse(remaining)?;
             let _ = remaining;
             Ok(devbtn)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_lockdevbtn(&self) -> SALockDeviceBtn {
-        fn do_the_parse(value: &[u8]) -> Result<SALockDeviceBtn, ParseError> {
-            let mut remaining = value;
-            let (lockdevbtn, new_remaining) = SALockDeviceBtn::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SALockDeviceBtn, ParseError> {
+            let (lockdevbtn, remaining) = SALockDeviceBtn::try_parse(remaining)?;
             let _ = remaining;
             Ok(lockdevbtn)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_devval(&self) -> SADeviceValuator {
-        fn do_the_parse(value: &[u8]) -> Result<SADeviceValuator, ParseError> {
-            let mut remaining = value;
-            let (devval, new_remaining) = SADeviceValuator::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<SADeviceValuator, ParseError> {
+            let (devval, remaining) = SADeviceValuator::try_parse(remaining)?;
             let _ = remaining;
             Ok(devval)
         }
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_type(&self) -> u8 {
-        fn do_the_parse(value: &[u8]) -> Result<u8, ParseError> {
-            let mut remaining = value;
-            let (type_, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<u8, ParseError> {
+            let (type_, remaining) = u8::try_parse(remaining)?;
             let _ = remaining;
             Ok(type_)
         }
@@ -6945,21 +6585,14 @@ pub struct UseExtensionReply {
     pub server_minor: u16,
 }
 impl UseExtensionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (supported, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (supported, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major, remaining) = u16::try_parse(remaining)?;
+        let (server_minor, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = UseExtensionReply { response_type, supported, sequence, length, server_major, server_minor };
         Ok((result, remaining))
     }
@@ -7530,46 +7163,27 @@ pub struct GetStateReply {
     pub ptr_btn_state: u16,
 }
 impl GetStateReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (base_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (latched_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (locked_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (locked_group, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (base_group, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (latched_group, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (compat_state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (grab_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (compat_grab_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (lookup_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (compat_lookup_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (ptr_btn_state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(6..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
+        let (base_mods, remaining) = u8::try_parse(remaining)?;
+        let (latched_mods, remaining) = u8::try_parse(remaining)?;
+        let (locked_mods, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = u8::try_parse(remaining)?;
+        let (locked_group, remaining) = u8::try_parse(remaining)?;
+        let (base_group, remaining) = i16::try_parse(remaining)?;
+        let (latched_group, remaining) = i16::try_parse(remaining)?;
+        let (compat_state, remaining) = u8::try_parse(remaining)?;
+        let (grab_mods, remaining) = u8::try_parse(remaining)?;
+        let (compat_grab_mods, remaining) = u8::try_parse(remaining)?;
+        let (lookup_mods, remaining) = u8::try_parse(remaining)?;
+        let (compat_lookup_mods, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (ptr_btn_state, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(6..).ok_or(ParseError::ParseError)?;
         let result = GetStateReply { response_type, device_id, sequence, length, mods, base_mods, latched_mods, locked_mods, group, locked_group, base_group, latched_group, compat_state, grab_mods, compat_grab_mods, lookup_mods, compat_lookup_mods, ptr_btn_state };
         Ok((result, remaining))
     }
@@ -7680,132 +7294,70 @@ pub struct GetControlsReply {
     pub per_key_repeat: [u8; 32],
 }
 impl GetControlsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mouse_keys_dflt_btn, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (groups_wrap, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (internal_mods_mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ignore_lock_mods_mask, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (internal_mods_real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ignore_lock_mods_real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (internal_mods_vmods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ignore_lock_mods_vmods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (repeat_delay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (repeat_interval, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (slow_keys_delay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (debounce_delay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mouse_keys_delay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mouse_keys_interval, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mouse_keys_time_to_max, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mouse_keys_max_speed, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mouse_keys_curve, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (access_x_option, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (access_x_timeout, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (access_x_timeout_options_mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (access_x_timeout_options_values, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (access_x_timeout_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (access_x_timeout_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enabled_controls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (per_key_repeat_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (mouse_keys_dflt_btn, remaining) = u8::try_parse(remaining)?;
+        let (num_groups, remaining) = u8::try_parse(remaining)?;
+        let (groups_wrap, remaining) = u8::try_parse(remaining)?;
+        let (internal_mods_mask, remaining) = u8::try_parse(remaining)?;
+        let (ignore_lock_mods_mask, remaining) = u8::try_parse(remaining)?;
+        let (internal_mods_real_mods, remaining) = u8::try_parse(remaining)?;
+        let (ignore_lock_mods_real_mods, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (internal_mods_vmods, remaining) = u16::try_parse(remaining)?;
+        let (ignore_lock_mods_vmods, remaining) = u16::try_parse(remaining)?;
+        let (repeat_delay, remaining) = u16::try_parse(remaining)?;
+        let (repeat_interval, remaining) = u16::try_parse(remaining)?;
+        let (slow_keys_delay, remaining) = u16::try_parse(remaining)?;
+        let (debounce_delay, remaining) = u16::try_parse(remaining)?;
+        let (mouse_keys_delay, remaining) = u16::try_parse(remaining)?;
+        let (mouse_keys_interval, remaining) = u16::try_parse(remaining)?;
+        let (mouse_keys_time_to_max, remaining) = u16::try_parse(remaining)?;
+        let (mouse_keys_max_speed, remaining) = u16::try_parse(remaining)?;
+        let (mouse_keys_curve, remaining) = i16::try_parse(remaining)?;
+        let (access_x_option, remaining) = u16::try_parse(remaining)?;
+        let (access_x_timeout, remaining) = u16::try_parse(remaining)?;
+        let (access_x_timeout_options_mask, remaining) = u16::try_parse(remaining)?;
+        let (access_x_timeout_options_values, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (access_x_timeout_mask, remaining) = u32::try_parse(remaining)?;
+        let (access_x_timeout_values, remaining) = u32::try_parse(remaining)?;
+        let (enabled_controls, remaining) = u32::try_parse(remaining)?;
+        let (per_key_repeat_0, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_1, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_2, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_3, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_4, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_5, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_6, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_7, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_8, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_9, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_10, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_11, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_12, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_13, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_14, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_15, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_16, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_17, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_18, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_19, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_20, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_21, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_22, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_23, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_24, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_25, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_26, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_27, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_28, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_29, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_30, remaining) = u8::try_parse(remaining)?;
+        let (per_key_repeat_31, remaining) = u8::try_parse(remaining)?;
         let per_key_repeat = [
             per_key_repeat_0,
             per_key_repeat_1,
@@ -8032,16 +7584,14 @@ pub struct GetMapMapBitcase3 {
     pub acts_rtrn_acts: Vec<Action>,
 }
 impl GetMapMapBitcase3 {
-    pub fn try_parse(value: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (acts_rtrn_count, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_key_actions as usize)?;
-        remaining = new_remaining;
+    pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_key_actions as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (acts_rtrn_acts, new_remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (acts_rtrn_acts, remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions as usize)?;
         let result = GetMapMapBitcase3 { acts_rtrn_count, acts_rtrn_acts };
         Ok((result, remaining))
     }
@@ -8074,77 +7624,87 @@ pub struct GetMapMap {
 }
 impl GetMapMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let types_rtrn = if present & Into::<u16>::into(MapPart::KeyTypes) != 0 {
-            let (types_rtrn, new_remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (types_rtrn, remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types as usize)?;
+            outer_remaining = remaining;
             Some(types_rtrn)
         } else {
             None
         };
         let syms_rtrn = if present & Into::<u16>::into(MapPart::KeySyms) != 0 {
-            let (syms_rtrn, new_remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (syms_rtrn, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms as usize)?;
+            outer_remaining = remaining;
             Some(syms_rtrn)
         } else {
             None
         };
         let bitcase3 = if present & Into::<u16>::into(MapPart::KeyActions) != 0 {
-            let (bitcase3, new_remaining) = GetMapMapBitcase3::try_parse(remaining, n_key_actions, total_actions)?;
-            remaining = new_remaining;
+            let (bitcase3, new_remaining) = GetMapMapBitcase3::try_parse(outer_remaining, n_key_actions, total_actions)?;
+            outer_remaining = new_remaining;
             Some(bitcase3)
         } else {
             None
         };
         let behaviors_rtrn = if present & Into::<u16>::into(MapPart::KeyBehaviors) != 0 {
-            let (behaviors_rtrn, new_remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (behaviors_rtrn, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors as usize)?;
+            outer_remaining = remaining;
             Some(behaviors_rtrn)
         } else {
             None
         };
         let vmods_rtrn = if present & Into::<u16>::into(MapPart::VirtualMods) != 0 {
-            let (vmods_rtrn, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let value = remaining;
+            let (vmods_rtrn, remaining) = crate::x11_utils::parse_list::<u8>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
-            remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             Some(vmods_rtrn)
         } else {
             None
         };
         let explicit_rtrn = if present & Into::<u16>::into(MapPart::ExplicitComponents) != 0 {
-            let (explicit_rtrn, new_remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let value = remaining;
+            let (explicit_rtrn, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit as usize)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
-            remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             Some(explicit_rtrn)
         } else {
             None
         };
         let modmap_rtrn = if present & Into::<u16>::into(MapPart::ModifierMap) != 0 {
-            let (modmap_rtrn, new_remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let value = remaining;
+            let (modmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys as usize)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
-            remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+            outer_remaining = remaining;
             Some(modmap_rtrn)
         } else {
             None
         };
         let vmodmap_rtrn = if present & Into::<u16>::into(MapPart::VirtualModMap) != 0 {
-            let (vmodmap_rtrn, new_remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (vmodmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys as usize)?;
+            outer_remaining = remaining;
             Some(vmodmap_rtrn)
         } else {
             None
         };
         let result = GetMapMap { types_rtrn, syms_rtrn, bitcase3, behaviors_rtrn, vmods_rtrn, explicit_rtrn, modmap_rtrn, vmodmap_rtrn };
-        Ok((result, remaining))
+        Ok((result, outer_remaining))
     }
 }
 #[derive(Debug, Clone)]
@@ -8181,70 +7741,39 @@ pub struct GetMapReply {
     pub map: GetMapMap,
 }
 impl GetMapReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (min_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (present, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_types, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_types, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_sym, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_syms, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_syms, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_action, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_actions, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_actions, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_behavior, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_behaviors, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_key_behaviors, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_explicit, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_explicit, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_key_explicit, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_mod_map_key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_mod_map_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_mod_map_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_v_mod_map_key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_v_mod_map_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_v_mod_map_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (virtual_mods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map, new_remaining) = GetMapMap::try_parse(remaining, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (present, remaining) = u16::try_parse(remaining)?;
+        let (first_type, remaining) = u8::try_parse(remaining)?;
+        let (n_types, remaining) = u8::try_parse(remaining)?;
+        let (total_types, remaining) = u8::try_parse(remaining)?;
+        let (first_key_sym, remaining) = KEYCODE::try_parse(remaining)?;
+        let (total_syms, remaining) = u16::try_parse(remaining)?;
+        let (n_key_syms, remaining) = u8::try_parse(remaining)?;
+        let (first_key_action, remaining) = KEYCODE::try_parse(remaining)?;
+        let (total_actions, remaining) = u16::try_parse(remaining)?;
+        let (n_key_actions, remaining) = u8::try_parse(remaining)?;
+        let (first_key_behavior, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_key_behaviors, remaining) = u8::try_parse(remaining)?;
+        let (total_key_behaviors, remaining) = u8::try_parse(remaining)?;
+        let (first_key_explicit, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
+        let (total_key_explicit, remaining) = u8::try_parse(remaining)?;
+        let (first_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let (total_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let (first_v_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let (total_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let (map, remaining) = GetMapMap::try_parse(remaining, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys)?;
         let result = GetMapReply { response_type, device_id, sequence, length, min_key_code, max_key_code, present, first_type, n_types, total_types, first_key_sym, total_syms, n_key_syms, first_key_action, total_actions, n_key_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, map };
         Ok((result, remaining))
     }
@@ -8523,30 +8052,19 @@ pub struct GetCompatMapReply {
     pub group_rtrn: Vec<ModDef>,
 }
 impl GetCompatMapReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (groups_rtrn, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (first_si_rtrn, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_si_rtrn, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_total_si, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (si_rtrn, new_remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si_rtrn as usize)?;
-        remaining = new_remaining;
-        let (group_rtrn, new_remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, TryInto::<usize>::try_into(groups_rtrn.count_ones()).unwrap())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (groups_rtrn, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (first_si_rtrn, remaining) = u16::try_parse(remaining)?;
+        let (n_si_rtrn, remaining) = u16::try_parse(remaining)?;
+        let (n_total_si, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let (si_rtrn, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si_rtrn as usize)?;
+        let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, TryInto::<usize>::try_into(groups_rtrn.count_ones()).unwrap())?;
         let result = GetCompatMapReply { response_type, device_id, sequence, length, groups_rtrn, first_si_rtrn, n_total_si, si_rtrn, group_rtrn };
         Ok((result, remaining))
     }
@@ -8637,19 +8155,13 @@ pub struct GetIndicatorStateReply {
     pub state: u32,
 }
 impl GetIndicatorStateReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (state, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = GetIndicatorStateReply { response_type, device_id, sequence, length, state };
         Ok((result, remaining))
     }
@@ -8702,25 +8214,16 @@ pub struct GetIndicatorMapReply {
     pub maps: Vec<IndicatorMap>,
 }
 impl GetIndicatorMapReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (which, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_indicators, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_indicators, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(15..).ok_or(ParseError::ParseError)?;
-        let (maps, new_remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, TryInto::<usize>::try_into(which.count_ones()).unwrap())?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (which, remaining) = u32::try_parse(remaining)?;
+        let (real_indicators, remaining) = u32::try_parse(remaining)?;
+        let (n_indicators, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
+        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, TryInto::<usize>::try_into(which.count_ones()).unwrap())?;
         let result = GetIndicatorMapReply { response_type, device_id, sequence, length, which, real_indicators, n_indicators, maps };
         Ok((result, remaining))
     }
@@ -8825,45 +8328,26 @@ pub struct GetNamedIndicatorReply {
     pub supported: bool,
 }
 impl GetNamedIndicatorReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (indicator, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (found, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (on, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (real_indicator, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ndx, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_which_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_which_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_real_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_vmod, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_ctrls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (supported, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (indicator, remaining) = ATOM::try_parse(remaining)?;
+        let (found, remaining) = bool::try_parse(remaining)?;
+        let (on, remaining) = bool::try_parse(remaining)?;
+        let (real_indicator, remaining) = bool::try_parse(remaining)?;
+        let (ndx, remaining) = u8::try_parse(remaining)?;
+        let (map_flags, remaining) = u8::try_parse(remaining)?;
+        let (map_which_groups, remaining) = u8::try_parse(remaining)?;
+        let (map_groups, remaining) = u8::try_parse(remaining)?;
+        let (map_which_mods, remaining) = u8::try_parse(remaining)?;
+        let (map_mods, remaining) = u8::try_parse(remaining)?;
+        let (map_real_mods, remaining) = u8::try_parse(remaining)?;
+        let (map_vmod, remaining) = u16::try_parse(remaining)?;
+        let (map_ctrls, remaining) = u32::try_parse(remaining)?;
+        let (supported, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = GetNamedIndicatorReply { response_type, device_id, sequence, length, indicator, found, on, real_indicator, ndx, map_flags, map_which_groups, map_groups, map_which_mods, map_mods, map_real_mods, map_vmod, map_ctrls, supported };
         Ok((result, remaining))
     }
@@ -8974,16 +8458,14 @@ pub struct GetNamesValueListBitcase8 {
     pub kt_level_names: Vec<ATOM>,
 }
 impl GetNamesValueListBitcase8 {
-    pub fn try_parse(value: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (n_levels_per_type, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_types as usize)?;
-        remaining = new_remaining;
+    pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (n_levels_per_type, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_types as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (kt_level_names, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_levels_per_type.iter().map(|x| TryInto::<usize>::try_into(*x).unwrap()).sum())?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_levels_per_type.iter().map(|x| TryInto::<usize>::try_into(*x).unwrap()).sum())?;
         let result = GetNamesValueListBitcase8 { n_levels_per_type, kt_level_names };
         Ok((result, remaining))
     }
@@ -9022,107 +8504,120 @@ pub struct GetNamesValueList {
 }
 impl GetNamesValueList {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
+        let mut outer_remaining = value;
         let keycodes_name = if which & Into::<u32>::into(NameDetail::Keycodes) != 0 {
-            let (keycodes_name, new_remaining) = ATOM::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (keycodes_name, remaining) = ATOM::try_parse(remaining)?;
+            outer_remaining = remaining;
             Some(keycodes_name)
         } else {
             None
         };
         let geometry_name = if which & Into::<u32>::into(NameDetail::Geometry) != 0 {
-            let (geometry_name, new_remaining) = ATOM::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (geometry_name, remaining) = ATOM::try_parse(remaining)?;
+            outer_remaining = remaining;
             Some(geometry_name)
         } else {
             None
         };
         let symbols_name = if which & Into::<u32>::into(NameDetail::Symbols) != 0 {
-            let (symbols_name, new_remaining) = ATOM::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (symbols_name, remaining) = ATOM::try_parse(remaining)?;
+            outer_remaining = remaining;
             Some(symbols_name)
         } else {
             None
         };
         let phys_symbols_name = if which & Into::<u32>::into(NameDetail::PhysSymbols) != 0 {
-            let (phys_symbols_name, new_remaining) = ATOM::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (phys_symbols_name, remaining) = ATOM::try_parse(remaining)?;
+            outer_remaining = remaining;
             Some(phys_symbols_name)
         } else {
             None
         };
         let types_name = if which & Into::<u32>::into(NameDetail::Types) != 0 {
-            let (types_name, new_remaining) = ATOM::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (types_name, remaining) = ATOM::try_parse(remaining)?;
+            outer_remaining = remaining;
             Some(types_name)
         } else {
             None
         };
         let compat_name = if which & Into::<u32>::into(NameDetail::Compat) != 0 {
-            let (compat_name, new_remaining) = ATOM::try_parse(remaining)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (compat_name, remaining) = ATOM::try_parse(remaining)?;
+            outer_remaining = remaining;
             Some(compat_name)
         } else {
             None
         };
         let type_names = if which & Into::<u32>::into(NameDetail::KeyTypeNames) != 0 {
-            let (type_names, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_types as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (type_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_types as usize)?;
+            outer_remaining = remaining;
             Some(type_names)
         } else {
             None
         };
         let bitcase8 = if which & Into::<u32>::into(NameDetail::KTLevelNames) != 0 {
-            let (bitcase8, new_remaining) = GetNamesValueListBitcase8::try_parse(remaining, n_types)?;
-            remaining = new_remaining;
+            let (bitcase8, new_remaining) = GetNamesValueListBitcase8::try_parse(outer_remaining, n_types)?;
+            outer_remaining = new_remaining;
             Some(bitcase8)
         } else {
             None
         };
         let indicator_names = if which & Into::<u32>::into(NameDetail::IndicatorNames) != 0 {
-            let (indicator_names, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(indicators.count_ones()).unwrap())?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (indicator_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(indicators.count_ones()).unwrap())?;
+            outer_remaining = remaining;
             Some(indicator_names)
         } else {
             None
         };
         let virtual_mod_names = if which & Into::<u32>::into(NameDetail::VirtualModNames) != 0 {
-            let (virtual_mod_names, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
+            outer_remaining = remaining;
             Some(virtual_mod_names)
         } else {
             None
         };
         let groups = if which & Into::<u32>::into(NameDetail::GroupNames) != 0 {
-            let (groups, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(group_names.count_ones()).unwrap())?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (groups, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(group_names.count_ones()).unwrap())?;
+            outer_remaining = remaining;
             Some(groups)
         } else {
             None
         };
         let key_names = if which & Into::<u32>::into(NameDetail::KeyNames) != 0 {
-            let (key_names, new_remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (key_names, remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys as usize)?;
+            outer_remaining = remaining;
             Some(key_names)
         } else {
             None
         };
         let key_aliases = if which & Into::<u32>::into(NameDetail::KeyAliases) != 0 {
-            let (key_aliases, new_remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (key_aliases, remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases as usize)?;
+            outer_remaining = remaining;
             Some(key_aliases)
         } else {
             None
         };
         let radio_group_names = if which & Into::<u32>::into(NameDetail::RGNames) != 0 {
-            let (radio_group_names, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_radio_groups as usize)?;
-            remaining = new_remaining;
+            let remaining = outer_remaining;
+            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_radio_groups as usize)?;
+            outer_remaining = remaining;
             Some(radio_group_names)
         } else {
             None
         };
         let result = GetNamesValueList { keycodes_name, geometry_name, symbols_name, phys_symbols_name, types_name, compat_name, type_names, bitcase8, indicator_names, virtual_mod_names, groups, key_names, key_aliases, radio_group_names };
-        Ok((result, remaining))
+        Ok((result, outer_remaining))
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9146,43 +8641,25 @@ pub struct GetNamesReply {
     pub value_list: GetNamesValueList,
 }
 impl GetNamesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (which, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_types, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group_names, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (virtual_mods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (indicators, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_radio_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_aliases, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_kt_levels, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (value_list, new_remaining) = GetNamesValueList::try_parse(remaining, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (which, remaining) = u32::try_parse(remaining)?;
+        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_types, remaining) = u8::try_parse(remaining)?;
+        let (group_names, remaining) = u8::try_parse(remaining)?;
+        let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let (first_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_keys, remaining) = u8::try_parse(remaining)?;
+        let (indicators, remaining) = u32::try_parse(remaining)?;
+        let (n_radio_groups, remaining) = u8::try_parse(remaining)?;
+        let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
+        let (n_kt_levels, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (value_list, remaining) = GetNamesValueList::try_parse(remaining, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups)?;
         let result = GetNamesReply { response_type, device_id, sequence, length, which, min_key_code, max_key_code, n_types, group_names, virtual_mods, first_key, n_keys, indicators, n_radio_groups, n_key_aliases, n_kt_levels, value_list };
         Ok((result, remaining))
     }
@@ -9529,25 +9006,16 @@ pub struct PerClientFlagsReply {
     pub auto_ctrls_values: u32,
 }
 impl PerClientFlagsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (supported, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_ctrls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_ctrls_values, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (supported, remaining) = u32::try_parse(remaining)?;
+        let (value, remaining) = u32::try_parse(remaining)?;
+        let (auto_ctrls, remaining) = u32::try_parse(remaining)?;
+        let (auto_ctrls_values, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let result = PerClientFlagsReply { response_type, device_id, sequence, length, supported, value, auto_ctrls, auto_ctrls_values };
         Ok((result, remaining))
     }
@@ -9599,43 +9067,25 @@ pub struct ListComponentsReply {
     pub geometries: Vec<Listing>,
 }
 impl ListComponentsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_keymaps, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_keycodes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_types, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_compat_maps, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_symbols, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_geometries, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extra, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(10..).ok_or(ParseError::ParseError)?;
-        let (keymaps, new_remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keymaps as usize)?;
-        remaining = new_remaining;
-        let (keycodes, new_remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keycodes as usize)?;
-        remaining = new_remaining;
-        let (types, new_remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_types as usize)?;
-        remaining = new_remaining;
-        let (compat_maps, new_remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_compat_maps as usize)?;
-        remaining = new_remaining;
-        let (symbols, new_remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_symbols as usize)?;
-        remaining = new_remaining;
-        let (geometries, new_remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_geometries as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (n_keymaps, remaining) = u16::try_parse(remaining)?;
+        let (n_keycodes, remaining) = u16::try_parse(remaining)?;
+        let (n_types, remaining) = u16::try_parse(remaining)?;
+        let (n_compat_maps, remaining) = u16::try_parse(remaining)?;
+        let (n_symbols, remaining) = u16::try_parse(remaining)?;
+        let (n_geometries, remaining) = u16::try_parse(remaining)?;
+        let (extra, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
+        let (keymaps, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keymaps as usize)?;
+        let (keycodes, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keycodes as usize)?;
+        let (types, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_types as usize)?;
+        let (compat_maps, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_compat_maps as usize)?;
+        let (symbols, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_symbols as usize)?;
+        let (geometries, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_geometries as usize)?;
         let result = ListComponentsReply { response_type, device_id, sequence, length, extra, keymaps, keycodes, types, compat_maps, symbols, geometries };
         Ok((result, remaining))
     }
@@ -9712,55 +9162,34 @@ pub struct GetDeviceInfoReply {
     pub leds: Vec<DeviceLedInfo>,
 }
 impl GetDeviceInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (present, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (supported, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (unsupported, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_device_led_f_bs, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_btn_wanted, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_btns_wanted, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_btn_rtrn, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_btns_rtrn, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (total_btns, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (has_own_state, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dflt_kbd_fb, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dflt_led_fb, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (dev_type, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (present, remaining) = u16::try_parse(remaining)?;
+        let (supported, remaining) = u16::try_parse(remaining)?;
+        let (unsupported, remaining) = u16::try_parse(remaining)?;
+        let (n_device_led_f_bs, remaining) = u16::try_parse(remaining)?;
+        let (first_btn_wanted, remaining) = u8::try_parse(remaining)?;
+        let (n_btns_wanted, remaining) = u8::try_parse(remaining)?;
+        let (first_btn_rtrn, remaining) = u8::try_parse(remaining)?;
+        let (n_btns_rtrn, remaining) = u8::try_parse(remaining)?;
+        let (total_btns, remaining) = u8::try_parse(remaining)?;
+        let (has_own_state, remaining) = bool::try_parse(remaining)?;
+        let (dflt_kbd_fb, remaining) = u16::try_parse(remaining)?;
+        let (dflt_led_fb, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (dev_type, remaining) = ATOM::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (btn_actions, new_remaining) = crate::x11_utils::parse_list::<Action>(remaining, n_btns_rtrn as usize)?;
-        remaining = new_remaining;
-        let (leds, new_remaining) = crate::x11_utils::parse_list::<DeviceLedInfo>(remaining, n_device_led_f_bs as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (btn_actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, n_btns_rtrn as usize)?;
+        let (leds, remaining) = crate::x11_utils::parse_list::<DeviceLedInfo>(remaining, n_device_led_f_bs as usize)?;
         let result = GetDeviceInfoReply { response_type, device_id, sequence, length, present, supported, unsupported, first_btn_wanted, n_btns_wanted, first_btn_rtrn, total_btns, has_own_state, dflt_kbd_fb, dflt_led_fb, dev_type, name, btn_actions, leds };
         Ok((result, remaining))
     }
@@ -9872,24 +9301,16 @@ pub struct SetDebuggingFlagsReply {
     pub supported_ctrls: u32,
 }
 impl SetDebuggingFlagsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (current_flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (current_ctrls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (supported_flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (supported_ctrls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (current_flags, remaining) = u32::try_parse(remaining)?;
+        let (current_ctrls, remaining) = u32::try_parse(remaining)?;
+        let (supported_flags, remaining) = u32::try_parse(remaining)?;
+        let (supported_ctrls, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let result = SetDebuggingFlagsReply { response_type, sequence, length, current_flags, current_ctrls, supported_flags, supported_ctrls };
         Ok((result, remaining))
     }
@@ -9920,35 +9341,21 @@ pub struct NewKeyboardNotifyEvent {
     pub changed: u16,
 }
 impl NewKeyboardNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (old_device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (old_min_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (old_max_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request_major, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request_minor, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (changed, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(14..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (old_device_id, remaining) = u8::try_parse(remaining)?;
+        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (old_min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (old_max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (request_major, remaining) = u8::try_parse(remaining)?;
+        let (request_minor, remaining) = u8::try_parse(remaining)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
         let result = NewKeyboardNotifyEvent { response_type, xkb_type, sequence, time, device_id, old_device_id, min_key_code, max_key_code, old_min_key_code, old_max_key_code, request_major, request_minor, changed };
         Ok((result, remaining))
     }
@@ -10018,57 +9425,32 @@ pub struct MapNotifyEvent {
     pub virtual_mods: u16,
 }
 impl MapNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ptr_btn_actions, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (changed, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_key_code, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_types, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_sym, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_syms, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_act, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_acts, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_behavior, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_behavior, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key_explicit, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_explicit, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_mod_map_key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_mod_map_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_v_mod_map_key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_v_mod_map_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (virtual_mods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (ptr_btn_actions, remaining) = u8::try_parse(remaining)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_type, remaining) = u8::try_parse(remaining)?;
+        let (n_types, remaining) = u8::try_parse(remaining)?;
+        let (first_key_sym, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_key_syms, remaining) = u8::try_parse(remaining)?;
+        let (first_key_act, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_key_acts, remaining) = u8::try_parse(remaining)?;
+        let (first_key_behavior, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_key_behavior, remaining) = u8::try_parse(remaining)?;
+        let (first_key_explicit, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
+        let (first_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let (first_v_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = MapNotifyEvent { response_type, xkb_type, sequence, time, device_id, ptr_btn_actions, changed, min_key_code, max_key_code, first_type, n_types, first_key_sym, n_key_syms, first_key_act, n_key_acts, first_key_behavior, n_key_behavior, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, virtual_mods };
         Ok((result, remaining))
     }
@@ -10139,56 +9521,31 @@ pub struct StateNotifyEvent {
     pub request_minor: u8,
 }
 impl StateNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (base_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (latched_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (locked_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (base_group, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (latched_group, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (locked_group, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (compat_state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (grab_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (compat_grab_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (lookup_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (compat_loockup_mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ptr_btn_state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (changed, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request_major, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request_minor, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
+        let (base_mods, remaining) = u8::try_parse(remaining)?;
+        let (latched_mods, remaining) = u8::try_parse(remaining)?;
+        let (locked_mods, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = u8::try_parse(remaining)?;
+        let (base_group, remaining) = i16::try_parse(remaining)?;
+        let (latched_group, remaining) = i16::try_parse(remaining)?;
+        let (locked_group, remaining) = u8::try_parse(remaining)?;
+        let (compat_state, remaining) = u8::try_parse(remaining)?;
+        let (grab_mods, remaining) = u8::try_parse(remaining)?;
+        let (compat_grab_mods, remaining) = u8::try_parse(remaining)?;
+        let (lookup_mods, remaining) = u8::try_parse(remaining)?;
+        let (compat_loockup_mods, remaining) = u8::try_parse(remaining)?;
+        let (ptr_btn_state, remaining) = u16::try_parse(remaining)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (event_type, remaining) = u8::try_parse(remaining)?;
+        let (request_major, remaining) = u8::try_parse(remaining)?;
+        let (request_minor, remaining) = u8::try_parse(remaining)?;
         let result = StateNotifyEvent { response_type, xkb_type, sequence, time, device_id, mods, base_mods, latched_mods, locked_mods, group, base_group, latched_group, locked_group, compat_state, grab_mods, compat_grab_mods, lookup_mods, compat_loockup_mods, ptr_btn_state, changed, keycode, event_type, request_major, request_minor };
         Ok((result, remaining))
     }
@@ -10250,36 +9607,22 @@ pub struct ControlsNotifyEvent {
     pub request_minor: u8,
 }
 impl ControlsNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (changed_controls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enabled_controls, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (enabled_control_changes, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request_major, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request_minor, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (num_groups, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (changed_controls, remaining) = u32::try_parse(remaining)?;
+        let (enabled_controls, remaining) = u32::try_parse(remaining)?;
+        let (enabled_control_changes, remaining) = u32::try_parse(remaining)?;
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (event_type, remaining) = u8::try_parse(remaining)?;
+        let (request_major, remaining) = u8::try_parse(remaining)?;
+        let (request_minor, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = ControlsNotifyEvent { response_type, xkb_type, sequence, time, device_id, num_groups, changed_controls, enabled_controls, enabled_control_changes, keycode, event_type, request_major, request_minor };
         Ok((result, remaining))
     }
@@ -10334,24 +9677,16 @@ pub struct IndicatorStateNotifyEvent {
     pub state_changed: u32,
 }
 impl IndicatorStateNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (state, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state_changed, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (state, remaining) = u32::try_parse(remaining)?;
+        let (state_changed, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let result = IndicatorStateNotifyEvent { response_type, xkb_type, sequence, time, device_id, state, state_changed };
         Ok((result, remaining))
     }
@@ -10405,24 +9740,16 @@ pub struct IndicatorMapNotifyEvent {
     pub map_changed: u32,
 }
 impl IndicatorMapNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
-        let (state, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_changed, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (state, remaining) = u32::try_parse(remaining)?;
+        let (map_changed, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let result = IndicatorMapNotifyEvent { response_type, xkb_type, sequence, time, device_id, state, map_changed };
         Ok((result, remaining))
     }
@@ -10486,45 +9813,27 @@ pub struct NamesNotifyEvent {
     pub changed_indicators: u32,
 }
 impl NamesNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (changed, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_types, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_level_name, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_level_names, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (n_radio_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_key_aliases, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (changed_group_names, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (changed_virtual_mods, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_key, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_keys, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (changed_indicators, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let (first_type, remaining) = u8::try_parse(remaining)?;
+        let (n_types, remaining) = u8::try_parse(remaining)?;
+        let (first_level_name, remaining) = u8::try_parse(remaining)?;
+        let (n_level_names, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (n_radio_groups, remaining) = u8::try_parse(remaining)?;
+        let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
+        let (changed_group_names, remaining) = u8::try_parse(remaining)?;
+        let (changed_virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let (first_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (n_keys, remaining) = u8::try_parse(remaining)?;
+        let (changed_indicators, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = NamesNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed, first_type, n_types, first_level_name, n_level_names, n_radio_groups, n_key_aliases, changed_group_names, changed_virtual_mods, first_key, n_keys, changed_indicators };
         Ok((result, remaining))
     }
@@ -10581,27 +9890,17 @@ pub struct CompatMapNotifyEvent {
     pub n_total_si: u16,
 }
 impl CompatMapNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (changed_groups, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_si, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_si, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_total_si, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (changed_groups, remaining) = u8::try_parse(remaining)?;
+        let (first_si, remaining) = u16::try_parse(remaining)?;
+        let (n_si, remaining) = u16::try_parse(remaining)?;
+        let (n_total_si, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = CompatMapNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed_groups, first_si, n_si, n_total_si };
         Ok((result, remaining))
     }
@@ -10662,35 +9961,21 @@ pub struct BellNotifyEvent {
     pub event_only: bool,
 }
 impl BellNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_class, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (percent, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pitch, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (duration, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_only, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(7..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (bell_class, remaining) = u8::try_parse(remaining)?;
+        let (bell_id, remaining) = u8::try_parse(remaining)?;
+        let (percent, remaining) = u8::try_parse(remaining)?;
+        let (pitch, remaining) = u16::try_parse(remaining)?;
+        let (duration, remaining) = u16::try_parse(remaining)?;
+        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event_only, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
         let result = BellNotifyEvent { response_type, xkb_type, sequence, time, device_id, bell_class, bell_id, percent, pitch, duration, name, window, event_only };
         Ok((result, remaining))
     }
@@ -10750,44 +10035,25 @@ pub struct ActionMessageEvent {
     pub message: [STRING8; 8],
 }
 impl ActionMessageEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (press, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (key_event_follows, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mods, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (group, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_0, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_1, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_2, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_3, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_4, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_5, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_6, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (message_7, new_remaining) = STRING8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (press, remaining) = bool::try_parse(remaining)?;
+        let (key_event_follows, remaining) = bool::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = u8::try_parse(remaining)?;
+        let (message_0, remaining) = STRING8::try_parse(remaining)?;
+        let (message_1, remaining) = STRING8::try_parse(remaining)?;
+        let (message_2, remaining) = STRING8::try_parse(remaining)?;
+        let (message_3, remaining) = STRING8::try_parse(remaining)?;
+        let (message_4, remaining) = STRING8::try_parse(remaining)?;
+        let (message_5, remaining) = STRING8::try_parse(remaining)?;
+        let (message_6, remaining) = STRING8::try_parse(remaining)?;
+        let (message_7, remaining) = STRING8::try_parse(remaining)?;
         let message = [
             message_0,
             message_1,
@@ -10798,7 +10064,7 @@ impl ActionMessageEvent {
             message_6,
             message_7,
         ];
-        remaining = &remaining.get(10..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
         let result = ActionMessageEvent { response_type, xkb_type, sequence, time, device_id, keycode, press, key_event_follows, mods, group, message };
         Ok((result, remaining))
     }
@@ -10852,27 +10118,17 @@ pub struct AccessXNotifyEvent {
     pub debounce_delay: u16,
 }
 impl AccessXNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detailt, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (slow_keys_delay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (debounce_delay, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(16..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (detailt, remaining) = u16::try_parse(remaining)?;
+        let (slow_keys_delay, remaining) = u16::try_parse(remaining)?;
+        let (debounce_delay, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = AccessXNotifyEvent { response_type, xkb_type, sequence, time, device_id, keycode, detailt, slow_keys_delay, debounce_delay };
         Ok((result, remaining))
     }
@@ -10934,38 +10190,23 @@ pub struct ExtensionDeviceNotifyEvent {
     pub unsupported: u16,
 }
 impl ExtensionDeviceNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (xkb_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (device_id, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (reason, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_class, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_id, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (leds_defined, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_state, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_button, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (n_buttons, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (supported, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (unsupported, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (reason, remaining) = u16::try_parse(remaining)?;
+        let (led_class, remaining) = u16::try_parse(remaining)?;
+        let (led_id, remaining) = u16::try_parse(remaining)?;
+        let (leds_defined, remaining) = u32::try_parse(remaining)?;
+        let (led_state, remaining) = u32::try_parse(remaining)?;
+        let (first_button, remaining) = u8::try_parse(remaining)?;
+        let (n_buttons, remaining) = u8::try_parse(remaining)?;
+        let (supported, remaining) = u16::try_parse(remaining)?;
+        let (unsupported, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = ExtensionDeviceNotifyEvent { response_type, xkb_type, sequence, time, device_id, reason, led_class, led_id, leds_defined, led_state, first_button, n_buttons, supported, unsupported };
         Ok((result, remaining))
     }

--- a/src/generated/xprint.rs
+++ b/src/generated/xprint.rs
@@ -45,24 +45,20 @@ pub struct Printer {
     pub description: Vec<STRING8>,
 }
 impl TryParse for Printer {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (name_len, remaining) = u32::try_parse(remaining)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (desc_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (description, new_remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, desc_len as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (desc_len, remaining) = u32::try_parse(remaining)?;
+        let (description, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, desc_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = Printer { name, description };
         Ok((result, remaining))
     }
@@ -402,19 +398,13 @@ pub struct PrintQueryVersionReply {
     pub minor_version: u16,
 }
 impl PrintQueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major_version, remaining) = u16::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
         let result = PrintQueryVersionReply { response_type, sequence, length, major_version, minor_version };
         Ok((result, remaining))
     }
@@ -469,20 +459,14 @@ pub struct PrintGetPrinterListReply {
     pub printers: Vec<Printer>,
 }
 impl PrintGetPrinterListReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (list_count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (printers, new_remaining) = crate::x11_utils::parse_list::<Printer>(remaining, list_count as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (list_count, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (printers, remaining) = crate::x11_utils::parse_list::<Printer>(remaining, list_count as usize)?;
         let result = PrintGetPrinterListReply { response_type, sequence, length, printers };
         Ok((result, remaining))
     }
@@ -607,17 +591,12 @@ pub struct PrintGetContextReply {
     pub context: u32,
 }
 impl PrintGetContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context, remaining) = u32::try_parse(remaining)?;
         let result = PrintGetContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -681,17 +660,12 @@ pub struct PrintGetScreenOfContextReply {
     pub root: WINDOW,
 }
 impl PrintGetScreenOfContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
         let result = PrintGetScreenOfContextReply { response_type, sequence, length, root };
         Ok((result, remaining))
     }
@@ -886,24 +860,16 @@ pub struct PrintGetDocumentDataReply {
     pub data: Vec<u8>,
 }
 impl PrintGetDocumentDataReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status_code, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (finished_flag, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, data_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (status_code, remaining) = u32::try_parse(remaining)?;
+        let (finished_flag, remaining) = u32::try_parse(remaining)?;
+        let (data_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, data_len as usize)?;
         let result = PrintGetDocumentDataReply { response_type, sequence, length, status_code, finished_flag, data };
         Ok((result, remaining))
     }
@@ -1028,19 +994,13 @@ pub struct PrintInputSelectedReply {
     pub all_events_mask: u32,
 }
 impl PrintInputSelectedReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (all_events_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_mask, remaining) = u32::try_parse(remaining)?;
+        let (all_events_mask, remaining) = u32::try_parse(remaining)?;
         let result = PrintInputSelectedReply { response_type, sequence, length, event_mask, all_events_mask };
         Ok((result, remaining))
     }
@@ -1089,20 +1049,14 @@ pub struct PrintGetAttributesReply {
     pub attributes: Vec<STRING8>,
 }
 impl PrintGetAttributesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (string_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attributes, new_remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, string_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (string_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (attributes, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, string_len as usize)?;
         let result = PrintGetAttributesReply { response_type, sequence, length, attributes };
         Ok((result, remaining))
     }
@@ -1160,20 +1114,14 @@ pub struct PrintGetOneAttributesReply {
     pub value: Vec<STRING8>,
 }
 impl PrintGetOneAttributesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (value, new_remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, value_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (value_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (value, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, value_len as usize)?;
         let result = PrintGetOneAttributesReply { response_type, sequence, length, value };
         Ok((result, remaining))
     }
@@ -1261,27 +1209,17 @@ pub struct PrintGetPageDimensionsReply {
     pub reproducible_height: u16,
 }
 impl PrintGetPageDimensionsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_x, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (offset_y, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (reproducible_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (reproducible_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (offset_x, remaining) = u16::try_parse(remaining)?;
+        let (offset_y, remaining) = u16::try_parse(remaining)?;
+        let (reproducible_width, remaining) = u16::try_parse(remaining)?;
+        let (reproducible_height, remaining) = u16::try_parse(remaining)?;
         let result = PrintGetPageDimensionsReply { response_type, sequence, length, width, height, offset_x, offset_y, reproducible_width, reproducible_height };
         Ok((result, remaining))
     }
@@ -1320,20 +1258,14 @@ pub struct PrintQueryScreensReply {
     pub roots: Vec<WINDOW>,
 }
 impl PrintQueryScreensReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (list_count, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (roots, new_remaining) = crate::x11_utils::parse_list::<WINDOW>(remaining, list_count as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (list_count, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (roots, remaining) = crate::x11_utils::parse_list::<WINDOW>(remaining, list_count as usize)?;
         let result = PrintQueryScreensReply { response_type, sequence, length, roots };
         Ok((result, remaining))
     }
@@ -1383,18 +1315,12 @@ pub struct PrintSetImageResolutionReply {
     pub previous_resolutions: u16,
 }
 impl PrintSetImageResolutionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (previous_resolutions, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (previous_resolutions, remaining) = u16::try_parse(remaining)?;
         let result = PrintSetImageResolutionReply { response_type, status, sequence, length, previous_resolutions };
         Ok((result, remaining))
     }
@@ -1438,17 +1364,12 @@ pub struct PrintGetImageResolutionReply {
     pub image_resolution: u16,
 }
 impl PrintGetImageResolutionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (image_resolution, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (image_resolution, remaining) = u16::try_parse(remaining)?;
         let result = PrintGetImageResolutionReply { response_type, sequence, length, image_resolution };
         Ok((result, remaining))
     }
@@ -1471,18 +1392,12 @@ pub struct NotifyEvent {
     pub cancel: bool,
 }
 impl NotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context, new_remaining) = PCONTEXT::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cancel, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (context, remaining) = PCONTEXT::try_parse(remaining)?;
+        let (cancel, remaining) = bool::try_parse(remaining)?;
         let result = NotifyEvent { response_type, detail, sequence, context, cancel };
         Ok((result, remaining))
     }
@@ -1531,16 +1446,11 @@ pub struct AttributNotifyEvent {
     pub context: PCONTEXT,
 }
 impl AttributNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context, new_remaining) = PCONTEXT::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (context, remaining) = PCONTEXT::try_parse(remaining)?;
         let result = AttributNotifyEvent { response_type, detail, sequence, context };
         Ok((result, remaining))
     }
@@ -1588,14 +1498,10 @@ pub struct BadContextError {
     pub sequence: u16,
 }
 impl BadContextError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadContextError { response_type, error_code, sequence };
         Ok((result, remaining))
     }
@@ -1642,14 +1548,10 @@ pub struct BadSequenceError {
     pub sequence: u16,
 }
 impl BadSequenceError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
         let result = BadSequenceError { response_type, error_code, sequence };
         Ok((result, remaining))
     }

--- a/src/generated/xproto.rs
+++ b/src/generated/xproto.rs
@@ -31,12 +31,9 @@ pub struct Char2b {
     pub byte2: u8,
 }
 impl TryParse for Char2b {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (byte1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (byte2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (byte1, remaining) = u8::try_parse(remaining)?;
+        let (byte2, remaining) = u8::try_parse(remaining)?;
         let result = Char2b { byte1, byte2 };
         Ok((result, remaining))
     }
@@ -102,12 +99,9 @@ pub struct Point {
     pub y: i16,
 }
 impl TryParse for Point {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
         let result = Point { x, y };
         Ok((result, remaining))
     }
@@ -145,16 +139,11 @@ pub struct Rectangle {
     pub height: u16,
 }
 impl TryParse for Rectangle {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
         let result = Rectangle { x, y, width, height };
         Ok((result, remaining))
     }
@@ -202,20 +191,13 @@ pub struct Arc {
     pub angle2: i16,
 }
 impl TryParse for Arc {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (angle1, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (angle2, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (angle1, remaining) = i16::try_parse(remaining)?;
+        let (angle2, remaining) = i16::try_parse(remaining)?;
         let result = Arc { x, y, width, height, angle1, angle2 };
         Ok((result, remaining))
     }
@@ -268,15 +250,11 @@ pub struct Format {
     pub scanline_pad: u8,
 }
 impl TryParse for Format {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bits_per_pixel, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (scanline_pad, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(5..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let (bits_per_pixel, remaining) = u8::try_parse(remaining)?;
+        let (scanline_pad, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(5..).ok_or(ParseError::ParseError)?;
         let result = Format { depth, bits_per_pixel, scanline_pad };
         Ok((result, remaining))
     }
@@ -398,23 +376,15 @@ pub struct Visualtype {
     pub blue_mask: u32,
 }
 impl TryParse for Visualtype {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (visual_id, new_remaining) = VISUALID::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (class, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bits_per_rgb_value, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (colormap_entries, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (red_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (visual_id, remaining) = VISUALID::try_parse(remaining)?;
+        let (class, remaining) = u8::try_parse(remaining)?;
+        let (bits_per_rgb_value, remaining) = u8::try_parse(remaining)?;
+        let (colormap_entries, remaining) = u16::try_parse(remaining)?;
+        let (red_mask, remaining) = u32::try_parse(remaining)?;
+        let (green_mask, remaining) = u32::try_parse(remaining)?;
+        let (blue_mask, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = Visualtype { visual_id, class, bits_per_rgb_value, colormap_entries, red_mask, green_mask, blue_mask };
         Ok((result, remaining))
     }
@@ -481,16 +451,12 @@ pub struct Depth {
     pub visuals: Vec<Visualtype>,
 }
 impl TryParse for Depth {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (visuals_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (visuals, new_remaining) = crate::x11_utils::parse_list::<Visualtype>(remaining, visuals_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (visuals_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (visuals, remaining) = crate::x11_utils::parse_list::<Visualtype>(remaining, visuals_len as usize)?;
         let result = Depth { depth, visuals };
         Ok((result, remaining))
     }
@@ -707,42 +673,24 @@ pub struct Screen {
     pub allowed_depths: Vec<Depth>,
 }
 impl TryParse for Screen {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (default_colormap, new_remaining) = COLORMAP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (white_pixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (black_pixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (current_input_masks, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width_in_pixels, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height_in_pixels, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width_in_millimeters, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height_in_millimeters, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_installed_maps, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_installed_maps, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_visual, new_remaining) = VISUALID::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (backing_stores, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (save_unders, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (allowed_depths_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (allowed_depths, new_remaining) = crate::x11_utils::parse_list::<Depth>(remaining, allowed_depths_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (default_colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let (white_pixel, remaining) = u32::try_parse(remaining)?;
+        let (black_pixel, remaining) = u32::try_parse(remaining)?;
+        let (current_input_masks, remaining) = u32::try_parse(remaining)?;
+        let (width_in_pixels, remaining) = u16::try_parse(remaining)?;
+        let (height_in_pixels, remaining) = u16::try_parse(remaining)?;
+        let (width_in_millimeters, remaining) = u16::try_parse(remaining)?;
+        let (height_in_millimeters, remaining) = u16::try_parse(remaining)?;
+        let (min_installed_maps, remaining) = u16::try_parse(remaining)?;
+        let (max_installed_maps, remaining) = u16::try_parse(remaining)?;
+        let (root_visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (backing_stores, remaining) = u8::try_parse(remaining)?;
+        let (save_unders, remaining) = bool::try_parse(remaining)?;
+        let (root_depth, remaining) = u8::try_parse(remaining)?;
+        let (allowed_depths_len, remaining) = u8::try_parse(remaining)?;
+        let (allowed_depths, remaining) = crate::x11_utils::parse_list::<Depth>(remaining, allowed_depths_len as usize)?;
         let result = Screen { root, default_colormap, white_pixel, black_pixel, current_input_masks, width_in_pixels, height_in_pixels, width_in_millimeters, height_in_millimeters, min_installed_maps, max_installed_maps, root_visual, backing_stores, save_unders, root_depth, allowed_depths };
         Ok((result, remaining))
     }
@@ -792,32 +740,25 @@ pub struct SetupRequest {
     pub authorization_protocol_data: Vec<u8>,
 }
 impl TryParse for SetupRequest {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (byte_order, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (protocol_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (protocol_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (authorization_protocol_name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (authorization_protocol_data_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (authorization_protocol_name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, authorization_protocol_name_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (byte_order, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (protocol_major_version, remaining) = u16::try_parse(remaining)?;
+        let (protocol_minor_version, remaining) = u16::try_parse(remaining)?;
+        let (authorization_protocol_name_len, remaining) = u16::try_parse(remaining)?;
+        let (authorization_protocol_data_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (authorization_protocol_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, authorization_protocol_name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (authorization_protocol_data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, authorization_protocol_data_len as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (authorization_protocol_data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, authorization_protocol_data_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = SetupRequest { byte_order, protocol_major_version, protocol_minor_version, authorization_protocol_name, authorization_protocol_data };
         Ok((result, remaining))
     }
@@ -862,20 +803,13 @@ pub struct SetupFailed {
     pub reason: Vec<u8>,
 }
 impl TryParse for SetupFailed {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (reason_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (protocol_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (protocol_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (reason, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, reason_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (reason_len, remaining) = u8::try_parse(remaining)?;
+        let (protocol_major_version, remaining) = u16::try_parse(remaining)?;
+        let (protocol_minor_version, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u16::try_parse(remaining)?;
+        let (reason, remaining) = crate::x11_utils::parse_list::<u8>(remaining, reason_len as usize)?;
         let result = SetupFailed { status, protocol_major_version, protocol_minor_version, length, reason };
         Ok((result, remaining))
     }
@@ -911,15 +845,11 @@ pub struct SetupAuthenticate {
     pub reason: Vec<u8>,
 }
 impl TryParse for SetupAuthenticate {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(5..).ok_or(ParseError::ParseError)?;
-        let (length, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (reason, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(5..).ok_or(ParseError::ParseError)?;
+        let (length, remaining) = u16::try_parse(remaining)?;
+        let (reason, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = SetupAuthenticate { status, reason };
         Ok((result, remaining))
     }
@@ -1032,56 +962,35 @@ pub struct Setup {
     pub roots: Vec<Screen>,
 }
 impl TryParse for Setup {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (protocol_major_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (protocol_minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (release_number, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resource_id_base, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (resource_id_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (motion_buffer_size, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (vendor_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (maximum_request_length, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (roots_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixmap_formats_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (image_byte_order, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bitmap_format_bit_order, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bitmap_format_scanline_unit, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bitmap_format_scanline_pad, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (vendor, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (protocol_major_version, remaining) = u16::try_parse(remaining)?;
+        let (protocol_minor_version, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u16::try_parse(remaining)?;
+        let (release_number, remaining) = u32::try_parse(remaining)?;
+        let (resource_id_base, remaining) = u32::try_parse(remaining)?;
+        let (resource_id_mask, remaining) = u32::try_parse(remaining)?;
+        let (motion_buffer_size, remaining) = u32::try_parse(remaining)?;
+        let (vendor_len, remaining) = u16::try_parse(remaining)?;
+        let (maximum_request_length, remaining) = u16::try_parse(remaining)?;
+        let (roots_len, remaining) = u8::try_parse(remaining)?;
+        let (pixmap_formats_len, remaining) = u8::try_parse(remaining)?;
+        let (image_byte_order, remaining) = u8::try_parse(remaining)?;
+        let (bitmap_format_bit_order, remaining) = u8::try_parse(remaining)?;
+        let (bitmap_format_scanline_unit, remaining) = u8::try_parse(remaining)?;
+        let (bitmap_format_scanline_pad, remaining) = u8::try_parse(remaining)?;
+        let (min_keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (max_keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (vendor, remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (pixmap_formats, new_remaining) = crate::x11_utils::parse_list::<Format>(remaining, pixmap_formats_len as usize)?;
-        remaining = new_remaining;
-        let (roots, new_remaining) = crate::x11_utils::parse_list::<Screen>(remaining, roots_len as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (pixmap_formats, remaining) = crate::x11_utils::parse_list::<Format>(remaining, pixmap_formats_len as usize)?;
+        let (roots, remaining) = crate::x11_utils::parse_list::<Screen>(remaining, roots_len as usize)?;
         let result = Setup { status, protocol_major_version, protocol_minor_version, length, release_number, resource_id_base, resource_id_mask, motion_buffer_size, maximum_request_length, image_byte_order, bitmap_format_bit_order, bitmap_format_scanline_unit, bitmap_format_scanline_pad, min_keycode, max_keycode, vendor, pixmap_formats, roots };
         Ok((result, remaining))
     }
@@ -1382,35 +1291,21 @@ pub struct KeyPressEvent {
     pub same_screen: bool,
 }
 impl KeyPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = KEYCODE::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = KeyPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         Ok((result, remaining))
     }
@@ -1501,35 +1396,21 @@ pub struct KeyReleaseEvent {
     pub same_screen: bool,
 }
 impl KeyReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = KEYCODE::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = KeyReleaseEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         Ok((result, remaining))
     }
@@ -1679,35 +1560,21 @@ pub struct ButtonPressEvent {
     pub same_screen: bool,
 }
 impl ButtonPressEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = BUTTON::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = BUTTON::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ButtonPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         Ok((result, remaining))
     }
@@ -1798,35 +1665,21 @@ pub struct ButtonReleaseEvent {
     pub same_screen: bool,
 }
 impl ButtonReleaseEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = BUTTON::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = BUTTON::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ButtonReleaseEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         Ok((result, remaining))
     }
@@ -1979,35 +1832,21 @@ pub struct MotionNotifyEvent {
     pub same_screen: bool,
 }
 impl MotionNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = MotionNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         Ok((result, remaining))
     }
@@ -2237,36 +2076,21 @@ pub struct EnterNotifyEvent {
     pub same_screen_focus: u8,
 }
 impl EnterNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen_focus, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (same_screen_focus, remaining) = u8::try_parse(remaining)?;
         let result = EnterNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, mode, same_screen_focus };
         Ok((result, remaining))
     }
@@ -2348,36 +2172,21 @@ pub struct LeaveNotifyEvent {
     pub same_screen_focus: u8,
 }
 impl LeaveNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen_focus, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (same_screen_focus, remaining) = u8::try_parse(remaining)?;
         let result = LeaveNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, mode, same_screen_focus };
         Ok((result, remaining))
     }
@@ -2442,19 +2251,13 @@ pub struct FocusInEvent {
     pub mode: u8,
 }
 impl FocusInEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = FocusInEvent { response_type, detail, sequence, event, mode };
         Ok((result, remaining))
     }
@@ -2511,19 +2314,13 @@ pub struct FocusOutEvent {
     pub mode: u8,
 }
 impl FocusOutEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (detail, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = FocusOutEvent { response_type, detail, sequence, event, mode };
         Ok((result, remaining))
     }
@@ -2570,72 +2367,39 @@ pub struct KeymapNotifyEvent {
     pub keys: [u8; 31],
 }
 impl KeymapNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (keys_0, remaining) = u8::try_parse(remaining)?;
+        let (keys_1, remaining) = u8::try_parse(remaining)?;
+        let (keys_2, remaining) = u8::try_parse(remaining)?;
+        let (keys_3, remaining) = u8::try_parse(remaining)?;
+        let (keys_4, remaining) = u8::try_parse(remaining)?;
+        let (keys_5, remaining) = u8::try_parse(remaining)?;
+        let (keys_6, remaining) = u8::try_parse(remaining)?;
+        let (keys_7, remaining) = u8::try_parse(remaining)?;
+        let (keys_8, remaining) = u8::try_parse(remaining)?;
+        let (keys_9, remaining) = u8::try_parse(remaining)?;
+        let (keys_10, remaining) = u8::try_parse(remaining)?;
+        let (keys_11, remaining) = u8::try_parse(remaining)?;
+        let (keys_12, remaining) = u8::try_parse(remaining)?;
+        let (keys_13, remaining) = u8::try_parse(remaining)?;
+        let (keys_14, remaining) = u8::try_parse(remaining)?;
+        let (keys_15, remaining) = u8::try_parse(remaining)?;
+        let (keys_16, remaining) = u8::try_parse(remaining)?;
+        let (keys_17, remaining) = u8::try_parse(remaining)?;
+        let (keys_18, remaining) = u8::try_parse(remaining)?;
+        let (keys_19, remaining) = u8::try_parse(remaining)?;
+        let (keys_20, remaining) = u8::try_parse(remaining)?;
+        let (keys_21, remaining) = u8::try_parse(remaining)?;
+        let (keys_22, remaining) = u8::try_parse(remaining)?;
+        let (keys_23, remaining) = u8::try_parse(remaining)?;
+        let (keys_24, remaining) = u8::try_parse(remaining)?;
+        let (keys_25, remaining) = u8::try_parse(remaining)?;
+        let (keys_26, remaining) = u8::try_parse(remaining)?;
+        let (keys_27, remaining) = u8::try_parse(remaining)?;
+        let (keys_28, remaining) = u8::try_parse(remaining)?;
+        let (keys_29, remaining) = u8::try_parse(remaining)?;
+        let (keys_30, remaining) = u8::try_parse(remaining)?;
         let keys = [
             keys_0,
             keys_1,
@@ -2735,26 +2499,17 @@ pub struct ExposeEvent {
     pub count: u16,
 }
 impl ExposeEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = u16::try_parse(remaining)?;
+        let (y, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = ExposeEvent { response_type, sequence, window, x, y, width, height, count };
         Ok((result, remaining))
     }
@@ -2814,30 +2569,19 @@ pub struct GraphicsExposureEvent {
     pub major_opcode: u8,
 }
 impl GraphicsExposureEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (x, remaining) = u16::try_parse(remaining)?;
+        let (y, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = GraphicsExposureEvent { response_type, sequence, drawable, x, y, width, height, minor_opcode, count, major_opcode };
         Ok((result, remaining))
     }
@@ -2893,20 +2637,14 @@ pub struct NoExposureEvent {
     pub major_opcode: u8,
 }
 impl NoExposureEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (drawable, new_remaining) = DRAWABLE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = NoExposureEvent { response_type, sequence, drawable, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -3021,18 +2759,13 @@ pub struct VisibilityNotifyEvent {
     pub state: u8,
 }
 impl VisibilityNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = VisibilityNotifyEvent { response_type, sequence, window, state };
         Ok((result, remaining))
     }
@@ -3087,30 +2820,19 @@ pub struct CreateNotifyEvent {
     pub override_redirect: bool,
 }
 impl CreateNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (parent, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (override_redirect, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (parent, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (border_width, remaining) = u16::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = CreateNotifyEvent { response_type, sequence, parent, window, x, y, width, height, border_width, override_redirect };
         Ok((result, remaining))
     }
@@ -3177,17 +2899,12 @@ pub struct DestroyNotifyEvent {
     pub window: WINDOW,
 }
 impl DestroyNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
         let result = DestroyNotifyEvent { response_type, sequence, event, window };
         Ok((result, remaining))
     }
@@ -3252,20 +2969,14 @@ pub struct UnmapNotifyEvent {
     pub from_configure: bool,
 }
 impl UnmapNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (from_configure, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (from_configure, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = UnmapNotifyEvent { response_type, sequence, event, window, from_configure };
         Ok((result, remaining))
     }
@@ -3329,20 +3040,14 @@ pub struct MapNotifyEvent {
     pub override_redirect: bool,
 }
 impl MapNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (override_redirect, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = MapNotifyEvent { response_type, sequence, event, window, override_redirect };
         Ok((result, remaining))
     }
@@ -3403,17 +3108,12 @@ pub struct MapRequestEvent {
     pub window: WINDOW,
 }
 impl MapRequestEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (parent, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (parent, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
         let result = MapRequestEvent { response_type, sequence, parent, window };
         Ok((result, remaining))
     }
@@ -3467,26 +3167,17 @@ pub struct ReparentNotifyEvent {
     pub override_redirect: bool,
 }
 impl ReparentNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (parent, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (override_redirect, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (parent, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = ReparentNotifyEvent { response_type, sequence, event, window, parent, x, y, override_redirect };
         Ok((result, remaining))
     }
@@ -3569,32 +3260,20 @@ pub struct ConfigureNotifyEvent {
     pub override_redirect: bool,
 }
 impl ConfigureNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (above_sibling, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (override_redirect, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (above_sibling, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (border_width, remaining) = u16::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ConfigureNotifyEvent { response_type, sequence, event, window, above_sibling, x, y, width, height, border_width, override_redirect };
         Ok((result, remaining))
     }
@@ -3658,32 +3337,19 @@ pub struct ConfigureRequestEvent {
     pub value_mask: u16,
 }
 impl ConfigureRequestEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (stack_mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (parent, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sibling, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value_mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (stack_mode, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (parent, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (sibling, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (border_width, remaining) = u16::try_parse(remaining)?;
+        let (value_mask, remaining) = u16::try_parse(remaining)?;
         let result = ConfigureRequestEvent { response_type, stack_mode, sequence, parent, window, sibling, x, y, width, height, border_width, value_mask };
         Ok((result, remaining))
     }
@@ -3742,21 +3408,14 @@ pub struct GravityNotifyEvent {
     pub y: i16,
 }
 impl GravityNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
         let result = GravityNotifyEvent { response_type, sequence, event, window, x, y };
         Ok((result, remaining))
     }
@@ -3809,19 +3468,13 @@ pub struct ResizeRequestEvent {
     pub height: u16,
 }
 impl ResizeRequestEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
         let result = ResizeRequestEvent { response_type, sequence, window, width, height };
         Ok((result, remaining))
     }
@@ -3954,21 +3607,15 @@ pub struct CirculateNotifyEvent {
     pub place: u8,
 }
 impl CirculateNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (place, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (place, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = CirculateNotifyEvent { response_type, sequence, event, window, place };
         Ok((result, remaining))
     }
@@ -4031,21 +3678,15 @@ pub struct CirculateRequestEvent {
     pub place: u8,
 }
 impl CirculateRequestEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (place, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (place, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = CirculateRequestEvent { response_type, sequence, event, window, place };
         Ok((result, remaining))
     }
@@ -4171,22 +3812,15 @@ pub struct PropertyNotifyEvent {
     pub state: u8,
 }
 impl PropertyNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (atom, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(3..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (atom, remaining) = ATOM::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = PropertyNotifyEvent { response_type, sequence, window, atom, time, state };
         Ok((result, remaining))
     }
@@ -4238,19 +3872,13 @@ pub struct SelectionClearEvent {
     pub selection: ATOM,
 }
 impl SelectionClearEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (owner, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (selection, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (owner, remaining) = WINDOW::try_parse(remaining)?;
+        let (selection, remaining) = ATOM::try_parse(remaining)?;
         let result = SelectionClearEvent { response_type, sequence, time, owner, selection };
         Ok((result, remaining))
     }
@@ -4540,25 +4168,16 @@ pub struct SelectionRequestEvent {
     pub property: ATOM,
 }
 impl SelectionRequestEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (owner, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (requestor, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (selection, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (target, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (property, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (owner, remaining) = WINDOW::try_parse(remaining)?;
+        let (requestor, remaining) = WINDOW::try_parse(remaining)?;
+        let (selection, remaining) = ATOM::try_parse(remaining)?;
+        let (target, remaining) = ATOM::try_parse(remaining)?;
+        let (property, remaining) = ATOM::try_parse(remaining)?;
         let result = SelectionRequestEvent { response_type, sequence, time, owner, requestor, selection, target, property };
         Ok((result, remaining))
     }
@@ -4615,23 +4234,15 @@ pub struct SelectionNotifyEvent {
     pub property: ATOM,
 }
 impl SelectionNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (requestor, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (selection, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (target, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (property, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (requestor, remaining) = WINDOW::try_parse(remaining)?;
+        let (selection, remaining) = ATOM::try_parse(remaining)?;
+        let (target, remaining) = ATOM::try_parse(remaining)?;
+        let (property, remaining) = ATOM::try_parse(remaining)?;
         let result = SelectionNotifyEvent { response_type, sequence, time, requestor, selection, target, property };
         Ok((result, remaining))
     }
@@ -4827,22 +4438,15 @@ pub struct ColormapNotifyEvent {
     pub state: u8,
 }
 impl ColormapNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (colormap, new_remaining) = COLORMAP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (new, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let (new, remaining) = bool::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = ColormapNotifyEvent { response_type, sequence, window, colormap, new, state };
         Ok((result, remaining))
     }
@@ -4886,48 +4490,27 @@ impl From<ColormapNotifyEvent> for [u8; 32] {
 pub struct ClientMessageData([u8; 20]);
 impl ClientMessageData {
     pub fn as_data8(&self) -> [u8; 20] {
-        fn do_the_parse(value: &[u8]) -> Result<[u8; 20], ParseError> {
-            let mut remaining = value;
-            let (data8_0, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_1, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_2, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_3, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_4, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_5, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_6, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_7, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_8, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_9, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_10, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_11, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_12, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_13, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_14, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_15, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_16, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_17, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_18, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data8_19, new_remaining) = u8::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<[u8; 20], ParseError> {
+            let (data8_0, remaining) = u8::try_parse(remaining)?;
+            let (data8_1, remaining) = u8::try_parse(remaining)?;
+            let (data8_2, remaining) = u8::try_parse(remaining)?;
+            let (data8_3, remaining) = u8::try_parse(remaining)?;
+            let (data8_4, remaining) = u8::try_parse(remaining)?;
+            let (data8_5, remaining) = u8::try_parse(remaining)?;
+            let (data8_6, remaining) = u8::try_parse(remaining)?;
+            let (data8_7, remaining) = u8::try_parse(remaining)?;
+            let (data8_8, remaining) = u8::try_parse(remaining)?;
+            let (data8_9, remaining) = u8::try_parse(remaining)?;
+            let (data8_10, remaining) = u8::try_parse(remaining)?;
+            let (data8_11, remaining) = u8::try_parse(remaining)?;
+            let (data8_12, remaining) = u8::try_parse(remaining)?;
+            let (data8_13, remaining) = u8::try_parse(remaining)?;
+            let (data8_14, remaining) = u8::try_parse(remaining)?;
+            let (data8_15, remaining) = u8::try_parse(remaining)?;
+            let (data8_16, remaining) = u8::try_parse(remaining)?;
+            let (data8_17, remaining) = u8::try_parse(remaining)?;
+            let (data8_18, remaining) = u8::try_parse(remaining)?;
+            let (data8_19, remaining) = u8::try_parse(remaining)?;
             let data8 = [
                 data8_0,
                 data8_1,
@@ -4956,28 +4539,17 @@ impl ClientMessageData {
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_data16(&self) -> [u16; 10] {
-        fn do_the_parse(value: &[u8]) -> Result<[u16; 10], ParseError> {
-            let mut remaining = value;
-            let (data16_0, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_1, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_2, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_3, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_4, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_5, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_6, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_7, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_8, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data16_9, new_remaining) = u16::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<[u16; 10], ParseError> {
+            let (data16_0, remaining) = u16::try_parse(remaining)?;
+            let (data16_1, remaining) = u16::try_parse(remaining)?;
+            let (data16_2, remaining) = u16::try_parse(remaining)?;
+            let (data16_3, remaining) = u16::try_parse(remaining)?;
+            let (data16_4, remaining) = u16::try_parse(remaining)?;
+            let (data16_5, remaining) = u16::try_parse(remaining)?;
+            let (data16_6, remaining) = u16::try_parse(remaining)?;
+            let (data16_7, remaining) = u16::try_parse(remaining)?;
+            let (data16_8, remaining) = u16::try_parse(remaining)?;
+            let (data16_9, remaining) = u16::try_parse(remaining)?;
             let data16 = [
                 data16_0,
                 data16_1,
@@ -4996,18 +4568,12 @@ impl ClientMessageData {
         do_the_parse(&self.0).unwrap()
     }
     pub fn as_data32(&self) -> [u32; 5] {
-        fn do_the_parse(value: &[u8]) -> Result<[u32; 5], ParseError> {
-            let mut remaining = value;
-            let (data32_0, new_remaining) = u32::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data32_1, new_remaining) = u32::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data32_2, new_remaining) = u32::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data32_3, new_remaining) = u32::try_parse(remaining)?;
-            remaining = new_remaining;
-            let (data32_4, new_remaining) = u32::try_parse(remaining)?;
-            remaining = new_remaining;
+        fn do_the_parse(remaining: &[u8]) -> Result<[u32; 5], ParseError> {
+            let (data32_0, remaining) = u32::try_parse(remaining)?;
+            let (data32_1, remaining) = u32::try_parse(remaining)?;
+            let (data32_2, remaining) = u32::try_parse(remaining)?;
+            let (data32_3, remaining) = u32::try_parse(remaining)?;
+            let (data32_4, remaining) = u32::try_parse(remaining)?;
             let data32 = [
                 data32_0,
                 data32_1,
@@ -5144,20 +4710,13 @@ pub struct ClientMessageEvent {
     pub data: ClientMessageData,
 }
 impl ClientMessageEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (window, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data, new_remaining) = ClientMessageData::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (format, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (data, remaining) = ClientMessageData::try_parse(remaining)?;
         let result = ClientMessageEvent { response_type, format, sequence, window, type_, data };
         Ok((result, remaining))
     }
@@ -5281,20 +4840,14 @@ pub struct MappingNotifyEvent {
     pub count: u8,
 }
 impl MappingNotifyEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (request, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_keycode, new_remaining) = KEYCODE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (count, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (request, remaining) = u8::try_parse(remaining)?;
+        let (first_keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (count, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = MappingNotifyEvent { response_type, sequence, request, first_keycode, count };
         Ok((result, remaining))
     }
@@ -5351,19 +4904,13 @@ pub struct GeGenericEvent {
     pub event_type: u16,
 }
 impl GeGenericEvent {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (extension, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (event_type, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
         let result = GeGenericEvent { response_type, extension, sequence, length, event_type };
         Ok((result, remaining))
     }
@@ -5399,21 +4946,14 @@ pub struct RequestError {
     pub major_opcode: u8,
 }
 impl RequestError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = RequestError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5465,21 +5005,14 @@ pub struct ValueError {
     pub major_opcode: u8,
 }
 impl ValueError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ValueError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5531,21 +5064,14 @@ pub struct WindowError {
     pub major_opcode: u8,
 }
 impl WindowError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = WindowError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5597,21 +5123,14 @@ pub struct PixmapError {
     pub major_opcode: u8,
 }
 impl PixmapError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = PixmapError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5663,21 +5182,14 @@ pub struct AtomError {
     pub major_opcode: u8,
 }
 impl AtomError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = AtomError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5729,21 +5241,14 @@ pub struct CursorError {
     pub major_opcode: u8,
 }
 impl CursorError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = CursorError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5795,21 +5300,14 @@ pub struct FontError {
     pub major_opcode: u8,
 }
 impl FontError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = FontError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5861,21 +5359,14 @@ pub struct MatchError {
     pub major_opcode: u8,
 }
 impl MatchError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = MatchError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5927,21 +5418,14 @@ pub struct DrawableError {
     pub major_opcode: u8,
 }
 impl DrawableError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = DrawableError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -5993,21 +5477,14 @@ pub struct AccessError {
     pub major_opcode: u8,
 }
 impl AccessError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = AccessError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -6059,21 +5536,14 @@ pub struct AllocError {
     pub major_opcode: u8,
 }
 impl AllocError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = AllocError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -6125,21 +5595,14 @@ pub struct ColormapError {
     pub major_opcode: u8,
 }
 impl ColormapError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ColormapError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -6191,21 +5654,14 @@ pub struct GContextError {
     pub major_opcode: u8,
 }
 impl GContextError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = GContextError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -6257,21 +5713,14 @@ pub struct IDChoiceError {
     pub major_opcode: u8,
 }
 impl IDChoiceError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = IDChoiceError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -6323,21 +5772,14 @@ pub struct NameError {
     pub major_opcode: u8,
 }
 impl NameError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = NameError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -6389,21 +5831,14 @@ pub struct LengthError {
     pub major_opcode: u8,
 }
 impl LengthError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = LengthError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -6455,21 +5890,14 @@ pub struct ImplementationError {
     pub major_opcode: u8,
 }
 impl ImplementationError {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (error_code, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bad_value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_opcode, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (error_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (bad_value, remaining) = u32::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ImplementationError { response_type, error_code, sequence, bad_value, minor_opcode, major_opcode };
         Ok((result, remaining))
     }
@@ -7566,45 +6994,26 @@ pub struct GetWindowAttributesReply {
     pub do_not_propagate_mask: u16,
 }
 impl GetWindowAttributesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (backing_store, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual, new_remaining) = VISUALID::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (class, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bit_gravity, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (win_gravity, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (backing_planes, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (backing_pixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (save_under, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_is_installed, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_state, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (override_redirect, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (colormap, new_remaining) = COLORMAP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (all_event_masks, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (your_event_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (do_not_propagate_mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (backing_store, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (class, remaining) = u16::try_parse(remaining)?;
+        let (bit_gravity, remaining) = u8::try_parse(remaining)?;
+        let (win_gravity, remaining) = u8::try_parse(remaining)?;
+        let (backing_planes, remaining) = u32::try_parse(remaining)?;
+        let (backing_pixel, remaining) = u32::try_parse(remaining)?;
+        let (save_under, remaining) = bool::try_parse(remaining)?;
+        let (map_is_installed, remaining) = bool::try_parse(remaining)?;
+        let (map_state, remaining) = u8::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let (colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let (all_event_masks, remaining) = u32::try_parse(remaining)?;
+        let (your_event_mask, remaining) = u32::try_parse(remaining)?;
+        let (do_not_propagate_mask, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = GetWindowAttributesReply { response_type, backing_store, sequence, length, visual, class, bit_gravity, win_gravity, backing_planes, backing_pixel, save_under, map_is_installed, map_state, override_redirect, colormap, all_event_masks, your_event_mask, do_not_propagate_mask };
         Ok((result, remaining))
     }
@@ -8538,29 +7947,18 @@ pub struct GetGeometryReply {
     pub border_width: u16,
 }
 impl GetGeometryReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (border_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (border_width, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = GetGeometryReply { response_type, depth, sequence, length, root, x, y, width, height, border_width };
         Ok((result, remaining))
     }
@@ -8649,24 +8047,16 @@ pub struct QueryTreeReply {
     pub children: Vec<WINDOW>,
 }
 impl QueryTreeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (parent, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (children_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(14..).ok_or(ParseError::ParseError)?;
-        let (children, new_remaining) = crate::x11_utils::parse_list::<WINDOW>(remaining, children_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (parent, remaining) = WINDOW::try_parse(remaining)?;
+        let (children_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
+        let (children, remaining) = crate::x11_utils::parse_list::<WINDOW>(remaining, children_len as usize)?;
         let result = QueryTreeReply { response_type, sequence, length, root, parent, children };
         Ok((result, remaining))
     }
@@ -8758,17 +8148,12 @@ pub struct InternAtomReply {
     pub atom: ATOM,
 }
 impl InternAtomReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (atom, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (atom, remaining) = ATOM::try_parse(remaining)?;
         let result = InternAtomReply { response_type, sequence, length, atom };
         Ok((result, remaining))
     }
@@ -8810,20 +8195,14 @@ pub struct GetAtomNameReply {
     pub name: Vec<u8>,
 }
 impl GetAtomNameReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (name_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         let result = GetAtomNameReply { response_type, sequence, length, name };
         Ok((result, remaining))
     }
@@ -9399,25 +8778,16 @@ pub struct GetPropertyReply {
     pub value: Vec<u8>,
 }
 impl GetPropertyReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (format, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (type_, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bytes_after, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (value, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (value_len as usize) * ((format as usize) / (8)))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (format, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (bytes_after, remaining) = u32::try_parse(remaining)?;
+        let (value_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (value, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (value_len as usize) * ((format as usize) / (8)))?;
         let result = GetPropertyReply { response_type, format, sequence, length, type_, bytes_after, value_len, value };
         Ok((result, remaining))
     }
@@ -9459,20 +8829,14 @@ pub struct ListPropertiesReply {
     pub atoms: Vec<ATOM>,
 }
 impl ListPropertiesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (atoms_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, new_remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, atoms_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (atoms_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, atoms_len as usize)?;
         let result = ListPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -9599,17 +8963,12 @@ pub struct GetSelectionOwnerReply {
     pub owner: WINDOW,
 }
 impl GetSelectionOwnerReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (owner, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (owner, remaining) = WINDOW::try_parse(remaining)?;
         let result = GetSelectionOwnerReply { response_type, sequence, length, owner };
         Ok((result, remaining))
     }
@@ -10156,16 +9515,11 @@ pub struct GrabPointerReply {
     pub length: u32,
 }
 impl GrabPointerReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = GrabPointerReply { response_type, status, sequence, length };
         Ok((result, remaining))
     }
@@ -10589,16 +9943,11 @@ pub struct GrabKeyboardReply {
     pub length: u32,
 }
 impl GrabKeyboardReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = GrabKeyboardReply { response_type, status, sequence, length };
         Ok((result, remaining))
     }
@@ -11134,31 +10483,19 @@ pub struct QueryPointerReply {
     pub mask: u16,
 }
 impl QueryPointerReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (root_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (win_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (win_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mask, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (win_x, remaining) = i16::try_parse(remaining)?;
+        let (win_y, remaining) = i16::try_parse(remaining)?;
+        let (mask, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = QueryPointerReply { response_type, same_screen, sequence, length, root, child, root_x, root_y, win_x, win_y, mask };
         Ok((result, remaining))
     }
@@ -11177,14 +10514,10 @@ pub struct Timecoord {
     pub y: i16,
 }
 impl TryParse for Timecoord {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (time, new_remaining) = TIMESTAMP::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
         let result = Timecoord { time, x, y };
         Ok((result, remaining))
     }
@@ -11260,20 +10593,14 @@ pub struct GetMotionEventsReply {
     pub events: Vec<Timecoord>,
 }
 impl GetMotionEventsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (events_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (events, new_remaining) = crate::x11_utils::parse_list::<Timecoord>(remaining, events_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (events_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (events, remaining) = crate::x11_utils::parse_list::<Timecoord>(remaining, events_len as usize)?;
         let result = GetMotionEventsReply { response_type, sequence, length, events };
         Ok((result, remaining))
     }
@@ -11329,22 +10656,14 @@ pub struct TranslateCoordinatesReply {
     pub dst_y: i16,
 }
 impl TranslateCoordinatesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same_screen, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (child, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dst_x, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (dst_y, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (dst_x, remaining) = i16::try_parse(remaining)?;
+        let (dst_y, remaining) = i16::try_parse(remaining)?;
         let result = TranslateCoordinatesReply { response_type, same_screen, sequence, length, child, dst_x, dst_y };
         Ok((result, remaining))
     }
@@ -11605,18 +10924,12 @@ pub struct GetInputFocusReply {
     pub focus: WINDOW,
 }
 impl GetInputFocusReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (revert_to, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (focus, new_remaining) = WINDOW::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (revert_to, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (focus, remaining) = WINDOW::try_parse(remaining)?;
         let result = GetInputFocusReply { response_type, revert_to, sequence, length, focus };
         Ok((result, remaining))
     }
@@ -11653,79 +10966,43 @@ pub struct QueryKeymapReply {
     pub keys: [u8; 32],
 }
 impl QueryKeymapReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keys_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (keys_0, remaining) = u8::try_parse(remaining)?;
+        let (keys_1, remaining) = u8::try_parse(remaining)?;
+        let (keys_2, remaining) = u8::try_parse(remaining)?;
+        let (keys_3, remaining) = u8::try_parse(remaining)?;
+        let (keys_4, remaining) = u8::try_parse(remaining)?;
+        let (keys_5, remaining) = u8::try_parse(remaining)?;
+        let (keys_6, remaining) = u8::try_parse(remaining)?;
+        let (keys_7, remaining) = u8::try_parse(remaining)?;
+        let (keys_8, remaining) = u8::try_parse(remaining)?;
+        let (keys_9, remaining) = u8::try_parse(remaining)?;
+        let (keys_10, remaining) = u8::try_parse(remaining)?;
+        let (keys_11, remaining) = u8::try_parse(remaining)?;
+        let (keys_12, remaining) = u8::try_parse(remaining)?;
+        let (keys_13, remaining) = u8::try_parse(remaining)?;
+        let (keys_14, remaining) = u8::try_parse(remaining)?;
+        let (keys_15, remaining) = u8::try_parse(remaining)?;
+        let (keys_16, remaining) = u8::try_parse(remaining)?;
+        let (keys_17, remaining) = u8::try_parse(remaining)?;
+        let (keys_18, remaining) = u8::try_parse(remaining)?;
+        let (keys_19, remaining) = u8::try_parse(remaining)?;
+        let (keys_20, remaining) = u8::try_parse(remaining)?;
+        let (keys_21, remaining) = u8::try_parse(remaining)?;
+        let (keys_22, remaining) = u8::try_parse(remaining)?;
+        let (keys_23, remaining) = u8::try_parse(remaining)?;
+        let (keys_24, remaining) = u8::try_parse(remaining)?;
+        let (keys_25, remaining) = u8::try_parse(remaining)?;
+        let (keys_26, remaining) = u8::try_parse(remaining)?;
+        let (keys_27, remaining) = u8::try_parse(remaining)?;
+        let (keys_28, remaining) = u8::try_parse(remaining)?;
+        let (keys_29, remaining) = u8::try_parse(remaining)?;
+        let (keys_30, remaining) = u8::try_parse(remaining)?;
+        let (keys_31, remaining) = u8::try_parse(remaining)?;
         let keys = [
             keys_0,
             keys_1,
@@ -11914,12 +11191,9 @@ pub struct Fontprop {
     pub value: u32,
 }
 impl TryParse for Fontprop {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (value, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (value, remaining) = u32::try_parse(remaining)?;
         let result = Fontprop { name, value };
         Ok((result, remaining))
     }
@@ -11963,20 +11237,13 @@ pub struct Charinfo {
     pub attributes: u16,
 }
 impl TryParse for Charinfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (left_side_bearing, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (right_side_bearing, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (character_width, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (ascent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (descent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (attributes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (left_side_bearing, remaining) = i16::try_parse(remaining)?;
+        let (right_side_bearing, remaining) = i16::try_parse(remaining)?;
+        let (character_width, remaining) = i16::try_parse(remaining)?;
+        let (ascent, remaining) = i16::try_parse(remaining)?;
+        let (descent, remaining) = i16::try_parse(remaining)?;
+        let (attributes, remaining) = u16::try_parse(remaining)?;
         let result = Charinfo { left_side_bearing, right_side_bearing, character_width, ascent, descent, attributes };
         Ok((result, remaining))
     }
@@ -12085,47 +11352,28 @@ pub struct QueryFontReply {
     pub char_infos: Vec<Charinfo>,
 }
 impl QueryFontReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_bounds, new_remaining) = Charinfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (max_bounds, new_remaining) = Charinfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (min_char_or_byte2, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_char_or_byte2, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (default_char, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (properties_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (draw_direction, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_byte1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_byte1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (all_chars_exist, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (font_ascent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (font_descent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (char_infos_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (properties, new_remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len as usize)?;
-        remaining = new_remaining;
-        let (char_infos, new_remaining) = crate::x11_utils::parse_list::<Charinfo>(remaining, char_infos_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (min_bounds, remaining) = Charinfo::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (max_bounds, remaining) = Charinfo::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (min_char_or_byte2, remaining) = u16::try_parse(remaining)?;
+        let (max_char_or_byte2, remaining) = u16::try_parse(remaining)?;
+        let (default_char, remaining) = u16::try_parse(remaining)?;
+        let (properties_len, remaining) = u16::try_parse(remaining)?;
+        let (draw_direction, remaining) = u8::try_parse(remaining)?;
+        let (min_byte1, remaining) = u8::try_parse(remaining)?;
+        let (max_byte1, remaining) = u8::try_parse(remaining)?;
+        let (all_chars_exist, remaining) = bool::try_parse(remaining)?;
+        let (font_ascent, remaining) = i16::try_parse(remaining)?;
+        let (font_descent, remaining) = i16::try_parse(remaining)?;
+        let (char_infos_len, remaining) = u32::try_parse(remaining)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len as usize)?;
+        let (char_infos, remaining) = crate::x11_utils::parse_list::<Charinfo>(remaining, char_infos_len as usize)?;
         let result = QueryFontReply { response_type, sequence, length, min_bounds, max_bounds, min_char_or_byte2, max_char_or_byte2, default_char, draw_direction, min_byte1, max_byte1, all_chars_exist, font_ascent, font_descent, properties, char_infos };
         Ok((result, remaining))
     }
@@ -12217,30 +11465,18 @@ pub struct QueryTextExtentsReply {
     pub overall_right: i32,
 }
 impl QueryTextExtentsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (draw_direction, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (font_ascent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (font_descent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (overall_ascent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (overall_descent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (overall_width, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (overall_left, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (overall_right, new_remaining) = i32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (draw_direction, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (font_ascent, remaining) = i16::try_parse(remaining)?;
+        let (font_descent, remaining) = i16::try_parse(remaining)?;
+        let (overall_ascent, remaining) = i16::try_parse(remaining)?;
+        let (overall_descent, remaining) = i16::try_parse(remaining)?;
+        let (overall_width, remaining) = i32::try_parse(remaining)?;
+        let (overall_left, remaining) = i32::try_parse(remaining)?;
+        let (overall_right, remaining) = i32::try_parse(remaining)?;
         let result = QueryTextExtentsReply { response_type, draw_direction, sequence, length, font_ascent, font_descent, overall_ascent, overall_descent, overall_width, overall_left, overall_right };
         Ok((result, remaining))
     }
@@ -12257,12 +11493,9 @@ pub struct Str {
     pub name: Vec<u8>,
 }
 impl TryParse for Str {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (name_len, remaining) = u8::try_parse(remaining)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         let result = Str { name };
         Ok((result, remaining))
     }
@@ -12342,20 +11575,14 @@ pub struct ListFontsReply {
     pub names: Vec<Str>,
 }
 impl ListFontsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (names_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (names, new_remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (names_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len as usize)?;
         let result = ListFontsReply { response_type, sequence, length, names };
         Ok((result, remaining))
     }
@@ -12446,48 +11673,28 @@ pub struct ListFontsWithInfoReply {
     pub name: Vec<u8>,
 }
 impl ListFontsWithInfoReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (name_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_bounds, new_remaining) = Charinfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (max_bounds, new_remaining) = Charinfo::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (min_char_or_byte2, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_char_or_byte2, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (default_char, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (properties_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (draw_direction, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (min_byte1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_byte1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (all_chars_exist, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (font_ascent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (font_descent, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (replies_hint, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (properties, new_remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len as usize)?;
-        remaining = new_remaining;
-        let (name, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (name_len, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (min_bounds, remaining) = Charinfo::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (max_bounds, remaining) = Charinfo::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (min_char_or_byte2, remaining) = u16::try_parse(remaining)?;
+        let (max_char_or_byte2, remaining) = u16::try_parse(remaining)?;
+        let (default_char, remaining) = u16::try_parse(remaining)?;
+        let (properties_len, remaining) = u16::try_parse(remaining)?;
+        let (draw_direction, remaining) = u8::try_parse(remaining)?;
+        let (min_byte1, remaining) = u8::try_parse(remaining)?;
+        let (max_byte1, remaining) = u8::try_parse(remaining)?;
+        let (all_chars_exist, remaining) = bool::try_parse(remaining)?;
+        let (font_ascent, remaining) = i16::try_parse(remaining)?;
+        let (font_descent, remaining) = i16::try_parse(remaining)?;
+        let (replies_hint, remaining) = u32::try_parse(remaining)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         let result = ListFontsWithInfoReply { response_type, sequence, length, min_bounds, max_bounds, min_char_or_byte2, max_char_or_byte2, default_char, draw_direction, min_byte1, max_byte1, all_chars_exist, font_ascent, font_descent, replies_hint, properties, name };
         Ok((result, remaining))
     }
@@ -12552,20 +11759,14 @@ pub struct GetFontPathReply {
     pub path: Vec<Str>,
 }
 impl GetFontPathReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (path_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (path, new_remaining) = crate::x11_utils::parse_list::<Str>(remaining, path_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (path_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (path, remaining) = crate::x11_utils::parse_list::<Str>(remaining, path_len as usize)?;
         let result = GetFontPathReply { response_type, sequence, length, path };
         Ok((result, remaining))
     }
@@ -14712,16 +13913,11 @@ pub struct Segment {
     pub y2: i16,
 }
 impl TryParse for Segment {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (x1, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y1, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (x2, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (y2, new_remaining) = i16::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (x1, remaining) = i16::try_parse(remaining)?;
+        let (y1, remaining) = i16::try_parse(remaining)?;
+        let (x2, remaining) = i16::try_parse(remaining)?;
+        let (y2, remaining) = i16::try_parse(remaining)?;
         let result = Segment { x1, y1, x2, y2 };
         Ok((result, remaining))
     }
@@ -15241,21 +14437,14 @@ pub struct GetImageReply {
     pub data: Vec<u8>,
 }
 impl GetImageReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (depth, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual, new_remaining) = VISUALID::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (data, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (depth, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetImageReply { response_type, depth, sequence, visual, data };
         Ok((result, remaining))
     }
@@ -15713,20 +14902,14 @@ pub struct ListInstalledColormapsReply {
     pub cmaps: Vec<COLORMAP>,
 }
 impl ListInstalledColormapsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (cmaps_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (cmaps, new_remaining) = crate::x11_utils::parse_list::<COLORMAP>(remaining, cmaps_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (cmaps_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (cmaps, remaining) = crate::x11_utils::parse_list::<COLORMAP>(remaining, cmaps_len as usize)?;
         let result = ListInstalledColormapsReply { response_type, sequence, length, cmaps };
         Ok((result, remaining))
     }
@@ -15800,24 +14983,16 @@ pub struct AllocColorReply {
     pub pixel: u32,
 }
 impl AllocColorReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (pixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (red, remaining) = u16::try_parse(remaining)?;
+        let (green, remaining) = u16::try_parse(remaining)?;
+        let (blue, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (pixel, remaining) = u32::try_parse(remaining)?;
         let result = AllocColorReply { response_type, sequence, length, red, green, blue, pixel };
         Ok((result, remaining))
     }
@@ -15874,29 +15049,18 @@ pub struct AllocNamedColorReply {
     pub visual_blue: u16,
 }
 impl AllocNamedColorReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (exact_red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (exact_green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (exact_blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual_red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual_green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual_blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (pixel, remaining) = u32::try_parse(remaining)?;
+        let (exact_red, remaining) = u16::try_parse(remaining)?;
+        let (exact_green, remaining) = u16::try_parse(remaining)?;
+        let (exact_blue, remaining) = u16::try_parse(remaining)?;
+        let (visual_red, remaining) = u16::try_parse(remaining)?;
+        let (visual_green, remaining) = u16::try_parse(remaining)?;
+        let (visual_blue, remaining) = u16::try_parse(remaining)?;
         let result = AllocNamedColorReply { response_type, sequence, length, pixel, exact_red, exact_green, exact_blue, visual_red, visual_green, visual_blue };
         Ok((result, remaining))
     }
@@ -15946,24 +15110,16 @@ pub struct AllocColorCellsReply {
     pub masks: Vec<u32>,
 }
 impl AllocColorCellsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixels_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (masks_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (pixels, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len as usize)?;
-        remaining = new_remaining;
-        let (masks, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, masks_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (pixels_len, remaining) = u16::try_parse(remaining)?;
+        let (masks_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (pixels, remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len as usize)?;
+        let (masks, remaining) = crate::x11_utils::parse_list::<u32>(remaining, masks_len as usize)?;
         let result = AllocColorCellsReply { response_type, sequence, length, pixels, masks };
         Ok((result, remaining))
     }
@@ -16021,27 +15177,18 @@ pub struct AllocColorPlanesReply {
     pub pixels: Vec<u32>,
 }
 impl AllocColorPlanesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pixels_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (red_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (pixels, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (pixels_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (red_mask, remaining) = u32::try_parse(remaining)?;
+        let (green_mask, remaining) = u32::try_parse(remaining)?;
+        let (blue_mask, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let (pixels, remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len as usize)?;
         let result = AllocColorPlanesReply { response_type, sequence, length, red_mask, green_mask, blue_mask, pixels };
         Ok((result, remaining))
     }
@@ -16160,19 +15307,13 @@ pub struct Coloritem {
     pub flags: u8,
 }
 impl TryParse for Coloritem {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (pixel, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (pixel, remaining) = u32::try_parse(remaining)?;
+        let (red, remaining) = u16::try_parse(remaining)?;
+        let (green, remaining) = u16::try_parse(remaining)?;
+        let (blue, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = Coloritem { pixel, red, green, blue, flags };
         Ok((result, remaining))
     }
@@ -16289,15 +15430,11 @@ pub struct Rgb {
     pub blue: u16,
 }
 impl TryParse for Rgb {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (red, remaining) = u16::try_parse(remaining)?;
+        let (green, remaining) = u16::try_parse(remaining)?;
+        let (blue, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = Rgb { red, green, blue };
         Ok((result, remaining))
     }
@@ -16368,20 +15505,14 @@ pub struct QueryColorsReply {
     pub colors: Vec<Rgb>,
 }
 impl QueryColorsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (colors_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (colors, new_remaining) = crate::x11_utils::parse_list::<Rgb>(remaining, colors_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (colors_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (colors, remaining) = crate::x11_utils::parse_list::<Rgb>(remaining, colors_len as usize)?;
         let result = QueryColorsReply { response_type, sequence, length, colors };
         Ok((result, remaining))
     }
@@ -16437,27 +15568,17 @@ pub struct LookupColorReply {
     pub visual_blue: u16,
 }
 impl LookupColorReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (exact_red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (exact_green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (exact_blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual_red, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual_green, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (visual_blue, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (exact_red, remaining) = u16::try_parse(remaining)?;
+        let (exact_green, remaining) = u16::try_parse(remaining)?;
+        let (exact_blue, remaining) = u16::try_parse(remaining)?;
+        let (visual_red, remaining) = u16::try_parse(remaining)?;
+        let (visual_green, remaining) = u16::try_parse(remaining)?;
+        let (visual_blue, remaining) = u16::try_parse(remaining)?;
         let result = LookupColorReply { response_type, sequence, length, exact_red, exact_green, exact_blue, visual_red, visual_green, visual_blue };
         Ok((result, remaining))
     }
@@ -16914,19 +16035,13 @@ pub struct QueryBestSizeReply {
     pub height: u16,
 }
 impl QueryBestSizeReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
         let result = QueryBestSizeReply { response_type, sequence, length, width, height };
         Ok((result, remaining))
     }
@@ -17006,23 +16121,15 @@ pub struct QueryExtensionReply {
     pub first_error: u8,
 }
 impl QueryExtensionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (present, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_opcode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_event, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (first_error, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (present, remaining) = bool::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let (first_event, remaining) = u8::try_parse(remaining)?;
+        let (first_error, remaining) = u8::try_parse(remaining)?;
         let result = QueryExtensionReply { response_type, sequence, length, present, major_opcode, first_event, first_error };
         Ok((result, remaining))
     }
@@ -17059,19 +16166,13 @@ pub struct ListExtensionsReply {
     pub names: Vec<Str>,
 }
 impl ListExtensionsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (names_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (names, new_remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (names_len, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len as usize)?;
         let result = ListExtensionsReply { response_type, sequence, length, names };
         Ok((result, remaining))
     }
@@ -17144,19 +16245,13 @@ pub struct GetKeyboardMappingReply {
     pub keysyms: Vec<KEYSYM>,
 }
 impl GetKeyboardMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keysyms_per_keycode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (keysyms, new_remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (keysyms_per_keycode, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, length as usize)?;
         let result = GetKeyboardMappingReply { response_type, keysyms_per_keycode, sequence, keysyms };
         Ok((result, remaining))
     }
@@ -17555,91 +16650,49 @@ pub struct GetKeyboardControlReply {
     pub auto_repeats: [u8; 32],
 }
 impl GetKeyboardControlReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (global_auto_repeat, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (led_mask, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (key_click_percent, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_percent, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_pitch, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (bell_duration, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (auto_repeats_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_4, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_5, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_6, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_7, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_8, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_9, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_10, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_11, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_12, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_13, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_14, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_15, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_16, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_17, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_18, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_19, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_20, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_21, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_22, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_23, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_24, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_25, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_26, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_27, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_28, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_29, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_30, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (auto_repeats_31, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (global_auto_repeat, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (led_mask, remaining) = u32::try_parse(remaining)?;
+        let (key_click_percent, remaining) = u8::try_parse(remaining)?;
+        let (bell_percent, remaining) = u8::try_parse(remaining)?;
+        let (bell_pitch, remaining) = u16::try_parse(remaining)?;
+        let (bell_duration, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (auto_repeats_0, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_1, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_2, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_3, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_4, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_5, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_6, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_7, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_8, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_9, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_10, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_11, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_12, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_13, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_14, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_15, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_16, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_17, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_18, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_19, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_20, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_21, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_22, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_23, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_24, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_25, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_26, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_27, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_28, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_29, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_30, remaining) = u8::try_parse(remaining)?;
+        let (auto_repeats_31, remaining) = u8::try_parse(remaining)?;
         let auto_repeats = [
             auto_repeats_0,
             auto_repeats_1,
@@ -17762,22 +16815,15 @@ pub struct GetPointerControlReply {
     pub threshold: u16,
 }
 impl GetPointerControlReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (acceleration_numerator, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (acceleration_denominator, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (threshold, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (acceleration_numerator, remaining) = u16::try_parse(remaining)?;
+        let (acceleration_denominator, remaining) = u16::try_parse(remaining)?;
+        let (threshold, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let result = GetPointerControlReply { response_type, sequence, length, acceleration_numerator, acceleration_denominator, threshold };
         Ok((result, remaining))
     }
@@ -17979,24 +17025,16 @@ pub struct GetScreenSaverReply {
     pub allow_exposures: u8,
 }
 impl GetScreenSaverReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (timeout, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (interval, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (prefer_blanking, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (allow_exposures, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(18..).ok_or(ParseError::ParseError)?;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (timeout, remaining) = u16::try_parse(remaining)?;
+        let (interval, remaining) = u16::try_parse(remaining)?;
+        let (prefer_blanking, remaining) = u8::try_parse(remaining)?;
+        let (allow_exposures, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let result = GetScreenSaverReply { response_type, sequence, length, timeout, interval, prefer_blanking, allow_exposures };
         Ok((result, remaining))
     }
@@ -18178,19 +17216,16 @@ pub struct Host {
     pub address: Vec<u8>,
 }
 impl TryParse for Host {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (family, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (address_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (address, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, address_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (family, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (address_len, remaining) = u16::try_parse(remaining)?;
+        let (address, remaining) = crate::x11_utils::parse_list::<u8>(remaining, address_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = Host { family, address };
         Ok((result, remaining))
     }
@@ -18245,21 +17280,14 @@ pub struct ListHostsReply {
     pub hosts: Vec<Host>,
 }
 impl ListHostsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mode, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (hosts_len, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (hosts, new_remaining) = crate::x11_utils::parse_list::<Host>(remaining, hosts_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (hosts_len, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let (hosts, remaining) = crate::x11_utils::parse_list::<Host>(remaining, hosts_len as usize)?;
         let result = ListHostsReply { response_type, mode, sequence, length, hosts };
         Ok((result, remaining))
     }
@@ -18750,16 +17778,11 @@ pub struct SetPointerMappingReply {
     pub length: u32,
 }
 impl SetPointerMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = SetPointerMappingReply { response_type, status, sequence, length };
         Ok((result, remaining))
     }
@@ -18796,19 +17819,13 @@ pub struct GetPointerMappingReply {
     pub map: Vec<u8>,
 }
 impl GetPointerMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (map_len, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (map, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, map_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (map_len, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (map, remaining) = crate::x11_utils::parse_list::<u8>(remaining, map_len as usize)?;
         let result = GetPointerMappingReply { response_type, sequence, length, map };
         Ok((result, remaining))
     }
@@ -18931,16 +17948,11 @@ pub struct SetModifierMappingReply {
     pub length: u32,
 }
 impl SetModifierMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (status, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (status, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = SetModifierMappingReply { response_type, status, sequence, length };
         Ok((result, remaining))
     }
@@ -18977,19 +17989,13 @@ pub struct GetModifierMappingReply {
     pub keycodes: Vec<KEYCODE>,
 }
 impl GetModifierMappingReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (keycodes_per_modifier, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (keycodes, new_remaining) = crate::x11_utils::parse_list::<KEYCODE>(remaining, (keycodes_per_modifier as usize) * (8))?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (keycodes_per_modifier, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (keycodes, remaining) = crate::x11_utils::parse_list::<KEYCODE>(remaining, (keycodes_per_modifier as usize) * (8))?;
         let result = GetModifierMappingReply { response_type, sequence, length, keycodes };
         Ok((result, remaining))
     }

--- a/src/generated/xselinux.rs
+++ b/src/generated/xselinux.rs
@@ -71,19 +71,13 @@ pub struct QueryVersionReply {
     pub server_minor: u16,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_major, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (server_minor, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (server_major, remaining) = u16::try_parse(remaining)?;
+        let (server_minor, remaining) = u16::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, server_major, server_minor };
         Ok((result, remaining))
     }
@@ -151,20 +145,14 @@ pub struct GetDeviceCreateContextReply {
     pub context: Vec<u8>,
 }
 impl GetDeviceCreateContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetDeviceCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -242,20 +230,14 @@ pub struct GetDeviceContextReply {
     pub context: Vec<u8>,
 }
 impl GetDeviceContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetDeviceContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -323,20 +305,14 @@ pub struct GetWindowCreateContextReply {
     pub context: Vec<u8>,
 }
 impl GetWindowCreateContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetWindowCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -380,20 +356,14 @@ pub struct GetWindowContextReply {
     pub context: Vec<u8>,
 }
 impl GetWindowContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetWindowContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -412,26 +382,21 @@ pub struct ListItem {
     pub data_context: Vec<u8>,
 }
 impl TryParse for ListItem {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (name, new_remaining) = ATOM::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (object_context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (data_context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (object_context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, object_context_len as usize)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let value = remaining;
+        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (object_context_len, remaining) = u32::try_parse(remaining)?;
+        let (data_context_len, remaining) = u32::try_parse(remaining)?;
+        let (object_context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, object_context_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (data_context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, data_context_len as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let (data_context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, data_context_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
-        remaining = &remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
+        let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let result = ListItem { name, object_context, data_context };
         Ok((result, remaining))
     }
@@ -519,20 +484,14 @@ pub struct GetPropertyCreateContextReply {
     pub context: Vec<u8>,
 }
 impl GetPropertyCreateContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetPropertyCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -600,20 +559,14 @@ pub struct GetPropertyUseContextReply {
     pub context: Vec<u8>,
 }
 impl GetPropertyUseContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetPropertyUseContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -662,20 +615,14 @@ pub struct GetPropertyContextReply {
     pub context: Vec<u8>,
 }
 impl GetPropertyContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetPropertyContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -724,20 +671,14 @@ pub struct GetPropertyDataContextReply {
     pub context: Vec<u8>,
 }
 impl GetPropertyDataContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetPropertyDataContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -781,20 +722,14 @@ pub struct ListPropertiesReply {
     pub properties: Vec<ListItem>,
 }
 impl ListPropertiesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (properties_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (properties, new_remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, properties_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (properties_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, properties_len as usize)?;
         let result = ListPropertiesReply { response_type, sequence, length, properties };
         Ok((result, remaining))
     }
@@ -862,20 +797,14 @@ pub struct GetSelectionCreateContextReply {
     pub context: Vec<u8>,
 }
 impl GetSelectionCreateContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetSelectionCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -943,20 +872,14 @@ pub struct GetSelectionUseContextReply {
     pub context: Vec<u8>,
 }
 impl GetSelectionUseContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetSelectionUseContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -1000,20 +923,14 @@ pub struct GetSelectionContextReply {
     pub context: Vec<u8>,
 }
 impl GetSelectionContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetSelectionContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -1057,20 +974,14 @@ pub struct GetSelectionDataContextReply {
     pub context: Vec<u8>,
 }
 impl GetSelectionDataContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetSelectionDataContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -1109,20 +1020,14 @@ pub struct ListSelectionsReply {
     pub selections: Vec<ListItem>,
 }
 impl ListSelectionsReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (selections_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (selections, new_remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, selections_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (selections_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (selections, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, selections_len as usize)?;
         let result = ListSelectionsReply { response_type, sequence, length, selections };
         Ok((result, remaining))
     }
@@ -1166,20 +1071,14 @@ pub struct GetClientContextReply {
     pub context: Vec<u8>,
 }
 impl GetClientContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (context_len, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, new_remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (context_len, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
         let result = GetClientContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }

--- a/src/generated/xtest.rs
+++ b/src/generated/xtest.rs
@@ -71,18 +71,12 @@ pub struct GetVersionReply {
     pub minor_version: u16,
 }
 impl GetVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major_version, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor_version, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (major_version, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (minor_version, remaining) = u16::try_parse(remaining)?;
         let result = GetVersionReply { response_type, major_version, sequence, length, minor_version };
         Ok((result, remaining))
     }
@@ -193,16 +187,11 @@ pub struct CompareCursorReply {
     pub length: u32,
 }
 impl CompareCursorReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (same, new_remaining) = bool::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (same, remaining) = bool::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
         let result = CompareCursorReply { response_type, same, sequence, length };
         Ok((result, remaining))
     }

--- a/src/generated/xvmc.rs
+++ b/src/generated/xvmc.rs
@@ -60,26 +60,16 @@ pub struct SurfaceInfo {
     pub flags: u32,
 }
 impl TryParse for SurfaceInfo {
-    fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (id, new_remaining) = SURFACE::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (chroma_format, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (pad0, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (max_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subpicture_max_width, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (subpicture_max_height, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (mc_type, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (id, remaining) = SURFACE::try_parse(remaining)?;
+        let (chroma_format, remaining) = u16::try_parse(remaining)?;
+        let (pad0, remaining) = u16::try_parse(remaining)?;
+        let (max_width, remaining) = u16::try_parse(remaining)?;
+        let (max_height, remaining) = u16::try_parse(remaining)?;
+        let (subpicture_max_width, remaining) = u16::try_parse(remaining)?;
+        let (subpicture_max_height, remaining) = u16::try_parse(remaining)?;
+        let (mc_type, remaining) = u32::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
         let result = SurfaceInfo { id, chroma_format, pad0, max_width, max_height, subpicture_max_width, subpicture_max_height, mc_type, flags };
         Ok((result, remaining))
     }
@@ -171,19 +161,13 @@ pub struct QueryVersionReply {
     pub minor: u32,
 }
 impl QueryVersionReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (major, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (minor, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (major, remaining) = u32::try_parse(remaining)?;
+        let (minor, remaining) = u32::try_parse(remaining)?;
         let result = QueryVersionReply { response_type, sequence, length, major, minor };
         Ok((result, remaining))
     }
@@ -227,20 +211,14 @@ pub struct ListSurfaceTypesReply {
     pub surfaces: Vec<SurfaceInfo>,
 }
 impl ListSurfaceTypesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (surfaces, new_remaining) = crate::x11_utils::parse_list::<SurfaceInfo>(remaining, num as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (surfaces, remaining) = crate::x11_utils::parse_list::<SurfaceInfo>(remaining, num as usize)?;
         let result = ListSurfaceTypesReply { response_type, sequence, length, surfaces };
         Ok((result, remaining))
     }
@@ -307,24 +285,16 @@ pub struct CreateContextReply {
     pub priv_data: Vec<u32>,
 }
 impl CreateContextReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width_actual, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height_actual, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (flags_return, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (priv_data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width_actual, remaining) = u16::try_parse(remaining)?;
+        let (height_actual, remaining) = u16::try_parse(remaining)?;
+        let (flags_return, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = CreateContextReply { response_type, sequence, width_actual, height_actual, flags_return, priv_data };
         Ok((result, remaining))
     }
@@ -397,18 +367,13 @@ pub struct CreateSurfaceReply {
     pub priv_data: Vec<u32>,
 }
 impl CreateSurfaceReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (priv_data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = CreateSurfaceReply { response_type, sequence, priv_data };
         Ok((result, remaining))
     }
@@ -497,40 +462,27 @@ pub struct CreateSubpictureReply {
     pub priv_data: Vec<u32>,
 }
 impl CreateSubpictureReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (width_actual, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (height_actual, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num_palette_entries, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (entry_bytes, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (component_order_0, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (component_order_1, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (component_order_2, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (component_order_3, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (width_actual, remaining) = u16::try_parse(remaining)?;
+        let (height_actual, remaining) = u16::try_parse(remaining)?;
+        let (num_palette_entries, remaining) = u16::try_parse(remaining)?;
+        let (entry_bytes, remaining) = u16::try_parse(remaining)?;
+        let (component_order_0, remaining) = u8::try_parse(remaining)?;
+        let (component_order_1, remaining) = u8::try_parse(remaining)?;
+        let (component_order_2, remaining) = u8::try_parse(remaining)?;
+        let (component_order_3, remaining) = u8::try_parse(remaining)?;
         let component_order = [
             component_order_0,
             component_order_1,
             component_order_2,
             component_order_3,
         ];
-        remaining = &remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (priv_data, new_remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
-        remaining = new_remaining;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = CreateSubpictureReply { response_type, sequence, width_actual, height_actual, num_palette_entries, entry_bytes, component_order, priv_data };
         Ok((result, remaining))
     }
@@ -604,20 +556,14 @@ pub struct ListSubpictureTypesReply {
     pub types: Vec<xv::ImageFormatInfo>,
 }
 impl ListSubpictureTypesReply {
-    pub(crate) fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let mut remaining = value;
-        let (response_type, new_remaining) = u8::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (sequence, new_remaining) = u16::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (length, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        let (num, new_remaining) = u32::try_parse(remaining)?;
-        remaining = new_remaining;
-        remaining = &remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (types, new_remaining) = crate::x11_utils::parse_list::<xv::ImageFormatInfo>(remaining, num as usize)?;
-        remaining = new_remaining;
+    pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (num, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let (types, remaining) = crate::x11_utils::parse_list::<xv::ImageFormatInfo>(remaining, num as usize)?;
         let result = ListSubpictureTypesReply { response_type, sequence, length, types };
         Ok((result, remaining))
     }


### PR DESCRIPTION
This commit continues an idea originally attempted by @dalcde. Instead
of generating the following code:

    let (response_type, new_remaining) = u8::try_parse(remaining)?;
    remaining = new_remaining;

...this code is generated:

    let (response_type, remaining) = u8::try_parse(remaining)?;

This small looking change results in lots of saved lines:

 32 files changed, 7061 insertions(+), 12964 deletions(-)

A downside of this is that loops become a bit more complicated (because
they have to keep the old form and thus need an extra 'let mut remaining
= remaining;') and parsing switches also becomes a bit more complicated
(because there the 'remaining' variable also needs to be passed out of
its enclosing scope to an outer one). However, all in all, this is still
a net benefit and makes a lot of the generated code a lot easier to
read.

Thanks to @dalcde for this great idea.

Fixes: https://github.com/psychon/x11rb/issues/289
Signed-off-by: Uli Schlachter <psychon@znc.in>

Edit: The Travis build passed, but GitHub doesn't know: https://travis-ci.org/github/psychon/x11rb/builds/665421862