### PR TITLE
Make property and type arguments of ChangeProperty generic

### DIFF
--- a/code_generator_helpers/request.py
+++ b/code_generator_helpers/request.py
@@ -79,7 +79,8 @@ def collect_function_arguments(module, obj, name, aux_name):
             # - It is the "event" argument of SendEvent
             if (field.enum is not None and not field.type.is_list) or \
                     (field.isfd and not field.type.is_list) or \
-                    (name == ('xcb', 'SendEvent') and field.field_name == 'event'):
+                    (name == ('xcb', 'SendEvent') and field.field_name == 'event') or \
+                    (name == ('xcb', 'ChangeProperty') and field.field_type == ('xcb', 'ATOM')):
                 if name == ('xcb', 'SendEvent') and field.field_name == 'event':
                     # Turn &[u8; 32] into [u8; 32]
                     assert rust_type[0] == '&'
@@ -323,7 +324,8 @@ def request_implementation(module, obj, name, fds, fds_is_list):
                     # (Needed because this is not a function argument)
                     module.out("let %s: %s = %s.len().try_into()?;", rust_variable,
                                module._field_type(field), list_var_name)
-            if field.enum is not None and not hasattr(field, 'lenfield_for_switch'):
+            if (field.enum is not None and not hasattr(field, 'lenfield_for_switch')) or \
+                    (name == ('xcb', 'ChangeProperty') and field.field_type == ('xcb', 'ATOM')):
                 # This is a generic parameter, call Into::into
                 module.out("let %s = %s.into();", rust_variable, rust_variable)
             field_bytes = module._to_rust_variable(field_name + "_bytes")

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -51,8 +51,8 @@ fn main() {
     conn.change_property8(
         PropMode::Replace,
         win_id,
-        Atom::WM_NAME.into(),
-        Atom::STRING.into(),
+        Atom::WM_NAME,
+        Atom::STRING,
         title.as_bytes(),
     )
     .unwrap();
@@ -60,7 +60,7 @@ fn main() {
         PropMode::Replace,
         win_id,
         wm_protocols,
-        Atom::ATOM.into(),
+        Atom::ATOM,
         &[wm_delete_window],
     )
     .unwrap();

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -1587,17 +1587,44 @@ fn example8() -> Result<(), Box<dyn Error>> {
 //
 // To change the property of a window, we use one of the following functions:
 //
-//    fn change_property8<A>(&self, mode: A, window: u32, property: u32, type_: u32, data: &[u8])
-//    -> Result<SequenceNumber, ConnectionError>
-//    where A: Into<u8>
+//    fn change_property8<A, B, C>(
+//        &self,
+//        mode: A,
+//        window: WINDOW,
+//        property: B,
+//        type_: C,
+//        data: &[u8],
+//    ) -> Result<VoidCookie<'_, Self>, ConnectionError>
+//    where
+//        A: Into<u8>,
+//        B: Into<ATOM>,
+//        C: Into<ATOM>
 //
-//    fn change_property16<A>(&self, mode: A, window: u32, property: u32, type_: u32, data: &[u16])
-//    -> Result<SequenceNumber, ConnectionError>
-//    where A: Into<u8>
+//    fn change_property16<A, B, C>(
+//        &self,
+//        mode: A,
+//        window: WINDOW,
+//        property: B,
+//        type_: C,
+//        data: &[u16],
+//    ) -> Result<VoidCookie<'_, Self>, ConnectionError>
+//    where
+//        A: Into<u8>,
+//        B: Into<ATOM>,
+//        C: Into<ATOM>
 //
-//    fn change_property32<A>(&self, mode: A, window: u32, property: u32, type_: u32, data: &[u32])
-//    -> Result<SequenceNumber, ConnectionError>
-//    where A: Into<u8>
+//    fn change_property32<A, B, C>(
+//        &self,
+//        mode: A,
+//        window: WINDOW,
+//        property: B,
+//        type_: C,
+//        data: &[u32],
+//    ) -> Result<VoidCookie<'_, Self>, ConnectionError>
+//    where
+//        A: Into<u8>,
+//        B: Into<ATOM>,
+//        C: Into<ATOM>
 //
 // The `mode` parameter could be one of the following values (defined in enumeration
 // xcb_prop_mode_t in the xproto.h header file):
@@ -1649,8 +1676,8 @@ fn example9() -> Result<(), Box<dyn Error>> {
     conn.change_property8(
         PropMode::Replace,
         win,
-        Atom::WM_NAME.into(),
-        Atom::STRING.into(), // FIXME: Get rid of these ugly into()
+        Atom::WM_NAME,
+        Atom::STRING,
         title.as_bytes(),
     )?;
 
@@ -1659,8 +1686,8 @@ fn example9() -> Result<(), Box<dyn Error>> {
     conn.change_property8(
         PropMode::Replace,
         win,
-        Atom::WM_ICON_NAME.into(),
-        Atom::STRING.into(), // FIXME: Get rid of these ugly into()
+        Atom::WM_ICON_NAME,
+        Atom::STRING,
         title_icon.as_bytes(),
     )?;
 

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -236,8 +236,8 @@ fn setup_window<C: Connection>(
     conn.change_property8(
         PropMode::Replace,
         win_id,
-        Atom::WM_NAME.into(),
-        Atom::STRING.into(),
+        Atom::WM_NAME,
+        Atom::STRING,
         title.as_bytes(),
     )
     .unwrap();
@@ -245,7 +245,7 @@ fn setup_window<C: Connection>(
         PropMode::Replace,
         win_id,
         wm_protocols,
-        Atom::ATOM.into(),
+        Atom::ATOM,
         &[wm_delete_window],
     )
     .unwrap();

--- a/src/generated/xproto.rs
+++ b/src/generated/xproto.rs
@@ -8488,15 +8488,17 @@ pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 ///     xcb_flush(conn);
 /// }
 /// ```
-pub fn change_property<'c, Conn, A>(conn: &'c Conn, mode: A, window: WINDOW, property: ATOM, type_: ATOM, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<u8>
+pub fn change_property<'c, Conn, A, B, C>(conn: &'c Conn, mode: A, window: WINDOW, property: B, type_: C, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<ATOM>, C: Into<ATOM>
 {
     let length: usize = (24 + 1 * data.len() + 3) / 4;
     let mode = mode.into();
     let mode_bytes = mode.serialize();
     let length_bytes = TryInto::<u16>::try_into(length).unwrap_or(0).serialize();
     let window_bytes = window.serialize();
+    let property = property.into();
     let property_bytes = property.serialize();
+    let type_ = type_.into();
     let type_bytes = type_.serialize();
     let format_bytes = format.serialize();
     let data_len_bytes = data_len.serialize();
@@ -18724,8 +18726,8 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(conn);
     /// }
     /// ```
-    fn change_property<'c, A>(&'c self, mode: A, window: WINDOW, property: ATOM, type_: ATOM, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where A: Into<u8>
+    fn change_property<'c, A, B, C>(&'c self, mode: A, window: WINDOW, property: B, type_: C, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    where A: Into<u8>, B: Into<ATOM>, C: Into<ATOM>
     {
         change_property(self, mode, window, property, type_, format, data_len, data)
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use super::cookie::VoidCookie;
 use super::errors::{ConnectionError, ReplyError};
 use super::x11_utils::TryParse;
-use super::xproto::ConnectionExt as XProtoConnectionExt;
+use super::xproto::{ConnectionExt as XProtoConnectionExt, ATOM, WINDOW};
 
 /// Iterator implementation used by `GetPropertyReply`.
 ///
@@ -51,16 +51,18 @@ impl<T: TryParse> std::iter::FusedIterator for PropertyIterator<'_, T> {}
 /// Extension trait that simplifies API use
 pub trait ConnectionExt: XProtoConnectionExt {
     /// Change a property on a window with format 8.
-    fn change_property8<A>(
+    fn change_property8<A, B, C>(
         &self,
         mode: A,
-        window: u32,
-        property: u32,
-        type_: u32,
+        window: WINDOW,
+        property: B,
+        type_: C,
         data: &[u8],
     ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
+        B: Into<ATOM>,
+        C: Into<ATOM>,
     {
         self.change_property(
             mode,
@@ -74,16 +76,18 @@ pub trait ConnectionExt: XProtoConnectionExt {
     }
 
     /// Change a property on a window with format 16.
-    fn change_property16<A>(
+    fn change_property16<A, B, C>(
         &self,
         mode: A,
-        window: u32,
-        property: u32,
-        type_: u32,
+        window: WINDOW,
+        property: B,
+        type_: C,
         data: &[u16],
     ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
+        B: Into<ATOM>,
+        C: Into<ATOM>,
     {
         let mut data_u8 = Vec::with_capacity(data.len() * 2);
         for item in data {
@@ -101,16 +105,18 @@ pub trait ConnectionExt: XProtoConnectionExt {
     }
 
     /// Change a property on a window with format 32.
-    fn change_property32<A>(
+    fn change_property32<A, B, C>(
         &self,
         mode: A,
-        window: u32,
-        property: u32,
-        type_: u32,
+        window: WINDOW,
+        property: B,
+        type_: C,
         data: &[u32],
     ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
+        B: Into<ATOM>,
+        C: Into<ATOM>,
     {
         let mut data_u8 = Vec::with_capacity(data.len() * 4);
         for item in data {


### PR DESCRIPTION
Before this, the arguments 'property' and 'type' of ChangeProperty had
type u32. This commit changes that into (basically) impl Into<ATOM>.
That way, for example xproto::ATOM::WM_NAME can be passed in directly.

This is a breaking change, because code that previously passed e.g.
Atom::WM_NAME.into() to change_property no longer compiles (because the
compiler cannot infer which type the argument should be converted to).

Fixes: https://github.com/psychon/x11rb/issues/21
Signed-off-by: Uli Schlachter <psychon@znc.in>