### PR TITLE
Add enums for all events/errors

### DIFF
--- a/code_generator_helpers/__init__.py
+++ b/code_generator_helpers/__init__.py
@@ -1,0 +1,13 @@
+import re
+
+
+def camel_case_to_lower_snake(arg):
+    # Based on _cname_re from libxcb's c_client.py
+    pattern = re.compile('([A-Z][a-z0-9]+|[A-Z]+(?![a-z0-9])|[a-z0-9]+)')
+    split = pattern.finditer(arg)
+    arg_parts = [match.group(0) for match in split]
+    return '_'.join(arg_parts).lower()
+
+
+def camel_case_to_upper_snake(arg):
+    return camel_case_to_lower_snake(arg).upper()

--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -27,7 +27,7 @@ def _get_events_from_module(module):
 
 def _errors(out, modules):
     errors = [_get_errors_from_module(module) for module in modules]
-    xproto_index = next(filter(lambda m: not m[1].namespace.is_ext, enumerate(modules)))[0]
+    xproto_index = next(iter(filter(lambda m: not m[1].namespace.is_ext, enumerate(modules))))[0]
 
     out("/// Enumeration of all possible X11 errors.")
     out("#[derive(Debug, Clone)]")
@@ -97,7 +97,7 @@ def _errors(out, modules):
 
 def _events(out, modules):
     events = [_get_events_from_module(module) for module in modules]
-    xproto_index = next(filter(lambda m: not m[1].namespace.is_ext, enumerate(modules)))[0]
+    xproto_index = next(iter(filter(lambda m: not m[1].namespace.is_ext, enumerate(modules))))[0]
 
     out("/// Enumeration of all possible X11 events.")
     out("#[derive(Debug, Clone)]")

--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -52,15 +52,14 @@ def _errors(out, modules):
         out(") -> Result<Self, ParseError> {")
         with Indent(out):
             out("let error_code = error.error_code();")
-            out("let bytes = error.raw_bytes();")
 
             out("// Check if this is a core protocol error")
             out("match error_code {")
             for name, err in errors[xproto_index]:
                 opcode = camel_case_to_upper_snake(name[-1]) + "_ERROR"
                 err_name = name[-1] + "Error"
-                out.indent("xproto::%s => return Ok(Self::Xproto%s(xproto::%s::try_parse(bytes)?.0)),",
-                           opcode, err_name, err_name)
+                out.indent("xproto::%s => return Ok(Self::Xproto%s(error.into())),",
+                           opcode, err_name)
             out.indent("_ => {}")
             out("}")
 
@@ -85,8 +84,8 @@ def _errors(out, modules):
                         for name, error in mod_errors:
                             opcode = camel_case_to_upper_snake(name[-1]) + "_ERROR"
                             err_name = name[-1] + "Error"
-                            out.indent("%s::%s => Ok(Self::%s%s(%s::%s::try_parse(bytes)?.0)),",
-                                       mod_name, opcode, variant, err_name, mod_name, err_name)
+                            out.indent("%s::%s => Ok(Self::%s%s(error.into())),",
+                                       mod_name, opcode, variant, err_name)
                         out.indent("_ => Ok(Self::Unknown(error))")
                         out("}")
                     out("}")
@@ -124,7 +123,6 @@ def _events(out, modules):
         out(") -> Result<Self, ParseError> {")
         with Indent(out):
             out("let event_type = event.response_type();")
-            out("let bytes = event.raw_bytes();")
             out("// Check if this is a core protocol error or from the generic event extension")
             out("match event_type {")
             with Indent(out):
@@ -135,8 +133,8 @@ def _events(out, modules):
                         continue
                     opcode = camel_case_to_upper_snake(name[-1]) + "_EVENT"
                     event_name = name[-1] + "Event"
-                    out("xproto::%s => return Ok(Self::Xproto%s(xproto::%s::try_parse(bytes)?.0)),",
-                        opcode, event_name, event_name)
+                    out("xproto::%s => return Ok(Self::Xproto%s(event.into())),",
+                        opcode, event_name)
                 out("xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, iter),")
                 out("_ => {}")
             out("}")
@@ -172,8 +170,8 @@ def _events(out, modules):
                                 continue
                             opcode = camel_case_to_upper_snake(name[-1]) + "_EVENT"
                             event_name = name[-1] + "Event"
-                            out.indent("%s::%s => Ok(Self::%s%s(%s::%s::try_parse(bytes)?.0)),",
-                                       mod_name, opcode, variant, event_name, mod_name, event_name)
+                            out.indent("%s::%s => Ok(Self::%s%s(event.into())),",
+                                       mod_name, opcode, variant, event_name)
                         out.indent("_ => Ok(Self::Unknown(event))")
                         out("}")
                     out("}")
@@ -213,8 +211,8 @@ def _events(out, modules):
                                 continue
                             opcode = camel_case_to_upper_snake(name[-1]) + "_EVENT"
                             event_name = name[-1] + "Event"
-                            out.indent("%s::%s => Ok(Self::%s%s(%s::%s::try_parse(bytes)?.0)),",
-                                       mod_name, opcode, variant, event_name, mod_name, event_name)
+                            out.indent("%s::%s => Ok(Self::%s%s(event.try_into()?)),",
+                                       mod_name, opcode, variant, event_name)
                         out.indent("_ => Ok(Self::Unknown(event))")
                         out("}")
                     out("}")

--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -160,7 +160,13 @@ def _events(out, modules):
                         out("#[cfg(feature = \"%s\")]", module.namespace.header)
                     out("Some((\"%s\", first_event)) => {", ext_xname)
                     with Indent(out):
-                        out("match event_type - first_event {")
+                        if module.namespace.header == 'xkb':
+                            out("if event_type != first_event {")
+                            out.indent("return Ok(Self::Unknown(event));")
+                            out("}")
+                            out("match event.raw_bytes()[1] {")
+                        else:
+                            out("match event_type - first_event {")
                         for name, event in mod_events:
                             if event.is_ge_event:
                                 continue

--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -30,6 +30,8 @@ def _errors(out, modules):
         variant = mod_name[0].upper() + mod_name[1:]
         for name, error in mod_errors:
             err_name = name[-1] + "Error"
+            if module.has_feature:
+                out.indent("#[cfg(feature = \"%s\")]", module.namespace.header)
             out.indent("%s%s(%s::%s),", variant, err_name, mod_name, err_name)
     out("}")
 
@@ -41,7 +43,6 @@ def _errors(out, modules):
         out.indent("iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,")
         out(") -> Result<Self, ParseError> {")
         with Indent(out):
-            out("// Find the extension that this error could belong to")
             out("let error_code = error.error_code();")
             out("let bytes = error.raw_bytes();")
 
@@ -54,6 +55,7 @@ def _errors(out, modules):
             out.indent("_ => {}")
             out("}")
 
+            out("// Find the extension that this error could belong to")
             out("let ext_info = iter")
             out.indent(".map(|(name, reply)| (name, reply.first_error))")
             out.indent(".filter(|&(_, first_error)| first_error <= error_code)")
@@ -66,6 +68,8 @@ def _errors(out, modules):
                     mod_name = module.namespace.header
                     ext_xname = module.namespace.ext_xname
                     variant = mod_name[0].upper() + mod_name[1:]
+                    if module.has_feature:
+                        out("#[cfg(feature = \"%s\")]", module.namespace.header)
                     out("Some((\"%s\", first_error)) => {", ext_xname)
                     with Indent(out):
                         out("match error_code - first_error {")

--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -187,6 +187,7 @@ def _events(out, modules):
         with Indent(out):
             out("let bytes = event.raw_bytes();")
             out("let ge_event = xproto::GeGenericEvent::try_from(bytes)?;")
+            out("#[allow(unused_variables)]")
             out("let (extension, event_type) = (ge_event.extension, ge_event.event_type);")
             out("let ext_name = iter")
             out.indent(".map(|(name, reply)| (name, reply.major_opcode))")

--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -1,0 +1,86 @@
+"""
+This module generates the code for parsing a GenericEvent or GenericError into a
+specific instance of the right event/error.
+"""
+
+from .output import Indent
+
+
+def _get_errors_from_module(module):
+    """Get errors from this module"""
+    prefix = module.outer_module.namespace.prefix
+    errors = module.outer_module.errors.values()
+    errors = filter(lambda x: x[0][:len(prefix)] == prefix, errors)
+    # The XML for GLX has a comment saying "fake number"
+    errors = filter(lambda x: x[0] != ('xcb', 'Glx', 'Generic'), errors)
+    return sorted(errors)
+
+
+def _errors(out, modules):
+    errors = [_get_errors_from_module(module) for module in modules]
+    opcodes = [[int(error.opcodes[name]) for name, error in mod_errors] for mod_errors in errors]
+    xproto_index = next(filter(lambda m: not m[1].namespace.is_ext, enumerate(modules)))[0]
+
+    out("/// Enumeration of all possible X11 errors.")
+    out("#[derive(Debug, Clone)]")
+    out("pub enum Error<B: std::fmt::Debug + AsRef<[u8]>> {")
+    out.indent("Unknown(GenericError<B>),")
+    for module, mod_errors in zip(modules, errors):
+        mod_name = module.namespace.header
+        variant = mod_name[0].upper() + mod_name[1:]
+        for name, error in mod_errors:
+            err_name = name[-1] + "Error"
+            out.indent("%s%s(%s::%s),", variant, err_name, mod_name, err_name)
+    out("}")
+
+    out("impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {")
+    with Indent(out):
+        out("/// Parse a generic X11 error into a concrete error type.")
+        out("pub fn parse(")
+        out.indent("error: GenericError<B>,")
+        out.indent("iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,")
+        out(") -> Result<Self, ParseError> {")
+        with Indent(out):
+            out("// Find the extension that this error could belong to")
+            out("let error_code = error.error_code();")
+            out("let bytes = error.raw_bytes();")
+
+            out("// Check if this is a core protocol error")
+            out("match error_code {")
+            for (name, err), opcode in zip(errors[xproto_index], opcodes[xproto_index]):
+                err_name = name[-1] + "Error"
+                out.indent("%s => return Ok(Self::Xproto%s(xproto::%s::try_parse(bytes)?.0)),",
+                           opcode, err_name, err_name)
+            out.indent("_ => {}")
+            out("}")
+
+            out("let ext_info = iter")
+            out.indent(".map(|(name, reply)| (name, reply.first_error))")
+            out.indent(".filter(|&(_, first_error)| first_error <= error_code)")
+            out.indent(".max_by_key(|&(_, first_error)| first_error);")
+            out("match ext_info {")
+            with Indent(out):
+                for module, mod_errors, mod_opcodes in zip(modules, errors, opcodes):
+                    if not mod_errors or not module.namespace.is_ext:
+                        continue
+                    mod_name = module.namespace.header
+                    ext_xname = module.namespace.ext_xname
+                    variant = mod_name[0].upper() + mod_name[1:]
+                    out("Some((\"%s\", first_error)) => {", ext_xname)
+                    with Indent(out):
+                        out("match error_code - first_error {")
+                        for (name, error), opcode in zip(mod_errors, mod_opcodes):
+                            err_name = name[-1] + "Error"
+                            out.indent("%s => Ok(Self::%s%s(%s::%s::try_parse(bytes)?.0)),",
+                                       opcode, variant, err_name, mod_name, err_name)
+                        out.indent("_ => Ok(Self::Unknown(error))")
+                        out("}")
+                    out("}")
+                out("_ => Ok(Self::Unknown(error))")
+            out("}")
+        out("}")
+    out("}")
+
+
+def generate(out, modules):
+    _errors(out, modules)

--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -16,6 +16,14 @@ def _get_errors_from_module(module):
     return sorted(errors)
 
 
+def _get_events_from_module(module):
+    """Get events from this module"""
+    prefix = module.outer_module.namespace.prefix
+    events = module.outer_module.events.values()
+    events = filter(lambda x: x[0][:len(prefix)] == prefix, events)
+    return sorted(events)
+
+
 def _errors(out, modules):
     errors = [_get_errors_from_module(module) for module in modules]
     opcodes = [[int(error.opcodes[name]) for name, error in mod_errors] for mod_errors in errors]
@@ -86,5 +94,95 @@ def _errors(out, modules):
     out("}")
 
 
+def _events(out, modules):
+    events = [_get_events_from_module(module) for module in modules]
+    opcodes = [[int(event.opcodes[name]) for name, event in mod_events] for mod_events in events]
+    xproto_index = next(filter(lambda m: not m[1].namespace.is_ext, enumerate(modules)))[0]
+
+    out("/// Enumeration of all possible X11 events.")
+    out("#[derive(Debug, Clone)]")
+    out("pub enum Event<B: std::fmt::Debug + AsRef<[u8]>> {")
+    out.indent("Unknown(GenericEvent<B>),")
+    out.indent("Error(Error<B>),")
+    for module, mod_events in zip(modules, events):
+        mod_name = module.namespace.header
+        variant = mod_name[0].upper() + mod_name[1:]
+        for name, event in mod_events:
+            err_name = name[-1] + "Event"
+            if module.has_feature:
+                out.indent("#[cfg(feature = \"%s\")]", module.namespace.header)
+            out.indent("%s%s(%s::%s),", variant, err_name, mod_name, err_name)
+    out("}")
+
+    out("impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {")
+    with Indent(out):
+        out("/// Parse a generic X11 event into a concrete event type.")
+        out("pub fn parse(")
+        out.indent("event: GenericEvent<B>,")
+        out.indent("iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,")
+        out(") -> Result<Self, ParseError> {")
+        with Indent(out):
+            out("let event_type = event.response_type();")
+            out("let bytes = event.raw_bytes();")
+            out("// Check if this is a core protocol error or from the generic event extension")
+            out("match event_type {")
+            with Indent(out):
+                out("0 => return Ok(Self::Error(Error::parse(event.try_into()?, iter)?)),")
+                for (name, event), opcode in zip(events[xproto_index], opcodes[xproto_index]):
+                    if name == ('xcb', 'GeGeneric'):
+                        # This does not really count and is parsed as an extension's event
+                        continue
+                    event_name = name[-1] + "Event"
+                    out("%s => return Ok(Self::Xproto%s(xproto::%s::try_parse(bytes)?.0)),",
+                        opcode, event_name, event_name)
+                out("xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, iter),")
+                out("_ => {}")
+            out("}")
+
+            out("// Find the extension that this event could belong to")
+            out("let ext_info = iter")
+            out.indent(".map(|(name, reply)| (name, reply.first_event))")
+            out.indent(".filter(|&(_, first_event)| first_event <= event_type)")
+            out.indent(".max_by_key(|&(_, first_event)| first_event);")
+            out("match ext_info {")
+            with Indent(out):
+                for module, mod_events, mod_opcodes in zip(modules, events, opcodes):
+                    # XGE events are handled separately
+                    has_normal_events = any(not e[1].is_ge_event for e in mod_events)
+                    if not has_normal_events or not module.namespace.is_ext:
+                        continue
+                    mod_name = module.namespace.header
+                    ext_xname = module.namespace.ext_xname
+                    variant = mod_name[0].upper() + mod_name[1:]
+                    if module.has_feature:
+                        out("#[cfg(feature = \"%s\")]", module.namespace.header)
+                    out("Some((\"%s\", first_event)) => {", ext_xname)
+                    with Indent(out):
+                        out("match event_type - first_event {")
+                        for (name, event), opcode in zip(mod_events, mod_opcodes):
+                            if event.is_ge_event:
+                                continue
+                            event_name = name[-1] + "Event"
+                            out.indent("%s => Ok(Self::%s%s(%s::%s::try_parse(bytes)?.0)),",
+                                       opcode, variant, event_name, mod_name, event_name)
+                        out.indent("_ => Ok(Self::Unknown(event))")
+                        out("}")
+                    out("}")
+                out("_ => Ok(Self::Unknown(event))")
+            out("}")
+        out("}")
+        out("")
+
+        out("fn from_generic_event(")
+        out.indent("event: GenericEvent<B>,")
+        out.indent("iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,")
+        out(") -> Result<Self, ParseError> {")
+        with Indent(out):
+            out("todo!()")
+        out("}")
+    out("}")
+
+
 def generate(out, modules):
     _errors(out, modules)
+    _events(out, modules)

--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -3,6 +3,7 @@ import re
 from .output import Output, Indent, generated_code_header
 import code_generator_helpers.special_cases as special_cases
 from .request import generate_request_code as generate_request_code
+from . import camel_case_to_lower_snake, camel_case_to_upper_snake
 
 
 rust_type_mapping = {
@@ -1400,17 +1401,12 @@ class Module(object):
         """Convert a name tuple to a lowercase snake name. MonitorInfo is turned
         into monitor_info."""
 
-        name = self._name(name)
-        # Based on _cname_re from libxcb's c_client.py
-        pattern = re.compile('([A-Z][a-z0-9]+|[A-Z]+(?![a-z0-9])|[a-z0-9]+)')
-        split = pattern.finditer(name)
-        name_parts = [match.group(0) for match in split]
-        return '_'.join(name_parts).lower()
+        return camel_case_to_lower_snake(self._name(name))
 
     def _upper_snake_name(self, name):
         """Convert a name tuple to a uppercase snake name. MonitorInfo is turned
         into MONITOR_INFO."""
-        return self._lower_snake_name(name).upper()
+        return camel_case_to_upper_snake(self._name(name))
 
     def _aux_field_name(self, field):
         return self._lower_snake_name((field.field_name,))

--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -1,29 +1,23 @@
 // This example tests support for generic events (XGE). It generates a window and uses the PRESENT
 // extension to cause an XGE event to be sent.
 
-use std::convert::TryFrom;
 use std::process::exit;
 
 use x11rb::connection::{Connection as _, RequestConnection as _};
 use x11rb::present;
-use x11rb::x11_utils::Event;
 use x11rb::xproto::{
-    ConfigureWindowAux, ConnectionExt as _, CreateWindowAux, GeGenericEvent, WindowClass,
-    GE_GENERIC_EVENT,
+    ConfigureWindowAux, ConnectionExt as _, CreateWindowAux, WindowClass,
 };
-use x11rb::COPY_DEPTH_FROM_PARENT;
+use x11rb::{COPY_DEPTH_FROM_PARENT, Event};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (conn, screen_num) = x11rb::connect(None)?;
     let screen = &conn.setup().roots[screen_num];
 
-    let present_info = match conn.extension_information(present::X11_EXTENSION_NAME)? {
-        Some(info) => info,
-        None => {
-            eprintln!("Present extension is not supported");
-            exit(1);
-        }
-    };
+    if conn.extension_information(present::X11_EXTENSION_NAME)?.is_none() {
+        eprintln!("Present extension is not supported");
+        exit(1);
+    }
 
     // Create a window
     let win_id = conn.generate_id()?;
@@ -59,15 +53,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let event = conn.wait_for_event()?;
 
     // Now check that the event really is what we wanted to get
-    assert_eq!(event.response_type(), GE_GENERIC_EVENT);
-    let generic_event = GeGenericEvent::try_from(&event)?;
-    assert_eq!(generic_event.extension, present_info.major_opcode);
-    assert_eq!(
-        generic_event.event_type,
-        present::Event::ConfigureNotify.into()
-    );
-
-    let event = present::ConfigureNotifyEvent::try_from(event)?;
+    let event = conn.parse_event(event)?;
+    let event = match event {
+        Event::PresentConfigureNotifyEvent(event) => event,
+        other => panic!("Unexpected event {:?}", other)
+    };
     println!(
         "Got a Present ConfigureNotify event for event ID 0x{:x} and window 0x{:x}.",
         event.event, event.window

--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -5,16 +5,17 @@ use std::process::exit;
 
 use x11rb::connection::{Connection as _, RequestConnection as _};
 use x11rb::present;
-use x11rb::xproto::{
-    ConfigureWindowAux, ConnectionExt as _, CreateWindowAux, WindowClass,
-};
-use x11rb::{COPY_DEPTH_FROM_PARENT, Event};
+use x11rb::xproto::{ConfigureWindowAux, ConnectionExt as _, CreateWindowAux, WindowClass};
+use x11rb::{Event, COPY_DEPTH_FROM_PARENT};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (conn, screen_num) = x11rb::connect(None)?;
     let screen = &conn.setup().roots[screen_num];
 
-    if conn.extension_information(present::X11_EXTENSION_NAME)?.is_none() {
+    if conn
+        .extension_information(present::X11_EXTENSION_NAME)?
+        .is_none()
+    {
         eprintln!("Present extension is not supported");
         exit(1);
     }
@@ -56,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let event = conn.parse_event(event)?;
     let event = match event {
         Event::PresentConfigureNotifyEvent(event) => event,
-        other => panic!("Unexpected event {:?}", other)
+        other => panic!("Unexpected event {:?}", other),
     };
     println!(
         "Got a Present ConfigureNotify event for event ID 0x{:x} and window 0x{:x}.",

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use x11rb::connection::Connection;
 use x11rb::errors::{ReplyError, ReplyOrIdError};
 use x11rb::xproto::*;
-use x11rb::{COPY_DEPTH_FROM_PARENT, Event};
+use x11rb::{Event, COPY_DEPTH_FROM_PARENT};
 
 /// Lag angle for the follow line
 const LAG: f64 = 0.3;

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -1,11 +1,9 @@
 extern crate x11rb;
 
-use std::convert::TryFrom;
-
 use x11rb::connection::Connection;
 use x11rb::wrapper::ConnectionExt as _;
-use x11rb::x11_utils::{Event, GenericError};
 use x11rb::xproto::*;
+use x11rb::Event;
 
 fn main() {
     let (conn, screen_num) = x11rb::connect(None).unwrap();
@@ -88,10 +86,10 @@ fn main() {
 
     loop {
         let event = conn.wait_for_event().unwrap();
-        match event.response_type() {
-            EXPOSE_EVENT => {
-                let event = ExposeEvent::from(event);
-                println!("{:?})", event);
+        let event = conn.parse_event(event).unwrap();
+        println!("{:?})", event);
+        match event {
+            Event::XprotoExposeEvent(event) => {
                 if event.count == 0 {
                     // We ought to clear the background before drawing something new, but...
                     // whatever
@@ -116,26 +114,19 @@ fn main() {
                     conn.flush().unwrap();
                 }
             }
-            CONFIGURE_NOTIFY_EVENT => {
-                let event = ConfigureNotifyEvent::from(event);
+            Event::XprotoConfigureNotifyEvent(event) => {
                 width = event.width;
                 height = event.height;
             }
-            CLIENT_MESSAGE_EVENT => {
-                let event = ClientMessageEvent::from(event);
-                println!("{:?})", event);
+            Event::XprotoClientMessageEvent(event) => {
                 let data = event.data.as_data32();
                 if event.format == 32 && event.window == win_id && data[0] == wm_delete_window {
                     println!("Window was asked to close");
                     return;
                 }
             }
-            0 => {
-                println!("Unknown error {:?}", GenericError::try_from(event));
-            }
-            _ => {
-                println!("Unknown event {:?}", event);
-            }
+            Event::Error(_) => println!("Got an unexpected error"),
+            _ => println!("Got an unknown event")
         }
     }
 }

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -126,7 +126,7 @@ fn main() {
                 }
             }
             Event::Error(_) => println!("Got an unexpected error"),
-            _ => println!("Got an unknown event")
+            _ => println!("Got an unknown event"),
         }
     }
 }

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -10,7 +10,7 @@ use x11rb::connection::Connection;
 use x11rb::errors::{ReplyError, ReplyOrIdError};
 use x11rb::x11_utils::Event as _;
 use x11rb::xproto::*;
-use x11rb::{COPY_DEPTH_FROM_PARENT, Event};
+use x11rb::{Event, COPY_DEPTH_FROM_PARENT};
 
 const TITLEBAR_HEIGHT: u16 = 20;
 

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -7,7 +7,7 @@ use x11rb::errors::{ConnectionError, ReplyOrIdError};
 use x11rb::shape::{self, ConnectionExt as _};
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xproto::*;
-use x11rb::{COPY_DEPTH_FROM_PARENT, Event};
+use x11rb::{Event, COPY_DEPTH_FROM_PARENT};
 
 const PUPIL_SIZE: i16 = 50;
 const EYE_SIZE: i16 = 50;

--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -29,7 +29,7 @@ if args:
 
 main_output_file = output_helper.Output()
 output_helper.generated_code_header(main_output_file)
-main_output_file("use std::convert::TryInto;")
+main_output_file("use std::convert::{TryFrom, TryInto};")
 main_output_file("use crate::errors::ParseError;")
 main_output_file("use crate::x11_utils::{Event as _, GenericError, GenericEvent};")
 main_output_file("use xproto::QueryExtensionReply;")

--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -57,12 +57,14 @@ def rs_close(self):
     current_module.close(self)
     output_file = os.path.join(output_dir, "%s.rs" % self.namespace.header)
     current_module.out.write_file(output_file)
-    current_module = None
 
     WITHOUT_FEATURE = ["bigreq", "ge", "xc_misc", "xproto"]
-    if self.namespace.header not in WITHOUT_FEATURE:
+    current_module.has_feature = self.namespace.header not in WITHOUT_FEATURE
+    if current_module.has_feature:
         main_output_file("#[cfg(feature = \"%s\")]", self.namespace.header)
     main_output_file("pub mod %s;", self.namespace.header)
+
+    current_module = None
 
 
 def rs_enum(self, name):

--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -6,6 +6,7 @@ import glob
 import os
 import code_generator_helpers.output as output_helper
 import code_generator_helpers.module as module_helper
+import code_generator_helpers.errors_events as errors_events
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], "p:o:i:")
@@ -28,17 +29,27 @@ if args:
 
 main_output_file = output_helper.Output()
 output_helper.generated_code_header(main_output_file)
+main_output_file("use crate::errors::ParseError;")
+main_output_file("use crate::x11_utils::{Event, GenericError};")
+main_output_file("use xproto::QueryExtensionReply;")
 
 
 # Now the real fun begins
 
 current_module = None
+all_modules = []
+
+
+def add_main_output():
+    main_output_file("")
+    errors_events.generate(main_output_file, all_modules)
 
 
 def rs_open(self):
     global current_module
     assert current_module is None
     current_module = module_helper.Module(self)
+    all_modules.append(current_module)
 
 
 def rs_close(self):
@@ -111,6 +122,8 @@ for name in sorted(names):
     except Exception:
         sys.stderr.write('Error occurred while generating: %s\n' % module.namespace.header)
         raise
+
+add_main_output()
 
 output_file = os.path.join(output_dir, "mod.rs")
 main_output_file.write_file(output_file)

--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -29,8 +29,9 @@ if args:
 
 main_output_file = output_helper.Output()
 output_helper.generated_code_header(main_output_file)
+main_output_file("use std::convert::TryInto;")
 main_output_file("use crate::errors::ParseError;")
-main_output_file("use crate::x11_utils::{Event, GenericError};")
+main_output_file("use crate::x11_utils::{Event as _, GenericError, GenericEvent};")
 main_output_file("use xproto::QueryExtensionReply;")
 
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -48,6 +48,7 @@ use crate::errors::{ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::utils::RawFdContainer;
 use crate::x11_utils::{GenericError, GenericEvent};
 use crate::xproto::{QueryExtensionReply, Setup};
+use crate::{Error, Event};
 
 /// Number type used for referring to things that were sent to the server in responses from the
 /// server.
@@ -279,6 +280,12 @@ pub trait Connection: RequestConnection {
     fn poll_for_event_with_sequence(
         &self,
     ) -> Result<Option<EventAndSeqNumber<Self::Buf>>, ConnectionError>;
+
+    /// Parse a generic error.
+    fn parse_error(&self, error: GenericError<Self::Buf>) -> Result<Error<Self::Buf>, ParseError>;
+
+    /// Parse a generic event.
+    fn parse_event(&self, event: GenericEvent<Self::Buf>) -> Result<Event<Self::Buf>, ParseError>;
 
     /// Send all pending requests to the server.
     ///

--- a/src/extension_information.rs
+++ b/src/extension_information.rs
@@ -95,14 +95,16 @@ impl ExtensionInformation {
     /// This function returns an iterator that provides information about all the extensions that
     /// were queried and found to be present. Extensions that were not queried or which are not
     /// present are not returned.
-    pub fn known_present<'a>(&'a self) -> impl 'a + Iterator<Item=(&'static str, QueryExtensionReply)> {
-        self.0.iter()
-            .filter_map(|(name, state)|
-                        if let CheckState::Present(reply) = state {
-                            Some((*name, *reply))
-                        } else {
-                            None
-                        })
+    pub fn known_present<'a>(
+        &'a self,
+    ) -> impl 'a + Iterator<Item = (&'static str, QueryExtensionReply)> {
+        self.0.iter().filter_map(|(name, state)| {
+            if let CheckState::Present(reply) = state {
+                Some((*name, *reply))
+            } else {
+                None
+            }
+        })
     }
 }
 
@@ -121,7 +123,7 @@ mod test {
     use crate::x11_utils::GenericError;
     use crate::xproto::QueryExtensionReply;
 
-    use super::{ExtensionInformation, CheckState};
+    use super::{CheckState, ExtensionInformation};
 
     struct FakeConnection(RefCell<SequenceNumber>);
 

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -1,6 +1,9 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
+use crate::errors::ParseError;
+use crate::x11_utils::{Event, GenericError};
+use xproto::QueryExtensionReply;
 pub mod bigreq;
 #[cfg(feature = "composite")]
 pub mod composite;
@@ -59,3 +62,224 @@ pub mod xtest;
 pub mod xv;
 #[cfg(feature = "xvmc")]
 pub mod xvmc;
+
+/// Enumeration of all possible X11 errors.
+#[derive(Debug, Clone)]
+pub enum Error<B: std::fmt::Debug + AsRef<[u8]>> {
+    Unknown(GenericError<B>),
+    DamageBadDamageError(damage::BadDamageError),
+    GlxBadContextError(glx::BadContextError),
+    GlxBadContextStateError(glx::BadContextStateError),
+    GlxBadContextTagError(glx::BadContextTagError),
+    GlxBadCurrentDrawableError(glx::BadCurrentDrawableError),
+    GlxBadCurrentWindowError(glx::BadCurrentWindowError),
+    GlxBadDrawableError(glx::BadDrawableError),
+    GlxBadFBConfigError(glx::BadFBConfigError),
+    GlxBadLargeRequestError(glx::BadLargeRequestError),
+    GlxBadPbufferError(glx::BadPbufferError),
+    GlxBadPixmapError(glx::BadPixmapError),
+    GlxBadRenderRequestError(glx::BadRenderRequestError),
+    GlxBadWindowError(glx::BadWindowError),
+    GlxGLXBadProfileARBError(glx::GLXBadProfileARBError),
+    GlxUnsupportedPrivateRequestError(glx::UnsupportedPrivateRequestError),
+    RandrBadCrtcError(randr::BadCrtcError),
+    RandrBadModeError(randr::BadModeError),
+    RandrBadOutputError(randr::BadOutputError),
+    RandrBadProviderError(randr::BadProviderError),
+    RecordBadContextError(record::BadContextError),
+    RenderGlyphError(render::GlyphError),
+    RenderGlyphSetError(render::GlyphSetError),
+    RenderPictFormatError(render::PictFormatError),
+    RenderPictOpError(render::PictOpError),
+    RenderPictureError(render::PictureError),
+    ShmBadSegError(shm::BadSegError),
+    SyncAlarmError(sync::AlarmError),
+    SyncCounterError(sync::CounterError),
+    Xf86vidmodeBadClockError(xf86vidmode::BadClockError),
+    Xf86vidmodeBadHTimingsError(xf86vidmode::BadHTimingsError),
+    Xf86vidmodeBadVTimingsError(xf86vidmode::BadVTimingsError),
+    Xf86vidmodeClientNotLocalError(xf86vidmode::ClientNotLocalError),
+    Xf86vidmodeExtensionDisabledError(xf86vidmode::ExtensionDisabledError),
+    Xf86vidmodeModeUnsuitableError(xf86vidmode::ModeUnsuitableError),
+    Xf86vidmodeZoomLockedError(xf86vidmode::ZoomLockedError),
+    XfixesBadRegionError(xfixes::BadRegionError),
+    XinputClassError(xinput::ClassError),
+    XinputDeviceError(xinput::DeviceError),
+    XinputDeviceBusyError(xinput::DeviceBusyError),
+    XinputEventError(xinput::EventError),
+    XinputModeError(xinput::ModeError),
+    XkbKeyboardError(xkb::KeyboardError),
+    XprintBadContextError(xprint::BadContextError),
+    XprintBadSequenceError(xprint::BadSequenceError),
+    XprotoAccessError(xproto::AccessError),
+    XprotoAllocError(xproto::AllocError),
+    XprotoAtomError(xproto::AtomError),
+    XprotoColormapError(xproto::ColormapError),
+    XprotoCursorError(xproto::CursorError),
+    XprotoDrawableError(xproto::DrawableError),
+    XprotoFontError(xproto::FontError),
+    XprotoGContextError(xproto::GContextError),
+    XprotoIDChoiceError(xproto::IDChoiceError),
+    XprotoImplementationError(xproto::ImplementationError),
+    XprotoLengthError(xproto::LengthError),
+    XprotoMatchError(xproto::MatchError),
+    XprotoNameError(xproto::NameError),
+    XprotoPixmapError(xproto::PixmapError),
+    XprotoRequestError(xproto::RequestError),
+    XprotoValueError(xproto::ValueError),
+    XprotoWindowError(xproto::WindowError),
+    XvBadControlError(xv::BadControlError),
+    XvBadEncodingError(xv::BadEncodingError),
+    XvBadPortError(xv::BadPortError),
+}
+impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
+    /// Parse a generic X11 error into a concrete error type.
+    pub fn parse(
+        error: GenericError<B>,
+        iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,
+    ) -> Result<Self, ParseError> {
+        // Find the extension that this error could belong to
+        let error_code = error.error_code();
+        let bytes = error.raw_bytes();
+        // Check if this is a core protocol error
+        match error_code {
+            10 => return Ok(Self::XprotoAccessError(xproto::AccessError::try_parse(bytes)?.0)),
+            11 => return Ok(Self::XprotoAllocError(xproto::AllocError::try_parse(bytes)?.0)),
+            5 => return Ok(Self::XprotoAtomError(xproto::AtomError::try_parse(bytes)?.0)),
+            12 => return Ok(Self::XprotoColormapError(xproto::ColormapError::try_parse(bytes)?.0)),
+            6 => return Ok(Self::XprotoCursorError(xproto::CursorError::try_parse(bytes)?.0)),
+            9 => return Ok(Self::XprotoDrawableError(xproto::DrawableError::try_parse(bytes)?.0)),
+            7 => return Ok(Self::XprotoFontError(xproto::FontError::try_parse(bytes)?.0)),
+            13 => return Ok(Self::XprotoGContextError(xproto::GContextError::try_parse(bytes)?.0)),
+            14 => return Ok(Self::XprotoIDChoiceError(xproto::IDChoiceError::try_parse(bytes)?.0)),
+            17 => return Ok(Self::XprotoImplementationError(xproto::ImplementationError::try_parse(bytes)?.0)),
+            16 => return Ok(Self::XprotoLengthError(xproto::LengthError::try_parse(bytes)?.0)),
+            8 => return Ok(Self::XprotoMatchError(xproto::MatchError::try_parse(bytes)?.0)),
+            15 => return Ok(Self::XprotoNameError(xproto::NameError::try_parse(bytes)?.0)),
+            4 => return Ok(Self::XprotoPixmapError(xproto::PixmapError::try_parse(bytes)?.0)),
+            1 => return Ok(Self::XprotoRequestError(xproto::RequestError::try_parse(bytes)?.0)),
+            2 => return Ok(Self::XprotoValueError(xproto::ValueError::try_parse(bytes)?.0)),
+            3 => return Ok(Self::XprotoWindowError(xproto::WindowError::try_parse(bytes)?.0)),
+            _ => {}
+        }
+        let ext_info = iter
+            .map(|(name, reply)| (name, reply.first_error))
+            .filter(|&(_, first_error)| first_error <= error_code)
+            .max_by_key(|&(_, first_error)| first_error);
+        match ext_info {
+            Some(("DAMAGE", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::DamageBadDamageError(damage::BadDamageError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("GLX", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::GlxBadContextError(glx::BadContextError::try_parse(bytes)?.0)),
+                    1 => Ok(Self::GlxBadContextStateError(glx::BadContextStateError::try_parse(bytes)?.0)),
+                    4 => Ok(Self::GlxBadContextTagError(glx::BadContextTagError::try_parse(bytes)?.0)),
+                    11 => Ok(Self::GlxBadCurrentDrawableError(glx::BadCurrentDrawableError::try_parse(bytes)?.0)),
+                    5 => Ok(Self::GlxBadCurrentWindowError(glx::BadCurrentWindowError::try_parse(bytes)?.0)),
+                    2 => Ok(Self::GlxBadDrawableError(glx::BadDrawableError::try_parse(bytes)?.0)),
+                    9 => Ok(Self::GlxBadFBConfigError(glx::BadFBConfigError::try_parse(bytes)?.0)),
+                    7 => Ok(Self::GlxBadLargeRequestError(glx::BadLargeRequestError::try_parse(bytes)?.0)),
+                    10 => Ok(Self::GlxBadPbufferError(glx::BadPbufferError::try_parse(bytes)?.0)),
+                    3 => Ok(Self::GlxBadPixmapError(glx::BadPixmapError::try_parse(bytes)?.0)),
+                    6 => Ok(Self::GlxBadRenderRequestError(glx::BadRenderRequestError::try_parse(bytes)?.0)),
+                    12 => Ok(Self::GlxBadWindowError(glx::BadWindowError::try_parse(bytes)?.0)),
+                    13 => Ok(Self::GlxGLXBadProfileARBError(glx::GLXBadProfileARBError::try_parse(bytes)?.0)),
+                    8 => Ok(Self::GlxUnsupportedPrivateRequestError(glx::UnsupportedPrivateRequestError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("RANDR", first_error)) => {
+                match error_code - first_error {
+                    1 => Ok(Self::RandrBadCrtcError(randr::BadCrtcError::try_parse(bytes)?.0)),
+                    2 => Ok(Self::RandrBadModeError(randr::BadModeError::try_parse(bytes)?.0)),
+                    0 => Ok(Self::RandrBadOutputError(randr::BadOutputError::try_parse(bytes)?.0)),
+                    3 => Ok(Self::RandrBadProviderError(randr::BadProviderError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("RECORD", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::RecordBadContextError(record::BadContextError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("RENDER", first_error)) => {
+                match error_code - first_error {
+                    4 => Ok(Self::RenderGlyphError(render::GlyphError::try_parse(bytes)?.0)),
+                    3 => Ok(Self::RenderGlyphSetError(render::GlyphSetError::try_parse(bytes)?.0)),
+                    0 => Ok(Self::RenderPictFormatError(render::PictFormatError::try_parse(bytes)?.0)),
+                    2 => Ok(Self::RenderPictOpError(render::PictOpError::try_parse(bytes)?.0)),
+                    1 => Ok(Self::RenderPictureError(render::PictureError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("MIT-SHM", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::ShmBadSegError(shm::BadSegError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("SYNC", first_error)) => {
+                match error_code - first_error {
+                    1 => Ok(Self::SyncAlarmError(sync::AlarmError::try_parse(bytes)?.0)),
+                    0 => Ok(Self::SyncCounterError(sync::CounterError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("XFree86-VidModeExtension", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::Xf86vidmodeBadClockError(xf86vidmode::BadClockError::try_parse(bytes)?.0)),
+                    1 => Ok(Self::Xf86vidmodeBadHTimingsError(xf86vidmode::BadHTimingsError::try_parse(bytes)?.0)),
+                    2 => Ok(Self::Xf86vidmodeBadVTimingsError(xf86vidmode::BadVTimingsError::try_parse(bytes)?.0)),
+                    5 => Ok(Self::Xf86vidmodeClientNotLocalError(xf86vidmode::ClientNotLocalError::try_parse(bytes)?.0)),
+                    4 => Ok(Self::Xf86vidmodeExtensionDisabledError(xf86vidmode::ExtensionDisabledError::try_parse(bytes)?.0)),
+                    3 => Ok(Self::Xf86vidmodeModeUnsuitableError(xf86vidmode::ModeUnsuitableError::try_parse(bytes)?.0)),
+                    6 => Ok(Self::Xf86vidmodeZoomLockedError(xf86vidmode::ZoomLockedError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("XFIXES", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::XfixesBadRegionError(xfixes::BadRegionError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("XInputExtension", first_error)) => {
+                match error_code - first_error {
+                    4 => Ok(Self::XinputClassError(xinput::ClassError::try_parse(bytes)?.0)),
+                    0 => Ok(Self::XinputDeviceError(xinput::DeviceError::try_parse(bytes)?.0)),
+                    3 => Ok(Self::XinputDeviceBusyError(xinput::DeviceBusyError::try_parse(bytes)?.0)),
+                    1 => Ok(Self::XinputEventError(xinput::EventError::try_parse(bytes)?.0)),
+                    2 => Ok(Self::XinputModeError(xinput::ModeError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("XKEYBOARD", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::XkbKeyboardError(xkb::KeyboardError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("XpExtension", first_error)) => {
+                match error_code - first_error {
+                    0 => Ok(Self::XprintBadContextError(xprint::BadContextError::try_parse(bytes)?.0)),
+                    1 => Ok(Self::XprintBadSequenceError(xprint::BadSequenceError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            Some(("XVideo", first_error)) => {
+                match error_code - first_error {
+                    2 => Ok(Self::XvBadControlError(xv::BadControlError::try_parse(bytes)?.0)),
+                    1 => Ok(Self::XvBadEncodingError(xv::BadEncodingError::try_parse(bytes)?.0)),
+                    0 => Ok(Self::XvBadPortError(xv::BadPortError::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(error))
+                }
+            }
+            _ => Ok(Self::Unknown(error))
+        }
+    }
+}

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -190,23 +190,23 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
         let bytes = error.raw_bytes();
         // Check if this is a core protocol error
         match error_code {
-            10 => return Ok(Self::XprotoAccessError(xproto::AccessError::try_parse(bytes)?.0)),
-            11 => return Ok(Self::XprotoAllocError(xproto::AllocError::try_parse(bytes)?.0)),
-            5 => return Ok(Self::XprotoAtomError(xproto::AtomError::try_parse(bytes)?.0)),
-            12 => return Ok(Self::XprotoColormapError(xproto::ColormapError::try_parse(bytes)?.0)),
-            6 => return Ok(Self::XprotoCursorError(xproto::CursorError::try_parse(bytes)?.0)),
-            9 => return Ok(Self::XprotoDrawableError(xproto::DrawableError::try_parse(bytes)?.0)),
-            7 => return Ok(Self::XprotoFontError(xproto::FontError::try_parse(bytes)?.0)),
-            13 => return Ok(Self::XprotoGContextError(xproto::GContextError::try_parse(bytes)?.0)),
-            14 => return Ok(Self::XprotoIDChoiceError(xproto::IDChoiceError::try_parse(bytes)?.0)),
-            17 => return Ok(Self::XprotoImplementationError(xproto::ImplementationError::try_parse(bytes)?.0)),
-            16 => return Ok(Self::XprotoLengthError(xproto::LengthError::try_parse(bytes)?.0)),
-            8 => return Ok(Self::XprotoMatchError(xproto::MatchError::try_parse(bytes)?.0)),
-            15 => return Ok(Self::XprotoNameError(xproto::NameError::try_parse(bytes)?.0)),
-            4 => return Ok(Self::XprotoPixmapError(xproto::PixmapError::try_parse(bytes)?.0)),
-            1 => return Ok(Self::XprotoRequestError(xproto::RequestError::try_parse(bytes)?.0)),
-            2 => return Ok(Self::XprotoValueError(xproto::ValueError::try_parse(bytes)?.0)),
-            3 => return Ok(Self::XprotoWindowError(xproto::WindowError::try_parse(bytes)?.0)),
+            xproto::ACCESS_ERROR => return Ok(Self::XprotoAccessError(xproto::AccessError::try_parse(bytes)?.0)),
+            xproto::ALLOC_ERROR => return Ok(Self::XprotoAllocError(xproto::AllocError::try_parse(bytes)?.0)),
+            xproto::ATOM_ERROR => return Ok(Self::XprotoAtomError(xproto::AtomError::try_parse(bytes)?.0)),
+            xproto::COLORMAP_ERROR => return Ok(Self::XprotoColormapError(xproto::ColormapError::try_parse(bytes)?.0)),
+            xproto::CURSOR_ERROR => return Ok(Self::XprotoCursorError(xproto::CursorError::try_parse(bytes)?.0)),
+            xproto::DRAWABLE_ERROR => return Ok(Self::XprotoDrawableError(xproto::DrawableError::try_parse(bytes)?.0)),
+            xproto::FONT_ERROR => return Ok(Self::XprotoFontError(xproto::FontError::try_parse(bytes)?.0)),
+            xproto::G_CONTEXT_ERROR => return Ok(Self::XprotoGContextError(xproto::GContextError::try_parse(bytes)?.0)),
+            xproto::ID_CHOICE_ERROR => return Ok(Self::XprotoIDChoiceError(xproto::IDChoiceError::try_parse(bytes)?.0)),
+            xproto::IMPLEMENTATION_ERROR => return Ok(Self::XprotoImplementationError(xproto::ImplementationError::try_parse(bytes)?.0)),
+            xproto::LENGTH_ERROR => return Ok(Self::XprotoLengthError(xproto::LengthError::try_parse(bytes)?.0)),
+            xproto::MATCH_ERROR => return Ok(Self::XprotoMatchError(xproto::MatchError::try_parse(bytes)?.0)),
+            xproto::NAME_ERROR => return Ok(Self::XprotoNameError(xproto::NameError::try_parse(bytes)?.0)),
+            xproto::PIXMAP_ERROR => return Ok(Self::XprotoPixmapError(xproto::PixmapError::try_parse(bytes)?.0)),
+            xproto::REQUEST_ERROR => return Ok(Self::XprotoRequestError(xproto::RequestError::try_parse(bytes)?.0)),
+            xproto::VALUE_ERROR => return Ok(Self::XprotoValueError(xproto::ValueError::try_parse(bytes)?.0)),
+            xproto::WINDOW_ERROR => return Ok(Self::XprotoWindowError(xproto::WindowError::try_parse(bytes)?.0)),
             _ => {}
         }
         // Find the extension that this error could belong to
@@ -218,125 +218,125 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
             #[cfg(feature = "damage")]
             Some(("DAMAGE", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::DamageBadDamageError(damage::BadDamageError::try_parse(bytes)?.0)),
+                    damage::BAD_DAMAGE_ERROR => Ok(Self::DamageBadDamageError(damage::BadDamageError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "glx")]
             Some(("GLX", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::GlxBadContextError(glx::BadContextError::try_parse(bytes)?.0)),
-                    1 => Ok(Self::GlxBadContextStateError(glx::BadContextStateError::try_parse(bytes)?.0)),
-                    4 => Ok(Self::GlxBadContextTagError(glx::BadContextTagError::try_parse(bytes)?.0)),
-                    11 => Ok(Self::GlxBadCurrentDrawableError(glx::BadCurrentDrawableError::try_parse(bytes)?.0)),
-                    5 => Ok(Self::GlxBadCurrentWindowError(glx::BadCurrentWindowError::try_parse(bytes)?.0)),
-                    2 => Ok(Self::GlxBadDrawableError(glx::BadDrawableError::try_parse(bytes)?.0)),
-                    9 => Ok(Self::GlxBadFBConfigError(glx::BadFBConfigError::try_parse(bytes)?.0)),
-                    7 => Ok(Self::GlxBadLargeRequestError(glx::BadLargeRequestError::try_parse(bytes)?.0)),
-                    10 => Ok(Self::GlxBadPbufferError(glx::BadPbufferError::try_parse(bytes)?.0)),
-                    3 => Ok(Self::GlxBadPixmapError(glx::BadPixmapError::try_parse(bytes)?.0)),
-                    6 => Ok(Self::GlxBadRenderRequestError(glx::BadRenderRequestError::try_parse(bytes)?.0)),
-                    12 => Ok(Self::GlxBadWindowError(glx::BadWindowError::try_parse(bytes)?.0)),
-                    13 => Ok(Self::GlxGLXBadProfileARBError(glx::GLXBadProfileARBError::try_parse(bytes)?.0)),
-                    8 => Ok(Self::GlxUnsupportedPrivateRequestError(glx::UnsupportedPrivateRequestError::try_parse(bytes)?.0)),
+                    glx::BAD_CONTEXT_ERROR => Ok(Self::GlxBadContextError(glx::BadContextError::try_parse(bytes)?.0)),
+                    glx::BAD_CONTEXT_STATE_ERROR => Ok(Self::GlxBadContextStateError(glx::BadContextStateError::try_parse(bytes)?.0)),
+                    glx::BAD_CONTEXT_TAG_ERROR => Ok(Self::GlxBadContextTagError(glx::BadContextTagError::try_parse(bytes)?.0)),
+                    glx::BAD_CURRENT_DRAWABLE_ERROR => Ok(Self::GlxBadCurrentDrawableError(glx::BadCurrentDrawableError::try_parse(bytes)?.0)),
+                    glx::BAD_CURRENT_WINDOW_ERROR => Ok(Self::GlxBadCurrentWindowError(glx::BadCurrentWindowError::try_parse(bytes)?.0)),
+                    glx::BAD_DRAWABLE_ERROR => Ok(Self::GlxBadDrawableError(glx::BadDrawableError::try_parse(bytes)?.0)),
+                    glx::BAD_FB_CONFIG_ERROR => Ok(Self::GlxBadFBConfigError(glx::BadFBConfigError::try_parse(bytes)?.0)),
+                    glx::BAD_LARGE_REQUEST_ERROR => Ok(Self::GlxBadLargeRequestError(glx::BadLargeRequestError::try_parse(bytes)?.0)),
+                    glx::BAD_PBUFFER_ERROR => Ok(Self::GlxBadPbufferError(glx::BadPbufferError::try_parse(bytes)?.0)),
+                    glx::BAD_PIXMAP_ERROR => Ok(Self::GlxBadPixmapError(glx::BadPixmapError::try_parse(bytes)?.0)),
+                    glx::BAD_RENDER_REQUEST_ERROR => Ok(Self::GlxBadRenderRequestError(glx::BadRenderRequestError::try_parse(bytes)?.0)),
+                    glx::BAD_WINDOW_ERROR => Ok(Self::GlxBadWindowError(glx::BadWindowError::try_parse(bytes)?.0)),
+                    glx::GLX_BAD_PROFILE_ARB_ERROR => Ok(Self::GlxGLXBadProfileARBError(glx::GLXBadProfileARBError::try_parse(bytes)?.0)),
+                    glx::UNSUPPORTED_PRIVATE_REQUEST_ERROR => Ok(Self::GlxUnsupportedPrivateRequestError(glx::UnsupportedPrivateRequestError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "randr")]
             Some(("RANDR", first_error)) => {
                 match error_code - first_error {
-                    1 => Ok(Self::RandrBadCrtcError(randr::BadCrtcError::try_parse(bytes)?.0)),
-                    2 => Ok(Self::RandrBadModeError(randr::BadModeError::try_parse(bytes)?.0)),
-                    0 => Ok(Self::RandrBadOutputError(randr::BadOutputError::try_parse(bytes)?.0)),
-                    3 => Ok(Self::RandrBadProviderError(randr::BadProviderError::try_parse(bytes)?.0)),
+                    randr::BAD_CRTC_ERROR => Ok(Self::RandrBadCrtcError(randr::BadCrtcError::try_parse(bytes)?.0)),
+                    randr::BAD_MODE_ERROR => Ok(Self::RandrBadModeError(randr::BadModeError::try_parse(bytes)?.0)),
+                    randr::BAD_OUTPUT_ERROR => Ok(Self::RandrBadOutputError(randr::BadOutputError::try_parse(bytes)?.0)),
+                    randr::BAD_PROVIDER_ERROR => Ok(Self::RandrBadProviderError(randr::BadProviderError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "record")]
             Some(("RECORD", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::RecordBadContextError(record::BadContextError::try_parse(bytes)?.0)),
+                    record::BAD_CONTEXT_ERROR => Ok(Self::RecordBadContextError(record::BadContextError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "render")]
             Some(("RENDER", first_error)) => {
                 match error_code - first_error {
-                    4 => Ok(Self::RenderGlyphError(render::GlyphError::try_parse(bytes)?.0)),
-                    3 => Ok(Self::RenderGlyphSetError(render::GlyphSetError::try_parse(bytes)?.0)),
-                    0 => Ok(Self::RenderPictFormatError(render::PictFormatError::try_parse(bytes)?.0)),
-                    2 => Ok(Self::RenderPictOpError(render::PictOpError::try_parse(bytes)?.0)),
-                    1 => Ok(Self::RenderPictureError(render::PictureError::try_parse(bytes)?.0)),
+                    render::GLYPH_ERROR => Ok(Self::RenderGlyphError(render::GlyphError::try_parse(bytes)?.0)),
+                    render::GLYPH_SET_ERROR => Ok(Self::RenderGlyphSetError(render::GlyphSetError::try_parse(bytes)?.0)),
+                    render::PICT_FORMAT_ERROR => Ok(Self::RenderPictFormatError(render::PictFormatError::try_parse(bytes)?.0)),
+                    render::PICT_OP_ERROR => Ok(Self::RenderPictOpError(render::PictOpError::try_parse(bytes)?.0)),
+                    render::PICTURE_ERROR => Ok(Self::RenderPictureError(render::PictureError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "shm")]
             Some(("MIT-SHM", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::ShmBadSegError(shm::BadSegError::try_parse(bytes)?.0)),
+                    shm::BAD_SEG_ERROR => Ok(Self::ShmBadSegError(shm::BadSegError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "sync")]
             Some(("SYNC", first_error)) => {
                 match error_code - first_error {
-                    1 => Ok(Self::SyncAlarmError(sync::AlarmError::try_parse(bytes)?.0)),
-                    0 => Ok(Self::SyncCounterError(sync::CounterError::try_parse(bytes)?.0)),
+                    sync::ALARM_ERROR => Ok(Self::SyncAlarmError(sync::AlarmError::try_parse(bytes)?.0)),
+                    sync::COUNTER_ERROR => Ok(Self::SyncCounterError(sync::CounterError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xf86vidmode")]
             Some(("XFree86-VidModeExtension", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::Xf86vidmodeBadClockError(xf86vidmode::BadClockError::try_parse(bytes)?.0)),
-                    1 => Ok(Self::Xf86vidmodeBadHTimingsError(xf86vidmode::BadHTimingsError::try_parse(bytes)?.0)),
-                    2 => Ok(Self::Xf86vidmodeBadVTimingsError(xf86vidmode::BadVTimingsError::try_parse(bytes)?.0)),
-                    5 => Ok(Self::Xf86vidmodeClientNotLocalError(xf86vidmode::ClientNotLocalError::try_parse(bytes)?.0)),
-                    4 => Ok(Self::Xf86vidmodeExtensionDisabledError(xf86vidmode::ExtensionDisabledError::try_parse(bytes)?.0)),
-                    3 => Ok(Self::Xf86vidmodeModeUnsuitableError(xf86vidmode::ModeUnsuitableError::try_parse(bytes)?.0)),
-                    6 => Ok(Self::Xf86vidmodeZoomLockedError(xf86vidmode::ZoomLockedError::try_parse(bytes)?.0)),
+                    xf86vidmode::BAD_CLOCK_ERROR => Ok(Self::Xf86vidmodeBadClockError(xf86vidmode::BadClockError::try_parse(bytes)?.0)),
+                    xf86vidmode::BAD_H_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadHTimingsError(xf86vidmode::BadHTimingsError::try_parse(bytes)?.0)),
+                    xf86vidmode::BAD_V_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadVTimingsError(xf86vidmode::BadVTimingsError::try_parse(bytes)?.0)),
+                    xf86vidmode::CLIENT_NOT_LOCAL_ERROR => Ok(Self::Xf86vidmodeClientNotLocalError(xf86vidmode::ClientNotLocalError::try_parse(bytes)?.0)),
+                    xf86vidmode::EXTENSION_DISABLED_ERROR => Ok(Self::Xf86vidmodeExtensionDisabledError(xf86vidmode::ExtensionDisabledError::try_parse(bytes)?.0)),
+                    xf86vidmode::MODE_UNSUITABLE_ERROR => Ok(Self::Xf86vidmodeModeUnsuitableError(xf86vidmode::ModeUnsuitableError::try_parse(bytes)?.0)),
+                    xf86vidmode::ZOOM_LOCKED_ERROR => Ok(Self::Xf86vidmodeZoomLockedError(xf86vidmode::ZoomLockedError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xfixes")]
             Some(("XFIXES", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::XfixesBadRegionError(xfixes::BadRegionError::try_parse(bytes)?.0)),
+                    xfixes::BAD_REGION_ERROR => Ok(Self::XfixesBadRegionError(xfixes::BadRegionError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xinput")]
             Some(("XInputExtension", first_error)) => {
                 match error_code - first_error {
-                    4 => Ok(Self::XinputClassError(xinput::ClassError::try_parse(bytes)?.0)),
-                    0 => Ok(Self::XinputDeviceError(xinput::DeviceError::try_parse(bytes)?.0)),
-                    3 => Ok(Self::XinputDeviceBusyError(xinput::DeviceBusyError::try_parse(bytes)?.0)),
-                    1 => Ok(Self::XinputEventError(xinput::EventError::try_parse(bytes)?.0)),
-                    2 => Ok(Self::XinputModeError(xinput::ModeError::try_parse(bytes)?.0)),
+                    xinput::CLASS_ERROR => Ok(Self::XinputClassError(xinput::ClassError::try_parse(bytes)?.0)),
+                    xinput::DEVICE_ERROR => Ok(Self::XinputDeviceError(xinput::DeviceError::try_parse(bytes)?.0)),
+                    xinput::DEVICE_BUSY_ERROR => Ok(Self::XinputDeviceBusyError(xinput::DeviceBusyError::try_parse(bytes)?.0)),
+                    xinput::EVENT_ERROR => Ok(Self::XinputEventError(xinput::EventError::try_parse(bytes)?.0)),
+                    xinput::MODE_ERROR => Ok(Self::XinputModeError(xinput::ModeError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xkb")]
             Some(("XKEYBOARD", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::XkbKeyboardError(xkb::KeyboardError::try_parse(bytes)?.0)),
+                    xkb::KEYBOARD_ERROR => Ok(Self::XkbKeyboardError(xkb::KeyboardError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xprint")]
             Some(("XpExtension", first_error)) => {
                 match error_code - first_error {
-                    0 => Ok(Self::XprintBadContextError(xprint::BadContextError::try_parse(bytes)?.0)),
-                    1 => Ok(Self::XprintBadSequenceError(xprint::BadSequenceError::try_parse(bytes)?.0)),
+                    xprint::BAD_CONTEXT_ERROR => Ok(Self::XprintBadContextError(xprint::BadContextError::try_parse(bytes)?.0)),
+                    xprint::BAD_SEQUENCE_ERROR => Ok(Self::XprintBadSequenceError(xprint::BadSequenceError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xv")]
             Some(("XVideo", first_error)) => {
                 match error_code - first_error {
-                    2 => Ok(Self::XvBadControlError(xv::BadControlError::try_parse(bytes)?.0)),
-                    1 => Ok(Self::XvBadEncodingError(xv::BadEncodingError::try_parse(bytes)?.0)),
-                    0 => Ok(Self::XvBadPortError(xv::BadPortError::try_parse(bytes)?.0)),
+                    xv::BAD_CONTROL_ERROR => Ok(Self::XvBadControlError(xv::BadControlError::try_parse(bytes)?.0)),
+                    xv::BAD_ENCODING_ERROR => Ok(Self::XvBadEncodingError(xv::BadEncodingError::try_parse(bytes)?.0)),
+                    xv::BAD_PORT_ERROR => Ok(Self::XvBadPortError(xv::BadPortError::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(error))
                 }
             }
@@ -551,39 +551,39 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
         // Check if this is a core protocol error or from the generic event extension
         match event_type {
             0 => return Ok(Self::Error(Error::parse(event.try_into()?, iter)?)),
-            4 => return Ok(Self::XprotoButtonPressEvent(xproto::ButtonPressEvent::try_parse(bytes)?.0)),
-            5 => return Ok(Self::XprotoButtonReleaseEvent(xproto::ButtonReleaseEvent::try_parse(bytes)?.0)),
-            26 => return Ok(Self::XprotoCirculateNotifyEvent(xproto::CirculateNotifyEvent::try_parse(bytes)?.0)),
-            27 => return Ok(Self::XprotoCirculateRequestEvent(xproto::CirculateRequestEvent::try_parse(bytes)?.0)),
-            33 => return Ok(Self::XprotoClientMessageEvent(xproto::ClientMessageEvent::try_parse(bytes)?.0)),
-            32 => return Ok(Self::XprotoColormapNotifyEvent(xproto::ColormapNotifyEvent::try_parse(bytes)?.0)),
-            22 => return Ok(Self::XprotoConfigureNotifyEvent(xproto::ConfigureNotifyEvent::try_parse(bytes)?.0)),
-            23 => return Ok(Self::XprotoConfigureRequestEvent(xproto::ConfigureRequestEvent::try_parse(bytes)?.0)),
-            16 => return Ok(Self::XprotoCreateNotifyEvent(xproto::CreateNotifyEvent::try_parse(bytes)?.0)),
-            17 => return Ok(Self::XprotoDestroyNotifyEvent(xproto::DestroyNotifyEvent::try_parse(bytes)?.0)),
-            7 => return Ok(Self::XprotoEnterNotifyEvent(xproto::EnterNotifyEvent::try_parse(bytes)?.0)),
-            12 => return Ok(Self::XprotoExposeEvent(xproto::ExposeEvent::try_parse(bytes)?.0)),
-            9 => return Ok(Self::XprotoFocusInEvent(xproto::FocusInEvent::try_parse(bytes)?.0)),
-            10 => return Ok(Self::XprotoFocusOutEvent(xproto::FocusOutEvent::try_parse(bytes)?.0)),
-            13 => return Ok(Self::XprotoGraphicsExposureEvent(xproto::GraphicsExposureEvent::try_parse(bytes)?.0)),
-            24 => return Ok(Self::XprotoGravityNotifyEvent(xproto::GravityNotifyEvent::try_parse(bytes)?.0)),
-            2 => return Ok(Self::XprotoKeyPressEvent(xproto::KeyPressEvent::try_parse(bytes)?.0)),
-            3 => return Ok(Self::XprotoKeyReleaseEvent(xproto::KeyReleaseEvent::try_parse(bytes)?.0)),
-            11 => return Ok(Self::XprotoKeymapNotifyEvent(xproto::KeymapNotifyEvent::try_parse(bytes)?.0)),
-            8 => return Ok(Self::XprotoLeaveNotifyEvent(xproto::LeaveNotifyEvent::try_parse(bytes)?.0)),
-            19 => return Ok(Self::XprotoMapNotifyEvent(xproto::MapNotifyEvent::try_parse(bytes)?.0)),
-            20 => return Ok(Self::XprotoMapRequestEvent(xproto::MapRequestEvent::try_parse(bytes)?.0)),
-            34 => return Ok(Self::XprotoMappingNotifyEvent(xproto::MappingNotifyEvent::try_parse(bytes)?.0)),
-            6 => return Ok(Self::XprotoMotionNotifyEvent(xproto::MotionNotifyEvent::try_parse(bytes)?.0)),
-            14 => return Ok(Self::XprotoNoExposureEvent(xproto::NoExposureEvent::try_parse(bytes)?.0)),
-            28 => return Ok(Self::XprotoPropertyNotifyEvent(xproto::PropertyNotifyEvent::try_parse(bytes)?.0)),
-            21 => return Ok(Self::XprotoReparentNotifyEvent(xproto::ReparentNotifyEvent::try_parse(bytes)?.0)),
-            25 => return Ok(Self::XprotoResizeRequestEvent(xproto::ResizeRequestEvent::try_parse(bytes)?.0)),
-            29 => return Ok(Self::XprotoSelectionClearEvent(xproto::SelectionClearEvent::try_parse(bytes)?.0)),
-            31 => return Ok(Self::XprotoSelectionNotifyEvent(xproto::SelectionNotifyEvent::try_parse(bytes)?.0)),
-            30 => return Ok(Self::XprotoSelectionRequestEvent(xproto::SelectionRequestEvent::try_parse(bytes)?.0)),
-            18 => return Ok(Self::XprotoUnmapNotifyEvent(xproto::UnmapNotifyEvent::try_parse(bytes)?.0)),
-            15 => return Ok(Self::XprotoVisibilityNotifyEvent(xproto::VisibilityNotifyEvent::try_parse(bytes)?.0)),
+            xproto::BUTTON_PRESS_EVENT => return Ok(Self::XprotoButtonPressEvent(xproto::ButtonPressEvent::try_parse(bytes)?.0)),
+            xproto::BUTTON_RELEASE_EVENT => return Ok(Self::XprotoButtonReleaseEvent(xproto::ButtonReleaseEvent::try_parse(bytes)?.0)),
+            xproto::CIRCULATE_NOTIFY_EVENT => return Ok(Self::XprotoCirculateNotifyEvent(xproto::CirculateNotifyEvent::try_parse(bytes)?.0)),
+            xproto::CIRCULATE_REQUEST_EVENT => return Ok(Self::XprotoCirculateRequestEvent(xproto::CirculateRequestEvent::try_parse(bytes)?.0)),
+            xproto::CLIENT_MESSAGE_EVENT => return Ok(Self::XprotoClientMessageEvent(xproto::ClientMessageEvent::try_parse(bytes)?.0)),
+            xproto::COLORMAP_NOTIFY_EVENT => return Ok(Self::XprotoColormapNotifyEvent(xproto::ColormapNotifyEvent::try_parse(bytes)?.0)),
+            xproto::CONFIGURE_NOTIFY_EVENT => return Ok(Self::XprotoConfigureNotifyEvent(xproto::ConfigureNotifyEvent::try_parse(bytes)?.0)),
+            xproto::CONFIGURE_REQUEST_EVENT => return Ok(Self::XprotoConfigureRequestEvent(xproto::ConfigureRequestEvent::try_parse(bytes)?.0)),
+            xproto::CREATE_NOTIFY_EVENT => return Ok(Self::XprotoCreateNotifyEvent(xproto::CreateNotifyEvent::try_parse(bytes)?.0)),
+            xproto::DESTROY_NOTIFY_EVENT => return Ok(Self::XprotoDestroyNotifyEvent(xproto::DestroyNotifyEvent::try_parse(bytes)?.0)),
+            xproto::ENTER_NOTIFY_EVENT => return Ok(Self::XprotoEnterNotifyEvent(xproto::EnterNotifyEvent::try_parse(bytes)?.0)),
+            xproto::EXPOSE_EVENT => return Ok(Self::XprotoExposeEvent(xproto::ExposeEvent::try_parse(bytes)?.0)),
+            xproto::FOCUS_IN_EVENT => return Ok(Self::XprotoFocusInEvent(xproto::FocusInEvent::try_parse(bytes)?.0)),
+            xproto::FOCUS_OUT_EVENT => return Ok(Self::XprotoFocusOutEvent(xproto::FocusOutEvent::try_parse(bytes)?.0)),
+            xproto::GRAPHICS_EXPOSURE_EVENT => return Ok(Self::XprotoGraphicsExposureEvent(xproto::GraphicsExposureEvent::try_parse(bytes)?.0)),
+            xproto::GRAVITY_NOTIFY_EVENT => return Ok(Self::XprotoGravityNotifyEvent(xproto::GravityNotifyEvent::try_parse(bytes)?.0)),
+            xproto::KEY_PRESS_EVENT => return Ok(Self::XprotoKeyPressEvent(xproto::KeyPressEvent::try_parse(bytes)?.0)),
+            xproto::KEY_RELEASE_EVENT => return Ok(Self::XprotoKeyReleaseEvent(xproto::KeyReleaseEvent::try_parse(bytes)?.0)),
+            xproto::KEYMAP_NOTIFY_EVENT => return Ok(Self::XprotoKeymapNotifyEvent(xproto::KeymapNotifyEvent::try_parse(bytes)?.0)),
+            xproto::LEAVE_NOTIFY_EVENT => return Ok(Self::XprotoLeaveNotifyEvent(xproto::LeaveNotifyEvent::try_parse(bytes)?.0)),
+            xproto::MAP_NOTIFY_EVENT => return Ok(Self::XprotoMapNotifyEvent(xproto::MapNotifyEvent::try_parse(bytes)?.0)),
+            xproto::MAP_REQUEST_EVENT => return Ok(Self::XprotoMapRequestEvent(xproto::MapRequestEvent::try_parse(bytes)?.0)),
+            xproto::MAPPING_NOTIFY_EVENT => return Ok(Self::XprotoMappingNotifyEvent(xproto::MappingNotifyEvent::try_parse(bytes)?.0)),
+            xproto::MOTION_NOTIFY_EVENT => return Ok(Self::XprotoMotionNotifyEvent(xproto::MotionNotifyEvent::try_parse(bytes)?.0)),
+            xproto::NO_EXPOSURE_EVENT => return Ok(Self::XprotoNoExposureEvent(xproto::NoExposureEvent::try_parse(bytes)?.0)),
+            xproto::PROPERTY_NOTIFY_EVENT => return Ok(Self::XprotoPropertyNotifyEvent(xproto::PropertyNotifyEvent::try_parse(bytes)?.0)),
+            xproto::REPARENT_NOTIFY_EVENT => return Ok(Self::XprotoReparentNotifyEvent(xproto::ReparentNotifyEvent::try_parse(bytes)?.0)),
+            xproto::RESIZE_REQUEST_EVENT => return Ok(Self::XprotoResizeRequestEvent(xproto::ResizeRequestEvent::try_parse(bytes)?.0)),
+            xproto::SELECTION_CLEAR_EVENT => return Ok(Self::XprotoSelectionClearEvent(xproto::SelectionClearEvent::try_parse(bytes)?.0)),
+            xproto::SELECTION_NOTIFY_EVENT => return Ok(Self::XprotoSelectionNotifyEvent(xproto::SelectionNotifyEvent::try_parse(bytes)?.0)),
+            xproto::SELECTION_REQUEST_EVENT => return Ok(Self::XprotoSelectionRequestEvent(xproto::SelectionRequestEvent::try_parse(bytes)?.0)),
+            xproto::UNMAP_NOTIFY_EVENT => return Ok(Self::XprotoUnmapNotifyEvent(xproto::UnmapNotifyEvent::try_parse(bytes)?.0)),
+            xproto::VISIBILITY_NOTIFY_EVENT => return Ok(Self::XprotoVisibilityNotifyEvent(xproto::VisibilityNotifyEvent::try_parse(bytes)?.0)),
             xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, iter),
             _ => {}
         }
@@ -596,132 +596,132 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
             #[cfg(feature = "damage")]
             Some(("DAMAGE", first_event)) => {
                 match event_type - first_event {
-                    0 => Ok(Self::DamageNotifyEvent(damage::NotifyEvent::try_parse(bytes)?.0)),
+                    damage::NOTIFY_EVENT => Ok(Self::DamageNotifyEvent(damage::NotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "dri2")]
             Some(("DRI2", first_event)) => {
                 match event_type - first_event {
-                    0 => Ok(Self::Dri2BufferSwapCompleteEvent(dri2::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
-                    1 => Ok(Self::Dri2InvalidateBuffersEvent(dri2::InvalidateBuffersEvent::try_parse(bytes)?.0)),
+                    dri2::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::Dri2BufferSwapCompleteEvent(dri2::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
+                    dri2::INVALIDATE_BUFFERS_EVENT => Ok(Self::Dri2InvalidateBuffersEvent(dri2::InvalidateBuffersEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "glx")]
             Some(("GLX", first_event)) => {
                 match event_type - first_event {
-                    1 => Ok(Self::GlxBufferSwapCompleteEvent(glx::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::GlxPbufferClobberEvent(glx::PbufferClobberEvent::try_parse(bytes)?.0)),
+                    glx::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::GlxBufferSwapCompleteEvent(glx::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
+                    glx::PBUFFER_CLOBBER_EVENT => Ok(Self::GlxPbufferClobberEvent(glx::PbufferClobberEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "present")]
             Some(("Present", first_event)) => {
                 match event_type - first_event {
-                    0 => Ok(Self::PresentGenericEvent(present::GenericEvent::try_parse(bytes)?.0)),
+                    present::GENERIC_EVENT => Ok(Self::PresentGenericEvent(present::GenericEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "randr")]
             Some(("RANDR", first_event)) => {
                 match event_type - first_event {
-                    1 => Ok(Self::RandrNotifyEvent(randr::NotifyEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::RandrScreenChangeNotifyEvent(randr::ScreenChangeNotifyEvent::try_parse(bytes)?.0)),
+                    randr::NOTIFY_EVENT => Ok(Self::RandrNotifyEvent(randr::NotifyEvent::try_parse(bytes)?.0)),
+                    randr::SCREEN_CHANGE_NOTIFY_EVENT => Ok(Self::RandrScreenChangeNotifyEvent(randr::ScreenChangeNotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "screensaver")]
             Some(("MIT-SCREEN-SAVER", first_event)) => {
                 match event_type - first_event {
-                    0 => Ok(Self::ScreensaverNotifyEvent(screensaver::NotifyEvent::try_parse(bytes)?.0)),
+                    screensaver::NOTIFY_EVENT => Ok(Self::ScreensaverNotifyEvent(screensaver::NotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "shape")]
             Some(("SHAPE", first_event)) => {
                 match event_type - first_event {
-                    0 => Ok(Self::ShapeNotifyEvent(shape::NotifyEvent::try_parse(bytes)?.0)),
+                    shape::NOTIFY_EVENT => Ok(Self::ShapeNotifyEvent(shape::NotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "shm")]
             Some(("MIT-SHM", first_event)) => {
                 match event_type - first_event {
-                    0 => Ok(Self::ShmCompletionEvent(shm::CompletionEvent::try_parse(bytes)?.0)),
+                    shm::COMPLETION_EVENT => Ok(Self::ShmCompletionEvent(shm::CompletionEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "sync")]
             Some(("SYNC", first_event)) => {
                 match event_type - first_event {
-                    1 => Ok(Self::SyncAlarmNotifyEvent(sync::AlarmNotifyEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::SyncCounterNotifyEvent(sync::CounterNotifyEvent::try_parse(bytes)?.0)),
+                    sync::ALARM_NOTIFY_EVENT => Ok(Self::SyncAlarmNotifyEvent(sync::AlarmNotifyEvent::try_parse(bytes)?.0)),
+                    sync::COUNTER_NOTIFY_EVENT => Ok(Self::SyncCounterNotifyEvent(sync::CounterNotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xfixes")]
             Some(("XFIXES", first_event)) => {
                 match event_type - first_event {
-                    1 => Ok(Self::XfixesCursorNotifyEvent(xfixes::CursorNotifyEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::XfixesSelectionNotifyEvent(xfixes::SelectionNotifyEvent::try_parse(bytes)?.0)),
+                    xfixes::CURSOR_NOTIFY_EVENT => Ok(Self::XfixesCursorNotifyEvent(xfixes::CursorNotifyEvent::try_parse(bytes)?.0)),
+                    xfixes::SELECTION_NOTIFY_EVENT => Ok(Self::XfixesSelectionNotifyEvent(xfixes::SelectionNotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xinput")]
             Some(("XInputExtension", first_event)) => {
                 match event_type - first_event {
-                    12 => Ok(Self::XinputChangeDeviceNotifyEvent(xinput::ChangeDeviceNotifyEvent::try_parse(bytes)?.0)),
-                    3 => Ok(Self::XinputDeviceButtonPressEvent(xinput::DeviceButtonPressEvent::try_parse(bytes)?.0)),
-                    4 => Ok(Self::XinputDeviceButtonReleaseEvent(xinput::DeviceButtonReleaseEvent::try_parse(bytes)?.0)),
-                    14 => Ok(Self::XinputDeviceButtonStateNotifyEvent(xinput::DeviceButtonStateNotifyEvent::try_parse(bytes)?.0)),
-                    6 => Ok(Self::XinputDeviceFocusInEvent(xinput::DeviceFocusInEvent::try_parse(bytes)?.0)),
-                    7 => Ok(Self::XinputDeviceFocusOutEvent(xinput::DeviceFocusOutEvent::try_parse(bytes)?.0)),
-                    1 => Ok(Self::XinputDeviceKeyPressEvent(xinput::DeviceKeyPressEvent::try_parse(bytes)?.0)),
-                    2 => Ok(Self::XinputDeviceKeyReleaseEvent(xinput::DeviceKeyReleaseEvent::try_parse(bytes)?.0)),
-                    13 => Ok(Self::XinputDeviceKeyStateNotifyEvent(xinput::DeviceKeyStateNotifyEvent::try_parse(bytes)?.0)),
-                    11 => Ok(Self::XinputDeviceMappingNotifyEvent(xinput::DeviceMappingNotifyEvent::try_parse(bytes)?.0)),
-                    5 => Ok(Self::XinputDeviceMotionNotifyEvent(xinput::DeviceMotionNotifyEvent::try_parse(bytes)?.0)),
-                    15 => Ok(Self::XinputDevicePresenceNotifyEvent(xinput::DevicePresenceNotifyEvent::try_parse(bytes)?.0)),
-                    16 => Ok(Self::XinputDevicePropertyNotifyEvent(xinput::DevicePropertyNotifyEvent::try_parse(bytes)?.0)),
-                    10 => Ok(Self::XinputDeviceStateNotifyEvent(xinput::DeviceStateNotifyEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::XinputDeviceValuatorEvent(xinput::DeviceValuatorEvent::try_parse(bytes)?.0)),
-                    8 => Ok(Self::XinputProximityInEvent(xinput::ProximityInEvent::try_parse(bytes)?.0)),
-                    9 => Ok(Self::XinputProximityOutEvent(xinput::ProximityOutEvent::try_parse(bytes)?.0)),
+                    xinput::CHANGE_DEVICE_NOTIFY_EVENT => Ok(Self::XinputChangeDeviceNotifyEvent(xinput::ChangeDeviceNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_BUTTON_PRESS_EVENT => Ok(Self::XinputDeviceButtonPressEvent(xinput::DeviceButtonPressEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_BUTTON_RELEASE_EVENT => Ok(Self::XinputDeviceButtonReleaseEvent(xinput::DeviceButtonReleaseEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_BUTTON_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceButtonStateNotifyEvent(xinput::DeviceButtonStateNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_FOCUS_IN_EVENT => Ok(Self::XinputDeviceFocusInEvent(xinput::DeviceFocusInEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_FOCUS_OUT_EVENT => Ok(Self::XinputDeviceFocusOutEvent(xinput::DeviceFocusOutEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_KEY_PRESS_EVENT => Ok(Self::XinputDeviceKeyPressEvent(xinput::DeviceKeyPressEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_KEY_RELEASE_EVENT => Ok(Self::XinputDeviceKeyReleaseEvent(xinput::DeviceKeyReleaseEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_KEY_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceKeyStateNotifyEvent(xinput::DeviceKeyStateNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_MAPPING_NOTIFY_EVENT => Ok(Self::XinputDeviceMappingNotifyEvent(xinput::DeviceMappingNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_MOTION_NOTIFY_EVENT => Ok(Self::XinputDeviceMotionNotifyEvent(xinput::DeviceMotionNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_PRESENCE_NOTIFY_EVENT => Ok(Self::XinputDevicePresenceNotifyEvent(xinput::DevicePresenceNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_PROPERTY_NOTIFY_EVENT => Ok(Self::XinputDevicePropertyNotifyEvent(xinput::DevicePropertyNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceStateNotifyEvent(xinput::DeviceStateNotifyEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_VALUATOR_EVENT => Ok(Self::XinputDeviceValuatorEvent(xinput::DeviceValuatorEvent::try_parse(bytes)?.0)),
+                    xinput::PROXIMITY_IN_EVENT => Ok(Self::XinputProximityInEvent(xinput::ProximityInEvent::try_parse(bytes)?.0)),
+                    xinput::PROXIMITY_OUT_EVENT => Ok(Self::XinputProximityOutEvent(xinput::ProximityOutEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xkb")]
             Some(("XKEYBOARD", first_event)) => {
                 match event_type - first_event {
-                    10 => Ok(Self::XkbAccessXNotifyEvent(xkb::AccessXNotifyEvent::try_parse(bytes)?.0)),
-                    9 => Ok(Self::XkbActionMessageEvent(xkb::ActionMessageEvent::try_parse(bytes)?.0)),
-                    8 => Ok(Self::XkbBellNotifyEvent(xkb::BellNotifyEvent::try_parse(bytes)?.0)),
-                    7 => Ok(Self::XkbCompatMapNotifyEvent(xkb::CompatMapNotifyEvent::try_parse(bytes)?.0)),
-                    3 => Ok(Self::XkbControlsNotifyEvent(xkb::ControlsNotifyEvent::try_parse(bytes)?.0)),
-                    11 => Ok(Self::XkbExtensionDeviceNotifyEvent(xkb::ExtensionDeviceNotifyEvent::try_parse(bytes)?.0)),
-                    5 => Ok(Self::XkbIndicatorMapNotifyEvent(xkb::IndicatorMapNotifyEvent::try_parse(bytes)?.0)),
-                    4 => Ok(Self::XkbIndicatorStateNotifyEvent(xkb::IndicatorStateNotifyEvent::try_parse(bytes)?.0)),
-                    1 => Ok(Self::XkbMapNotifyEvent(xkb::MapNotifyEvent::try_parse(bytes)?.0)),
-                    6 => Ok(Self::XkbNamesNotifyEvent(xkb::NamesNotifyEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::XkbNewKeyboardNotifyEvent(xkb::NewKeyboardNotifyEvent::try_parse(bytes)?.0)),
-                    2 => Ok(Self::XkbStateNotifyEvent(xkb::StateNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::ACCESS_X_NOTIFY_EVENT => Ok(Self::XkbAccessXNotifyEvent(xkb::AccessXNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::ACTION_MESSAGE_EVENT => Ok(Self::XkbActionMessageEvent(xkb::ActionMessageEvent::try_parse(bytes)?.0)),
+                    xkb::BELL_NOTIFY_EVENT => Ok(Self::XkbBellNotifyEvent(xkb::BellNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::COMPAT_MAP_NOTIFY_EVENT => Ok(Self::XkbCompatMapNotifyEvent(xkb::CompatMapNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::CONTROLS_NOTIFY_EVENT => Ok(Self::XkbControlsNotifyEvent(xkb::ControlsNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::EXTENSION_DEVICE_NOTIFY_EVENT => Ok(Self::XkbExtensionDeviceNotifyEvent(xkb::ExtensionDeviceNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::INDICATOR_MAP_NOTIFY_EVENT => Ok(Self::XkbIndicatorMapNotifyEvent(xkb::IndicatorMapNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::INDICATOR_STATE_NOTIFY_EVENT => Ok(Self::XkbIndicatorStateNotifyEvent(xkb::IndicatorStateNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::MAP_NOTIFY_EVENT => Ok(Self::XkbMapNotifyEvent(xkb::MapNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::NAMES_NOTIFY_EVENT => Ok(Self::XkbNamesNotifyEvent(xkb::NamesNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::NEW_KEYBOARD_NOTIFY_EVENT => Ok(Self::XkbNewKeyboardNotifyEvent(xkb::NewKeyboardNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::STATE_NOTIFY_EVENT => Ok(Self::XkbStateNotifyEvent(xkb::StateNotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xprint")]
             Some(("XpExtension", first_event)) => {
                 match event_type - first_event {
-                    1 => Ok(Self::XprintAttributNotifyEvent(xprint::AttributNotifyEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::XprintNotifyEvent(xprint::NotifyEvent::try_parse(bytes)?.0)),
+                    xprint::ATTRIBUT_NOTIFY_EVENT => Ok(Self::XprintAttributNotifyEvent(xprint::AttributNotifyEvent::try_parse(bytes)?.0)),
+                    xprint::NOTIFY_EVENT => Ok(Self::XprintNotifyEvent(xprint::NotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xv")]
             Some(("XVideo", first_event)) => {
                 match event_type - first_event {
-                    1 => Ok(Self::XvPortNotifyEvent(xv::PortNotifyEvent::try_parse(bytes)?.0)),
-                    0 => Ok(Self::XvVideoNotifyEvent(xv::VideoNotifyEvent::try_parse(bytes)?.0)),
+                    xv::PORT_NOTIFY_EVENT => Ok(Self::XvPortNotifyEvent(xv::PortNotifyEvent::try_parse(bytes)?.0)),
+                    xv::VIDEO_NOTIFY_EVENT => Ok(Self::XvVideoNotifyEvent(xv::VideoNotifyEvent::try_parse(bytes)?.0)),
                     _ => Ok(Self::Unknown(event))
                 }
             }

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -736,6 +736,7 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
     ) -> Result<Self, ParseError> {
         let bytes = event.raw_bytes();
         let ge_event = xproto::GeGenericEvent::try_from(bytes)?;
+        #[allow(unused_variables)]
         let (extension, event_type) = (ge_event.extension, ge_event.event_type);
         let ext_name = iter
             .map(|(name, reply)| (name, reply.major_opcode))

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -693,7 +693,10 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
             }
             #[cfg(feature = "xkb")]
             Some(("XKEYBOARD", first_event)) => {
-                match event_type - first_event {
+                if event_type != first_event {
+                    return Ok(Self::Unknown(event));
+                }
+                match event.raw_bytes()[1] {
                     xkb::ACCESS_X_NOTIFY_EVENT => Ok(Self::XkbAccessXNotifyEvent(xkb::AccessXNotifyEvent::try_parse(bytes)?.0)),
                     xkb::ACTION_MESSAGE_EVENT => Ok(Self::XkbActionMessageEvent(xkb::ActionMessageEvent::try_parse(bytes)?.0)),
                     xkb::BELL_NOTIFY_EVENT => Ok(Self::XkbBellNotifyEvent(xkb::BellNotifyEvent::try_parse(bytes)?.0)),

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -1,7 +1,7 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use crate::errors::ParseError;
 use crate::x11_utils::{Event as _, GenericError, GenericEvent};
 use xproto::QueryExtensionReply;
@@ -736,6 +736,57 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
         event: GenericEvent<B>,
         iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,
     ) -> Result<Self, ParseError> {
-        todo!()
+        let bytes = event.raw_bytes();
+        let ge_event = xproto::GeGenericEvent::try_from(bytes)?;
+        let (extension, event_type) = (ge_event.extension, ge_event.event_type);
+        let ext_name = iter
+            .map(|(name, reply)| (name, reply.major_opcode))
+            .find(|&(_, opcode)| extension == opcode)
+            .map(|(name, _)| name);
+        match ext_name {
+            #[cfg(feature = "present")]
+            Some("Present") => {
+                match event_type {
+                    present::COMPLETE_NOTIFY_EVENT => Ok(Self::PresentCompleteNotifyEvent(present::CompleteNotifyEvent::try_parse(bytes)?.0)),
+                    present::CONFIGURE_NOTIFY_EVENT => Ok(Self::PresentConfigureNotifyEvent(present::ConfigureNotifyEvent::try_parse(bytes)?.0)),
+                    present::IDLE_NOTIFY_EVENT => Ok(Self::PresentIdleNotifyEvent(present::IdleNotifyEvent::try_parse(bytes)?.0)),
+                    present::REDIRECT_NOTIFY_EVENT => Ok(Self::PresentRedirectNotifyEvent(present::RedirectNotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "xinput")]
+            Some("XInputExtension") => {
+                match event_type {
+                    xinput::BARRIER_HIT_EVENT => Ok(Self::XinputBarrierHitEvent(xinput::BarrierHitEvent::try_parse(bytes)?.0)),
+                    xinput::BARRIER_LEAVE_EVENT => Ok(Self::XinputBarrierLeaveEvent(xinput::BarrierLeaveEvent::try_parse(bytes)?.0)),
+                    xinput::BUTTON_PRESS_EVENT => Ok(Self::XinputButtonPressEvent(xinput::ButtonPressEvent::try_parse(bytes)?.0)),
+                    xinput::BUTTON_RELEASE_EVENT => Ok(Self::XinputButtonReleaseEvent(xinput::ButtonReleaseEvent::try_parse(bytes)?.0)),
+                    xinput::DEVICE_CHANGED_EVENT => Ok(Self::XinputDeviceChangedEvent(xinput::DeviceChangedEvent::try_parse(bytes)?.0)),
+                    xinput::ENTER_EVENT => Ok(Self::XinputEnterEvent(xinput::EnterEvent::try_parse(bytes)?.0)),
+                    xinput::FOCUS_IN_EVENT => Ok(Self::XinputFocusInEvent(xinput::FocusInEvent::try_parse(bytes)?.0)),
+                    xinput::FOCUS_OUT_EVENT => Ok(Self::XinputFocusOutEvent(xinput::FocusOutEvent::try_parse(bytes)?.0)),
+                    xinput::HIERARCHY_EVENT => Ok(Self::XinputHierarchyEvent(xinput::HierarchyEvent::try_parse(bytes)?.0)),
+                    xinput::KEY_PRESS_EVENT => Ok(Self::XinputKeyPressEvent(xinput::KeyPressEvent::try_parse(bytes)?.0)),
+                    xinput::KEY_RELEASE_EVENT => Ok(Self::XinputKeyReleaseEvent(xinput::KeyReleaseEvent::try_parse(bytes)?.0)),
+                    xinput::LEAVE_EVENT => Ok(Self::XinputLeaveEvent(xinput::LeaveEvent::try_parse(bytes)?.0)),
+                    xinput::MOTION_EVENT => Ok(Self::XinputMotionEvent(xinput::MotionEvent::try_parse(bytes)?.0)),
+                    xinput::PROPERTY_EVENT => Ok(Self::XinputPropertyEvent(xinput::PropertyEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_BUTTON_PRESS_EVENT => Ok(Self::XinputRawButtonPressEvent(xinput::RawButtonPressEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_BUTTON_RELEASE_EVENT => Ok(Self::XinputRawButtonReleaseEvent(xinput::RawButtonReleaseEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_KEY_PRESS_EVENT => Ok(Self::XinputRawKeyPressEvent(xinput::RawKeyPressEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_KEY_RELEASE_EVENT => Ok(Self::XinputRawKeyReleaseEvent(xinput::RawKeyReleaseEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_MOTION_EVENT => Ok(Self::XinputRawMotionEvent(xinput::RawMotionEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_TOUCH_BEGIN_EVENT => Ok(Self::XinputRawTouchBeginEvent(xinput::RawTouchBeginEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_TOUCH_END_EVENT => Ok(Self::XinputRawTouchEndEvent(xinput::RawTouchEndEvent::try_parse(bytes)?.0)),
+                    xinput::RAW_TOUCH_UPDATE_EVENT => Ok(Self::XinputRawTouchUpdateEvent(xinput::RawTouchUpdateEvent::try_parse(bytes)?.0)),
+                    xinput::TOUCH_BEGIN_EVENT => Ok(Self::XinputTouchBeginEvent(xinput::TouchBeginEvent::try_parse(bytes)?.0)),
+                    xinput::TOUCH_END_EVENT => Ok(Self::XinputTouchEndEvent(xinput::TouchEndEvent::try_parse(bytes)?.0)),
+                    xinput::TOUCH_OWNERSHIP_EVENT => Ok(Self::XinputTouchOwnershipEvent(xinput::TouchOwnershipEvent::try_parse(bytes)?.0)),
+                    xinput::TOUCH_UPDATE_EVENT => Ok(Self::XinputTouchUpdateEvent(xinput::TouchUpdateEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            _ => Ok(Self::Unknown(event))
+        }
     }
 }

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -1,8 +1,9 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
+use std::convert::TryInto;
 use crate::errors::ParseError;
-use crate::x11_utils::{Event, GenericError};
+use crate::x11_utils::{Event as _, GenericError, GenericEvent};
 use xproto::QueryExtensionReply;
 pub mod bigreq;
 #[cfg(feature = "composite")]
@@ -341,5 +342,397 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
             }
             _ => Ok(Self::Unknown(error))
         }
+    }
+}
+/// Enumeration of all possible X11 events.
+#[derive(Debug, Clone)]
+pub enum Event<B: std::fmt::Debug + AsRef<[u8]>> {
+    Unknown(GenericEvent<B>),
+    Error(Error<B>),
+    #[cfg(feature = "damage")]
+    DamageNotifyEvent(damage::NotifyEvent),
+    #[cfg(feature = "dri2")]
+    Dri2BufferSwapCompleteEvent(dri2::BufferSwapCompleteEvent),
+    #[cfg(feature = "dri2")]
+    Dri2InvalidateBuffersEvent(dri2::InvalidateBuffersEvent),
+    #[cfg(feature = "glx")]
+    GlxBufferSwapCompleteEvent(glx::BufferSwapCompleteEvent),
+    #[cfg(feature = "glx")]
+    GlxPbufferClobberEvent(glx::PbufferClobberEvent),
+    #[cfg(feature = "present")]
+    PresentCompleteNotifyEvent(present::CompleteNotifyEvent),
+    #[cfg(feature = "present")]
+    PresentConfigureNotifyEvent(present::ConfigureNotifyEvent),
+    #[cfg(feature = "present")]
+    PresentGenericEvent(present::GenericEvent),
+    #[cfg(feature = "present")]
+    PresentIdleNotifyEvent(present::IdleNotifyEvent),
+    #[cfg(feature = "present")]
+    PresentRedirectNotifyEvent(present::RedirectNotifyEvent),
+    #[cfg(feature = "randr")]
+    RandrNotifyEvent(randr::NotifyEvent),
+    #[cfg(feature = "randr")]
+    RandrScreenChangeNotifyEvent(randr::ScreenChangeNotifyEvent),
+    #[cfg(feature = "screensaver")]
+    ScreensaverNotifyEvent(screensaver::NotifyEvent),
+    #[cfg(feature = "shape")]
+    ShapeNotifyEvent(shape::NotifyEvent),
+    #[cfg(feature = "shm")]
+    ShmCompletionEvent(shm::CompletionEvent),
+    #[cfg(feature = "sync")]
+    SyncAlarmNotifyEvent(sync::AlarmNotifyEvent),
+    #[cfg(feature = "sync")]
+    SyncCounterNotifyEvent(sync::CounterNotifyEvent),
+    #[cfg(feature = "xfixes")]
+    XfixesCursorNotifyEvent(xfixes::CursorNotifyEvent),
+    #[cfg(feature = "xfixes")]
+    XfixesSelectionNotifyEvent(xfixes::SelectionNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputBarrierHitEvent(xinput::BarrierHitEvent),
+    #[cfg(feature = "xinput")]
+    XinputBarrierLeaveEvent(xinput::BarrierLeaveEvent),
+    #[cfg(feature = "xinput")]
+    XinputButtonPressEvent(xinput::ButtonPressEvent),
+    #[cfg(feature = "xinput")]
+    XinputButtonReleaseEvent(xinput::ButtonReleaseEvent),
+    #[cfg(feature = "xinput")]
+    XinputChangeDeviceNotifyEvent(xinput::ChangeDeviceNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceButtonPressEvent(xinput::DeviceButtonPressEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceButtonReleaseEvent(xinput::DeviceButtonReleaseEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceButtonStateNotifyEvent(xinput::DeviceButtonStateNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceChangedEvent(xinput::DeviceChangedEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceFocusInEvent(xinput::DeviceFocusInEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceFocusOutEvent(xinput::DeviceFocusOutEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceKeyPressEvent(xinput::DeviceKeyPressEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceKeyReleaseEvent(xinput::DeviceKeyReleaseEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceKeyStateNotifyEvent(xinput::DeviceKeyStateNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceMappingNotifyEvent(xinput::DeviceMappingNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceMotionNotifyEvent(xinput::DeviceMotionNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDevicePresenceNotifyEvent(xinput::DevicePresenceNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDevicePropertyNotifyEvent(xinput::DevicePropertyNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceStateNotifyEvent(xinput::DeviceStateNotifyEvent),
+    #[cfg(feature = "xinput")]
+    XinputDeviceValuatorEvent(xinput::DeviceValuatorEvent),
+    #[cfg(feature = "xinput")]
+    XinputEnterEvent(xinput::EnterEvent),
+    #[cfg(feature = "xinput")]
+    XinputFocusInEvent(xinput::FocusInEvent),
+    #[cfg(feature = "xinput")]
+    XinputFocusOutEvent(xinput::FocusOutEvent),
+    #[cfg(feature = "xinput")]
+    XinputHierarchyEvent(xinput::HierarchyEvent),
+    #[cfg(feature = "xinput")]
+    XinputKeyPressEvent(xinput::KeyPressEvent),
+    #[cfg(feature = "xinput")]
+    XinputKeyReleaseEvent(xinput::KeyReleaseEvent),
+    #[cfg(feature = "xinput")]
+    XinputLeaveEvent(xinput::LeaveEvent),
+    #[cfg(feature = "xinput")]
+    XinputMotionEvent(xinput::MotionEvent),
+    #[cfg(feature = "xinput")]
+    XinputPropertyEvent(xinput::PropertyEvent),
+    #[cfg(feature = "xinput")]
+    XinputProximityInEvent(xinput::ProximityInEvent),
+    #[cfg(feature = "xinput")]
+    XinputProximityOutEvent(xinput::ProximityOutEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawButtonPressEvent(xinput::RawButtonPressEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawButtonReleaseEvent(xinput::RawButtonReleaseEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawKeyPressEvent(xinput::RawKeyPressEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawKeyReleaseEvent(xinput::RawKeyReleaseEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawMotionEvent(xinput::RawMotionEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawTouchBeginEvent(xinput::RawTouchBeginEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawTouchEndEvent(xinput::RawTouchEndEvent),
+    #[cfg(feature = "xinput")]
+    XinputRawTouchUpdateEvent(xinput::RawTouchUpdateEvent),
+    #[cfg(feature = "xinput")]
+    XinputTouchBeginEvent(xinput::TouchBeginEvent),
+    #[cfg(feature = "xinput")]
+    XinputTouchEndEvent(xinput::TouchEndEvent),
+    #[cfg(feature = "xinput")]
+    XinputTouchOwnershipEvent(xinput::TouchOwnershipEvent),
+    #[cfg(feature = "xinput")]
+    XinputTouchUpdateEvent(xinput::TouchUpdateEvent),
+    #[cfg(feature = "xkb")]
+    XkbAccessXNotifyEvent(xkb::AccessXNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbActionMessageEvent(xkb::ActionMessageEvent),
+    #[cfg(feature = "xkb")]
+    XkbBellNotifyEvent(xkb::BellNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbCompatMapNotifyEvent(xkb::CompatMapNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbControlsNotifyEvent(xkb::ControlsNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbExtensionDeviceNotifyEvent(xkb::ExtensionDeviceNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbIndicatorMapNotifyEvent(xkb::IndicatorMapNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbIndicatorStateNotifyEvent(xkb::IndicatorStateNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbMapNotifyEvent(xkb::MapNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbNamesNotifyEvent(xkb::NamesNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbNewKeyboardNotifyEvent(xkb::NewKeyboardNotifyEvent),
+    #[cfg(feature = "xkb")]
+    XkbStateNotifyEvent(xkb::StateNotifyEvent),
+    #[cfg(feature = "xprint")]
+    XprintAttributNotifyEvent(xprint::AttributNotifyEvent),
+    #[cfg(feature = "xprint")]
+    XprintNotifyEvent(xprint::NotifyEvent),
+    XprotoButtonPressEvent(xproto::ButtonPressEvent),
+    XprotoButtonReleaseEvent(xproto::ButtonReleaseEvent),
+    XprotoCirculateNotifyEvent(xproto::CirculateNotifyEvent),
+    XprotoCirculateRequestEvent(xproto::CirculateRequestEvent),
+    XprotoClientMessageEvent(xproto::ClientMessageEvent),
+    XprotoColormapNotifyEvent(xproto::ColormapNotifyEvent),
+    XprotoConfigureNotifyEvent(xproto::ConfigureNotifyEvent),
+    XprotoConfigureRequestEvent(xproto::ConfigureRequestEvent),
+    XprotoCreateNotifyEvent(xproto::CreateNotifyEvent),
+    XprotoDestroyNotifyEvent(xproto::DestroyNotifyEvent),
+    XprotoEnterNotifyEvent(xproto::EnterNotifyEvent),
+    XprotoExposeEvent(xproto::ExposeEvent),
+    XprotoFocusInEvent(xproto::FocusInEvent),
+    XprotoFocusOutEvent(xproto::FocusOutEvent),
+    XprotoGeGenericEvent(xproto::GeGenericEvent),
+    XprotoGraphicsExposureEvent(xproto::GraphicsExposureEvent),
+    XprotoGravityNotifyEvent(xproto::GravityNotifyEvent),
+    XprotoKeyPressEvent(xproto::KeyPressEvent),
+    XprotoKeyReleaseEvent(xproto::KeyReleaseEvent),
+    XprotoKeymapNotifyEvent(xproto::KeymapNotifyEvent),
+    XprotoLeaveNotifyEvent(xproto::LeaveNotifyEvent),
+    XprotoMapNotifyEvent(xproto::MapNotifyEvent),
+    XprotoMapRequestEvent(xproto::MapRequestEvent),
+    XprotoMappingNotifyEvent(xproto::MappingNotifyEvent),
+    XprotoMotionNotifyEvent(xproto::MotionNotifyEvent),
+    XprotoNoExposureEvent(xproto::NoExposureEvent),
+    XprotoPropertyNotifyEvent(xproto::PropertyNotifyEvent),
+    XprotoReparentNotifyEvent(xproto::ReparentNotifyEvent),
+    XprotoResizeRequestEvent(xproto::ResizeRequestEvent),
+    XprotoSelectionClearEvent(xproto::SelectionClearEvent),
+    XprotoSelectionNotifyEvent(xproto::SelectionNotifyEvent),
+    XprotoSelectionRequestEvent(xproto::SelectionRequestEvent),
+    XprotoUnmapNotifyEvent(xproto::UnmapNotifyEvent),
+    XprotoVisibilityNotifyEvent(xproto::VisibilityNotifyEvent),
+    #[cfg(feature = "xv")]
+    XvPortNotifyEvent(xv::PortNotifyEvent),
+    #[cfg(feature = "xv")]
+    XvVideoNotifyEvent(xv::VideoNotifyEvent),
+}
+impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
+    /// Parse a generic X11 event into a concrete event type.
+    pub fn parse(
+        event: GenericEvent<B>,
+        iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,
+    ) -> Result<Self, ParseError> {
+        let event_type = event.response_type();
+        let bytes = event.raw_bytes();
+        // Check if this is a core protocol error or from the generic event extension
+        match event_type {
+            0 => return Ok(Self::Error(Error::parse(event.try_into()?, iter)?)),
+            4 => return Ok(Self::XprotoButtonPressEvent(xproto::ButtonPressEvent::try_parse(bytes)?.0)),
+            5 => return Ok(Self::XprotoButtonReleaseEvent(xproto::ButtonReleaseEvent::try_parse(bytes)?.0)),
+            26 => return Ok(Self::XprotoCirculateNotifyEvent(xproto::CirculateNotifyEvent::try_parse(bytes)?.0)),
+            27 => return Ok(Self::XprotoCirculateRequestEvent(xproto::CirculateRequestEvent::try_parse(bytes)?.0)),
+            33 => return Ok(Self::XprotoClientMessageEvent(xproto::ClientMessageEvent::try_parse(bytes)?.0)),
+            32 => return Ok(Self::XprotoColormapNotifyEvent(xproto::ColormapNotifyEvent::try_parse(bytes)?.0)),
+            22 => return Ok(Self::XprotoConfigureNotifyEvent(xproto::ConfigureNotifyEvent::try_parse(bytes)?.0)),
+            23 => return Ok(Self::XprotoConfigureRequestEvent(xproto::ConfigureRequestEvent::try_parse(bytes)?.0)),
+            16 => return Ok(Self::XprotoCreateNotifyEvent(xproto::CreateNotifyEvent::try_parse(bytes)?.0)),
+            17 => return Ok(Self::XprotoDestroyNotifyEvent(xproto::DestroyNotifyEvent::try_parse(bytes)?.0)),
+            7 => return Ok(Self::XprotoEnterNotifyEvent(xproto::EnterNotifyEvent::try_parse(bytes)?.0)),
+            12 => return Ok(Self::XprotoExposeEvent(xproto::ExposeEvent::try_parse(bytes)?.0)),
+            9 => return Ok(Self::XprotoFocusInEvent(xproto::FocusInEvent::try_parse(bytes)?.0)),
+            10 => return Ok(Self::XprotoFocusOutEvent(xproto::FocusOutEvent::try_parse(bytes)?.0)),
+            13 => return Ok(Self::XprotoGraphicsExposureEvent(xproto::GraphicsExposureEvent::try_parse(bytes)?.0)),
+            24 => return Ok(Self::XprotoGravityNotifyEvent(xproto::GravityNotifyEvent::try_parse(bytes)?.0)),
+            2 => return Ok(Self::XprotoKeyPressEvent(xproto::KeyPressEvent::try_parse(bytes)?.0)),
+            3 => return Ok(Self::XprotoKeyReleaseEvent(xproto::KeyReleaseEvent::try_parse(bytes)?.0)),
+            11 => return Ok(Self::XprotoKeymapNotifyEvent(xproto::KeymapNotifyEvent::try_parse(bytes)?.0)),
+            8 => return Ok(Self::XprotoLeaveNotifyEvent(xproto::LeaveNotifyEvent::try_parse(bytes)?.0)),
+            19 => return Ok(Self::XprotoMapNotifyEvent(xproto::MapNotifyEvent::try_parse(bytes)?.0)),
+            20 => return Ok(Self::XprotoMapRequestEvent(xproto::MapRequestEvent::try_parse(bytes)?.0)),
+            34 => return Ok(Self::XprotoMappingNotifyEvent(xproto::MappingNotifyEvent::try_parse(bytes)?.0)),
+            6 => return Ok(Self::XprotoMotionNotifyEvent(xproto::MotionNotifyEvent::try_parse(bytes)?.0)),
+            14 => return Ok(Self::XprotoNoExposureEvent(xproto::NoExposureEvent::try_parse(bytes)?.0)),
+            28 => return Ok(Self::XprotoPropertyNotifyEvent(xproto::PropertyNotifyEvent::try_parse(bytes)?.0)),
+            21 => return Ok(Self::XprotoReparentNotifyEvent(xproto::ReparentNotifyEvent::try_parse(bytes)?.0)),
+            25 => return Ok(Self::XprotoResizeRequestEvent(xproto::ResizeRequestEvent::try_parse(bytes)?.0)),
+            29 => return Ok(Self::XprotoSelectionClearEvent(xproto::SelectionClearEvent::try_parse(bytes)?.0)),
+            31 => return Ok(Self::XprotoSelectionNotifyEvent(xproto::SelectionNotifyEvent::try_parse(bytes)?.0)),
+            30 => return Ok(Self::XprotoSelectionRequestEvent(xproto::SelectionRequestEvent::try_parse(bytes)?.0)),
+            18 => return Ok(Self::XprotoUnmapNotifyEvent(xproto::UnmapNotifyEvent::try_parse(bytes)?.0)),
+            15 => return Ok(Self::XprotoVisibilityNotifyEvent(xproto::VisibilityNotifyEvent::try_parse(bytes)?.0)),
+            xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, iter),
+            _ => {}
+        }
+        // Find the extension that this event could belong to
+        let ext_info = iter
+            .map(|(name, reply)| (name, reply.first_event))
+            .filter(|&(_, first_event)| first_event <= event_type)
+            .max_by_key(|&(_, first_event)| first_event);
+        match ext_info {
+            #[cfg(feature = "damage")]
+            Some(("DAMAGE", first_event)) => {
+                match event_type - first_event {
+                    0 => Ok(Self::DamageNotifyEvent(damage::NotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "dri2")]
+            Some(("DRI2", first_event)) => {
+                match event_type - first_event {
+                    0 => Ok(Self::Dri2BufferSwapCompleteEvent(dri2::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
+                    1 => Ok(Self::Dri2InvalidateBuffersEvent(dri2::InvalidateBuffersEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "glx")]
+            Some(("GLX", first_event)) => {
+                match event_type - first_event {
+                    1 => Ok(Self::GlxBufferSwapCompleteEvent(glx::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::GlxPbufferClobberEvent(glx::PbufferClobberEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "present")]
+            Some(("Present", first_event)) => {
+                match event_type - first_event {
+                    0 => Ok(Self::PresentGenericEvent(present::GenericEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "randr")]
+            Some(("RANDR", first_event)) => {
+                match event_type - first_event {
+                    1 => Ok(Self::RandrNotifyEvent(randr::NotifyEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::RandrScreenChangeNotifyEvent(randr::ScreenChangeNotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "screensaver")]
+            Some(("MIT-SCREEN-SAVER", first_event)) => {
+                match event_type - first_event {
+                    0 => Ok(Self::ScreensaverNotifyEvent(screensaver::NotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "shape")]
+            Some(("SHAPE", first_event)) => {
+                match event_type - first_event {
+                    0 => Ok(Self::ShapeNotifyEvent(shape::NotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "shm")]
+            Some(("MIT-SHM", first_event)) => {
+                match event_type - first_event {
+                    0 => Ok(Self::ShmCompletionEvent(shm::CompletionEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "sync")]
+            Some(("SYNC", first_event)) => {
+                match event_type - first_event {
+                    1 => Ok(Self::SyncAlarmNotifyEvent(sync::AlarmNotifyEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::SyncCounterNotifyEvent(sync::CounterNotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "xfixes")]
+            Some(("XFIXES", first_event)) => {
+                match event_type - first_event {
+                    1 => Ok(Self::XfixesCursorNotifyEvent(xfixes::CursorNotifyEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::XfixesSelectionNotifyEvent(xfixes::SelectionNotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "xinput")]
+            Some(("XInputExtension", first_event)) => {
+                match event_type - first_event {
+                    12 => Ok(Self::XinputChangeDeviceNotifyEvent(xinput::ChangeDeviceNotifyEvent::try_parse(bytes)?.0)),
+                    3 => Ok(Self::XinputDeviceButtonPressEvent(xinput::DeviceButtonPressEvent::try_parse(bytes)?.0)),
+                    4 => Ok(Self::XinputDeviceButtonReleaseEvent(xinput::DeviceButtonReleaseEvent::try_parse(bytes)?.0)),
+                    14 => Ok(Self::XinputDeviceButtonStateNotifyEvent(xinput::DeviceButtonStateNotifyEvent::try_parse(bytes)?.0)),
+                    6 => Ok(Self::XinputDeviceFocusInEvent(xinput::DeviceFocusInEvent::try_parse(bytes)?.0)),
+                    7 => Ok(Self::XinputDeviceFocusOutEvent(xinput::DeviceFocusOutEvent::try_parse(bytes)?.0)),
+                    1 => Ok(Self::XinputDeviceKeyPressEvent(xinput::DeviceKeyPressEvent::try_parse(bytes)?.0)),
+                    2 => Ok(Self::XinputDeviceKeyReleaseEvent(xinput::DeviceKeyReleaseEvent::try_parse(bytes)?.0)),
+                    13 => Ok(Self::XinputDeviceKeyStateNotifyEvent(xinput::DeviceKeyStateNotifyEvent::try_parse(bytes)?.0)),
+                    11 => Ok(Self::XinputDeviceMappingNotifyEvent(xinput::DeviceMappingNotifyEvent::try_parse(bytes)?.0)),
+                    5 => Ok(Self::XinputDeviceMotionNotifyEvent(xinput::DeviceMotionNotifyEvent::try_parse(bytes)?.0)),
+                    15 => Ok(Self::XinputDevicePresenceNotifyEvent(xinput::DevicePresenceNotifyEvent::try_parse(bytes)?.0)),
+                    16 => Ok(Self::XinputDevicePropertyNotifyEvent(xinput::DevicePropertyNotifyEvent::try_parse(bytes)?.0)),
+                    10 => Ok(Self::XinputDeviceStateNotifyEvent(xinput::DeviceStateNotifyEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::XinputDeviceValuatorEvent(xinput::DeviceValuatorEvent::try_parse(bytes)?.0)),
+                    8 => Ok(Self::XinputProximityInEvent(xinput::ProximityInEvent::try_parse(bytes)?.0)),
+                    9 => Ok(Self::XinputProximityOutEvent(xinput::ProximityOutEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "xkb")]
+            Some(("XKEYBOARD", first_event)) => {
+                match event_type - first_event {
+                    10 => Ok(Self::XkbAccessXNotifyEvent(xkb::AccessXNotifyEvent::try_parse(bytes)?.0)),
+                    9 => Ok(Self::XkbActionMessageEvent(xkb::ActionMessageEvent::try_parse(bytes)?.0)),
+                    8 => Ok(Self::XkbBellNotifyEvent(xkb::BellNotifyEvent::try_parse(bytes)?.0)),
+                    7 => Ok(Self::XkbCompatMapNotifyEvent(xkb::CompatMapNotifyEvent::try_parse(bytes)?.0)),
+                    3 => Ok(Self::XkbControlsNotifyEvent(xkb::ControlsNotifyEvent::try_parse(bytes)?.0)),
+                    11 => Ok(Self::XkbExtensionDeviceNotifyEvent(xkb::ExtensionDeviceNotifyEvent::try_parse(bytes)?.0)),
+                    5 => Ok(Self::XkbIndicatorMapNotifyEvent(xkb::IndicatorMapNotifyEvent::try_parse(bytes)?.0)),
+                    4 => Ok(Self::XkbIndicatorStateNotifyEvent(xkb::IndicatorStateNotifyEvent::try_parse(bytes)?.0)),
+                    1 => Ok(Self::XkbMapNotifyEvent(xkb::MapNotifyEvent::try_parse(bytes)?.0)),
+                    6 => Ok(Self::XkbNamesNotifyEvent(xkb::NamesNotifyEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::XkbNewKeyboardNotifyEvent(xkb::NewKeyboardNotifyEvent::try_parse(bytes)?.0)),
+                    2 => Ok(Self::XkbStateNotifyEvent(xkb::StateNotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "xprint")]
+            Some(("XpExtension", first_event)) => {
+                match event_type - first_event {
+                    1 => Ok(Self::XprintAttributNotifyEvent(xprint::AttributNotifyEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::XprintNotifyEvent(xprint::NotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            #[cfg(feature = "xv")]
+            Some(("XVideo", first_event)) => {
+                match event_type - first_event {
+                    1 => Ok(Self::XvPortNotifyEvent(xv::PortNotifyEvent::try_parse(bytes)?.0)),
+                    0 => Ok(Self::XvVideoNotifyEvent(xv::VideoNotifyEvent::try_parse(bytes)?.0)),
+                    _ => Ok(Self::Unknown(event))
+                }
+            }
+            _ => Ok(Self::Unknown(event))
+        }
+    }
+
+    fn from_generic_event(
+        event: GenericEvent<B>,
+        iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,
+    ) -> Result<Self, ParseError> {
+        todo!()
     }
 }

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -187,26 +187,25 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
         iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,
     ) -> Result<Self, ParseError> {
         let error_code = error.error_code();
-        let bytes = error.raw_bytes();
         // Check if this is a core protocol error
         match error_code {
-            xproto::ACCESS_ERROR => return Ok(Self::XprotoAccessError(xproto::AccessError::try_parse(bytes)?.0)),
-            xproto::ALLOC_ERROR => return Ok(Self::XprotoAllocError(xproto::AllocError::try_parse(bytes)?.0)),
-            xproto::ATOM_ERROR => return Ok(Self::XprotoAtomError(xproto::AtomError::try_parse(bytes)?.0)),
-            xproto::COLORMAP_ERROR => return Ok(Self::XprotoColormapError(xproto::ColormapError::try_parse(bytes)?.0)),
-            xproto::CURSOR_ERROR => return Ok(Self::XprotoCursorError(xproto::CursorError::try_parse(bytes)?.0)),
-            xproto::DRAWABLE_ERROR => return Ok(Self::XprotoDrawableError(xproto::DrawableError::try_parse(bytes)?.0)),
-            xproto::FONT_ERROR => return Ok(Self::XprotoFontError(xproto::FontError::try_parse(bytes)?.0)),
-            xproto::G_CONTEXT_ERROR => return Ok(Self::XprotoGContextError(xproto::GContextError::try_parse(bytes)?.0)),
-            xproto::ID_CHOICE_ERROR => return Ok(Self::XprotoIDChoiceError(xproto::IDChoiceError::try_parse(bytes)?.0)),
-            xproto::IMPLEMENTATION_ERROR => return Ok(Self::XprotoImplementationError(xproto::ImplementationError::try_parse(bytes)?.0)),
-            xproto::LENGTH_ERROR => return Ok(Self::XprotoLengthError(xproto::LengthError::try_parse(bytes)?.0)),
-            xproto::MATCH_ERROR => return Ok(Self::XprotoMatchError(xproto::MatchError::try_parse(bytes)?.0)),
-            xproto::NAME_ERROR => return Ok(Self::XprotoNameError(xproto::NameError::try_parse(bytes)?.0)),
-            xproto::PIXMAP_ERROR => return Ok(Self::XprotoPixmapError(xproto::PixmapError::try_parse(bytes)?.0)),
-            xproto::REQUEST_ERROR => return Ok(Self::XprotoRequestError(xproto::RequestError::try_parse(bytes)?.0)),
-            xproto::VALUE_ERROR => return Ok(Self::XprotoValueError(xproto::ValueError::try_parse(bytes)?.0)),
-            xproto::WINDOW_ERROR => return Ok(Self::XprotoWindowError(xproto::WindowError::try_parse(bytes)?.0)),
+            xproto::ACCESS_ERROR => return Ok(Self::XprotoAccessError(error.into())),
+            xproto::ALLOC_ERROR => return Ok(Self::XprotoAllocError(error.into())),
+            xproto::ATOM_ERROR => return Ok(Self::XprotoAtomError(error.into())),
+            xproto::COLORMAP_ERROR => return Ok(Self::XprotoColormapError(error.into())),
+            xproto::CURSOR_ERROR => return Ok(Self::XprotoCursorError(error.into())),
+            xproto::DRAWABLE_ERROR => return Ok(Self::XprotoDrawableError(error.into())),
+            xproto::FONT_ERROR => return Ok(Self::XprotoFontError(error.into())),
+            xproto::G_CONTEXT_ERROR => return Ok(Self::XprotoGContextError(error.into())),
+            xproto::ID_CHOICE_ERROR => return Ok(Self::XprotoIDChoiceError(error.into())),
+            xproto::IMPLEMENTATION_ERROR => return Ok(Self::XprotoImplementationError(error.into())),
+            xproto::LENGTH_ERROR => return Ok(Self::XprotoLengthError(error.into())),
+            xproto::MATCH_ERROR => return Ok(Self::XprotoMatchError(error.into())),
+            xproto::NAME_ERROR => return Ok(Self::XprotoNameError(error.into())),
+            xproto::PIXMAP_ERROR => return Ok(Self::XprotoPixmapError(error.into())),
+            xproto::REQUEST_ERROR => return Ok(Self::XprotoRequestError(error.into())),
+            xproto::VALUE_ERROR => return Ok(Self::XprotoValueError(error.into())),
+            xproto::WINDOW_ERROR => return Ok(Self::XprotoWindowError(error.into())),
             _ => {}
         }
         // Find the extension that this error could belong to
@@ -218,125 +217,125 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
             #[cfg(feature = "damage")]
             Some(("DAMAGE", first_error)) => {
                 match error_code - first_error {
-                    damage::BAD_DAMAGE_ERROR => Ok(Self::DamageBadDamageError(damage::BadDamageError::try_parse(bytes)?.0)),
+                    damage::BAD_DAMAGE_ERROR => Ok(Self::DamageBadDamageError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "glx")]
             Some(("GLX", first_error)) => {
                 match error_code - first_error {
-                    glx::BAD_CONTEXT_ERROR => Ok(Self::GlxBadContextError(glx::BadContextError::try_parse(bytes)?.0)),
-                    glx::BAD_CONTEXT_STATE_ERROR => Ok(Self::GlxBadContextStateError(glx::BadContextStateError::try_parse(bytes)?.0)),
-                    glx::BAD_CONTEXT_TAG_ERROR => Ok(Self::GlxBadContextTagError(glx::BadContextTagError::try_parse(bytes)?.0)),
-                    glx::BAD_CURRENT_DRAWABLE_ERROR => Ok(Self::GlxBadCurrentDrawableError(glx::BadCurrentDrawableError::try_parse(bytes)?.0)),
-                    glx::BAD_CURRENT_WINDOW_ERROR => Ok(Self::GlxBadCurrentWindowError(glx::BadCurrentWindowError::try_parse(bytes)?.0)),
-                    glx::BAD_DRAWABLE_ERROR => Ok(Self::GlxBadDrawableError(glx::BadDrawableError::try_parse(bytes)?.0)),
-                    glx::BAD_FB_CONFIG_ERROR => Ok(Self::GlxBadFBConfigError(glx::BadFBConfigError::try_parse(bytes)?.0)),
-                    glx::BAD_LARGE_REQUEST_ERROR => Ok(Self::GlxBadLargeRequestError(glx::BadLargeRequestError::try_parse(bytes)?.0)),
-                    glx::BAD_PBUFFER_ERROR => Ok(Self::GlxBadPbufferError(glx::BadPbufferError::try_parse(bytes)?.0)),
-                    glx::BAD_PIXMAP_ERROR => Ok(Self::GlxBadPixmapError(glx::BadPixmapError::try_parse(bytes)?.0)),
-                    glx::BAD_RENDER_REQUEST_ERROR => Ok(Self::GlxBadRenderRequestError(glx::BadRenderRequestError::try_parse(bytes)?.0)),
-                    glx::BAD_WINDOW_ERROR => Ok(Self::GlxBadWindowError(glx::BadWindowError::try_parse(bytes)?.0)),
-                    glx::GLX_BAD_PROFILE_ARB_ERROR => Ok(Self::GlxGLXBadProfileARBError(glx::GLXBadProfileARBError::try_parse(bytes)?.0)),
-                    glx::UNSUPPORTED_PRIVATE_REQUEST_ERROR => Ok(Self::GlxUnsupportedPrivateRequestError(glx::UnsupportedPrivateRequestError::try_parse(bytes)?.0)),
+                    glx::BAD_CONTEXT_ERROR => Ok(Self::GlxBadContextError(error.into())),
+                    glx::BAD_CONTEXT_STATE_ERROR => Ok(Self::GlxBadContextStateError(error.into())),
+                    glx::BAD_CONTEXT_TAG_ERROR => Ok(Self::GlxBadContextTagError(error.into())),
+                    glx::BAD_CURRENT_DRAWABLE_ERROR => Ok(Self::GlxBadCurrentDrawableError(error.into())),
+                    glx::BAD_CURRENT_WINDOW_ERROR => Ok(Self::GlxBadCurrentWindowError(error.into())),
+                    glx::BAD_DRAWABLE_ERROR => Ok(Self::GlxBadDrawableError(error.into())),
+                    glx::BAD_FB_CONFIG_ERROR => Ok(Self::GlxBadFBConfigError(error.into())),
+                    glx::BAD_LARGE_REQUEST_ERROR => Ok(Self::GlxBadLargeRequestError(error.into())),
+                    glx::BAD_PBUFFER_ERROR => Ok(Self::GlxBadPbufferError(error.into())),
+                    glx::BAD_PIXMAP_ERROR => Ok(Self::GlxBadPixmapError(error.into())),
+                    glx::BAD_RENDER_REQUEST_ERROR => Ok(Self::GlxBadRenderRequestError(error.into())),
+                    glx::BAD_WINDOW_ERROR => Ok(Self::GlxBadWindowError(error.into())),
+                    glx::GLX_BAD_PROFILE_ARB_ERROR => Ok(Self::GlxGLXBadProfileARBError(error.into())),
+                    glx::UNSUPPORTED_PRIVATE_REQUEST_ERROR => Ok(Self::GlxUnsupportedPrivateRequestError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "randr")]
             Some(("RANDR", first_error)) => {
                 match error_code - first_error {
-                    randr::BAD_CRTC_ERROR => Ok(Self::RandrBadCrtcError(randr::BadCrtcError::try_parse(bytes)?.0)),
-                    randr::BAD_MODE_ERROR => Ok(Self::RandrBadModeError(randr::BadModeError::try_parse(bytes)?.0)),
-                    randr::BAD_OUTPUT_ERROR => Ok(Self::RandrBadOutputError(randr::BadOutputError::try_parse(bytes)?.0)),
-                    randr::BAD_PROVIDER_ERROR => Ok(Self::RandrBadProviderError(randr::BadProviderError::try_parse(bytes)?.0)),
+                    randr::BAD_CRTC_ERROR => Ok(Self::RandrBadCrtcError(error.into())),
+                    randr::BAD_MODE_ERROR => Ok(Self::RandrBadModeError(error.into())),
+                    randr::BAD_OUTPUT_ERROR => Ok(Self::RandrBadOutputError(error.into())),
+                    randr::BAD_PROVIDER_ERROR => Ok(Self::RandrBadProviderError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "record")]
             Some(("RECORD", first_error)) => {
                 match error_code - first_error {
-                    record::BAD_CONTEXT_ERROR => Ok(Self::RecordBadContextError(record::BadContextError::try_parse(bytes)?.0)),
+                    record::BAD_CONTEXT_ERROR => Ok(Self::RecordBadContextError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "render")]
             Some(("RENDER", first_error)) => {
                 match error_code - first_error {
-                    render::GLYPH_ERROR => Ok(Self::RenderGlyphError(render::GlyphError::try_parse(bytes)?.0)),
-                    render::GLYPH_SET_ERROR => Ok(Self::RenderGlyphSetError(render::GlyphSetError::try_parse(bytes)?.0)),
-                    render::PICT_FORMAT_ERROR => Ok(Self::RenderPictFormatError(render::PictFormatError::try_parse(bytes)?.0)),
-                    render::PICT_OP_ERROR => Ok(Self::RenderPictOpError(render::PictOpError::try_parse(bytes)?.0)),
-                    render::PICTURE_ERROR => Ok(Self::RenderPictureError(render::PictureError::try_parse(bytes)?.0)),
+                    render::GLYPH_ERROR => Ok(Self::RenderGlyphError(error.into())),
+                    render::GLYPH_SET_ERROR => Ok(Self::RenderGlyphSetError(error.into())),
+                    render::PICT_FORMAT_ERROR => Ok(Self::RenderPictFormatError(error.into())),
+                    render::PICT_OP_ERROR => Ok(Self::RenderPictOpError(error.into())),
+                    render::PICTURE_ERROR => Ok(Self::RenderPictureError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "shm")]
             Some(("MIT-SHM", first_error)) => {
                 match error_code - first_error {
-                    shm::BAD_SEG_ERROR => Ok(Self::ShmBadSegError(shm::BadSegError::try_parse(bytes)?.0)),
+                    shm::BAD_SEG_ERROR => Ok(Self::ShmBadSegError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "sync")]
             Some(("SYNC", first_error)) => {
                 match error_code - first_error {
-                    sync::ALARM_ERROR => Ok(Self::SyncAlarmError(sync::AlarmError::try_parse(bytes)?.0)),
-                    sync::COUNTER_ERROR => Ok(Self::SyncCounterError(sync::CounterError::try_parse(bytes)?.0)),
+                    sync::ALARM_ERROR => Ok(Self::SyncAlarmError(error.into())),
+                    sync::COUNTER_ERROR => Ok(Self::SyncCounterError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xf86vidmode")]
             Some(("XFree86-VidModeExtension", first_error)) => {
                 match error_code - first_error {
-                    xf86vidmode::BAD_CLOCK_ERROR => Ok(Self::Xf86vidmodeBadClockError(xf86vidmode::BadClockError::try_parse(bytes)?.0)),
-                    xf86vidmode::BAD_H_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadHTimingsError(xf86vidmode::BadHTimingsError::try_parse(bytes)?.0)),
-                    xf86vidmode::BAD_V_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadVTimingsError(xf86vidmode::BadVTimingsError::try_parse(bytes)?.0)),
-                    xf86vidmode::CLIENT_NOT_LOCAL_ERROR => Ok(Self::Xf86vidmodeClientNotLocalError(xf86vidmode::ClientNotLocalError::try_parse(bytes)?.0)),
-                    xf86vidmode::EXTENSION_DISABLED_ERROR => Ok(Self::Xf86vidmodeExtensionDisabledError(xf86vidmode::ExtensionDisabledError::try_parse(bytes)?.0)),
-                    xf86vidmode::MODE_UNSUITABLE_ERROR => Ok(Self::Xf86vidmodeModeUnsuitableError(xf86vidmode::ModeUnsuitableError::try_parse(bytes)?.0)),
-                    xf86vidmode::ZOOM_LOCKED_ERROR => Ok(Self::Xf86vidmodeZoomLockedError(xf86vidmode::ZoomLockedError::try_parse(bytes)?.0)),
+                    xf86vidmode::BAD_CLOCK_ERROR => Ok(Self::Xf86vidmodeBadClockError(error.into())),
+                    xf86vidmode::BAD_H_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadHTimingsError(error.into())),
+                    xf86vidmode::BAD_V_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadVTimingsError(error.into())),
+                    xf86vidmode::CLIENT_NOT_LOCAL_ERROR => Ok(Self::Xf86vidmodeClientNotLocalError(error.into())),
+                    xf86vidmode::EXTENSION_DISABLED_ERROR => Ok(Self::Xf86vidmodeExtensionDisabledError(error.into())),
+                    xf86vidmode::MODE_UNSUITABLE_ERROR => Ok(Self::Xf86vidmodeModeUnsuitableError(error.into())),
+                    xf86vidmode::ZOOM_LOCKED_ERROR => Ok(Self::Xf86vidmodeZoomLockedError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xfixes")]
             Some(("XFIXES", first_error)) => {
                 match error_code - first_error {
-                    xfixes::BAD_REGION_ERROR => Ok(Self::XfixesBadRegionError(xfixes::BadRegionError::try_parse(bytes)?.0)),
+                    xfixes::BAD_REGION_ERROR => Ok(Self::XfixesBadRegionError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xinput")]
             Some(("XInputExtension", first_error)) => {
                 match error_code - first_error {
-                    xinput::CLASS_ERROR => Ok(Self::XinputClassError(xinput::ClassError::try_parse(bytes)?.0)),
-                    xinput::DEVICE_ERROR => Ok(Self::XinputDeviceError(xinput::DeviceError::try_parse(bytes)?.0)),
-                    xinput::DEVICE_BUSY_ERROR => Ok(Self::XinputDeviceBusyError(xinput::DeviceBusyError::try_parse(bytes)?.0)),
-                    xinput::EVENT_ERROR => Ok(Self::XinputEventError(xinput::EventError::try_parse(bytes)?.0)),
-                    xinput::MODE_ERROR => Ok(Self::XinputModeError(xinput::ModeError::try_parse(bytes)?.0)),
+                    xinput::CLASS_ERROR => Ok(Self::XinputClassError(error.into())),
+                    xinput::DEVICE_ERROR => Ok(Self::XinputDeviceError(error.into())),
+                    xinput::DEVICE_BUSY_ERROR => Ok(Self::XinputDeviceBusyError(error.into())),
+                    xinput::EVENT_ERROR => Ok(Self::XinputEventError(error.into())),
+                    xinput::MODE_ERROR => Ok(Self::XinputModeError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xkb")]
             Some(("XKEYBOARD", first_error)) => {
                 match error_code - first_error {
-                    xkb::KEYBOARD_ERROR => Ok(Self::XkbKeyboardError(xkb::KeyboardError::try_parse(bytes)?.0)),
+                    xkb::KEYBOARD_ERROR => Ok(Self::XkbKeyboardError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xprint")]
             Some(("XpExtension", first_error)) => {
                 match error_code - first_error {
-                    xprint::BAD_CONTEXT_ERROR => Ok(Self::XprintBadContextError(xprint::BadContextError::try_parse(bytes)?.0)),
-                    xprint::BAD_SEQUENCE_ERROR => Ok(Self::XprintBadSequenceError(xprint::BadSequenceError::try_parse(bytes)?.0)),
+                    xprint::BAD_CONTEXT_ERROR => Ok(Self::XprintBadContextError(error.into())),
+                    xprint::BAD_SEQUENCE_ERROR => Ok(Self::XprintBadSequenceError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xv")]
             Some(("XVideo", first_error)) => {
                 match error_code - first_error {
-                    xv::BAD_CONTROL_ERROR => Ok(Self::XvBadControlError(xv::BadControlError::try_parse(bytes)?.0)),
-                    xv::BAD_ENCODING_ERROR => Ok(Self::XvBadEncodingError(xv::BadEncodingError::try_parse(bytes)?.0)),
-                    xv::BAD_PORT_ERROR => Ok(Self::XvBadPortError(xv::BadPortError::try_parse(bytes)?.0)),
+                    xv::BAD_CONTROL_ERROR => Ok(Self::XvBadControlError(error.into())),
+                    xv::BAD_ENCODING_ERROR => Ok(Self::XvBadEncodingError(error.into())),
+                    xv::BAD_PORT_ERROR => Ok(Self::XvBadPortError(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
@@ -547,43 +546,42 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
         iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,
     ) -> Result<Self, ParseError> {
         let event_type = event.response_type();
-        let bytes = event.raw_bytes();
         // Check if this is a core protocol error or from the generic event extension
         match event_type {
             0 => return Ok(Self::Error(Error::parse(event.try_into()?, iter)?)),
-            xproto::BUTTON_PRESS_EVENT => return Ok(Self::XprotoButtonPressEvent(xproto::ButtonPressEvent::try_parse(bytes)?.0)),
-            xproto::BUTTON_RELEASE_EVENT => return Ok(Self::XprotoButtonReleaseEvent(xproto::ButtonReleaseEvent::try_parse(bytes)?.0)),
-            xproto::CIRCULATE_NOTIFY_EVENT => return Ok(Self::XprotoCirculateNotifyEvent(xproto::CirculateNotifyEvent::try_parse(bytes)?.0)),
-            xproto::CIRCULATE_REQUEST_EVENT => return Ok(Self::XprotoCirculateRequestEvent(xproto::CirculateRequestEvent::try_parse(bytes)?.0)),
-            xproto::CLIENT_MESSAGE_EVENT => return Ok(Self::XprotoClientMessageEvent(xproto::ClientMessageEvent::try_parse(bytes)?.0)),
-            xproto::COLORMAP_NOTIFY_EVENT => return Ok(Self::XprotoColormapNotifyEvent(xproto::ColormapNotifyEvent::try_parse(bytes)?.0)),
-            xproto::CONFIGURE_NOTIFY_EVENT => return Ok(Self::XprotoConfigureNotifyEvent(xproto::ConfigureNotifyEvent::try_parse(bytes)?.0)),
-            xproto::CONFIGURE_REQUEST_EVENT => return Ok(Self::XprotoConfigureRequestEvent(xproto::ConfigureRequestEvent::try_parse(bytes)?.0)),
-            xproto::CREATE_NOTIFY_EVENT => return Ok(Self::XprotoCreateNotifyEvent(xproto::CreateNotifyEvent::try_parse(bytes)?.0)),
-            xproto::DESTROY_NOTIFY_EVENT => return Ok(Self::XprotoDestroyNotifyEvent(xproto::DestroyNotifyEvent::try_parse(bytes)?.0)),
-            xproto::ENTER_NOTIFY_EVENT => return Ok(Self::XprotoEnterNotifyEvent(xproto::EnterNotifyEvent::try_parse(bytes)?.0)),
-            xproto::EXPOSE_EVENT => return Ok(Self::XprotoExposeEvent(xproto::ExposeEvent::try_parse(bytes)?.0)),
-            xproto::FOCUS_IN_EVENT => return Ok(Self::XprotoFocusInEvent(xproto::FocusInEvent::try_parse(bytes)?.0)),
-            xproto::FOCUS_OUT_EVENT => return Ok(Self::XprotoFocusOutEvent(xproto::FocusOutEvent::try_parse(bytes)?.0)),
-            xproto::GRAPHICS_EXPOSURE_EVENT => return Ok(Self::XprotoGraphicsExposureEvent(xproto::GraphicsExposureEvent::try_parse(bytes)?.0)),
-            xproto::GRAVITY_NOTIFY_EVENT => return Ok(Self::XprotoGravityNotifyEvent(xproto::GravityNotifyEvent::try_parse(bytes)?.0)),
-            xproto::KEY_PRESS_EVENT => return Ok(Self::XprotoKeyPressEvent(xproto::KeyPressEvent::try_parse(bytes)?.0)),
-            xproto::KEY_RELEASE_EVENT => return Ok(Self::XprotoKeyReleaseEvent(xproto::KeyReleaseEvent::try_parse(bytes)?.0)),
-            xproto::KEYMAP_NOTIFY_EVENT => return Ok(Self::XprotoKeymapNotifyEvent(xproto::KeymapNotifyEvent::try_parse(bytes)?.0)),
-            xproto::LEAVE_NOTIFY_EVENT => return Ok(Self::XprotoLeaveNotifyEvent(xproto::LeaveNotifyEvent::try_parse(bytes)?.0)),
-            xproto::MAP_NOTIFY_EVENT => return Ok(Self::XprotoMapNotifyEvent(xproto::MapNotifyEvent::try_parse(bytes)?.0)),
-            xproto::MAP_REQUEST_EVENT => return Ok(Self::XprotoMapRequestEvent(xproto::MapRequestEvent::try_parse(bytes)?.0)),
-            xproto::MAPPING_NOTIFY_EVENT => return Ok(Self::XprotoMappingNotifyEvent(xproto::MappingNotifyEvent::try_parse(bytes)?.0)),
-            xproto::MOTION_NOTIFY_EVENT => return Ok(Self::XprotoMotionNotifyEvent(xproto::MotionNotifyEvent::try_parse(bytes)?.0)),
-            xproto::NO_EXPOSURE_EVENT => return Ok(Self::XprotoNoExposureEvent(xproto::NoExposureEvent::try_parse(bytes)?.0)),
-            xproto::PROPERTY_NOTIFY_EVENT => return Ok(Self::XprotoPropertyNotifyEvent(xproto::PropertyNotifyEvent::try_parse(bytes)?.0)),
-            xproto::REPARENT_NOTIFY_EVENT => return Ok(Self::XprotoReparentNotifyEvent(xproto::ReparentNotifyEvent::try_parse(bytes)?.0)),
-            xproto::RESIZE_REQUEST_EVENT => return Ok(Self::XprotoResizeRequestEvent(xproto::ResizeRequestEvent::try_parse(bytes)?.0)),
-            xproto::SELECTION_CLEAR_EVENT => return Ok(Self::XprotoSelectionClearEvent(xproto::SelectionClearEvent::try_parse(bytes)?.0)),
-            xproto::SELECTION_NOTIFY_EVENT => return Ok(Self::XprotoSelectionNotifyEvent(xproto::SelectionNotifyEvent::try_parse(bytes)?.0)),
-            xproto::SELECTION_REQUEST_EVENT => return Ok(Self::XprotoSelectionRequestEvent(xproto::SelectionRequestEvent::try_parse(bytes)?.0)),
-            xproto::UNMAP_NOTIFY_EVENT => return Ok(Self::XprotoUnmapNotifyEvent(xproto::UnmapNotifyEvent::try_parse(bytes)?.0)),
-            xproto::VISIBILITY_NOTIFY_EVENT => return Ok(Self::XprotoVisibilityNotifyEvent(xproto::VisibilityNotifyEvent::try_parse(bytes)?.0)),
+            xproto::BUTTON_PRESS_EVENT => return Ok(Self::XprotoButtonPressEvent(event.into())),
+            xproto::BUTTON_RELEASE_EVENT => return Ok(Self::XprotoButtonReleaseEvent(event.into())),
+            xproto::CIRCULATE_NOTIFY_EVENT => return Ok(Self::XprotoCirculateNotifyEvent(event.into())),
+            xproto::CIRCULATE_REQUEST_EVENT => return Ok(Self::XprotoCirculateRequestEvent(event.into())),
+            xproto::CLIENT_MESSAGE_EVENT => return Ok(Self::XprotoClientMessageEvent(event.into())),
+            xproto::COLORMAP_NOTIFY_EVENT => return Ok(Self::XprotoColormapNotifyEvent(event.into())),
+            xproto::CONFIGURE_NOTIFY_EVENT => return Ok(Self::XprotoConfigureNotifyEvent(event.into())),
+            xproto::CONFIGURE_REQUEST_EVENT => return Ok(Self::XprotoConfigureRequestEvent(event.into())),
+            xproto::CREATE_NOTIFY_EVENT => return Ok(Self::XprotoCreateNotifyEvent(event.into())),
+            xproto::DESTROY_NOTIFY_EVENT => return Ok(Self::XprotoDestroyNotifyEvent(event.into())),
+            xproto::ENTER_NOTIFY_EVENT => return Ok(Self::XprotoEnterNotifyEvent(event.into())),
+            xproto::EXPOSE_EVENT => return Ok(Self::XprotoExposeEvent(event.into())),
+            xproto::FOCUS_IN_EVENT => return Ok(Self::XprotoFocusInEvent(event.into())),
+            xproto::FOCUS_OUT_EVENT => return Ok(Self::XprotoFocusOutEvent(event.into())),
+            xproto::GRAPHICS_EXPOSURE_EVENT => return Ok(Self::XprotoGraphicsExposureEvent(event.into())),
+            xproto::GRAVITY_NOTIFY_EVENT => return Ok(Self::XprotoGravityNotifyEvent(event.into())),
+            xproto::KEY_PRESS_EVENT => return Ok(Self::XprotoKeyPressEvent(event.into())),
+            xproto::KEY_RELEASE_EVENT => return Ok(Self::XprotoKeyReleaseEvent(event.into())),
+            xproto::KEYMAP_NOTIFY_EVENT => return Ok(Self::XprotoKeymapNotifyEvent(event.into())),
+            xproto::LEAVE_NOTIFY_EVENT => return Ok(Self::XprotoLeaveNotifyEvent(event.into())),
+            xproto::MAP_NOTIFY_EVENT => return Ok(Self::XprotoMapNotifyEvent(event.into())),
+            xproto::MAP_REQUEST_EVENT => return Ok(Self::XprotoMapRequestEvent(event.into())),
+            xproto::MAPPING_NOTIFY_EVENT => return Ok(Self::XprotoMappingNotifyEvent(event.into())),
+            xproto::MOTION_NOTIFY_EVENT => return Ok(Self::XprotoMotionNotifyEvent(event.into())),
+            xproto::NO_EXPOSURE_EVENT => return Ok(Self::XprotoNoExposureEvent(event.into())),
+            xproto::PROPERTY_NOTIFY_EVENT => return Ok(Self::XprotoPropertyNotifyEvent(event.into())),
+            xproto::REPARENT_NOTIFY_EVENT => return Ok(Self::XprotoReparentNotifyEvent(event.into())),
+            xproto::RESIZE_REQUEST_EVENT => return Ok(Self::XprotoResizeRequestEvent(event.into())),
+            xproto::SELECTION_CLEAR_EVENT => return Ok(Self::XprotoSelectionClearEvent(event.into())),
+            xproto::SELECTION_NOTIFY_EVENT => return Ok(Self::XprotoSelectionNotifyEvent(event.into())),
+            xproto::SELECTION_REQUEST_EVENT => return Ok(Self::XprotoSelectionRequestEvent(event.into())),
+            xproto::UNMAP_NOTIFY_EVENT => return Ok(Self::XprotoUnmapNotifyEvent(event.into())),
+            xproto::VISIBILITY_NOTIFY_EVENT => return Ok(Self::XprotoVisibilityNotifyEvent(event.into())),
             xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, iter),
             _ => {}
         }
@@ -596,98 +594,98 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
             #[cfg(feature = "damage")]
             Some(("DAMAGE", first_event)) => {
                 match event_type - first_event {
-                    damage::NOTIFY_EVENT => Ok(Self::DamageNotifyEvent(damage::NotifyEvent::try_parse(bytes)?.0)),
+                    damage::NOTIFY_EVENT => Ok(Self::DamageNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "dri2")]
             Some(("DRI2", first_event)) => {
                 match event_type - first_event {
-                    dri2::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::Dri2BufferSwapCompleteEvent(dri2::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
-                    dri2::INVALIDATE_BUFFERS_EVENT => Ok(Self::Dri2InvalidateBuffersEvent(dri2::InvalidateBuffersEvent::try_parse(bytes)?.0)),
+                    dri2::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::Dri2BufferSwapCompleteEvent(event.into())),
+                    dri2::INVALIDATE_BUFFERS_EVENT => Ok(Self::Dri2InvalidateBuffersEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "glx")]
             Some(("GLX", first_event)) => {
                 match event_type - first_event {
-                    glx::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::GlxBufferSwapCompleteEvent(glx::BufferSwapCompleteEvent::try_parse(bytes)?.0)),
-                    glx::PBUFFER_CLOBBER_EVENT => Ok(Self::GlxPbufferClobberEvent(glx::PbufferClobberEvent::try_parse(bytes)?.0)),
+                    glx::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::GlxBufferSwapCompleteEvent(event.into())),
+                    glx::PBUFFER_CLOBBER_EVENT => Ok(Self::GlxPbufferClobberEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "present")]
             Some(("Present", first_event)) => {
                 match event_type - first_event {
-                    present::GENERIC_EVENT => Ok(Self::PresentGenericEvent(present::GenericEvent::try_parse(bytes)?.0)),
+                    present::GENERIC_EVENT => Ok(Self::PresentGenericEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "randr")]
             Some(("RANDR", first_event)) => {
                 match event_type - first_event {
-                    randr::NOTIFY_EVENT => Ok(Self::RandrNotifyEvent(randr::NotifyEvent::try_parse(bytes)?.0)),
-                    randr::SCREEN_CHANGE_NOTIFY_EVENT => Ok(Self::RandrScreenChangeNotifyEvent(randr::ScreenChangeNotifyEvent::try_parse(bytes)?.0)),
+                    randr::NOTIFY_EVENT => Ok(Self::RandrNotifyEvent(event.into())),
+                    randr::SCREEN_CHANGE_NOTIFY_EVENT => Ok(Self::RandrScreenChangeNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "screensaver")]
             Some(("MIT-SCREEN-SAVER", first_event)) => {
                 match event_type - first_event {
-                    screensaver::NOTIFY_EVENT => Ok(Self::ScreensaverNotifyEvent(screensaver::NotifyEvent::try_parse(bytes)?.0)),
+                    screensaver::NOTIFY_EVENT => Ok(Self::ScreensaverNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "shape")]
             Some(("SHAPE", first_event)) => {
                 match event_type - first_event {
-                    shape::NOTIFY_EVENT => Ok(Self::ShapeNotifyEvent(shape::NotifyEvent::try_parse(bytes)?.0)),
+                    shape::NOTIFY_EVENT => Ok(Self::ShapeNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "shm")]
             Some(("MIT-SHM", first_event)) => {
                 match event_type - first_event {
-                    shm::COMPLETION_EVENT => Ok(Self::ShmCompletionEvent(shm::CompletionEvent::try_parse(bytes)?.0)),
+                    shm::COMPLETION_EVENT => Ok(Self::ShmCompletionEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "sync")]
             Some(("SYNC", first_event)) => {
                 match event_type - first_event {
-                    sync::ALARM_NOTIFY_EVENT => Ok(Self::SyncAlarmNotifyEvent(sync::AlarmNotifyEvent::try_parse(bytes)?.0)),
-                    sync::COUNTER_NOTIFY_EVENT => Ok(Self::SyncCounterNotifyEvent(sync::CounterNotifyEvent::try_parse(bytes)?.0)),
+                    sync::ALARM_NOTIFY_EVENT => Ok(Self::SyncAlarmNotifyEvent(event.into())),
+                    sync::COUNTER_NOTIFY_EVENT => Ok(Self::SyncCounterNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xfixes")]
             Some(("XFIXES", first_event)) => {
                 match event_type - first_event {
-                    xfixes::CURSOR_NOTIFY_EVENT => Ok(Self::XfixesCursorNotifyEvent(xfixes::CursorNotifyEvent::try_parse(bytes)?.0)),
-                    xfixes::SELECTION_NOTIFY_EVENT => Ok(Self::XfixesSelectionNotifyEvent(xfixes::SelectionNotifyEvent::try_parse(bytes)?.0)),
+                    xfixes::CURSOR_NOTIFY_EVENT => Ok(Self::XfixesCursorNotifyEvent(event.into())),
+                    xfixes::SELECTION_NOTIFY_EVENT => Ok(Self::XfixesSelectionNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xinput")]
             Some(("XInputExtension", first_event)) => {
                 match event_type - first_event {
-                    xinput::CHANGE_DEVICE_NOTIFY_EVENT => Ok(Self::XinputChangeDeviceNotifyEvent(xinput::ChangeDeviceNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_BUTTON_PRESS_EVENT => Ok(Self::XinputDeviceButtonPressEvent(xinput::DeviceButtonPressEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_BUTTON_RELEASE_EVENT => Ok(Self::XinputDeviceButtonReleaseEvent(xinput::DeviceButtonReleaseEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_BUTTON_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceButtonStateNotifyEvent(xinput::DeviceButtonStateNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_FOCUS_IN_EVENT => Ok(Self::XinputDeviceFocusInEvent(xinput::DeviceFocusInEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_FOCUS_OUT_EVENT => Ok(Self::XinputDeviceFocusOutEvent(xinput::DeviceFocusOutEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_KEY_PRESS_EVENT => Ok(Self::XinputDeviceKeyPressEvent(xinput::DeviceKeyPressEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_KEY_RELEASE_EVENT => Ok(Self::XinputDeviceKeyReleaseEvent(xinput::DeviceKeyReleaseEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_KEY_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceKeyStateNotifyEvent(xinput::DeviceKeyStateNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_MAPPING_NOTIFY_EVENT => Ok(Self::XinputDeviceMappingNotifyEvent(xinput::DeviceMappingNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_MOTION_NOTIFY_EVENT => Ok(Self::XinputDeviceMotionNotifyEvent(xinput::DeviceMotionNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_PRESENCE_NOTIFY_EVENT => Ok(Self::XinputDevicePresenceNotifyEvent(xinput::DevicePresenceNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_PROPERTY_NOTIFY_EVENT => Ok(Self::XinputDevicePropertyNotifyEvent(xinput::DevicePropertyNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceStateNotifyEvent(xinput::DeviceStateNotifyEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_VALUATOR_EVENT => Ok(Self::XinputDeviceValuatorEvent(xinput::DeviceValuatorEvent::try_parse(bytes)?.0)),
-                    xinput::PROXIMITY_IN_EVENT => Ok(Self::XinputProximityInEvent(xinput::ProximityInEvent::try_parse(bytes)?.0)),
-                    xinput::PROXIMITY_OUT_EVENT => Ok(Self::XinputProximityOutEvent(xinput::ProximityOutEvent::try_parse(bytes)?.0)),
+                    xinput::CHANGE_DEVICE_NOTIFY_EVENT => Ok(Self::XinputChangeDeviceNotifyEvent(event.into())),
+                    xinput::DEVICE_BUTTON_PRESS_EVENT => Ok(Self::XinputDeviceButtonPressEvent(event.into())),
+                    xinput::DEVICE_BUTTON_RELEASE_EVENT => Ok(Self::XinputDeviceButtonReleaseEvent(event.into())),
+                    xinput::DEVICE_BUTTON_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceButtonStateNotifyEvent(event.into())),
+                    xinput::DEVICE_FOCUS_IN_EVENT => Ok(Self::XinputDeviceFocusInEvent(event.into())),
+                    xinput::DEVICE_FOCUS_OUT_EVENT => Ok(Self::XinputDeviceFocusOutEvent(event.into())),
+                    xinput::DEVICE_KEY_PRESS_EVENT => Ok(Self::XinputDeviceKeyPressEvent(event.into())),
+                    xinput::DEVICE_KEY_RELEASE_EVENT => Ok(Self::XinputDeviceKeyReleaseEvent(event.into())),
+                    xinput::DEVICE_KEY_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceKeyStateNotifyEvent(event.into())),
+                    xinput::DEVICE_MAPPING_NOTIFY_EVENT => Ok(Self::XinputDeviceMappingNotifyEvent(event.into())),
+                    xinput::DEVICE_MOTION_NOTIFY_EVENT => Ok(Self::XinputDeviceMotionNotifyEvent(event.into())),
+                    xinput::DEVICE_PRESENCE_NOTIFY_EVENT => Ok(Self::XinputDevicePresenceNotifyEvent(event.into())),
+                    xinput::DEVICE_PROPERTY_NOTIFY_EVENT => Ok(Self::XinputDevicePropertyNotifyEvent(event.into())),
+                    xinput::DEVICE_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceStateNotifyEvent(event.into())),
+                    xinput::DEVICE_VALUATOR_EVENT => Ok(Self::XinputDeviceValuatorEvent(event.into())),
+                    xinput::PROXIMITY_IN_EVENT => Ok(Self::XinputProximityInEvent(event.into())),
+                    xinput::PROXIMITY_OUT_EVENT => Ok(Self::XinputProximityOutEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
@@ -697,34 +695,34 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
                     return Ok(Self::Unknown(event));
                 }
                 match event.raw_bytes()[1] {
-                    xkb::ACCESS_X_NOTIFY_EVENT => Ok(Self::XkbAccessXNotifyEvent(xkb::AccessXNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::ACTION_MESSAGE_EVENT => Ok(Self::XkbActionMessageEvent(xkb::ActionMessageEvent::try_parse(bytes)?.0)),
-                    xkb::BELL_NOTIFY_EVENT => Ok(Self::XkbBellNotifyEvent(xkb::BellNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::COMPAT_MAP_NOTIFY_EVENT => Ok(Self::XkbCompatMapNotifyEvent(xkb::CompatMapNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::CONTROLS_NOTIFY_EVENT => Ok(Self::XkbControlsNotifyEvent(xkb::ControlsNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::EXTENSION_DEVICE_NOTIFY_EVENT => Ok(Self::XkbExtensionDeviceNotifyEvent(xkb::ExtensionDeviceNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::INDICATOR_MAP_NOTIFY_EVENT => Ok(Self::XkbIndicatorMapNotifyEvent(xkb::IndicatorMapNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::INDICATOR_STATE_NOTIFY_EVENT => Ok(Self::XkbIndicatorStateNotifyEvent(xkb::IndicatorStateNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::MAP_NOTIFY_EVENT => Ok(Self::XkbMapNotifyEvent(xkb::MapNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::NAMES_NOTIFY_EVENT => Ok(Self::XkbNamesNotifyEvent(xkb::NamesNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::NEW_KEYBOARD_NOTIFY_EVENT => Ok(Self::XkbNewKeyboardNotifyEvent(xkb::NewKeyboardNotifyEvent::try_parse(bytes)?.0)),
-                    xkb::STATE_NOTIFY_EVENT => Ok(Self::XkbStateNotifyEvent(xkb::StateNotifyEvent::try_parse(bytes)?.0)),
+                    xkb::ACCESS_X_NOTIFY_EVENT => Ok(Self::XkbAccessXNotifyEvent(event.into())),
+                    xkb::ACTION_MESSAGE_EVENT => Ok(Self::XkbActionMessageEvent(event.into())),
+                    xkb::BELL_NOTIFY_EVENT => Ok(Self::XkbBellNotifyEvent(event.into())),
+                    xkb::COMPAT_MAP_NOTIFY_EVENT => Ok(Self::XkbCompatMapNotifyEvent(event.into())),
+                    xkb::CONTROLS_NOTIFY_EVENT => Ok(Self::XkbControlsNotifyEvent(event.into())),
+                    xkb::EXTENSION_DEVICE_NOTIFY_EVENT => Ok(Self::XkbExtensionDeviceNotifyEvent(event.into())),
+                    xkb::INDICATOR_MAP_NOTIFY_EVENT => Ok(Self::XkbIndicatorMapNotifyEvent(event.into())),
+                    xkb::INDICATOR_STATE_NOTIFY_EVENT => Ok(Self::XkbIndicatorStateNotifyEvent(event.into())),
+                    xkb::MAP_NOTIFY_EVENT => Ok(Self::XkbMapNotifyEvent(event.into())),
+                    xkb::NAMES_NOTIFY_EVENT => Ok(Self::XkbNamesNotifyEvent(event.into())),
+                    xkb::NEW_KEYBOARD_NOTIFY_EVENT => Ok(Self::XkbNewKeyboardNotifyEvent(event.into())),
+                    xkb::STATE_NOTIFY_EVENT => Ok(Self::XkbStateNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xprint")]
             Some(("XpExtension", first_event)) => {
                 match event_type - first_event {
-                    xprint::ATTRIBUT_NOTIFY_EVENT => Ok(Self::XprintAttributNotifyEvent(xprint::AttributNotifyEvent::try_parse(bytes)?.0)),
-                    xprint::NOTIFY_EVENT => Ok(Self::XprintNotifyEvent(xprint::NotifyEvent::try_parse(bytes)?.0)),
+                    xprint::ATTRIBUT_NOTIFY_EVENT => Ok(Self::XprintAttributNotifyEvent(event.into())),
+                    xprint::NOTIFY_EVENT => Ok(Self::XprintNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xv")]
             Some(("XVideo", first_event)) => {
                 match event_type - first_event {
-                    xv::PORT_NOTIFY_EVENT => Ok(Self::XvPortNotifyEvent(xv::PortNotifyEvent::try_parse(bytes)?.0)),
-                    xv::VIDEO_NOTIFY_EVENT => Ok(Self::XvVideoNotifyEvent(xv::VideoNotifyEvent::try_parse(bytes)?.0)),
+                    xv::PORT_NOTIFY_EVENT => Ok(Self::XvPortNotifyEvent(event.into())),
+                    xv::VIDEO_NOTIFY_EVENT => Ok(Self::XvVideoNotifyEvent(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
@@ -747,42 +745,42 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
             #[cfg(feature = "present")]
             Some("Present") => {
                 match event_type {
-                    present::COMPLETE_NOTIFY_EVENT => Ok(Self::PresentCompleteNotifyEvent(present::CompleteNotifyEvent::try_parse(bytes)?.0)),
-                    present::CONFIGURE_NOTIFY_EVENT => Ok(Self::PresentConfigureNotifyEvent(present::ConfigureNotifyEvent::try_parse(bytes)?.0)),
-                    present::IDLE_NOTIFY_EVENT => Ok(Self::PresentIdleNotifyEvent(present::IdleNotifyEvent::try_parse(bytes)?.0)),
-                    present::REDIRECT_NOTIFY_EVENT => Ok(Self::PresentRedirectNotifyEvent(present::RedirectNotifyEvent::try_parse(bytes)?.0)),
+                    present::COMPLETE_NOTIFY_EVENT => Ok(Self::PresentCompleteNotifyEvent(event.try_into()?)),
+                    present::CONFIGURE_NOTIFY_EVENT => Ok(Self::PresentConfigureNotifyEvent(event.try_into()?)),
+                    present::IDLE_NOTIFY_EVENT => Ok(Self::PresentIdleNotifyEvent(event.try_into()?)),
+                    present::REDIRECT_NOTIFY_EVENT => Ok(Self::PresentRedirectNotifyEvent(event.try_into()?)),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xinput")]
             Some("XInputExtension") => {
                 match event_type {
-                    xinput::BARRIER_HIT_EVENT => Ok(Self::XinputBarrierHitEvent(xinput::BarrierHitEvent::try_parse(bytes)?.0)),
-                    xinput::BARRIER_LEAVE_EVENT => Ok(Self::XinputBarrierLeaveEvent(xinput::BarrierLeaveEvent::try_parse(bytes)?.0)),
-                    xinput::BUTTON_PRESS_EVENT => Ok(Self::XinputButtonPressEvent(xinput::ButtonPressEvent::try_parse(bytes)?.0)),
-                    xinput::BUTTON_RELEASE_EVENT => Ok(Self::XinputButtonReleaseEvent(xinput::ButtonReleaseEvent::try_parse(bytes)?.0)),
-                    xinput::DEVICE_CHANGED_EVENT => Ok(Self::XinputDeviceChangedEvent(xinput::DeviceChangedEvent::try_parse(bytes)?.0)),
-                    xinput::ENTER_EVENT => Ok(Self::XinputEnterEvent(xinput::EnterEvent::try_parse(bytes)?.0)),
-                    xinput::FOCUS_IN_EVENT => Ok(Self::XinputFocusInEvent(xinput::FocusInEvent::try_parse(bytes)?.0)),
-                    xinput::FOCUS_OUT_EVENT => Ok(Self::XinputFocusOutEvent(xinput::FocusOutEvent::try_parse(bytes)?.0)),
-                    xinput::HIERARCHY_EVENT => Ok(Self::XinputHierarchyEvent(xinput::HierarchyEvent::try_parse(bytes)?.0)),
-                    xinput::KEY_PRESS_EVENT => Ok(Self::XinputKeyPressEvent(xinput::KeyPressEvent::try_parse(bytes)?.0)),
-                    xinput::KEY_RELEASE_EVENT => Ok(Self::XinputKeyReleaseEvent(xinput::KeyReleaseEvent::try_parse(bytes)?.0)),
-                    xinput::LEAVE_EVENT => Ok(Self::XinputLeaveEvent(xinput::LeaveEvent::try_parse(bytes)?.0)),
-                    xinput::MOTION_EVENT => Ok(Self::XinputMotionEvent(xinput::MotionEvent::try_parse(bytes)?.0)),
-                    xinput::PROPERTY_EVENT => Ok(Self::XinputPropertyEvent(xinput::PropertyEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_BUTTON_PRESS_EVENT => Ok(Self::XinputRawButtonPressEvent(xinput::RawButtonPressEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_BUTTON_RELEASE_EVENT => Ok(Self::XinputRawButtonReleaseEvent(xinput::RawButtonReleaseEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_KEY_PRESS_EVENT => Ok(Self::XinputRawKeyPressEvent(xinput::RawKeyPressEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_KEY_RELEASE_EVENT => Ok(Self::XinputRawKeyReleaseEvent(xinput::RawKeyReleaseEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_MOTION_EVENT => Ok(Self::XinputRawMotionEvent(xinput::RawMotionEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_TOUCH_BEGIN_EVENT => Ok(Self::XinputRawTouchBeginEvent(xinput::RawTouchBeginEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_TOUCH_END_EVENT => Ok(Self::XinputRawTouchEndEvent(xinput::RawTouchEndEvent::try_parse(bytes)?.0)),
-                    xinput::RAW_TOUCH_UPDATE_EVENT => Ok(Self::XinputRawTouchUpdateEvent(xinput::RawTouchUpdateEvent::try_parse(bytes)?.0)),
-                    xinput::TOUCH_BEGIN_EVENT => Ok(Self::XinputTouchBeginEvent(xinput::TouchBeginEvent::try_parse(bytes)?.0)),
-                    xinput::TOUCH_END_EVENT => Ok(Self::XinputTouchEndEvent(xinput::TouchEndEvent::try_parse(bytes)?.0)),
-                    xinput::TOUCH_OWNERSHIP_EVENT => Ok(Self::XinputTouchOwnershipEvent(xinput::TouchOwnershipEvent::try_parse(bytes)?.0)),
-                    xinput::TOUCH_UPDATE_EVENT => Ok(Self::XinputTouchUpdateEvent(xinput::TouchUpdateEvent::try_parse(bytes)?.0)),
+                    xinput::BARRIER_HIT_EVENT => Ok(Self::XinputBarrierHitEvent(event.try_into()?)),
+                    xinput::BARRIER_LEAVE_EVENT => Ok(Self::XinputBarrierLeaveEvent(event.try_into()?)),
+                    xinput::BUTTON_PRESS_EVENT => Ok(Self::XinputButtonPressEvent(event.try_into()?)),
+                    xinput::BUTTON_RELEASE_EVENT => Ok(Self::XinputButtonReleaseEvent(event.try_into()?)),
+                    xinput::DEVICE_CHANGED_EVENT => Ok(Self::XinputDeviceChangedEvent(event.try_into()?)),
+                    xinput::ENTER_EVENT => Ok(Self::XinputEnterEvent(event.try_into()?)),
+                    xinput::FOCUS_IN_EVENT => Ok(Self::XinputFocusInEvent(event.try_into()?)),
+                    xinput::FOCUS_OUT_EVENT => Ok(Self::XinputFocusOutEvent(event.try_into()?)),
+                    xinput::HIERARCHY_EVENT => Ok(Self::XinputHierarchyEvent(event.try_into()?)),
+                    xinput::KEY_PRESS_EVENT => Ok(Self::XinputKeyPressEvent(event.try_into()?)),
+                    xinput::KEY_RELEASE_EVENT => Ok(Self::XinputKeyReleaseEvent(event.try_into()?)),
+                    xinput::LEAVE_EVENT => Ok(Self::XinputLeaveEvent(event.try_into()?)),
+                    xinput::MOTION_EVENT => Ok(Self::XinputMotionEvent(event.try_into()?)),
+                    xinput::PROPERTY_EVENT => Ok(Self::XinputPropertyEvent(event.try_into()?)),
+                    xinput::RAW_BUTTON_PRESS_EVENT => Ok(Self::XinputRawButtonPressEvent(event.try_into()?)),
+                    xinput::RAW_BUTTON_RELEASE_EVENT => Ok(Self::XinputRawButtonReleaseEvent(event.try_into()?)),
+                    xinput::RAW_KEY_PRESS_EVENT => Ok(Self::XinputRawKeyPressEvent(event.try_into()?)),
+                    xinput::RAW_KEY_RELEASE_EVENT => Ok(Self::XinputRawKeyReleaseEvent(event.try_into()?)),
+                    xinput::RAW_MOTION_EVENT => Ok(Self::XinputRawMotionEvent(event.try_into()?)),
+                    xinput::RAW_TOUCH_BEGIN_EVENT => Ok(Self::XinputRawTouchBeginEvent(event.try_into()?)),
+                    xinput::RAW_TOUCH_END_EVENT => Ok(Self::XinputRawTouchEndEvent(event.try_into()?)),
+                    xinput::RAW_TOUCH_UPDATE_EVENT => Ok(Self::XinputRawTouchUpdateEvent(event.try_into()?)),
+                    xinput::TOUCH_BEGIN_EVENT => Ok(Self::XinputTouchBeginEvent(event.try_into()?)),
+                    xinput::TOUCH_END_EVENT => Ok(Self::XinputTouchEndEvent(event.try_into()?)),
+                    xinput::TOUCH_OWNERSHIP_EVENT => Ok(Self::XinputTouchOwnershipEvent(event.try_into()?)),
+                    xinput::TOUCH_UPDATE_EVENT => Ok(Self::XinputTouchUpdateEvent(event.try_into()?)),
                     _ => Ok(Self::Unknown(event))
                 }
             }

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -29,6 +29,8 @@ pub type GenericError = crate::x11_utils::GenericError<Buffer>;
 pub type GenericEvent = crate::x11_utils::GenericEvent<Buffer>;
 pub type EventAndSeqNumber = crate::connection::EventAndSeqNumber<Buffer>;
 pub type BufWithFds = crate::connection::BufWithFds<Buffer>;
+pub type Error = crate::Error<Buffer>;
+pub type Event = crate::Event<Buffer>;
 
 #[derive(Debug)]
 enum MaxRequestBytes {
@@ -409,6 +411,16 @@ impl<R: Read, W: Write> Connection for RustConnection<R, W> {
 
     fn poll_for_event_with_sequence(&self) -> Result<Option<EventAndSeqNumber>, ConnectionError> {
         Ok(self.inner.lock().unwrap().poll_for_event_with_sequence())
+    }
+
+    fn parse_error(&self, error: GenericError) -> Result<Error, ParseError> {
+        let ext_info = self.extension_information.lock().unwrap();
+        Error::parse(error, ext_info.known_present())
+    }
+
+    fn parse_event(&self, event: GenericEvent) -> Result<Event, ParseError> {
+        let ext_info = self.extension_information.lock().unwrap();
+        Event::parse(event, ext_info.known_present())
     }
 
     fn flush(&self) -> Result<(), ConnectionError> {


### PR DESCRIPTION
This fixes #180.

No idea if this code is correct. For example, XKB is a special case since technically it only has a single "protocol event" and this single event is interpreted differently based on a byte in there. I noticed this only accidentally, so other extensions might also do "weird things".

I only tested this with the examples that come with the library.