### PR TITLE
Exclude code generator from releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,12 @@ readme = "README.md"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11"]
+exclude = [
+    "/xcb-proto-1.14-1-g2b3559c",
+    "/Makefile",
+    "/rs_code_generator.py",
+    "/code_generator_helpers",
+]
 
 [dependencies]
 libc = { version = "0.2", optional = true }


### PR DESCRIPTION
There is no point in shipping the code generator and all of xcb-proto in
releases now that they come with pre-generated source code for the
extensions. Thus, exclude them.

Signed-off-by: Uli Schlachter <psychon@znc.in>