### PR TITLE
Use proper type names

### DIFF
--- a/code_generator_helpers/module.py
+++ b/code_generator_helpers/module.py
@@ -178,15 +178,18 @@ class Module(object):
         self.namespace = outer_module.namespace
         self.outer_module = outer_module
 
+        # Can only import xcbgen after it was added to sys.path
+        from xcbgen.xtypes import Enum
+
         # Collect a list of <typedef> and <xidtype>
         simples = []
         for (name, item) in outer_module.all:
-            if item.is_simple and item.__class__.__name__ != "Enum":
+            if item.is_simple and not isinstance(item, Enum):
                 simples.append(self._to_rust_identifier(self._name(name)))
         # Now check for name collisions with <enum>s
         for (name, item) in outer_module.all:
             rust_name = self._name(name)
-            if item.__class__.__name__ == "Enum":
+            if isinstance(item, Enum):
                 if rust_name in simples:
                     item.rust_name = rust_name + "Enum"
                 else:
@@ -1371,8 +1374,11 @@ class Module(object):
             return 'bool'
         name = self._name(field.field_type)
 
+        # Can only import xcbgen after it was added to sys.path
+        from xcbgen.xtypes import Enum
+
         field_type = field.type.member if field.type.is_list else field.type
-        if field_type.is_simple and field_type.__class__.__name__ != "Enum":
+        if field_type.is_simple and not isinstance(field_type, Enum):
             # This is a typedef or an xidtype
             name = self._to_rust_identifier(name)
         return name

--- a/code_generator_helpers/request.py
+++ b/code_generator_helpers/request.py
@@ -90,6 +90,11 @@ def collect_function_arguments(module, obj, name, aux_name):
                 where.append("%s: Into<%s>" % (letter, rust_type))
                 rust_type = letter
 
+            if name == ('xcb', 'Test', 'CompareCursor') and field.field_name == 'cursor':
+                # xtest contains a 'Cursor' enum that shadows the cursor type from xproto.
+                # Since this problem only occurs once, handle it explicitly/specially.
+                rust_type = "super::xproto::" + rust_type
+
             args.append("%s: %s" % (module._to_rust_variable(field.field_name), rust_type))
             arg_names.append(module._to_rust_variable(field.field_name))
             if field.isfd:

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -24,9 +24,9 @@ const FRAME_RATE: u64 = 10;
 const WINS: usize = 3;
 
 #[derive(Default)]
-struct Window {
-    window: WINDOW,
-    pixmap: PIXMAP,
+struct WindowState {
+    window: Window,
+    pixmap: Pixmap,
     angle_velocity: f64,
 }
 
@@ -56,7 +56,7 @@ fn main() {
     .unwrap();
 
     let windows: Vec<_> = (0..WINS)
-        .map(|_| Arc::new(Mutex::new(Window::default())))
+        .map(|_| Arc::new(Mutex::new(WindowState::default())))
         .collect();
 
     for win in windows.iter() {
@@ -70,10 +70,10 @@ fn main() {
 
 fn run<C: Connection>(
     conn: Arc<C>,
-    window_state: Arc<Mutex<Window>>,
+    window_state: Arc<Mutex<WindowState>>,
     screen_num: usize,
-    white: GCONTEXT,
-    black: GCONTEXT,
+    white: Gcontext,
+    black: Gcontext,
 ) -> Result<(), ReplyOrIdError<C::Buf>> {
     let screen = &conn.setup().roots[screen_num];
     let default_size = 300;
@@ -178,8 +178,8 @@ fn run<C: Connection>(
 
 fn event_thread<C>(
     conn_arc: Arc<C>,
-    windows: Vec<Arc<Mutex<Window>>>,
-    white: GCONTEXT,
+    windows: Vec<Arc<Mutex<WindowState>>>,
+    white: Gcontext,
 ) -> Result<(), ReplyError<C::Buf>>
 where
     C: Connection + Send + Sync + 'static,
@@ -248,9 +248,9 @@ where
 }
 
 fn find_window_by_id(
-    windows: &[Arc<Mutex<Window>>],
-    window: WINDOW,
-) -> Option<&Arc<Mutex<Window>>> {
+    windows: &[Arc<Mutex<WindowState>>],
+    window: Window,
+) -> Option<&Arc<Mutex<WindowState>>> {
     windows.iter().find(|state| {
         state
             .lock()

--- a/examples/integration_test_util/util.rs
+++ b/examples/integration_test_util/util.rs
@@ -11,11 +11,11 @@ mod util {
     use x11rb::connection::Connection;
     use x11rb::xproto::{
         ClientMessageData, ClientMessageEvent, ConnectionExt as _, EventMask, CLIENT_MESSAGE_EVENT,
-        WINDOW,
+        Window,
     };
     use x11rb::x11_utils::TryParse;
 
-    pub fn start_timeout_thread<C>(conn: Arc<C>, window: WINDOW)
+    pub fn start_timeout_thread<C>(conn: Arc<C>, window: Window)
     where
         C: Connection + Send + Sync + 'static,
     {

--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -15,7 +15,7 @@ use x11rb::xproto::{self, ConnectionExt as _, ImageFormat};
 
 const TEMP_FILE_CONTENT: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd, 0xfc];
 
-struct FreePixmap<'c, C: Connection>(&'c C, xproto::PIXMAP);
+struct FreePixmap<'c, C: Connection>(&'c C, xproto::Pixmap);
 impl<C: Connection> Drop for FreePixmap<'_, C> {
     fn drop(&mut self) {
         self.0.free_pixmap(self.1).unwrap();
@@ -40,7 +40,7 @@ fn check_shm_version<C: Connection>(conn: &C) -> Result<Option<(u16, u16)>, Repl
 fn get_shared_memory_content_at_offset<C: Connection>(
     conn: &C,
     screen: &xproto::Screen,
-    shmseg: shm::SEG,
+    shmseg: shm::Seg,
     offset: u32,
 ) -> Result<Vec<u8>, ReplyOrIdError<C::Buf>> {
     let width = match screen.root_depth {
@@ -69,7 +69,7 @@ fn get_shared_memory_content_at_offset<C: Connection>(
 fn use_shared_mem<C: Connection>(
     conn: &C,
     screen_num: usize,
-    shmseg: shm::SEG,
+    shmseg: shm::Seg,
 ) -> Result<(), ReplyOrIdError<C::Buf>> {
     let screen = &conn.setup().roots[screen_num];
 

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -51,8 +51,8 @@ fn main() {
     conn.change_property8(
         PropMode::Replace,
         win_id,
-        Atom::WM_NAME,
-        Atom::STRING,
+        AtomEnum::WM_NAME,
+        AtomEnum::STRING,
         title.as_bytes(),
     )
     .unwrap();
@@ -60,7 +60,7 @@ fn main() {
         PropMode::Replace,
         win_id,
         wm_protocols,
-        Atom::ATOM,
+        AtomEnum::ATOM,
         &[wm_delete_window],
     )
     .unwrap();
@@ -69,8 +69,8 @@ fn main() {
         .get_property(
             false,
             win_id,
-            Atom::WM_NAME.into(),
-            Atom::STRING.into(),
+            AtomEnum::WM_NAME.into(),
+            AtomEnum::STRING.into(),
             0,
             1024,
         )

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -17,8 +17,8 @@ const TITLEBAR_HEIGHT: u16 = 20;
 /// The state of a single window that we manage
 #[derive(Debug)]
 struct WindowState {
-    window: WINDOW,
-    frame_window: WINDOW,
+    window: Window,
+    frame_window: Window,
     x: i16,
     y: i16,
     width: u16,
@@ -26,7 +26,7 @@ struct WindowState {
 }
 
 impl WindowState {
-    fn new(window: WINDOW, frame_window: WINDOW, geom: &GetGeometryReply) -> WindowState {
+    fn new(window: Window, frame_window: Window, geom: &GetGeometryReply) -> WindowState {
         WindowState {
             window,
             frame_window,
@@ -47,11 +47,11 @@ impl WindowState {
 struct WMState<'a, C: Connection> {
     conn: &'a C,
     screen_num: usize,
-    black_gc: GCONTEXT,
+    black_gc: Gcontext,
     windows: Vec<WindowState>,
-    pending_expose: HashSet<WINDOW>,
-    wm_protocols: ATOM,
-    wm_delete_window: ATOM,
+    pending_expose: HashSet<Window>,
+    wm_protocols: Atom,
+    wm_delete_window: Atom,
 }
 
 impl<'a, C: Connection> WMState<'a, C> {
@@ -115,7 +115,7 @@ impl<'a, C: Connection> WMState<'a, C> {
     /// Add a new window that should be managed by the WM
     fn manage_window(
         &mut self,
-        win: WINDOW,
+        win: Window,
         geom: &GetGeometryReply,
     ) -> Result<(), ReplyOrIdError<C::Buf>> {
         println!("Managing window {:?}", win);
@@ -186,8 +186,8 @@ impl<'a, C: Connection> WMState<'a, C> {
             .get_property(
                 false,
                 state.window,
-                Atom::WM_NAME.into(),
-                Atom::STRING.into(),
+                AtomEnum::WM_NAME.into(),
+                AtomEnum::STRING.into(),
                 0,
                 std::u32::MAX,
             )?
@@ -213,13 +213,13 @@ impl<'a, C: Connection> WMState<'a, C> {
         Ok(())
     }
 
-    fn find_window_by_id(&self, win: WINDOW) -> Option<&WindowState> {
+    fn find_window_by_id(&self, win: Window) -> Option<&WindowState> {
         self.windows
             .iter()
             .find(|state| state.window == win || state.frame_window == win)
     }
 
-    fn find_window_by_id_mut(&mut self, win: WINDOW) -> Option<&mut WindowState> {
+    fn find_window_by_id_mut(&mut self, win: Window) -> Option<&mut WindowState> {
         self.windows
             .iter_mut()
             .find(|state| state.window == win || state.frame_window == win)

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -204,7 +204,7 @@ fn example1() -> Result<(), Box<dyn Error>> {
 
     let (conn, _) = x11rb::connect(None)?;
     const COUNT: usize = 500;
-    let mut atoms = [Into::<u32>::into(Atom::None); COUNT];
+    let mut atoms = [Into::<u32>::into(AtomEnum::None); COUNT];
 
     // Init names
     let names = (0..COUNT).map(|i| format!("NAME{}", i)).collect::<Vec<_>>();
@@ -349,7 +349,7 @@ fn example3() -> Result<(), Box<dyn Error>> {
 //
 
 #[allow(unused)]
-pub type WINDOW = u32;
+pub type Window = u32;
 
 //  We first ask for a new Id for our window, with this function:
 //
@@ -467,7 +467,7 @@ fn example4() -> Result<(), Box<dyn Error>> {
 // with a single window, in order to draw in multiple styles (different colors, different line
 // widths, etc). In XCB, a Graphics Context is, as a window, characterized by an Id:
 //
-//      pub type GCONTEXT = u32;
+//      pub type Gcontext = u32;
 //
 // We first ask the X server to attribute an Id to our graphic context with this function:
 //
@@ -919,7 +919,7 @@ fn example_or<C: Connection>(conn: &C, depth: u8, screen: &Screen) -> Result<(),
 // `Expose` and `ButtonPress` events:
 
 #[allow(unused)]
-fn example_change_event_mask<C: Connection>(conn: &C, win: WINDOW) -> Result<(), Box<dyn Error>> {
+fn example_change_event_mask<C: Connection>(conn: &C, win: Window) -> Result<(), Box<dyn Error>> {
     let values = ChangeWindowAttributesAux::default()
         .event_mask(EventMask::Exposure | EventMask::ButtonPress);
     conn.change_window_attributes(win, &values)?;
@@ -1395,7 +1395,7 @@ fn example7() -> Result<(), Box<dyn Error>> {
 //
 // In order to support flexible fonts, a font type is defined. You know what ? It's an Id:
 //
-//   pub type FONT = u32;
+//   pub type Font = u32;
 //
 // It is used to contain information about a font, and is passed to several functions that handle
 // fonts selection and text drawing. We ask the X server to attribute an Id to our font with the
@@ -1429,8 +1429,8 @@ fn example7() -> Result<(), Box<dyn Error>> {
 fn example_assign_font<C: Connection>(
     conn: &C,
     screen: &Screen,
-    window: WINDOW,
-    font: FONT,
+    window: Window,
+    font: Font,
 ) -> Result<(), Box<dyn Error>> {
     let gc = conn.generate_id()?;
     let values = CreateGCAux::default()
@@ -1469,7 +1469,7 @@ fn example_assign_font<C: Connection>(
 fn text_draw<C: Connection>(
     conn: &C,
     screen: &Screen,
-    window: WINDOW,
+    window: Window,
     x1: i16,
     y1: i16,
     label: &str,
@@ -1485,9 +1485,9 @@ fn text_draw<C: Connection>(
 fn gc_font_get<C: Connection>(
     conn: &C,
     screen: &Screen,
-    window: WINDOW,
+    window: Window,
     font_name: &str,
-) -> Result<GCONTEXT, ReplyOrIdError<C::Buf>> {
+) -> Result<Gcontext, ReplyOrIdError<C::Buf>> {
     let font = conn.generate_id()?;
 
     conn.open_font(font, font_name.as_bytes())?;
@@ -1590,7 +1590,7 @@ fn example8() -> Result<(), Box<dyn Error>> {
 //    fn change_property8<A, B, C>(
 //        &self,
 //        mode: A,
-//        window: WINDOW,
+//        window: Window,
 //        property: B,
 //        type_: C,
 //        data: &[u8],
@@ -1603,7 +1603,7 @@ fn example8() -> Result<(), Box<dyn Error>> {
 //    fn change_property16<A, B, C>(
 //        &self,
 //        mode: A,
-//        window: WINDOW,
+//        window: Window,
 //        property: B,
 //        type_: C,
 //        data: &[u16],
@@ -1616,7 +1616,7 @@ fn example8() -> Result<(), Box<dyn Error>> {
 //    fn change_property32<A, B, C>(
 //        &self,
 //        mode: A,
-//        window: WINDOW,
+//        window: Window,
 //        property: B,
 //        type_: C,
 //        data: &[u32],
@@ -1676,8 +1676,8 @@ fn example9() -> Result<(), Box<dyn Error>> {
     conn.change_property8(
         PropMode::Replace,
         win,
-        Atom::WM_NAME,
-        Atom::STRING,
+        AtomEnum::WM_NAME,
+        AtomEnum::STRING,
         title.as_bytes(),
     )?;
 
@@ -1686,8 +1686,8 @@ fn example9() -> Result<(), Box<dyn Error>> {
     conn.change_property8(
         PropMode::Replace,
         win,
-        Atom::WM_ICON_NAME,
-        Atom::STRING,
+        AtomEnum::WM_ICON_NAME,
+        AtomEnum::STRING,
         title_icon.as_bytes(),
     )?;
 
@@ -1768,7 +1768,7 @@ fn example9() -> Result<(), Box<dyn Error>> {
 // be done like this:
 
 #[allow(unused)]
-fn example_move<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_move<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     // Move the window to coordinates x = 10 and y = 20
     let values = ConfigureWindowAux::default().x(10).y(20);
     conn.configure_window(win, &values)?;
@@ -1786,7 +1786,7 @@ fn example_move<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C
 // following code:
 
 #[allow(unused)]
-fn example_resize<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_resize<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     // Move the window to coordinates width = 10 and height = 20
     let values = ConfigureWindowAux::default().width(10).height(20);
     conn.configure_window(win, &values)?;
@@ -1797,7 +1797,7 @@ fn example_resize<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError
 // `xcb_configure_window_t`:
 
 #[allow(unused)]
-fn example_move_resize<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_move_resize<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     // Move the window to coordinates x = 10 and y = 20
     // and resize the window to width = 200 and height = 300
     let values = ConfigureWindowAux::default()
@@ -1819,7 +1819,7 @@ fn example_move_resize<C: Connection>(conn: &C, win: WINDOW) -> Result<(), Reply
 // manipulate our windows stack order:
 
 #[allow(unused)]
-fn example_stack_above<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_stack_above<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     // Move the window on the top of the stack
     let values = ConfigureWindowAux::default().stack_mode(StackMode::Above);
     conn.configure_window(win, &values)?;
@@ -1827,7 +1827,7 @@ fn example_stack_above<C: Connection>(conn: &C, win: WINDOW) -> Result<(), Reply
 }
 
 #[allow(unused)]
-fn example_stack_below<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_stack_below<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     // Move the window to the bottom of the stack
     let values = ConfigureWindowAux::default().stack_mode(StackMode::Below);
     conn.configure_window(win, &values)?;
@@ -1861,7 +1861,7 @@ pub struct RenamedGetGeometryReply {
 // You use them as follows:
 
 #[allow(unused)]
-fn example_get_geometry<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_get_geometry<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     let geom = conn.get_geometry(win)?.reply()?;
 
     // Do something with the fields of geom
@@ -1913,7 +1913,7 @@ fn example_get_geometry<C: Connection>(conn: &C, win: WINDOW) -> Result<(), Repl
 // We use them as follows:
 
 #[allow(unused)]
-fn example_get_and_query<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_get_and_query<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     let geom = conn.get_geometry(win)?;
     let tree = conn.query_tree(win)?;
     let geom = geom.reply()?;
@@ -1960,7 +1960,7 @@ fn example_get_and_query<C: Connection>(conn: &C, win: WINDOW) -> Result<(), Rep
 // You use them as follows:
 
 #[allow(unused)]
-fn example_get_attributes<C: Connection>(conn: &C, win: WINDOW) -> Result<(), ReplyError<C::Buf>> {
+fn example_get_attributes<C: Connection>(conn: &C, win: Window) -> Result<(), ReplyError<C::Buf>> {
     let geom = conn.get_window_attributes(win)?.reply()?;
 
     // Do something with the fields of attr
@@ -2052,7 +2052,7 @@ fn example_get_colormap<C: Connection>(conn: &C) {
 #[allow(unused)]
 fn example_create_colormap<C: Connection>(
     conn: &C,
-    win: WINDOW,
+    win: Window,
     screen: &Screen,
 ) -> Result<(), ReplyOrIdError<C::Buf>> {
     let cmap = conn.generate_id()?;
@@ -2094,7 +2094,7 @@ fn example_create_colormap<C: Connection>(
 #[allow(unused)]
 fn example_fill_colormap<C: Connection>(
     conn: &C,
-    win: WINDOW,
+    win: Window,
     screen: &Screen,
 ) -> Result<(), ReplyOrIdError<C::Buf>> {
     let cmap = conn.generate_id()?;
@@ -2247,7 +2247,7 @@ fn example_fill_colormap<C: Connection>(
 #[allow(unused)]
 fn example_create_glyph_cursor<C: Connection>(
     conn: &C,
-    win: WINDOW,
+    win: Window,
     screen: &Screen,
 ) -> Result<(), ReplyOrIdError<C::Buf>> {
     let font = conn.generate_id()?;
@@ -2283,8 +2283,8 @@ fn example_create_glyph_cursor<C: Connection>(
 #[allow(unused)]
 fn example_change_window_cursor<C: Connection>(
     conn: &C,
-    win: WINDOW,
-    cursor: CURSOR,
+    win: Window,
+    cursor: Cursor,
 ) -> Result<(), ReplyError<C::Buf>> {
     let values = ChangeWindowAttributesAux::default().cursor(cursor);
     conn.change_window_attributes(win, &values)?;
@@ -2306,7 +2306,7 @@ fn example_change_window_cursor<C: Connection>(
 fn button_draw<C: Connection>(
     conn: &C,
     screen: &Screen,
-    window: WINDOW,
+    window: Window,
     x1: i16,
     y1: i16,
     label: &str,
@@ -2345,7 +2345,7 @@ fn button_draw<C: Connection>(
 fn cursor_set<C: Connection>(
     conn: &C,
     screen: &Screen,
-    window: WINDOW,
+    window: Window,
     cursor_id: u16,
 ) -> Result<(), ReplyOrIdError<C::Buf>> {
     let font = conn.generate_id()?;
@@ -2663,7 +2663,7 @@ fn example_get_screen2<C: Connection>(conn: &C, index: usize) {
 // Just use the .root member of `Screen`.
 
 #[allow(unused)]
-fn example_get_root<C: Connection>(conn: &C, index: usize) -> WINDOW {
+fn example_get_root<C: Connection>(conn: &C, index: usize) -> Window {
     // Open the connection to the X server. Use the DISPLAY environment variable.
     let (conn, screen_num) = x11rb::connect(None).unwrap();
     let default_screen = &conn.setup().roots[screen_num];
@@ -2719,7 +2719,7 @@ fn example_get_visual2<C: Connection>(conn: &C, screen_num: usize) {
 fn example_create_default_gc<C: Connection>(
     conn: &C,
     screen_num: usize,
-) -> Result<GCONTEXT, ReplyOrIdError<C::Buf>> {
+) -> Result<Gcontext, ReplyOrIdError<C::Buf>> {
     let screen = &conn.setup().roots[screen_num];
     let values = CreateGCAux::default()
         .foreground(screen.black_pixel)

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -15,9 +15,9 @@ const EYE_SIZE: i16 = 50;
 // Draw the big background of the eyes
 fn draw_eyes<C: Connection>(
     conn: &C,
-    win_id: WINDOW,
-    black: GCONTEXT,
-    white: GCONTEXT,
+    win_id: Window,
+    black: Gcontext,
+    white: Gcontext,
     window_size: (u16, u16),
 ) -> Result<(), ConnectionError> {
     // Draw the black outlines
@@ -48,8 +48,8 @@ fn draw_eyes<C: Connection>(
 // Draw the pupils inside the eye
 fn draw_pupils<C: Connection>(
     conn: &C,
-    win_id: WINDOW,
-    gc: GCONTEXT,
+    win_id: Window,
+    gc: Gcontext,
     ((x1, y1), (x2, y2)): ((i16, i16), (i16, i16)),
 ) -> Result<(), ConnectionError> {
     // Transform center to top left corner
@@ -152,13 +152,13 @@ fn compute_pupils(window_size: (u16, u16), mouse_position: (i16, i16)) -> ((i16,
     )
 }
 
-struct FreePixmap<'c, C: Connection>(&'c C, PIXMAP);
+struct FreePixmap<'c, C: Connection>(&'c C, Pixmap);
 impl<C: Connection> Drop for FreePixmap<'_, C> {
     fn drop(&mut self) {
         self.0.free_pixmap(self.1).unwrap();
     }
 }
-struct FreeGC<'c, C: Connection>(&'c C, GCONTEXT);
+struct FreeGC<'c, C: Connection>(&'c C, Gcontext);
 impl<C: Connection> Drop for FreeGC<'_, C> {
     fn drop(&mut self) {
         self.0.free_gc(self.1).unwrap();
@@ -168,7 +168,7 @@ impl<C: Connection> Drop for FreeGC<'_, C> {
 fn create_pixmap_wrapper<C: Connection>(
     conn: &C,
     depth: u8,
-    drawable: DRAWABLE,
+    drawable: Drawable,
     size: (u16, u16),
 ) -> Result<FreePixmap<C>, ReplyOrIdError<C::Buf>> {
     let pixmap = conn.generate_id()?;
@@ -178,7 +178,7 @@ fn create_pixmap_wrapper<C: Connection>(
 
 fn shape_window<C: Connection>(
     conn: &C,
-    win_id: WINDOW,
+    win_id: Window,
     window_size: (u16, u16),
 ) -> Result<(), ReplyOrIdError<C::Buf>> {
     // Create a pixmap for the shape
@@ -210,9 +210,9 @@ fn setup_window<C: Connection>(
     conn: &C,
     screen: &Screen,
     window_size: (u16, u16),
-    wm_protocols: ATOM,
-    wm_delete_window: ATOM,
-) -> Result<WINDOW, ReplyOrIdError<C::Buf>> {
+    wm_protocols: Atom,
+    wm_delete_window: Atom,
+) -> Result<Window, ReplyOrIdError<C::Buf>> {
     let win_id = conn.generate_id()?;
     let win_aux = CreateWindowAux::new()
         .event_mask(EventMask::Exposure | EventMask::StructureNotify | EventMask::PointerMotion)
@@ -236,8 +236,8 @@ fn setup_window<C: Connection>(
     conn.change_property8(
         PropMode::Replace,
         win_id,
-        Atom::WM_NAME,
-        Atom::STRING,
+        AtomEnum::WM_NAME,
+        AtomEnum::STRING,
         title.as_bytes(),
     )
     .unwrap();
@@ -245,7 +245,7 @@ fn setup_window<C: Connection>(
         PropMode::Replace,
         win_id,
         wm_protocols,
-        Atom::ATOM,
+        AtomEnum::ATOM,
         &[wm_delete_window],
     )
     .unwrap();
@@ -257,9 +257,9 @@ fn setup_window<C: Connection>(
 
 fn create_gc_with_foreground<C: Connection>(
     conn: &C,
-    win_id: WINDOW,
+    win_id: Window,
     foreground: u32,
-) -> Result<GCONTEXT, ReplyOrIdError<C::Buf>> {
+) -> Result<Gcontext, ReplyOrIdError<C::Buf>> {
     let gc = conn.generate_id()?;
     let gc_aux = CreateGCAux::new()
         .graphics_exposures(0)

--- a/src/generated/composite.rs
+++ b/src/generated/composite.rs
@@ -164,7 +164,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the RedirectWindow request
 pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
-pub fn redirect_window<Conn, A>(conn: &Conn, window: WINDOW, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn redirect_window<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -195,7 +195,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the RedirectSubwindows request
 pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
-pub fn redirect_subwindows<Conn, A>(conn: &Conn, window: WINDOW, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn redirect_subwindows<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -226,7 +226,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the UnredirectWindow request
 pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
-pub fn unredirect_window<Conn, A>(conn: &Conn, window: WINDOW, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unredirect_window<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -257,7 +257,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the UnredirectSubwindows request
 pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
-pub fn unredirect_subwindows<Conn, A>(conn: &Conn, window: WINDOW, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unredirect_subwindows<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -288,7 +288,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the CreateRegionFromBorderClip request
 pub const CREATE_REGION_FROM_BORDER_CLIP_REQUEST: u8 = 5;
-pub fn create_region_from_border_clip<Conn>(conn: &Conn, region: xfixes::REGION, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_border_clip<Conn>(conn: &Conn, region: xfixes::Region, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -318,7 +318,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the NameWindowPixmap request
 pub const NAME_WINDOW_PIXMAP_REQUEST: u8 = 6;
-pub fn name_window_pixmap<Conn>(conn: &Conn, window: WINDOW, pixmap: PIXMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn name_window_pixmap<Conn>(conn: &Conn, window: Window, pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -348,7 +348,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetOverlayWindow request
 pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
-pub fn get_overlay_window<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetOverlayWindowReply>, ConnectionError>
+pub fn get_overlay_window<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetOverlayWindowReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -375,7 +375,7 @@ pub struct GetOverlayWindowReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub overlay_win: WINDOW,
+    pub overlay_win: Window,
 }
 impl GetOverlayWindowReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -383,7 +383,7 @@ impl GetOverlayWindowReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (overlay_win, remaining) = WINDOW::try_parse(remaining)?;
+        let (overlay_win, remaining) = Window::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = GetOverlayWindowReply { response_type, sequence, length, overlay_win };
         Ok((result, remaining))
@@ -398,7 +398,7 @@ impl TryFrom<&[u8]> for GetOverlayWindowReply {
 
 /// Opcode for the ReleaseOverlayWindow request
 pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
-pub fn release_overlay_window<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn release_overlay_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -428,46 +428,46 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn composite_redirect_window<A>(&self, window: WINDOW, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_redirect_window<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         redirect_window(self, window, update)
     }
 
-    fn composite_redirect_subwindows<A>(&self, window: WINDOW, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_redirect_subwindows<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         redirect_subwindows(self, window, update)
     }
 
-    fn composite_unredirect_window<A>(&self, window: WINDOW, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_unredirect_window<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         unredirect_window(self, window, update)
     }
 
-    fn composite_unredirect_subwindows<A>(&self, window: WINDOW, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_unredirect_subwindows<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         unredirect_subwindows(self, window, update)
     }
 
-    fn composite_create_region_from_border_clip(&self, region: xfixes::REGION, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_create_region_from_border_clip(&self, region: xfixes::Region, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_region_from_border_clip(self, region, window)
     }
 
-    fn composite_name_window_pixmap(&self, window: WINDOW, pixmap: PIXMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_name_window_pixmap(&self, window: Window, pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         name_window_pixmap(self, window, pixmap)
     }
 
-    fn composite_get_overlay_window(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetOverlayWindowReply>, ConnectionError>
+    fn composite_get_overlay_window(&self, window: Window) -> Result<Cookie<'_, Self, GetOverlayWindowReply>, ConnectionError>
     {
         get_overlay_window(self, window)
     }
 
-    fn composite_release_overlay_window(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_release_overlay_window(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         release_overlay_window(self, window)
     }

--- a/src/generated/damage.rs
+++ b/src/generated/damage.rs
@@ -43,7 +43,7 @@ pub const X11_EXTENSION_NAME: &str = "DAMAGE";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
-pub type DAMAGE = u32;
+pub type Damage = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -224,7 +224,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Create request
 pub const CREATE_REQUEST: u8 = 1;
-pub fn create<Conn, A>(conn: &Conn, damage: DAMAGE, drawable: DRAWABLE, level: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create<Conn, A>(conn: &Conn, damage: Damage, drawable: Drawable, level: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -260,7 +260,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the Destroy request
 pub const DESTROY_REQUEST: u8 = 2;
-pub fn destroy<Conn>(conn: &Conn, damage: DAMAGE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy<Conn>(conn: &Conn, damage: Damage) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -285,7 +285,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the Subtract request
 pub const SUBTRACT_REQUEST: u8 = 3;
-pub fn subtract<Conn>(conn: &Conn, damage: DAMAGE, repair: xfixes::REGION, parts: xfixes::REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn subtract<Conn>(conn: &Conn, damage: Damage, repair: xfixes::Region, parts: xfixes::Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -320,7 +320,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the Add request
 pub const ADD_REQUEST: u8 = 4;
-pub fn add<Conn>(conn: &Conn, drawable: DRAWABLE, region: xfixes::REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn add<Conn>(conn: &Conn, drawable: Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -355,9 +355,9 @@ pub struct NotifyEvent {
     pub response_type: u8,
     pub level: ReportLevel,
     pub sequence: u16,
-    pub drawable: DRAWABLE,
-    pub damage: DAMAGE,
-    pub timestamp: TIMESTAMP,
+    pub drawable: Drawable,
+    pub damage: Damage,
+    pub timestamp: Timestamp,
     pub area: Rectangle,
     pub geometry: Rectangle,
 }
@@ -366,9 +366,9 @@ impl NotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (level, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
-        let (damage, remaining) = DAMAGE::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (damage, remaining) = Damage::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (area, remaining) = Rectangle::try_parse(remaining)?;
         let (geometry, remaining) = Rectangle::try_parse(remaining)?;
         let level = level.try_into()?;
@@ -423,23 +423,23 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn damage_create<A>(&self, damage: DAMAGE, drawable: DRAWABLE, level: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn damage_create<A>(&self, damage: Damage, drawable: Drawable, level: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         create(self, damage, drawable, level)
     }
 
-    fn damage_destroy(&self, damage: DAMAGE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn damage_destroy(&self, damage: Damage) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy(self, damage)
     }
 
-    fn damage_subtract(&self, damage: DAMAGE, repair: xfixes::REGION, parts: xfixes::REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn damage_subtract(&self, damage: Damage, repair: xfixes::Region, parts: xfixes::Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         subtract(self, damage, repair, parts)
     }
 
-    fn damage_add(&self, drawable: DRAWABLE, region: xfixes::REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn damage_add(&self, drawable: Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         add(self, drawable, region)
     }

--- a/src/generated/dri2.rs
+++ b/src/generated/dri2.rs
@@ -422,7 +422,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Connect request
 pub const CONNECT_REQUEST: u8 = 1;
-pub fn connect<Conn, A>(conn: &Conn, window: WINDOW, driver_type: A) -> Result<Cookie<'_, Conn, ConnectReply>, ConnectionError>
+pub fn connect<Conn, A>(conn: &Conn, window: Window, driver_type: A) -> Result<Cookie<'_, Conn, ConnectReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u32>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -484,7 +484,7 @@ impl TryFrom<&[u8]> for ConnectReply {
 
 /// Opcode for the Authenticate request
 pub const AUTHENTICATE_REQUEST: u8 = 2;
-pub fn authenticate<Conn>(conn: &Conn, window: WINDOW, magic: u32) -> Result<Cookie<'_, Conn, AuthenticateReply>, ConnectionError>
+pub fn authenticate<Conn>(conn: &Conn, window: Window, magic: u32) -> Result<Cookie<'_, Conn, AuthenticateReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -538,7 +538,7 @@ impl TryFrom<&[u8]> for AuthenticateReply {
 
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 3;
-pub fn create_drawable<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_drawable<Conn>(conn: &Conn, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -563,7 +563,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 4;
-pub fn destroy_drawable<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_drawable<Conn>(conn: &Conn, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -588,7 +588,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetBuffers request
 pub const GET_BUFFERS_REQUEST: u8 = 5;
-pub fn get_buffers<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
+pub fn get_buffers<'c, Conn>(conn: &'c Conn, drawable: Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -652,7 +652,7 @@ impl TryFrom<&[u8]> for GetBuffersReply {
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 6;
-pub fn copy_region<Conn>(conn: &Conn, drawable: DRAWABLE, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Conn, CopyRegionReply>, ConnectionError>
+pub fn copy_region<Conn>(conn: &Conn, drawable: Drawable, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Conn, CopyRegionReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -714,7 +714,7 @@ impl TryFrom<&[u8]> for CopyRegionReply {
 
 /// Opcode for the GetBuffersWithFormat request
 pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
-pub fn get_buffers_with_format<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
+pub fn get_buffers_with_format<'c, Conn>(conn: &'c Conn, drawable: Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -778,7 +778,7 @@ impl TryFrom<&[u8]> for GetBuffersWithFormatReply {
 
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 8;
-pub fn swap_buffers<Conn>(conn: &Conn, drawable: DRAWABLE, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, SwapBuffersReply>, ConnectionError>
+pub fn swap_buffers<Conn>(conn: &Conn, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, SwapBuffersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -859,7 +859,7 @@ impl TryFrom<&[u8]> for SwapBuffersReply {
 
 /// Opcode for the GetMSC request
 pub const GET_MSC_REQUEST: u8 = 9;
-pub fn get_msc<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<Cookie<'_, Conn, GetMSCReply>, ConnectionError>
+pub fn get_msc<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, GetMSCReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -918,7 +918,7 @@ impl TryFrom<&[u8]> for GetMSCReply {
 
 /// Opcode for the WaitMSC request
 pub const WAIT_MSC_REQUEST: u8 = 10;
-pub fn wait_msc<Conn>(conn: &Conn, drawable: DRAWABLE, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, WaitMSCReply>, ConnectionError>
+pub fn wait_msc<Conn>(conn: &Conn, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, WaitMSCReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1007,7 +1007,7 @@ impl TryFrom<&[u8]> for WaitMSCReply {
 
 /// Opcode for the WaitSBC request
 pub const WAIT_SBC_REQUEST: u8 = 11;
-pub fn wait_sbc<Conn>(conn: &Conn, drawable: DRAWABLE, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Conn, WaitSBCReply>, ConnectionError>
+pub fn wait_sbc<Conn>(conn: &Conn, drawable: Drawable, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Conn, WaitSBCReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1076,7 +1076,7 @@ impl TryFrom<&[u8]> for WaitSBCReply {
 
 /// Opcode for the SwapInterval request
 pub const SWAP_INTERVAL_REQUEST: u8 = 12;
-pub fn swap_interval<Conn>(conn: &Conn, drawable: DRAWABLE, interval: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn swap_interval<Conn>(conn: &Conn, drawable: Drawable, interval: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1106,7 +1106,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetParam request
 pub const GET_PARAM_REQUEST: u8 = 13;
-pub fn get_param<Conn>(conn: &Conn, drawable: DRAWABLE, param: u32) -> Result<Cookie<'_, Conn, GetParamReply>, ConnectionError>
+pub fn get_param<Conn>(conn: &Conn, drawable: Drawable, param: u32) -> Result<Cookie<'_, Conn, GetParamReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1168,7 +1168,7 @@ pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub event_type: EventType,
-    pub drawable: DRAWABLE,
+    pub drawable: Drawable,
     pub ust_hi: u32,
     pub ust_lo: u32,
     pub msc_hi: u32,
@@ -1182,7 +1182,7 @@ impl BufferSwapCompleteEvent {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let (ust_hi, remaining) = u32::try_parse(remaining)?;
         let (ust_lo, remaining) = u32::try_parse(remaining)?;
         let (msc_hi, remaining) = u32::try_parse(remaining)?;
@@ -1240,14 +1240,14 @@ pub const INVALIDATE_BUFFERS_EVENT: u8 = 1;
 pub struct InvalidateBuffersEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub drawable: DRAWABLE,
+    pub drawable: Drawable,
 }
 impl InvalidateBuffersEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let result = InvalidateBuffersEvent { response_type, sequence, drawable };
         Ok((result, remaining))
     }
@@ -1294,68 +1294,68 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn dri2_connect<A>(&self, window: WINDOW, driver_type: A) -> Result<Cookie<'_, Self, ConnectReply>, ConnectionError>
+    fn dri2_connect<A>(&self, window: Window, driver_type: A) -> Result<Cookie<'_, Self, ConnectReply>, ConnectionError>
     where A: Into<u32>
     {
         connect(self, window, driver_type)
     }
 
-    fn dri2_authenticate(&self, window: WINDOW, magic: u32) -> Result<Cookie<'_, Self, AuthenticateReply>, ConnectionError>
+    fn dri2_authenticate(&self, window: Window, magic: u32) -> Result<Cookie<'_, Self, AuthenticateReply>, ConnectionError>
     {
         authenticate(self, window, magic)
     }
 
-    fn dri2_create_drawable(&self, drawable: DRAWABLE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri2_create_drawable(&self, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_drawable(self, drawable)
     }
 
-    fn dri2_destroy_drawable(&self, drawable: DRAWABLE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri2_destroy_drawable(&self, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_drawable(self, drawable)
     }
 
-    fn dri2_get_buffers<'c>(&'c self, drawable: DRAWABLE, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Self, GetBuffersReply>, ConnectionError>
+    fn dri2_get_buffers<'c>(&'c self, drawable: Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Self, GetBuffersReply>, ConnectionError>
     {
         get_buffers(self, drawable, count, attachments)
     }
 
-    fn dri2_copy_region(&self, drawable: DRAWABLE, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Self, CopyRegionReply>, ConnectionError>
+    fn dri2_copy_region(&self, drawable: Drawable, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Self, CopyRegionReply>, ConnectionError>
     {
         copy_region(self, drawable, region, dest, src)
     }
 
-    fn dri2_get_buffers_with_format<'c>(&'c self, drawable: DRAWABLE, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Self, GetBuffersWithFormatReply>, ConnectionError>
+    fn dri2_get_buffers_with_format<'c>(&'c self, drawable: Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Self, GetBuffersWithFormatReply>, ConnectionError>
     {
         get_buffers_with_format(self, drawable, count, attachments)
     }
 
-    fn dri2_swap_buffers(&self, drawable: DRAWABLE, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, SwapBuffersReply>, ConnectionError>
+    fn dri2_swap_buffers(&self, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, SwapBuffersReply>, ConnectionError>
     {
         swap_buffers(self, drawable, target_msc_hi, target_msc_lo, divisor_hi, divisor_lo, remainder_hi, remainder_lo)
     }
 
-    fn dri2_get_msc(&self, drawable: DRAWABLE) -> Result<Cookie<'_, Self, GetMSCReply>, ConnectionError>
+    fn dri2_get_msc(&self, drawable: Drawable) -> Result<Cookie<'_, Self, GetMSCReply>, ConnectionError>
     {
         get_msc(self, drawable)
     }
 
-    fn dri2_wait_msc(&self, drawable: DRAWABLE, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, WaitMSCReply>, ConnectionError>
+    fn dri2_wait_msc(&self, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, WaitMSCReply>, ConnectionError>
     {
         wait_msc(self, drawable, target_msc_hi, target_msc_lo, divisor_hi, divisor_lo, remainder_hi, remainder_lo)
     }
 
-    fn dri2_wait_sbc(&self, drawable: DRAWABLE, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Self, WaitSBCReply>, ConnectionError>
+    fn dri2_wait_sbc(&self, drawable: Drawable, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Self, WaitSBCReply>, ConnectionError>
     {
         wait_sbc(self, drawable, target_sbc_hi, target_sbc_lo)
     }
 
-    fn dri2_swap_interval(&self, drawable: DRAWABLE, interval: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri2_swap_interval(&self, drawable: Drawable, interval: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         swap_interval(self, drawable, interval)
     }
 
-    fn dri2_get_param(&self, drawable: DRAWABLE, param: u32) -> Result<Cookie<'_, Self, GetParamReply>, ConnectionError>
+    fn dri2_get_param(&self, drawable: Drawable, param: u32) -> Result<Cookie<'_, Self, GetParamReply>, ConnectionError>
     {
         get_param(self, drawable, param)
     }

--- a/src/generated/dri3.rs
+++ b/src/generated/dri3.rs
@@ -95,7 +95,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Open request
 pub const OPEN_REQUEST: u8 = 1;
-pub fn open<Conn>(conn: &Conn, drawable: DRAWABLE, provider: u32) -> Result<CookieWithFds<'_, Conn, OpenReply>, ConnectionError>
+pub fn open<Conn>(conn: &Conn, drawable: Drawable, provider: u32) -> Result<CookieWithFds<'_, Conn, OpenReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -153,7 +153,7 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for OpenReply {
 
 /// Opcode for the PixmapFromBuffer request
 pub const PIXMAP_FROM_BUFFER_REQUEST: u8 = 2;
-pub fn pixmap_from_buffer<Conn, A>(conn: &Conn, pixmap: PIXMAP, drawable: DRAWABLE, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn pixmap_from_buffer<Conn, A>(conn: &Conn, pixmap: Pixmap, drawable: Drawable, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -202,7 +202,7 @@ where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 
 /// Opcode for the BufferFromPixmap request
 pub const BUFFER_FROM_PIXMAP_REQUEST: u8 = 3;
-pub fn buffer_from_pixmap<Conn>(conn: &Conn, pixmap: PIXMAP) -> Result<CookieWithFds<'_, Conn, BufferFromPixmapReply>, ConnectionError>
+pub fn buffer_from_pixmap<Conn>(conn: &Conn, pixmap: Pixmap) -> Result<CookieWithFds<'_, Conn, BufferFromPixmapReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -267,7 +267,7 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for BufferFromPixmapReply {
 
 /// Opcode for the FenceFromFD request
 pub const FENCE_FROM_FD_REQUEST: u8 = 4;
-pub fn fence_from_fd<Conn, A>(conn: &Conn, drawable: DRAWABLE, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn fence_from_fd<Conn, A>(conn: &Conn, drawable: Drawable, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -303,7 +303,7 @@ where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 
 /// Opcode for the FDFromFence request
 pub const FD_FROM_FENCE_REQUEST: u8 = 5;
-pub fn fd_from_fence<Conn>(conn: &Conn, drawable: DRAWABLE, fence: u32) -> Result<CookieWithFds<'_, Conn, FDFromFenceReply>, ConnectionError>
+pub fn fd_from_fence<Conn>(conn: &Conn, drawable: Drawable, fence: u32) -> Result<CookieWithFds<'_, Conn, FDFromFenceReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -421,7 +421,7 @@ impl TryFrom<&[u8]> for GetSupportedModifiersReply {
 
 /// Opcode for the PixmapFromBuffers request
 pub const PIXMAP_FROM_BUFFERS_REQUEST: u8 = 7;
-pub fn pixmap_from_buffers<'c, Conn>(conn: &'c Conn, pixmap: PIXMAP, window: WINDOW, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn pixmap_from_buffers<'c, Conn>(conn: &'c Conn, pixmap: Pixmap, window: Window, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -518,7 +518,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the BuffersFromPixmap request
 pub const BUFFERS_FROM_PIXMAP_REQUEST: u8 = 8;
-pub fn buffers_from_pixmap<Conn>(conn: &Conn, pixmap: PIXMAP) -> Result<CookieWithFds<'_, Conn, BuffersFromPixmapReply>, ConnectionError>
+pub fn buffers_from_pixmap<Conn>(conn: &Conn, pixmap: Pixmap) -> Result<CookieWithFds<'_, Conn, BuffersFromPixmapReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -593,29 +593,29 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn dri3_open(&self, drawable: DRAWABLE, provider: u32) -> Result<CookieWithFds<'_, Self, OpenReply>, ConnectionError>
+    fn dri3_open(&self, drawable: Drawable, provider: u32) -> Result<CookieWithFds<'_, Self, OpenReply>, ConnectionError>
     {
         open(self, drawable, provider)
     }
 
-    fn dri3_pixmap_from_buffer<A>(&self, pixmap: PIXMAP, drawable: DRAWABLE, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri3_pixmap_from_buffer<A>(&self, pixmap: Pixmap, drawable: Drawable, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<RawFdContainer>
     {
         pixmap_from_buffer(self, pixmap, drawable, size, width, height, stride, depth, bpp, pixmap_fd)
     }
 
-    fn dri3_buffer_from_pixmap(&self, pixmap: PIXMAP) -> Result<CookieWithFds<'_, Self, BufferFromPixmapReply>, ConnectionError>
+    fn dri3_buffer_from_pixmap(&self, pixmap: Pixmap) -> Result<CookieWithFds<'_, Self, BufferFromPixmapReply>, ConnectionError>
     {
         buffer_from_pixmap(self, pixmap)
     }
 
-    fn dri3_fence_from_fd<A>(&self, drawable: DRAWABLE, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri3_fence_from_fd<A>(&self, drawable: Drawable, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<RawFdContainer>
     {
         fence_from_fd(self, drawable, fence, initially_triggered, fence_fd)
     }
 
-    fn dri3_fd_from_fence(&self, drawable: DRAWABLE, fence: u32) -> Result<CookieWithFds<'_, Self, FDFromFenceReply>, ConnectionError>
+    fn dri3_fd_from_fence(&self, drawable: Drawable, fence: u32) -> Result<CookieWithFds<'_, Self, FDFromFenceReply>, ConnectionError>
     {
         fd_from_fence(self, drawable, fence)
     }
@@ -625,12 +625,12 @@ pub trait ConnectionExt: RequestConnection {
         get_supported_modifiers(self, window, depth, bpp)
     }
 
-    fn dri3_pixmap_from_buffers<'c>(&'c self, pixmap: PIXMAP, window: WINDOW, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn dri3_pixmap_from_buffers<'c>(&'c self, pixmap: Pixmap, window: Window, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         pixmap_from_buffers(self, pixmap, window, width, height, stride0, offset0, stride1, offset1, stride2, offset2, stride3, offset3, depth, bpp, modifier, buffers)
     }
 
-    fn dri3_buffers_from_pixmap(&self, pixmap: PIXMAP) -> Result<CookieWithFds<'_, Self, BuffersFromPixmapReply>, ConnectionError>
+    fn dri3_buffers_from_pixmap(&self, pixmap: Pixmap) -> Result<CookieWithFds<'_, Self, BuffersFromPixmapReply>, ConnectionError>
     {
         buffers_from_pixmap(self, pixmap)
     }

--- a/src/generated/glx.rs
+++ b/src/generated/glx.rs
@@ -35,23 +35,23 @@ pub const X11_EXTENSION_NAME: &str = "GLX";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 4);
 
-pub type PIXMAP = u32;
+pub type Pixmap = u32;
 
-pub type CONTEXT = u32;
+pub type Context = u32;
 
-pub type PBUFFER = u32;
+pub type Pbuffer = u32;
 
-pub type WINDOW = u32;
+pub type Window = u32;
 
-pub type FBCONFIG = u32;
+pub type Fbconfig = u32;
 
-pub type DRAWABLE = u32;
+pub type Drawable = u32;
 
-pub type FLOAT32 = f32;
+pub type Float32 = f32;
 
-pub type FLOAT64 = f64;
+pub type Float64 = f64;
 
-pub type BOOL32 = u32;
+pub type Bool32 = u32;
 
 pub type ContextTag = u32;
 
@@ -991,7 +991,7 @@ pub struct PbufferClobberEvent {
     pub sequence: u16,
     pub event_type: u16,
     pub draw_type: u16,
-    pub drawable: DRAWABLE,
+    pub drawable: Drawable,
     pub b_mask: u32,
     pub aux_buffer: u16,
     pub x: u16,
@@ -1007,7 +1007,7 @@ impl PbufferClobberEvent {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (draw_type, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let (b_mask, remaining) = u32::try_parse(remaining)?;
         let (aux_buffer, remaining) = u16::try_parse(remaining)?;
         let (x, remaining) = u16::try_parse(remaining)?;
@@ -1071,7 +1071,7 @@ pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub event_type: u16,
-    pub drawable: DRAWABLE,
+    pub drawable: Drawable,
     pub ust_hi: u32,
     pub ust_lo: u32,
     pub msc_hi: u32,
@@ -1085,7 +1085,7 @@ impl BufferSwapCompleteEvent {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let (ust_hi, remaining) = u32::try_parse(remaining)?;
         let (ust_lo, remaining) = u32::try_parse(remaining)?;
         let (msc_hi, remaining) = u32::try_parse(remaining)?;
@@ -1298,7 +1298,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 3;
-pub fn create_context<Conn>(conn: &Conn, context: CONTEXT, visual: VISUALID, screen: u32, share_list: CONTEXT, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_context<Conn>(conn: &Conn, context: Context, visual: Visualid, screen: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1343,7 +1343,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 4;
-pub fn destroy_context<Conn>(conn: &Conn, context: CONTEXT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_context<Conn>(conn: &Conn, context: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1368,7 +1368,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the MakeCurrent request
 pub const MAKE_CURRENT_REQUEST: u8 = 5;
-pub fn make_current<Conn>(conn: &Conn, drawable: DRAWABLE, context: CONTEXT, old_context_tag: ContextTag) -> Result<Cookie<'_, Conn, MakeCurrentReply>, ConnectionError>
+pub fn make_current<Conn>(conn: &Conn, drawable: Drawable, context: Context, old_context_tag: ContextTag) -> Result<Cookie<'_, Conn, MakeCurrentReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1428,7 +1428,7 @@ impl TryFrom<&[u8]> for MakeCurrentReply {
 
 /// Opcode for the IsDirect request
 pub const IS_DIRECT_REQUEST: u8 = 6;
-pub fn is_direct<Conn>(conn: &Conn, context: CONTEXT) -> Result<Cookie<'_, Conn, IsDirectReply>, ConnectionError>
+pub fn is_direct<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, IsDirectReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1585,7 +1585,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CopyContext request
 pub const COPY_CONTEXT_REQUEST: u8 = 10;
-pub fn copy_context<Conn>(conn: &Conn, src: CONTEXT, dest: CONTEXT, mask: u32, src_context_tag: ContextTag) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn copy_context<Conn>(conn: &Conn, src: Context, dest: Context, mask: u32, src_context_tag: ContextTag) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1713,7 +1713,7 @@ impl TryFrom<u32> for GC {
 
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 11;
-pub fn swap_buffers<Conn>(conn: &Conn, context_tag: ContextTag, drawable: DRAWABLE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn swap_buffers<Conn>(conn: &Conn, context_tag: ContextTag, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1743,7 +1743,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the UseXFont request
 pub const USE_X_FONT_REQUEST: u8 = 12;
-pub fn use_x_font<Conn>(conn: &Conn, context_tag: ContextTag, font: FONT, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn use_x_font<Conn>(conn: &Conn, context_tag: ContextTag, font: Font, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1788,7 +1788,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateGLXPixmap request
 pub const CREATE_GLX_PIXMAP_REQUEST: u8 = 13;
-pub fn create_glx_pixmap<Conn>(conn: &Conn, screen: u32, visual: VISUALID, pixmap: PIXMAP, glx_pixmap: PIXMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_glx_pixmap<Conn>(conn: &Conn, screen: u32, visual: Visualid, pixmap: Pixmap, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1881,7 +1881,7 @@ impl TryFrom<&[u8]> for GetVisualConfigsReply {
 
 /// Opcode for the DestroyGLXPixmap request
 pub const DESTROY_GLX_PIXMAP_REQUEST: u8 = 15;
-pub fn destroy_glx_pixmap<Conn>(conn: &Conn, glx_pixmap: PIXMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_glx_pixmap<Conn>(conn: &Conn, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2248,7 +2248,7 @@ impl TryFrom<&[u8]> for GetFBConfigsReply {
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 22;
-pub fn create_pixmap<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: FBCONFIG, pixmap: PIXMAP, glx_pixmap: PIXMAP, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pixmap<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pixmap: Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2299,7 +2299,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyPixmap request
 pub const DESTROY_PIXMAP_REQUEST: u8 = 23;
-pub fn destroy_pixmap<Conn>(conn: &Conn, glx_pixmap: PIXMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_pixmap<Conn>(conn: &Conn, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2324,7 +2324,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateNewContext request
 pub const CREATE_NEW_CONTEXT_REQUEST: u8 = 24;
-pub fn create_new_context<Conn>(conn: &Conn, context: CONTEXT, fbconfig: FBCONFIG, screen: u32, render_type: u32, share_list: CONTEXT, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_new_context<Conn>(conn: &Conn, context: Context, fbconfig: Fbconfig, screen: u32, render_type: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2374,7 +2374,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the QueryContext request
 pub const QUERY_CONTEXT_REQUEST: u8 = 25;
-pub fn query_context<Conn>(conn: &Conn, context: CONTEXT) -> Result<Cookie<'_, Conn, QueryContextReply>, ConnectionError>
+pub fn query_context<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, QueryContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2425,7 +2425,7 @@ impl TryFrom<&[u8]> for QueryContextReply {
 
 /// Opcode for the MakeContextCurrent request
 pub const MAKE_CONTEXT_CURRENT_REQUEST: u8 = 26;
-pub fn make_context_current<Conn>(conn: &Conn, old_context_tag: ContextTag, drawable: DRAWABLE, read_drawable: DRAWABLE, context: CONTEXT) -> Result<Cookie<'_, Conn, MakeContextCurrentReply>, ConnectionError>
+pub fn make_context_current<Conn>(conn: &Conn, old_context_tag: ContextTag, drawable: Drawable, read_drawable: Drawable, context: Context) -> Result<Cookie<'_, Conn, MakeContextCurrentReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2490,7 +2490,7 @@ impl TryFrom<&[u8]> for MakeContextCurrentReply {
 
 /// Opcode for the CreatePbuffer request
 pub const CREATE_PBUFFER_REQUEST: u8 = 27;
-pub fn create_pbuffer<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: FBCONFIG, pbuffer: PBUFFER, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pbuffer<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pbuffer: Pbuffer, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2536,7 +2536,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyPbuffer request
 pub const DESTROY_PBUFFER_REQUEST: u8 = 28;
-pub fn destroy_pbuffer<Conn>(conn: &Conn, pbuffer: PBUFFER) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_pbuffer<Conn>(conn: &Conn, pbuffer: Pbuffer) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2561,7 +2561,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetDrawableAttributes request
 pub const GET_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 29;
-pub fn get_drawable_attributes<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<Cookie<'_, Conn, GetDrawableAttributesReply>, ConnectionError>
+pub fn get_drawable_attributes<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, GetDrawableAttributesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2612,7 +2612,7 @@ impl TryFrom<&[u8]> for GetDrawableAttributesReply {
 
 /// Opcode for the ChangeDrawableAttributes request
 pub const CHANGE_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 30;
-pub fn change_drawable_attributes<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_drawable_attributes<'c, Conn>(conn: &'c Conn, drawable: Drawable, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2648,7 +2648,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateWindow request
 pub const CREATE_WINDOW_REQUEST: u8 = 31;
-pub fn create_window<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: FBCONFIG, window: WINDOW, glx_window: WINDOW, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_window<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, window: Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2699,7 +2699,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeleteWindow request
 pub const DELETE_WINDOW_REQUEST: u8 = 32;
-pub fn delete_window<Conn>(conn: &Conn, glxwindow: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_window<Conn>(conn: &Conn, glxwindow: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2779,7 +2779,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateContextAttribsARB request
 pub const CREATE_CONTEXT_ATTRIBS_ARB_REQUEST: u8 = 34;
-pub fn create_context_attribs_arb<'c, Conn>(conn: &'c Conn, context: CONTEXT, fbconfig: FBCONFIG, screen: u32, share_list: CONTEXT, is_direct: bool, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_context_attribs_arb<'c, Conn>(conn: &'c Conn, context: Context, fbconfig: Fbconfig, screen: u32, share_list: Context, is_direct: bool, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3261,7 +3261,7 @@ impl TryFrom<&[u8]> for FinishReply {
 
 /// Opcode for the PixelStoref request
 pub const PIXEL_STOREF_REQUEST: u8 = 109;
-pub fn pixel_storef<Conn>(conn: &Conn, context_tag: ContextTag, pname: u32, datum: FLOAT32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn pixel_storef<Conn>(conn: &Conn, context_tag: ContextTag, pname: u32, datum: Float32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3506,7 +3506,7 @@ where Conn: RequestConnection + ?Sized
 pub struct GetClipPlaneReply {
     pub response_type: u8,
     pub sequence: u16,
-    pub data: Vec<FLOAT64>,
+    pub data: Vec<Float64>,
 }
 impl GetClipPlaneReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3515,7 +3515,7 @@ impl GetClipPlaneReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, (length as usize) / (2))?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, (length as usize) / (2))?;
         let result = GetClipPlaneReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -3561,8 +3561,8 @@ pub struct GetDoublevReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT64,
-    pub data: Vec<FLOAT64>,
+    pub datum: Float64,
+    pub data: Vec<Float64>,
 }
 impl GetDoublevReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3572,9 +3572,9 @@ impl GetDoublevReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT64::try_parse(remaining)?;
+        let (datum, remaining) = Float64::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n as usize)?;
         let result = GetDoublevReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -3669,8 +3669,8 @@ pub struct GetFloatvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetFloatvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3680,9 +3680,9 @@ impl GetFloatvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetFloatvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -3792,8 +3792,8 @@ pub struct GetLightfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetLightfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3803,9 +3803,9 @@ impl GetLightfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetLightfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -3920,8 +3920,8 @@ pub struct GetMapdvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT64,
-    pub data: Vec<FLOAT64>,
+    pub datum: Float64,
+    pub data: Vec<Float64>,
 }
 impl GetMapdvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3931,9 +3931,9 @@ impl GetMapdvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT64::try_parse(remaining)?;
+        let (datum, remaining) = Float64::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n as usize)?;
         let result = GetMapdvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -3984,8 +3984,8 @@ pub struct GetMapfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetMapfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3995,9 +3995,9 @@ impl GetMapfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetMapfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4112,8 +4112,8 @@ pub struct GetMaterialfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetMaterialfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4123,9 +4123,9 @@ impl GetMaterialfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetMaterialfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4235,8 +4235,8 @@ pub struct GetPixelMapfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetPixelMapfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4246,9 +4246,9 @@ impl GetPixelMapfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetPixelMapfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4528,8 +4528,8 @@ pub struct GetTexEnvfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetTexEnvfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4539,9 +4539,9 @@ impl GetTexEnvfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetTexEnvfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4656,8 +4656,8 @@ pub struct GetTexGendvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT64,
-    pub data: Vec<FLOAT64>,
+    pub datum: Float64,
+    pub data: Vec<Float64>,
 }
 impl GetTexGendvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4667,9 +4667,9 @@ impl GetTexGendvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT64::try_parse(remaining)?;
+        let (datum, remaining) = Float64::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT64>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n as usize)?;
         let result = GetTexGendvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4720,8 +4720,8 @@ pub struct GetTexGenfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetTexGenfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4731,9 +4731,9 @@ impl GetTexGenfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetTexGenfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4929,8 +4929,8 @@ pub struct GetTexParameterfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetTexParameterfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4940,9 +4940,9 @@ impl GetTexParameterfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetTexParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5062,8 +5062,8 @@ pub struct GetTexLevelParameterfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetTexLevelParameterfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5073,9 +5073,9 @@ impl GetTexLevelParameterfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetTexLevelParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5190,7 +5190,7 @@ pub struct IsEnabledReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub ret_val: BOOL32,
+    pub ret_val: Bool32,
 }
 impl IsEnabledReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5198,7 +5198,7 @@ impl IsEnabledReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
+        let (ret_val, remaining) = Bool32::try_parse(remaining)?;
         let result = IsEnabledReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -5244,7 +5244,7 @@ pub struct IsListReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub ret_val: BOOL32,
+    pub ret_val: Bool32,
 }
 impl IsListReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5252,7 +5252,7 @@ impl IsListReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
+        let (ret_val, remaining) = Bool32::try_parse(remaining)?;
         let result = IsListReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -5327,7 +5327,7 @@ where Conn: RequestConnection + ?Sized
 pub struct AreTexturesResidentReply {
     pub response_type: u8,
     pub sequence: u16,
-    pub ret_val: BOOL32,
+    pub ret_val: Bool32,
     pub data: Vec<u8>,
 }
 impl AreTexturesResidentReply {
@@ -5336,7 +5336,7 @@ impl AreTexturesResidentReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
+        let (ret_val, remaining) = Bool32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = AreTexturesResidentReply { response_type, sequence, ret_val, data };
@@ -5473,7 +5473,7 @@ pub struct IsTextureReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub ret_val: BOOL32,
+    pub ret_val: Bool32,
 }
 impl IsTextureReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5481,7 +5481,7 @@ impl IsTextureReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
+        let (ret_val, remaining) = Bool32::try_parse(remaining)?;
         let result = IsTextureReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -5604,8 +5604,8 @@ pub struct GetColorTableParameterfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetColorTableParameterfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5615,9 +5615,9 @@ impl GetColorTableParameterfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetColorTableParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5806,8 +5806,8 @@ pub struct GetConvolutionParameterfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetConvolutionParameterfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5817,9 +5817,9 @@ impl GetConvolutionParameterfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetConvolutionParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6081,8 +6081,8 @@ pub struct GetHistogramParameterfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetHistogramParameterfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6092,9 +6092,9 @@ impl GetHistogramParameterfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetHistogramParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6279,8 +6279,8 @@ pub struct GetMinmaxParameterfvReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub datum: FLOAT32,
-    pub data: Vec<FLOAT32>,
+    pub datum: Float32,
+    pub data: Vec<Float32>,
 }
 impl GetMinmaxParameterfvReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6290,9 +6290,9 @@ impl GetMinmaxParameterfvReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
-        let (datum, remaining) = FLOAT32::try_parse(remaining)?;
+        let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<FLOAT32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
         let result = GetMinmaxParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6553,7 +6553,7 @@ pub struct IsQueryARBReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub ret_val: BOOL32,
+    pub ret_val: Bool32,
 }
 impl IsQueryARBReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6561,7 +6561,7 @@ impl IsQueryARBReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (ret_val, remaining) = BOOL32::try_parse(remaining)?;
+        let (ret_val, remaining) = Bool32::try_parse(remaining)?;
         let result = IsQueryARBReply { response_type, sequence, length, ret_val };
         Ok((result, remaining))
     }
@@ -6777,22 +6777,22 @@ pub trait ConnectionExt: RequestConnection {
         render_large(self, context_tag, request_num, request_total, data)
     }
 
-    fn glx_create_context(&self, context: CONTEXT, visual: VISUALID, screen: u32, share_list: CONTEXT, is_direct: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_create_context(&self, context: Context, visual: Visualid, screen: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_context(self, context, visual, screen, share_list, is_direct)
     }
 
-    fn glx_destroy_context(&self, context: CONTEXT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_destroy_context(&self, context: Context) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_context(self, context)
     }
 
-    fn glx_make_current(&self, drawable: DRAWABLE, context: CONTEXT, old_context_tag: ContextTag) -> Result<Cookie<'_, Self, MakeCurrentReply>, ConnectionError>
+    fn glx_make_current(&self, drawable: Drawable, context: Context, old_context_tag: ContextTag) -> Result<Cookie<'_, Self, MakeCurrentReply>, ConnectionError>
     {
         make_current(self, drawable, context, old_context_tag)
     }
 
-    fn glx_is_direct(&self, context: CONTEXT) -> Result<Cookie<'_, Self, IsDirectReply>, ConnectionError>
+    fn glx_is_direct(&self, context: Context) -> Result<Cookie<'_, Self, IsDirectReply>, ConnectionError>
     {
         is_direct(self, context)
     }
@@ -6812,22 +6812,22 @@ pub trait ConnectionExt: RequestConnection {
         wait_x(self, context_tag)
     }
 
-    fn glx_copy_context(&self, src: CONTEXT, dest: CONTEXT, mask: u32, src_context_tag: ContextTag) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_copy_context(&self, src: Context, dest: Context, mask: u32, src_context_tag: ContextTag) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         copy_context(self, src, dest, mask, src_context_tag)
     }
 
-    fn glx_swap_buffers(&self, context_tag: ContextTag, drawable: DRAWABLE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_swap_buffers(&self, context_tag: ContextTag, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         swap_buffers(self, context_tag, drawable)
     }
 
-    fn glx_use_x_font(&self, context_tag: ContextTag, font: FONT, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_use_x_font(&self, context_tag: ContextTag, font: Font, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         use_x_font(self, context_tag, font, first, count, list_base)
     }
 
-    fn glx_create_glx_pixmap(&self, screen: u32, visual: VISUALID, pixmap: PIXMAP, glx_pixmap: PIXMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_create_glx_pixmap(&self, screen: u32, visual: Visualid, pixmap: Pixmap, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_glx_pixmap(self, screen, visual, pixmap, glx_pixmap)
     }
@@ -6837,7 +6837,7 @@ pub trait ConnectionExt: RequestConnection {
         get_visual_configs(self, screen)
     }
 
-    fn glx_destroy_glx_pixmap(&self, glx_pixmap: PIXMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_destroy_glx_pixmap(&self, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_glx_pixmap(self, glx_pixmap)
     }
@@ -6872,57 +6872,57 @@ pub trait ConnectionExt: RequestConnection {
         get_fb_configs(self, screen)
     }
 
-    fn glx_create_pixmap<'c>(&'c self, screen: u32, fbconfig: FBCONFIG, pixmap: PIXMAP, glx_pixmap: PIXMAP, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_pixmap<'c>(&'c self, screen: u32, fbconfig: Fbconfig, pixmap: Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pixmap(self, screen, fbconfig, pixmap, glx_pixmap, attribs)
     }
 
-    fn glx_destroy_pixmap(&self, glx_pixmap: PIXMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_destroy_pixmap(&self, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_pixmap(self, glx_pixmap)
     }
 
-    fn glx_create_new_context(&self, context: CONTEXT, fbconfig: FBCONFIG, screen: u32, render_type: u32, share_list: CONTEXT, is_direct: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_create_new_context(&self, context: Context, fbconfig: Fbconfig, screen: u32, render_type: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_new_context(self, context, fbconfig, screen, render_type, share_list, is_direct)
     }
 
-    fn glx_query_context(&self, context: CONTEXT) -> Result<Cookie<'_, Self, QueryContextReply>, ConnectionError>
+    fn glx_query_context(&self, context: Context) -> Result<Cookie<'_, Self, QueryContextReply>, ConnectionError>
     {
         query_context(self, context)
     }
 
-    fn glx_make_context_current(&self, old_context_tag: ContextTag, drawable: DRAWABLE, read_drawable: DRAWABLE, context: CONTEXT) -> Result<Cookie<'_, Self, MakeContextCurrentReply>, ConnectionError>
+    fn glx_make_context_current(&self, old_context_tag: ContextTag, drawable: Drawable, read_drawable: Drawable, context: Context) -> Result<Cookie<'_, Self, MakeContextCurrentReply>, ConnectionError>
     {
         make_context_current(self, old_context_tag, drawable, read_drawable, context)
     }
 
-    fn glx_create_pbuffer<'c>(&'c self, screen: u32, fbconfig: FBCONFIG, pbuffer: PBUFFER, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_pbuffer<'c>(&'c self, screen: u32, fbconfig: Fbconfig, pbuffer: Pbuffer, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pbuffer(self, screen, fbconfig, pbuffer, attribs)
     }
 
-    fn glx_destroy_pbuffer(&self, pbuffer: PBUFFER) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_destroy_pbuffer(&self, pbuffer: Pbuffer) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_pbuffer(self, pbuffer)
     }
 
-    fn glx_get_drawable_attributes(&self, drawable: DRAWABLE) -> Result<Cookie<'_, Self, GetDrawableAttributesReply>, ConnectionError>
+    fn glx_get_drawable_attributes(&self, drawable: Drawable) -> Result<Cookie<'_, Self, GetDrawableAttributesReply>, ConnectionError>
     {
         get_drawable_attributes(self, drawable)
     }
 
-    fn glx_change_drawable_attributes<'c>(&'c self, drawable: DRAWABLE, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_change_drawable_attributes<'c>(&'c self, drawable: Drawable, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_drawable_attributes(self, drawable, attribs)
     }
 
-    fn glx_create_window<'c>(&'c self, screen: u32, fbconfig: FBCONFIG, window: WINDOW, glx_window: WINDOW, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_window<'c>(&'c self, screen: u32, fbconfig: Fbconfig, window: Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_window(self, screen, fbconfig, window, glx_window, attribs)
     }
 
-    fn glx_delete_window(&self, glxwindow: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_delete_window(&self, glxwindow: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_window(self, glxwindow)
     }
@@ -6932,7 +6932,7 @@ pub trait ConnectionExt: RequestConnection {
         set_client_info_arb(self, major_version, minor_version, gl_versions, gl_extension_string, glx_extension_string)
     }
 
-    fn glx_create_context_attribs_arb<'c>(&'c self, context: CONTEXT, fbconfig: FBCONFIG, screen: u32, share_list: CONTEXT, is_direct: bool, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_context_attribs_arb<'c>(&'c self, context: Context, fbconfig: Fbconfig, screen: u32, share_list: Context, is_direct: bool, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_context_attribs_arb(self, context, fbconfig, screen, share_list, is_direct, attribs)
     }
@@ -6982,7 +6982,7 @@ pub trait ConnectionExt: RequestConnection {
         finish(self, context_tag)
     }
 
-    fn glx_pixel_storef(&self, context_tag: ContextTag, pname: u32, datum: FLOAT32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_pixel_storef(&self, context_tag: ContextTag, pname: u32, datum: Float32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         pixel_storef(self, context_tag, pname, datum)
     }

--- a/src/generated/present.rs
+++ b/src/generated/present.rs
@@ -47,66 +47,66 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Event {
+pub enum EventEnum {
     ConfigureNotify = 0,
     CompleteNotify = 1,
     IdleNotify = 2,
     RedirectNotify = 3,
 }
-impl From<Event> for u8 {
-    fn from(input: Event) -> Self {
+impl From<EventEnum> for u8 {
+    fn from(input: EventEnum) -> Self {
         match input {
-            Event::ConfigureNotify => 0,
-            Event::CompleteNotify => 1,
-            Event::IdleNotify => 2,
-            Event::RedirectNotify => 3,
+            EventEnum::ConfigureNotify => 0,
+            EventEnum::CompleteNotify => 1,
+            EventEnum::IdleNotify => 2,
+            EventEnum::RedirectNotify => 3,
         }
     }
 }
-impl From<Event> for std::option::Option<u8> {
-    fn from(input: Event) -> Self {
+impl From<EventEnum> for std::option::Option<u8> {
+    fn from(input: EventEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Event> for u16 {
-    fn from(input: Event) -> Self {
+impl From<EventEnum> for u16 {
+    fn from(input: EventEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Event> for std::option::Option<u16> {
-    fn from(input: Event) -> Self {
+impl From<EventEnum> for std::option::Option<u16> {
+    fn from(input: EventEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Event> for u32 {
-    fn from(input: Event) -> Self {
+impl From<EventEnum> for u32 {
+    fn from(input: EventEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Event> for std::option::Option<u32> {
-    fn from(input: Event) -> Self {
+impl From<EventEnum> for std::option::Option<u32> {
+    fn from(input: EventEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Event {
+impl TryFrom<u8> for EventEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Event::ConfigureNotify),
-            1 => Ok(Event::CompleteNotify),
-            2 => Ok(Event::IdleNotify),
-            3 => Ok(Event::RedirectNotify),
+            0 => Ok(EventEnum::ConfigureNotify),
+            1 => Ok(EventEnum::CompleteNotify),
+            2 => Ok(EventEnum::IdleNotify),
+            3 => Ok(EventEnum::RedirectNotify),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Event {
+impl TryFrom<u16> for EventEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Event {
+impl TryFrom<u32> for EventEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -460,12 +460,12 @@ impl TryFrom<u32> for CompleteMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Notify {
-    pub window: WINDOW,
+    pub window: Window,
     pub serial: u32,
 }
 impl TryParse for Notify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
         let result = Notify { window, serial };
         Ok((result, remaining))
@@ -558,7 +558,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Pixmap request
 pub const PIXMAP_REQUEST: u8 = 1;
-pub fn pixmap<'c, Conn>(conn: &'c Conn, window: WINDOW, pixmap: PIXMAP, serial: u32, valid: xfixes::REGION, update: xfixes::REGION, x_off: i16, y_off: i16, target_crtc: randr::CRTC, wait_fence: sync::FENCE, idle_fence: sync::FENCE, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn pixmap<'c, Conn>(conn: &'c Conn, window: Window, pixmap: Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -664,7 +664,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the NotifyMSC request
 pub const NOTIFY_MSC_REQUEST: u8 = 2;
-pub fn notify_msc<Conn>(conn: &Conn, window: WINDOW, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn notify_msc<Conn>(conn: &Conn, window: Window, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -723,11 +723,11 @@ where Conn: RequestConnection + ?Sized
     Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], Vec::new())?)
 }
 
-pub type EVENT = u32;
+pub type Event = u32;
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 3;
-pub fn select_input<Conn>(conn: &Conn, eid: EVENT, window: WINDOW, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, eid: Event, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -818,7 +818,7 @@ pub struct GenericEvent {
     pub sequence: u16,
     pub length: u32,
     pub evtype: u16,
-    pub event: EVENT,
+    pub event: Event,
 }
 impl GenericEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -828,7 +828,7 @@ impl GenericEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (evtype, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (event, remaining) = EVENT::try_parse(remaining)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
         let result = GenericEvent { response_type, extension, sequence, length, evtype, event };
         Ok((result, remaining))
     }
@@ -880,8 +880,8 @@ pub struct ConfigureNotifyEvent {
     pub sequence: u16,
     pub length: u32,
     pub event_type: u16,
-    pub event: EVENT,
-    pub window: WINDOW,
+    pub event: Event,
+    pub window: Window,
     pub x: i16,
     pub y: i16,
     pub width: u16,
@@ -900,8 +900,8 @@ impl ConfigureNotifyEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (event, remaining) = EVENT::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -945,8 +945,8 @@ pub struct CompleteNotifyEvent {
     pub event_type: u16,
     pub kind: CompleteKind,
     pub mode: CompleteMode,
-    pub event: EVENT,
-    pub window: WINDOW,
+    pub event: Event,
+    pub window: Window,
     pub serial: u32,
     pub ust: u64,
     pub msc: u64,
@@ -960,8 +960,8 @@ impl CompleteNotifyEvent {
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
-        let (event, remaining) = EVENT::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
         let (ust, remaining) = u64::try_parse(remaining)?;
         let (msc, remaining) = u64::try_parse(remaining)?;
@@ -999,11 +999,11 @@ pub struct IdleNotifyEvent {
     pub sequence: u16,
     pub length: u32,
     pub event_type: u16,
-    pub event: EVENT,
-    pub window: WINDOW,
+    pub event: Event,
+    pub window: Window,
     pub serial: u32,
-    pub pixmap: PIXMAP,
-    pub idle_fence: sync::FENCE,
+    pub pixmap: Pixmap,
+    pub idle_fence: sync::Fence,
 }
 impl IdleNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1013,11 +1013,11 @@ impl IdleNotifyEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (event, remaining) = EVENT::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
-        let (pixmap, remaining) = PIXMAP::try_parse(remaining)?;
-        let (idle_fence, remaining) = sync::FENCE::try_parse(remaining)?;
+        let (pixmap, remaining) = Pixmap::try_parse(remaining)?;
+        let (idle_fence, remaining) = sync::Fence::try_parse(remaining)?;
         let result = IdleNotifyEvent { response_type, extension, sequence, length, event_type, event, window, serial, pixmap, idle_fence };
         Ok((result, remaining))
     }
@@ -1051,20 +1051,20 @@ pub struct RedirectNotifyEvent {
     pub length: u32,
     pub event_type: u16,
     pub update_window: bool,
-    pub event: EVENT,
-    pub event_window: WINDOW,
-    pub window: WINDOW,
-    pub pixmap: PIXMAP,
+    pub event: Event,
+    pub event_window: Window,
+    pub window: Window,
+    pub pixmap: Pixmap,
     pub serial: u32,
-    pub valid_region: xfixes::REGION,
-    pub update_region: xfixes::REGION,
+    pub valid_region: xfixes::Region,
+    pub update_region: xfixes::Region,
     pub valid_rect: Rectangle,
     pub update_rect: Rectangle,
     pub x_off: i16,
     pub y_off: i16,
-    pub target_crtc: randr::CRTC,
-    pub wait_fence: sync::FENCE,
-    pub idle_fence: sync::FENCE,
+    pub target_crtc: randr::Crtc,
+    pub wait_fence: sync::Fence,
+    pub idle_fence: sync::Fence,
     pub options: u32,
     pub target_msc: u64,
     pub divisor: u64,
@@ -1080,20 +1080,20 @@ impl RedirectNotifyEvent {
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (update_window, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (event, remaining) = EVENT::try_parse(remaining)?;
-        let (event_window, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (pixmap, remaining) = PIXMAP::try_parse(remaining)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (event_window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (pixmap, remaining) = Pixmap::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
-        let (valid_region, remaining) = xfixes::REGION::try_parse(remaining)?;
-        let (update_region, remaining) = xfixes::REGION::try_parse(remaining)?;
+        let (valid_region, remaining) = xfixes::Region::try_parse(remaining)?;
+        let (update_region, remaining) = xfixes::Region::try_parse(remaining)?;
         let (valid_rect, remaining) = Rectangle::try_parse(remaining)?;
         let (update_rect, remaining) = Rectangle::try_parse(remaining)?;
         let (x_off, remaining) = i16::try_parse(remaining)?;
         let (y_off, remaining) = i16::try_parse(remaining)?;
-        let (target_crtc, remaining) = randr::CRTC::try_parse(remaining)?;
-        let (wait_fence, remaining) = sync::FENCE::try_parse(remaining)?;
-        let (idle_fence, remaining) = sync::FENCE::try_parse(remaining)?;
+        let (target_crtc, remaining) = randr::Crtc::try_parse(remaining)?;
+        let (wait_fence, remaining) = sync::Fence::try_parse(remaining)?;
+        let (idle_fence, remaining) = sync::Fence::try_parse(remaining)?;
         let (options, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (target_msc, remaining) = u64::try_parse(remaining)?;
@@ -1137,17 +1137,17 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn present_pixmap<'c>(&'c self, window: WINDOW, pixmap: PIXMAP, serial: u32, valid: xfixes::REGION, update: xfixes::REGION, x_off: i16, y_off: i16, target_crtc: randr::CRTC, wait_fence: sync::FENCE, idle_fence: sync::FENCE, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn present_pixmap<'c>(&'c self, window: Window, pixmap: Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         self::pixmap(self, window, pixmap, serial, valid, update, x_off, y_off, target_crtc, wait_fence, idle_fence, options, target_msc, divisor, remainder, notifies)
     }
 
-    fn present_notify_msc(&self, window: WINDOW, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn present_notify_msc(&self, window: Window, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         notify_msc(self, window, serial, target_msc, divisor, remainder)
     }
 
-    fn present_select_input(&self, eid: EVENT, window: WINDOW, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn present_select_input(&self, eid: Event, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, eid, window, event_mask)
     }

--- a/src/generated/randr.rs
+++ b/src/generated/randr.rs
@@ -39,15 +39,15 @@ pub const X11_EXTENSION_NAME: &str = "RANDR";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 6);
 
-pub type MODE = u32;
+pub type Mode = u32;
 
-pub type CRTC = u32;
+pub type Crtc = u32;
 
-pub type OUTPUT = u32;
+pub type Output = u32;
 
-pub type PROVIDER = u32;
+pub type Provider = u32;
 
-pub type LEASE = u32;
+pub type Lease = u32;
 
 /// Opcode for the BadOutput error
 pub const BAD_OUTPUT_ERROR: u8 = 0;
@@ -542,7 +542,7 @@ impl TryFrom<u32> for SetConfig {
 
 /// Opcode for the SetScreenConfig request
 pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
-pub fn set_screen_config<Conn>(conn: &Conn, window: WINDOW, timestamp: TIMESTAMP, config_timestamp: TIMESTAMP, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
+pub fn set_screen_config<Conn>(conn: &Conn, window: Window, timestamp: Timestamp, config_timestamp: Timestamp, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -591,9 +591,9 @@ pub struct SetScreenConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub new_timestamp: TIMESTAMP,
-    pub config_timestamp: TIMESTAMP,
-    pub root: WINDOW,
+    pub new_timestamp: Timestamp,
+    pub config_timestamp: Timestamp,
+    pub root: Window,
     pub subpixel_order: render::SubPixel,
 }
 impl SetScreenConfigReply {
@@ -602,9 +602,9 @@ impl SetScreenConfigReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (new_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (new_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
         let (subpixel_order, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
         let status = status.try_into()?;
@@ -703,7 +703,7 @@ bitmask_binop!(NotifyMask, u8);
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
-pub fn select_input<Conn>(conn: &Conn, window: WINDOW, enable: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, window: Window, enable: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -733,7 +733,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetScreenInfo request
 pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
-pub fn get_screen_info<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetScreenInfoReply>, ConnectionError>
+pub fn get_screen_info<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -761,9 +761,9 @@ pub struct GetScreenInfoReply {
     pub rotations: u8,
     pub sequence: u16,
     pub length: u32,
-    pub root: WINDOW,
-    pub timestamp: TIMESTAMP,
-    pub config_timestamp: TIMESTAMP,
+    pub root: Window,
+    pub timestamp: Timestamp,
+    pub config_timestamp: Timestamp,
     pub size_id: u16,
     pub rotation: u16,
     pub rate: u16,
@@ -777,9 +777,9 @@ impl GetScreenInfoReply {
         let (rotations, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (n_sizes, remaining) = u16::try_parse(remaining)?;
         let (size_id, remaining) = u16::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
@@ -801,7 +801,7 @@ impl TryFrom<&[u8]> for GetScreenInfoReply {
 
 /// Opcode for the GetScreenSizeRange request
 pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
-pub fn get_screen_size_range<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetScreenSizeRangeReply>, ConnectionError>
+pub fn get_screen_size_range<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenSizeRangeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -857,7 +857,7 @@ impl TryFrom<&[u8]> for GetScreenSizeRangeReply {
 
 /// Opcode for the SetScreenSize request
 pub const SET_SCREEN_SIZE_REQUEST: u8 = 7;
-pub fn set_screen_size<Conn>(conn: &Conn, window: WINDOW, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_screen_size<Conn>(conn: &Conn, window: Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1091,7 +1091,7 @@ impl Serialize for ModeInfo {
 
 /// Opcode for the GetScreenResources request
 pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
-pub fn get_screen_resources<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetScreenResourcesReply>, ConnectionError>
+pub fn get_screen_resources<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenResourcesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1118,10 +1118,10 @@ pub struct GetScreenResourcesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
-    pub config_timestamp: TIMESTAMP,
-    pub crtcs: Vec<CRTC>,
-    pub outputs: Vec<OUTPUT>,
+    pub timestamp: Timestamp,
+    pub config_timestamp: Timestamp,
+    pub crtcs: Vec<Crtc>,
+    pub outputs: Vec<Output>,
     pub modes: Vec<ModeInfo>,
     pub names: Vec<u8>,
 }
@@ -1131,15 +1131,15 @@ impl GetScreenResourcesReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (num_crtcs, remaining) = u16::try_parse(remaining)?;
         let (num_outputs, remaining) = u16::try_parse(remaining)?;
         let (num_modes, remaining) = u16::try_parse(remaining)?;
         let (names_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<Crtc>(remaining, num_crtcs as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_outputs as usize)?;
         let (modes, remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
         let (names, remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
         let result = GetScreenResourcesReply { response_type, sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
@@ -1220,7 +1220,7 @@ impl TryFrom<u32> for Connection {
 
 /// Opcode for the GetOutputInfo request
 pub const GET_OUTPUT_INFO_REQUEST: u8 = 9;
-pub fn get_output_info<Conn>(conn: &Conn, output: OUTPUT, config_timestamp: TIMESTAMP) -> Result<Cookie<'_, Conn, GetOutputInfoReply>, ConnectionError>
+pub fn get_output_info<Conn>(conn: &Conn, output: Output, config_timestamp: Timestamp) -> Result<Cookie<'_, Conn, GetOutputInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1253,16 +1253,16 @@ pub struct GetOutputInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
-    pub crtc: CRTC,
+    pub timestamp: Timestamp,
+    pub crtc: Crtc,
     pub mm_width: u32,
     pub mm_height: u32,
     pub connection: Connection,
     pub subpixel_order: render::SubPixel,
     pub num_preferred: u16,
-    pub crtcs: Vec<CRTC>,
-    pub modes: Vec<MODE>,
-    pub clones: Vec<OUTPUT>,
+    pub crtcs: Vec<Crtc>,
+    pub modes: Vec<Mode>,
+    pub clones: Vec<Output>,
     pub name: Vec<u8>,
 }
 impl GetOutputInfoReply {
@@ -1271,8 +1271,8 @@ impl GetOutputInfoReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (crtc, remaining) = CRTC::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (crtc, remaining) = Crtc::try_parse(remaining)?;
         let (mm_width, remaining) = u32::try_parse(remaining)?;
         let (mm_height, remaining) = u32::try_parse(remaining)?;
         let (connection, remaining) = u8::try_parse(remaining)?;
@@ -1282,9 +1282,9 @@ impl GetOutputInfoReply {
         let (num_preferred, remaining) = u16::try_parse(remaining)?;
         let (num_clones, remaining) = u16::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
-        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        let (modes, remaining) = crate::x11_utils::parse_list::<MODE>(remaining, num_modes as usize)?;
-        let (clones, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_clones as usize)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<Crtc>(remaining, num_crtcs as usize)?;
+        let (modes, remaining) = crate::x11_utils::parse_list::<Mode>(remaining, num_modes as usize)?;
+        let (clones, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_clones as usize)?;
         let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         let status = status.try_into()?;
         let connection = connection.try_into()?;
@@ -1302,7 +1302,7 @@ impl TryFrom<&[u8]> for GetOutputInfoReply {
 
 /// Opcode for the ListOutputProperties request
 pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
-pub fn list_output_properties<Conn>(conn: &Conn, output: OUTPUT) -> Result<Cookie<'_, Conn, ListOutputPropertiesReply>, ConnectionError>
+pub fn list_output_properties<Conn>(conn: &Conn, output: Output) -> Result<Cookie<'_, Conn, ListOutputPropertiesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1329,7 +1329,7 @@ pub struct ListOutputPropertiesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atoms: Vec<ATOM>,
+    pub atoms: Vec<Atom>,
 }
 impl ListOutputPropertiesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1339,7 +1339,7 @@ impl ListOutputPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_atoms, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_atoms as usize)?;
         let result = ListOutputPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -1353,7 +1353,7 @@ impl TryFrom<&[u8]> for ListOutputPropertiesReply {
 
 /// Opcode for the QueryOutputProperty request
 pub const QUERY_OUTPUT_PROPERTY_REQUEST: u8 = 11;
-pub fn query_output_property<Conn>(conn: &Conn, output: OUTPUT, property: ATOM) -> Result<Cookie<'_, Conn, QueryOutputPropertyReply>, ConnectionError>
+pub fn query_output_property<Conn>(conn: &Conn, output: Output, property: Atom) -> Result<Cookie<'_, Conn, QueryOutputPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1413,7 +1413,7 @@ impl TryFrom<&[u8]> for QueryOutputPropertyReply {
 
 /// Opcode for the ConfigureOutputProperty request
 pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
-pub fn configure_output_property<'c, Conn>(conn: &'c Conn, output: OUTPUT, property: ATOM, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_output_property<'c, Conn>(conn: &'c Conn, output: Output, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1453,7 +1453,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ChangeOutputProperty request
 pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
-pub fn change_output_property<'c, Conn, A>(conn: &'c Conn, output: OUTPUT, property: ATOM, type_: ATOM, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_output_property<'c, Conn, A>(conn: &'c Conn, output: Output, property: Atom, type_: Atom, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1504,7 +1504,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the DeleteOutputProperty request
 pub const DELETE_OUTPUT_PROPERTY_REQUEST: u8 = 14;
-pub fn delete_output_property<Conn>(conn: &Conn, output: OUTPUT, property: ATOM) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_output_property<Conn>(conn: &Conn, output: Output, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1534,7 +1534,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetOutputProperty request
 pub const GET_OUTPUT_PROPERTY_REQUEST: u8 = 15;
-pub fn get_output_property<Conn>(conn: &Conn, output: OUTPUT, property: ATOM, type_: ATOM, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetOutputPropertyReply>, ConnectionError>
+pub fn get_output_property<Conn>(conn: &Conn, output: Output, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetOutputPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1588,7 +1588,7 @@ pub struct GetOutputPropertyReply {
     pub format: u8,
     pub sequence: u16,
     pub length: u32,
-    pub type_: ATOM,
+    pub type_: Atom,
     pub bytes_after: u32,
     pub num_items: u32,
     pub data: Vec<u8>,
@@ -1599,7 +1599,7 @@ impl GetOutputPropertyReply {
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (type_, remaining) = Atom::try_parse(remaining)?;
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
@@ -1617,7 +1617,7 @@ impl TryFrom<&[u8]> for GetOutputPropertyReply {
 
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
-pub fn create_mode<'c, Conn>(conn: &'c Conn, window: WINDOW, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
+pub fn create_mode<'c, Conn>(conn: &'c Conn, window: Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1680,7 +1680,7 @@ pub struct CreateModeReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub mode: MODE,
+    pub mode: Mode,
 }
 impl CreateModeReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1688,7 +1688,7 @@ impl CreateModeReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let (mode, remaining) = Mode::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = CreateModeReply { response_type, sequence, length, mode };
         Ok((result, remaining))
@@ -1703,7 +1703,7 @@ impl TryFrom<&[u8]> for CreateModeReply {
 
 /// Opcode for the DestroyMode request
 pub const DESTROY_MODE_REQUEST: u8 = 17;
-pub fn destroy_mode<Conn>(conn: &Conn, mode: MODE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_mode<Conn>(conn: &Conn, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1728,7 +1728,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the AddOutputMode request
 pub const ADD_OUTPUT_MODE_REQUEST: u8 = 18;
-pub fn add_output_mode<Conn>(conn: &Conn, output: OUTPUT, mode: MODE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn add_output_mode<Conn>(conn: &Conn, output: Output, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1758,7 +1758,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeleteOutputMode request
 pub const DELETE_OUTPUT_MODE_REQUEST: u8 = 19;
-pub fn delete_output_mode<Conn>(conn: &Conn, output: OUTPUT, mode: MODE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_output_mode<Conn>(conn: &Conn, output: Output, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1788,7 +1788,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetCrtcInfo request
 pub const GET_CRTC_INFO_REQUEST: u8 = 20;
-pub fn get_crtc_info<Conn>(conn: &Conn, crtc: CRTC, config_timestamp: TIMESTAMP) -> Result<Cookie<'_, Conn, GetCrtcInfoReply>, ConnectionError>
+pub fn get_crtc_info<Conn>(conn: &Conn, crtc: Crtc, config_timestamp: Timestamp) -> Result<Cookie<'_, Conn, GetCrtcInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1821,16 +1821,16 @@ pub struct GetCrtcInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
     pub x: i16,
     pub y: i16,
     pub width: u16,
     pub height: u16,
-    pub mode: MODE,
+    pub mode: Mode,
     pub rotation: u16,
     pub rotations: u16,
-    pub outputs: Vec<OUTPUT>,
-    pub possible: Vec<OUTPUT>,
+    pub outputs: Vec<Output>,
+    pub possible: Vec<Output>,
 }
 impl GetCrtcInfoReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1838,18 +1838,18 @@ impl GetCrtcInfoReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
         let (height, remaining) = u16::try_parse(remaining)?;
-        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let (mode, remaining) = Mode::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
         let (rotations, remaining) = u16::try_parse(remaining)?;
         let (num_outputs, remaining) = u16::try_parse(remaining)?;
         let (num_possible_outputs, remaining) = u16::try_parse(remaining)?;
-        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
-        let (possible, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_possible_outputs as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_outputs as usize)?;
+        let (possible, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_possible_outputs as usize)?;
         let status = status.try_into()?;
         let result = GetCrtcInfoReply { response_type, status, sequence, length, timestamp, x, y, width, height, mode, rotation, rotations, outputs, possible };
         Ok((result, remaining))
@@ -1864,7 +1864,7 @@ impl TryFrom<&[u8]> for GetCrtcInfoReply {
 
 /// Opcode for the SetCrtcConfig request
 pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
-pub fn set_crtc_config<'c, Conn>(conn: &'c Conn, crtc: CRTC, timestamp: TIMESTAMP, config_timestamp: TIMESTAMP, x: i16, y: i16, mode: MODE, rotation: u16, outputs: &[OUTPUT]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
+pub fn set_crtc_config<'c, Conn>(conn: &'c Conn, crtc: Crtc, timestamp: Timestamp, config_timestamp: Timestamp, x: i16, y: i16, mode: Mode, rotation: u16, outputs: &[Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1922,7 +1922,7 @@ pub struct SetCrtcConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
 }
 impl SetCrtcConfigReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1930,7 +1930,7 @@ impl SetCrtcConfigReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let status = status.try_into()?;
         let result = SetCrtcConfigReply { response_type, status, sequence, length, timestamp };
@@ -1946,7 +1946,7 @@ impl TryFrom<&[u8]> for SetCrtcConfigReply {
 
 /// Opcode for the GetCrtcGammaSize request
 pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
-pub fn get_crtc_gamma_size<Conn>(conn: &Conn, crtc: CRTC) -> Result<Cookie<'_, Conn, GetCrtcGammaSizeReply>, ConnectionError>
+pub fn get_crtc_gamma_size<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcGammaSizeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1996,7 +1996,7 @@ impl TryFrom<&[u8]> for GetCrtcGammaSizeReply {
 
 /// Opcode for the GetCrtcGamma request
 pub const GET_CRTC_GAMMA_REQUEST: u8 = 23;
-pub fn get_crtc_gamma<Conn>(conn: &Conn, crtc: CRTC) -> Result<Cookie<'_, Conn, GetCrtcGammaReply>, ConnectionError>
+pub fn get_crtc_gamma<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcGammaReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2052,7 +2052,7 @@ impl TryFrom<&[u8]> for GetCrtcGammaReply {
 
 /// Opcode for the SetCrtcGamma request
 pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
-pub fn set_crtc_gamma<'c, Conn>(conn: &'c Conn, crtc: CRTC, size: u16, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_crtc_gamma<'c, Conn>(conn: &'c Conn, crtc: Crtc, size: u16, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2093,7 +2093,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetScreenResourcesCurrent request
 pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
-pub fn get_screen_resources_current<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetScreenResourcesCurrentReply>, ConnectionError>
+pub fn get_screen_resources_current<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenResourcesCurrentReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2120,10 +2120,10 @@ pub struct GetScreenResourcesCurrentReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
-    pub config_timestamp: TIMESTAMP,
-    pub crtcs: Vec<CRTC>,
-    pub outputs: Vec<OUTPUT>,
+    pub timestamp: Timestamp,
+    pub config_timestamp: Timestamp,
+    pub crtcs: Vec<Crtc>,
+    pub outputs: Vec<Output>,
     pub modes: Vec<ModeInfo>,
     pub names: Vec<u8>,
 }
@@ -2133,15 +2133,15 @@ impl GetScreenResourcesCurrentReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (num_crtcs, remaining) = u16::try_parse(remaining)?;
         let (num_outputs, remaining) = u16::try_parse(remaining)?;
         let (num_modes, remaining) = u16::try_parse(remaining)?;
         let (names_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<Crtc>(remaining, num_crtcs as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_outputs as usize)?;
         let (modes, remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
         let (names, remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
         let result = GetScreenResourcesCurrentReply { response_type, sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
@@ -2226,7 +2226,7 @@ bitmask_binop!(Transform, u8);
 
 /// Opcode for the SetCrtcTransform request
 pub const SET_CRTC_TRANSFORM_REQUEST: u8 = 26;
-pub fn set_crtc_transform<'c, Conn>(conn: &'c Conn, crtc: CRTC, transform: render::Transform, filter_name: &[u8], filter_params: &[render::FIXED]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_crtc_transform<'c, Conn>(conn: &'c Conn, crtc: Crtc, transform: render::Transform, filter_name: &[u8], filter_params: &[render::Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2301,7 +2301,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetCrtcTransform request
 pub const GET_CRTC_TRANSFORM_REQUEST: u8 = 27;
-pub fn get_crtc_transform<Conn>(conn: &Conn, crtc: CRTC) -> Result<Cookie<'_, Conn, GetCrtcTransformReply>, ConnectionError>
+pub fn get_crtc_transform<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcTransformReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2332,9 +2332,9 @@ pub struct GetCrtcTransformReply {
     pub has_transforms: bool,
     pub current_transform: render::Transform,
     pub pending_filter_name: Vec<u8>,
-    pub pending_params: Vec<render::FIXED>,
+    pub pending_params: Vec<render::Fixed>,
     pub current_filter_name: Vec<u8>,
-    pub current_params: Vec<render::FIXED>,
+    pub current_params: Vec<render::Fixed>,
 }
 impl GetCrtcTransformReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2357,13 +2357,13 @@ impl GetCrtcTransformReply {
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (pending_params, remaining) = crate::x11_utils::parse_list::<render::FIXED>(remaining, pending_nparams as usize)?;
+        let (pending_params, remaining) = crate::x11_utils::parse_list::<render::Fixed>(remaining, pending_nparams as usize)?;
         let (current_filter_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, current_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (current_params, remaining) = crate::x11_utils::parse_list::<render::FIXED>(remaining, current_nparams as usize)?;
+        let (current_params, remaining) = crate::x11_utils::parse_list::<render::Fixed>(remaining, current_nparams as usize)?;
         let result = GetCrtcTransformReply { response_type, sequence, length, pending_transform, has_transforms, current_transform, pending_filter_name, pending_params, current_filter_name, current_params };
         Ok((result, remaining))
     }
@@ -2377,7 +2377,7 @@ impl TryFrom<&[u8]> for GetCrtcTransformReply {
 
 /// Opcode for the GetPanning request
 pub const GET_PANNING_REQUEST: u8 = 28;
-pub fn get_panning<Conn>(conn: &Conn, crtc: CRTC) -> Result<Cookie<'_, Conn, GetPanningReply>, ConnectionError>
+pub fn get_panning<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetPanningReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2405,7 +2405,7 @@ pub struct GetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
     pub left: u16,
     pub top: u16,
     pub width: u16,
@@ -2425,7 +2425,7 @@ impl GetPanningReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (left, remaining) = u16::try_parse(remaining)?;
         let (top, remaining) = u16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -2452,7 +2452,7 @@ impl TryFrom<&[u8]> for GetPanningReply {
 
 /// Opcode for the SetPanning request
 pub const SET_PANNING_REQUEST: u8 = 29;
-pub fn set_panning<Conn>(conn: &Conn, crtc: CRTC, timestamp: TIMESTAMP, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Conn, SetPanningReply>, ConnectionError>
+pub fn set_panning<Conn>(conn: &Conn, crtc: Crtc, timestamp: Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Conn, SetPanningReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2521,7 +2521,7 @@ pub struct SetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
 }
 impl SetPanningReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2529,7 +2529,7 @@ impl SetPanningReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let status = status.try_into()?;
         let result = SetPanningReply { response_type, status, sequence, length, timestamp };
         Ok((result, remaining))
@@ -2544,7 +2544,7 @@ impl TryFrom<&[u8]> for SetPanningReply {
 
 /// Opcode for the SetOutputPrimary request
 pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
-pub fn set_output_primary<Conn>(conn: &Conn, window: WINDOW, output: OUTPUT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_output_primary<Conn>(conn: &Conn, window: Window, output: Output) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2574,7 +2574,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetOutputPrimary request
 pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
-pub fn get_output_primary<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetOutputPrimaryReply>, ConnectionError>
+pub fn get_output_primary<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetOutputPrimaryReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2601,7 +2601,7 @@ pub struct GetOutputPrimaryReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub output: OUTPUT,
+    pub output: Output,
 }
 impl GetOutputPrimaryReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2609,7 +2609,7 @@ impl GetOutputPrimaryReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (output, remaining) = OUTPUT::try_parse(remaining)?;
+        let (output, remaining) = Output::try_parse(remaining)?;
         let result = GetOutputPrimaryReply { response_type, sequence, length, output };
         Ok((result, remaining))
     }
@@ -2623,7 +2623,7 @@ impl TryFrom<&[u8]> for GetOutputPrimaryReply {
 
 /// Opcode for the GetProviders request
 pub const GET_PROVIDERS_REQUEST: u8 = 32;
-pub fn get_providers<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetProvidersReply>, ConnectionError>
+pub fn get_providers<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetProvidersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2650,8 +2650,8 @@ pub struct GetProvidersReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
-    pub providers: Vec<PROVIDER>,
+    pub timestamp: Timestamp,
+    pub providers: Vec<Provider>,
 }
 impl GetProvidersReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2659,10 +2659,10 @@ impl GetProvidersReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (num_providers, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
-        let (providers, remaining) = crate::x11_utils::parse_list::<PROVIDER>(remaining, num_providers as usize)?;
+        let (providers, remaining) = crate::x11_utils::parse_list::<Provider>(remaining, num_providers as usize)?;
         let result = GetProvidersReply { response_type, sequence, length, timestamp, providers };
         Ok((result, remaining))
     }
@@ -2745,7 +2745,7 @@ bitmask_binop!(ProviderCapability, u8);
 
 /// Opcode for the GetProviderInfo request
 pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;
-pub fn get_provider_info<Conn>(conn: &Conn, provider: PROVIDER, config_timestamp: TIMESTAMP) -> Result<Cookie<'_, Conn, GetProviderInfoReply>, ConnectionError>
+pub fn get_provider_info<Conn>(conn: &Conn, provider: Provider, config_timestamp: Timestamp) -> Result<Cookie<'_, Conn, GetProviderInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2778,12 +2778,12 @@ pub struct GetProviderInfoReply {
     pub status: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
     pub capabilities: u32,
     pub num_associated_providers: u16,
-    pub crtcs: Vec<CRTC>,
-    pub outputs: Vec<OUTPUT>,
-    pub associated_providers: Vec<PROVIDER>,
+    pub crtcs: Vec<Crtc>,
+    pub outputs: Vec<Output>,
+    pub associated_providers: Vec<Provider>,
     pub associated_capability: Vec<u32>,
     pub name: Vec<u8>,
 }
@@ -2793,16 +2793,16 @@ impl GetProviderInfoReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (capabilities, remaining) = u32::try_parse(remaining)?;
         let (num_crtcs, remaining) = u16::try_parse(remaining)?;
         let (num_outputs, remaining) = u16::try_parse(remaining)?;
         let (num_associated_providers, remaining) = u16::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (crtcs, remaining) = crate::x11_utils::parse_list::<CRTC>(remaining, num_crtcs as usize)?;
-        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, num_outputs as usize)?;
-        let (associated_providers, remaining) = crate::x11_utils::parse_list::<PROVIDER>(remaining, num_associated_providers as usize)?;
+        let (crtcs, remaining) = crate::x11_utils::parse_list::<Crtc>(remaining, num_crtcs as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_outputs as usize)?;
+        let (associated_providers, remaining) = crate::x11_utils::parse_list::<Provider>(remaining, num_associated_providers as usize)?;
         let (associated_capability, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_associated_providers as usize)?;
         let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
         let result = GetProviderInfoReply { response_type, status, sequence, length, timestamp, capabilities, num_associated_providers, crtcs, outputs, associated_providers, associated_capability, name };
@@ -2818,7 +2818,7 @@ impl TryFrom<&[u8]> for GetProviderInfoReply {
 
 /// Opcode for the SetProviderOffloadSink request
 pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
-pub fn set_provider_offload_sink<Conn>(conn: &Conn, provider: PROVIDER, sink_provider: PROVIDER, config_timestamp: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_provider_offload_sink<Conn>(conn: &Conn, provider: Provider, sink_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2853,7 +2853,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetProviderOutputSource request
 pub const SET_PROVIDER_OUTPUT_SOURCE_REQUEST: u8 = 35;
-pub fn set_provider_output_source<Conn>(conn: &Conn, provider: PROVIDER, source_provider: PROVIDER, config_timestamp: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_provider_output_source<Conn>(conn: &Conn, provider: Provider, source_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2888,7 +2888,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ListProviderProperties request
 pub const LIST_PROVIDER_PROPERTIES_REQUEST: u8 = 36;
-pub fn list_provider_properties<Conn>(conn: &Conn, provider: PROVIDER) -> Result<Cookie<'_, Conn, ListProviderPropertiesReply>, ConnectionError>
+pub fn list_provider_properties<Conn>(conn: &Conn, provider: Provider) -> Result<Cookie<'_, Conn, ListProviderPropertiesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2915,7 +2915,7 @@ pub struct ListProviderPropertiesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atoms: Vec<ATOM>,
+    pub atoms: Vec<Atom>,
 }
 impl ListProviderPropertiesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2925,7 +2925,7 @@ impl ListProviderPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_atoms, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_atoms as usize)?;
         let result = ListProviderPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -2939,7 +2939,7 @@ impl TryFrom<&[u8]> for ListProviderPropertiesReply {
 
 /// Opcode for the QueryProviderProperty request
 pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
-pub fn query_provider_property<Conn>(conn: &Conn, provider: PROVIDER, property: ATOM) -> Result<Cookie<'_, Conn, QueryProviderPropertyReply>, ConnectionError>
+pub fn query_provider_property<Conn>(conn: &Conn, provider: Provider, property: Atom) -> Result<Cookie<'_, Conn, QueryProviderPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2999,7 +2999,7 @@ impl TryFrom<&[u8]> for QueryProviderPropertyReply {
 
 /// Opcode for the ConfigureProviderProperty request
 pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
-pub fn configure_provider_property<'c, Conn>(conn: &'c Conn, provider: PROVIDER, property: ATOM, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3039,7 +3039,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ChangeProviderProperty request
 pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
-pub fn change_provider_property<'c, Conn>(conn: &'c Conn, provider: PROVIDER, property: ATOM, type_: ATOM, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: Atom, type_: Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3089,7 +3089,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeleteProviderProperty request
 pub const DELETE_PROVIDER_PROPERTY_REQUEST: u8 = 40;
-pub fn delete_provider_property<Conn>(conn: &Conn, provider: PROVIDER, property: ATOM) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_provider_property<Conn>(conn: &Conn, provider: Provider, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3119,7 +3119,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetProviderProperty request
 pub const GET_PROVIDER_PROPERTY_REQUEST: u8 = 41;
-pub fn get_provider_property<Conn>(conn: &Conn, provider: PROVIDER, property: ATOM, type_: ATOM, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetProviderPropertyReply>, ConnectionError>
+pub fn get_provider_property<Conn>(conn: &Conn, provider: Provider, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetProviderPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3173,7 +3173,7 @@ pub struct GetProviderPropertyReply {
     pub format: u8,
     pub sequence: u16,
     pub length: u32,
-    pub type_: ATOM,
+    pub type_: Atom,
     pub bytes_after: u32,
     pub num_items: u32,
     pub data: Vec<u8>,
@@ -3184,7 +3184,7 @@ impl GetProviderPropertyReply {
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (type_, remaining) = Atom::try_parse(remaining)?;
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
@@ -3207,10 +3207,10 @@ pub struct ScreenChangeNotifyEvent {
     pub response_type: u8,
     pub rotation: u8,
     pub sequence: u16,
-    pub timestamp: TIMESTAMP,
-    pub config_timestamp: TIMESTAMP,
-    pub root: WINDOW,
-    pub request_window: WINDOW,
+    pub timestamp: Timestamp,
+    pub config_timestamp: Timestamp,
+    pub root: Window,
+    pub request_window: Window,
     pub size_id: u16,
     pub subpixel_order: render::SubPixel,
     pub width: u16,
@@ -3223,10 +3223,10 @@ impl ScreenChangeNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (rotation, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (request_window, remaining) = WINDOW::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (request_window, remaining) = Window::try_parse(remaining)?;
         let (size_id, remaining) = u16::try_parse(remaining)?;
         let (subpixel_order, remaining) = u16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -3362,10 +3362,10 @@ impl TryFrom<u32> for Notify {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CrtcChange {
-    pub timestamp: TIMESTAMP,
-    pub window: WINDOW,
-    pub crtc: CRTC,
-    pub mode: MODE,
+    pub timestamp: Timestamp,
+    pub window: Window,
+    pub crtc: Crtc,
+    pub mode: Mode,
     pub rotation: u16,
     pub x: i16,
     pub y: i16,
@@ -3374,10 +3374,10 @@ pub struct CrtcChange {
 }
 impl TryParse for CrtcChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (crtc, remaining) = CRTC::try_parse(remaining)?;
-        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (crtc, remaining) = Crtc::try_parse(remaining)?;
+        let (mode, remaining) = Mode::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (x, remaining) = i16::try_parse(remaining)?;
@@ -3454,24 +3454,24 @@ impl Serialize for CrtcChange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutputChange {
-    pub timestamp: TIMESTAMP,
-    pub config_timestamp: TIMESTAMP,
-    pub window: WINDOW,
-    pub output: OUTPUT,
-    pub crtc: CRTC,
-    pub mode: MODE,
+    pub timestamp: Timestamp,
+    pub config_timestamp: Timestamp,
+    pub window: Window,
+    pub output: Output,
+    pub crtc: Crtc,
+    pub mode: Mode,
     pub rotation: u16,
     pub connection: Connection,
     pub subpixel_order: render::SubPixel,
 }
 impl TryParse for OutputChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (config_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (output, remaining) = OUTPUT::try_parse(remaining)?;
-        let (crtc, remaining) = CRTC::try_parse(remaining)?;
-        let (mode, remaining) = MODE::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (output, remaining) = Output::try_parse(remaining)?;
+        let (crtc, remaining) = Crtc::try_parse(remaining)?;
+        let (mode, remaining) = Mode::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
         let (connection, remaining) = u8::try_parse(remaining)?;
         let (subpixel_order, remaining) = u8::try_parse(remaining)?;
@@ -3546,18 +3546,18 @@ impl Serialize for OutputChange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutputProperty {
-    pub window: WINDOW,
-    pub output: OUTPUT,
-    pub atom: ATOM,
-    pub timestamp: TIMESTAMP,
+    pub window: Window,
+    pub output: Output,
+    pub atom: Atom,
+    pub timestamp: Timestamp,
     pub status: Property,
 }
 impl TryParse for OutputProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (output, remaining) = OUTPUT::try_parse(remaining)?;
-        let (atom, remaining) = ATOM::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (output, remaining) = Output::try_parse(remaining)?;
+        let (atom, remaining) = Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let status = status.try_into()?;
@@ -3623,15 +3623,15 @@ impl Serialize for OutputProperty {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderChange {
-    pub timestamp: TIMESTAMP,
-    pub window: WINDOW,
-    pub provider: PROVIDER,
+    pub timestamp: Timestamp,
+    pub window: Window,
+    pub provider: Provider,
 }
 impl TryParse for ProviderChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (provider, remaining) = PROVIDER::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (provider, remaining) = Provider::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = ProviderChange { timestamp, window, provider };
         Ok((result, remaining))
@@ -3691,18 +3691,18 @@ impl Serialize for ProviderChange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderProperty {
-    pub window: WINDOW,
-    pub provider: PROVIDER,
-    pub atom: ATOM,
-    pub timestamp: TIMESTAMP,
+    pub window: Window,
+    pub provider: Provider,
+    pub atom: Atom,
+    pub timestamp: Timestamp,
     pub state: u8,
 }
 impl TryParse for ProviderProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (provider, remaining) = PROVIDER::try_parse(remaining)?;
-        let (atom, remaining) = ATOM::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (provider, remaining) = Provider::try_parse(remaining)?;
+        let (atom, remaining) = Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let result = ProviderProperty { window, provider, atom, timestamp, state };
@@ -3767,13 +3767,13 @@ impl Serialize for ProviderProperty {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResourceChange {
-    pub timestamp: TIMESTAMP,
-    pub window: WINDOW,
+    pub timestamp: Timestamp,
+    pub window: Window,
 }
 impl TryParse for ResourceChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = ResourceChange { timestamp, window };
         Ok((result, remaining))
@@ -3831,7 +3831,7 @@ impl Serialize for ResourceChange {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MonitorInfo {
-    pub name: ATOM,
+    pub name: Atom,
     pub primary: bool,
     pub automatic: bool,
     pub x: i16,
@@ -3840,11 +3840,11 @@ pub struct MonitorInfo {
     pub height: u16,
     pub width_in_millimeters: u32,
     pub height_in_millimeters: u32,
-    pub outputs: Vec<OUTPUT>,
+    pub outputs: Vec<Output>,
 }
 impl TryParse for MonitorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (name, remaining) = Atom::try_parse(remaining)?;
         let (primary, remaining) = bool::try_parse(remaining)?;
         let (automatic, remaining) = bool::try_parse(remaining)?;
         let (n_output, remaining) = u16::try_parse(remaining)?;
@@ -3854,7 +3854,7 @@ impl TryParse for MonitorInfo {
         let (height, remaining) = u16::try_parse(remaining)?;
         let (width_in_millimeters, remaining) = u32::try_parse(remaining)?;
         let (height_in_millimeters, remaining) = u32::try_parse(remaining)?;
-        let (outputs, remaining) = crate::x11_utils::parse_list::<OUTPUT>(remaining, n_output as usize)?;
+        let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, n_output as usize)?;
         let result = MonitorInfo { name, primary, automatic, x, y, width, height, width_in_millimeters, height_in_millimeters, outputs };
         Ok((result, remaining))
     }
@@ -3891,7 +3891,7 @@ impl Serialize for MonitorInfo {
 
 /// Opcode for the GetMonitors request
 pub const GET_MONITORS_REQUEST: u8 = 42;
-pub fn get_monitors<Conn>(conn: &Conn, window: WINDOW, get_active: bool) -> Result<Cookie<'_, Conn, GetMonitorsReply>, ConnectionError>
+pub fn get_monitors<Conn>(conn: &Conn, window: Window, get_active: bool) -> Result<Cookie<'_, Conn, GetMonitorsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3923,7 +3923,7 @@ pub struct GetMonitorsReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
     pub n_outputs: u32,
     pub monitors: Vec<MonitorInfo>,
 }
@@ -3933,7 +3933,7 @@ impl GetMonitorsReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (n_monitors, remaining) = u32::try_parse(remaining)?;
         let (n_outputs, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
@@ -3951,7 +3951,7 @@ impl TryFrom<&[u8]> for GetMonitorsReply {
 
 /// Opcode for the SetMonitor request
 pub const SET_MONITOR_REQUEST: u8 = 43;
-pub fn set_monitor<Conn>(conn: &Conn, window: WINDOW, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_monitor<Conn>(conn: &Conn, window: Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3980,7 +3980,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeleteMonitor request
 pub const DELETE_MONITOR_REQUEST: u8 = 44;
-pub fn delete_monitor<Conn>(conn: &Conn, window: WINDOW, name: ATOM) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_monitor<Conn>(conn: &Conn, window: Window, name: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -4010,7 +4010,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateLease request
 pub const CREATE_LEASE_REQUEST: u8 = 45;
-pub fn create_lease<'c, Conn>(conn: &'c Conn, window: WINDOW, lid: LEASE, crtcs: &[CRTC], outputs: &[OUTPUT]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
+pub fn create_lease<'c, Conn>(conn: &'c Conn, window: Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -4082,7 +4082,7 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for CreateLeaseReply {
 
 /// Opcode for the FreeLease request
 pub const FREE_LEASE_REQUEST: u8 = 46;
-pub fn free_lease<Conn>(conn: &Conn, lid: LEASE, terminate: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_lease<Conn>(conn: &Conn, lid: Lease, terminate: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -4112,16 +4112,16 @@ where Conn: RequestConnection + ?Sized
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LeaseNotify {
-    pub timestamp: TIMESTAMP,
-    pub window: WINDOW,
-    pub lease: LEASE,
+    pub timestamp: Timestamp,
+    pub window: Window,
+    pub lease: Lease,
     pub created: u8,
 }
 impl TryParse for LeaseNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (lease, remaining) = LEASE::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (lease, remaining) = Lease::try_parse(remaining)?;
         let (created, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
         let result = LeaseNotify { timestamp, window, lease, created };
@@ -4360,223 +4360,223 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn randr_set_screen_config(&self, window: WINDOW, timestamp: TIMESTAMP, config_timestamp: TIMESTAMP, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Self, SetScreenConfigReply>, ConnectionError>
+    fn randr_set_screen_config(&self, window: Window, timestamp: Timestamp, config_timestamp: Timestamp, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Self, SetScreenConfigReply>, ConnectionError>
     {
         set_screen_config(self, window, timestamp, config_timestamp, size_id, rotation, rate)
     }
 
-    fn randr_select_input(&self, window: WINDOW, enable: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_select_input(&self, window: Window, enable: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, window, enable)
     }
 
-    fn randr_get_screen_info(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetScreenInfoReply>, ConnectionError>
+    fn randr_get_screen_info(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenInfoReply>, ConnectionError>
     {
         get_screen_info(self, window)
     }
 
-    fn randr_get_screen_size_range(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetScreenSizeRangeReply>, ConnectionError>
+    fn randr_get_screen_size_range(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenSizeRangeReply>, ConnectionError>
     {
         get_screen_size_range(self, window)
     }
 
-    fn randr_set_screen_size(&self, window: WINDOW, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_screen_size(&self, window: Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_screen_size(self, window, width, height, mm_width, mm_height)
     }
 
-    fn randr_get_screen_resources(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetScreenResourcesReply>, ConnectionError>
+    fn randr_get_screen_resources(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenResourcesReply>, ConnectionError>
     {
         get_screen_resources(self, window)
     }
 
-    fn randr_get_output_info(&self, output: OUTPUT, config_timestamp: TIMESTAMP) -> Result<Cookie<'_, Self, GetOutputInfoReply>, ConnectionError>
+    fn randr_get_output_info(&self, output: Output, config_timestamp: Timestamp) -> Result<Cookie<'_, Self, GetOutputInfoReply>, ConnectionError>
     {
         get_output_info(self, output, config_timestamp)
     }
 
-    fn randr_list_output_properties(&self, output: OUTPUT) -> Result<Cookie<'_, Self, ListOutputPropertiesReply>, ConnectionError>
+    fn randr_list_output_properties(&self, output: Output) -> Result<Cookie<'_, Self, ListOutputPropertiesReply>, ConnectionError>
     {
         list_output_properties(self, output)
     }
 
-    fn randr_query_output_property(&self, output: OUTPUT, property: ATOM) -> Result<Cookie<'_, Self, QueryOutputPropertyReply>, ConnectionError>
+    fn randr_query_output_property(&self, output: Output, property: Atom) -> Result<Cookie<'_, Self, QueryOutputPropertyReply>, ConnectionError>
     {
         query_output_property(self, output, property)
     }
 
-    fn randr_configure_output_property<'c>(&'c self, output: OUTPUT, property: ATOM, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_configure_output_property<'c>(&'c self, output: Output, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_output_property(self, output, property, pending, range, values)
     }
 
-    fn randr_change_output_property<'c, A>(&'c self, output: OUTPUT, property: ATOM, type_: ATOM, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_change_output_property<'c, A>(&'c self, output: Output, property: Atom, type_: Atom, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         change_output_property(self, output, property, type_, format, mode, num_units, data)
     }
 
-    fn randr_delete_output_property(&self, output: OUTPUT, property: ATOM) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_delete_output_property(&self, output: Output, property: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_output_property(self, output, property)
     }
 
-    fn randr_get_output_property(&self, output: OUTPUT, property: ATOM, type_: ATOM, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetOutputPropertyReply>, ConnectionError>
+    fn randr_get_output_property(&self, output: Output, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetOutputPropertyReply>, ConnectionError>
     {
         get_output_property(self, output, property, type_, long_offset, long_length, delete, pending)
     }
 
-    fn randr_create_mode<'c>(&'c self, window: WINDOW, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Self, CreateModeReply>, ConnectionError>
+    fn randr_create_mode<'c>(&'c self, window: Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Self, CreateModeReply>, ConnectionError>
     {
         create_mode(self, window, mode_info, name)
     }
 
-    fn randr_destroy_mode(&self, mode: MODE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_destroy_mode(&self, mode: Mode) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_mode(self, mode)
     }
 
-    fn randr_add_output_mode(&self, output: OUTPUT, mode: MODE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_add_output_mode(&self, output: Output, mode: Mode) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         add_output_mode(self, output, mode)
     }
 
-    fn randr_delete_output_mode(&self, output: OUTPUT, mode: MODE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_delete_output_mode(&self, output: Output, mode: Mode) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_output_mode(self, output, mode)
     }
 
-    fn randr_get_crtc_info(&self, crtc: CRTC, config_timestamp: TIMESTAMP) -> Result<Cookie<'_, Self, GetCrtcInfoReply>, ConnectionError>
+    fn randr_get_crtc_info(&self, crtc: Crtc, config_timestamp: Timestamp) -> Result<Cookie<'_, Self, GetCrtcInfoReply>, ConnectionError>
     {
         get_crtc_info(self, crtc, config_timestamp)
     }
 
-    fn randr_set_crtc_config<'c>(&'c self, crtc: CRTC, timestamp: TIMESTAMP, config_timestamp: TIMESTAMP, x: i16, y: i16, mode: MODE, rotation: u16, outputs: &[OUTPUT]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
+    fn randr_set_crtc_config<'c>(&'c self, crtc: Crtc, timestamp: Timestamp, config_timestamp: Timestamp, x: i16, y: i16, mode: Mode, rotation: u16, outputs: &[Output]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
     {
         set_crtc_config(self, crtc, timestamp, config_timestamp, x, y, mode, rotation, outputs)
     }
 
-    fn randr_get_crtc_gamma_size(&self, crtc: CRTC) -> Result<Cookie<'_, Self, GetCrtcGammaSizeReply>, ConnectionError>
+    fn randr_get_crtc_gamma_size(&self, crtc: Crtc) -> Result<Cookie<'_, Self, GetCrtcGammaSizeReply>, ConnectionError>
     {
         get_crtc_gamma_size(self, crtc)
     }
 
-    fn randr_get_crtc_gamma(&self, crtc: CRTC) -> Result<Cookie<'_, Self, GetCrtcGammaReply>, ConnectionError>
+    fn randr_get_crtc_gamma(&self, crtc: Crtc) -> Result<Cookie<'_, Self, GetCrtcGammaReply>, ConnectionError>
     {
         get_crtc_gamma(self, crtc)
     }
 
-    fn randr_set_crtc_gamma<'c>(&'c self, crtc: CRTC, size: u16, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_set_crtc_gamma<'c>(&'c self, crtc: Crtc, size: u16, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_crtc_gamma(self, crtc, size, red, green, blue)
     }
 
-    fn randr_get_screen_resources_current(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetScreenResourcesCurrentReply>, ConnectionError>
+    fn randr_get_screen_resources_current(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenResourcesCurrentReply>, ConnectionError>
     {
         get_screen_resources_current(self, window)
     }
 
-    fn randr_set_crtc_transform<'c>(&'c self, crtc: CRTC, transform: render::Transform, filter_name: &[u8], filter_params: &[render::FIXED]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_set_crtc_transform<'c>(&'c self, crtc: Crtc, transform: render::Transform, filter_name: &[u8], filter_params: &[render::Fixed]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_crtc_transform(self, crtc, transform, filter_name, filter_params)
     }
 
-    fn randr_get_crtc_transform(&self, crtc: CRTC) -> Result<Cookie<'_, Self, GetCrtcTransformReply>, ConnectionError>
+    fn randr_get_crtc_transform(&self, crtc: Crtc) -> Result<Cookie<'_, Self, GetCrtcTransformReply>, ConnectionError>
     {
         get_crtc_transform(self, crtc)
     }
 
-    fn randr_get_panning(&self, crtc: CRTC) -> Result<Cookie<'_, Self, GetPanningReply>, ConnectionError>
+    fn randr_get_panning(&self, crtc: Crtc) -> Result<Cookie<'_, Self, GetPanningReply>, ConnectionError>
     {
         get_panning(self, crtc)
     }
 
-    fn randr_set_panning(&self, crtc: CRTC, timestamp: TIMESTAMP, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Self, SetPanningReply>, ConnectionError>
+    fn randr_set_panning(&self, crtc: Crtc, timestamp: Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Self, SetPanningReply>, ConnectionError>
     {
         set_panning(self, crtc, timestamp, left, top, width, height, track_left, track_top, track_width, track_height, border_left, border_top, border_right, border_bottom)
     }
 
-    fn randr_set_output_primary(&self, window: WINDOW, output: OUTPUT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_output_primary(&self, window: Window, output: Output) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_output_primary(self, window, output)
     }
 
-    fn randr_get_output_primary(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetOutputPrimaryReply>, ConnectionError>
+    fn randr_get_output_primary(&self, window: Window) -> Result<Cookie<'_, Self, GetOutputPrimaryReply>, ConnectionError>
     {
         get_output_primary(self, window)
     }
 
-    fn randr_get_providers(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetProvidersReply>, ConnectionError>
+    fn randr_get_providers(&self, window: Window) -> Result<Cookie<'_, Self, GetProvidersReply>, ConnectionError>
     {
         get_providers(self, window)
     }
 
-    fn randr_get_provider_info(&self, provider: PROVIDER, config_timestamp: TIMESTAMP) -> Result<Cookie<'_, Self, GetProviderInfoReply>, ConnectionError>
+    fn randr_get_provider_info(&self, provider: Provider, config_timestamp: Timestamp) -> Result<Cookie<'_, Self, GetProviderInfoReply>, ConnectionError>
     {
         get_provider_info(self, provider, config_timestamp)
     }
 
-    fn randr_set_provider_offload_sink(&self, provider: PROVIDER, sink_provider: PROVIDER, config_timestamp: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_provider_offload_sink(&self, provider: Provider, sink_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_provider_offload_sink(self, provider, sink_provider, config_timestamp)
     }
 
-    fn randr_set_provider_output_source(&self, provider: PROVIDER, source_provider: PROVIDER, config_timestamp: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_provider_output_source(&self, provider: Provider, source_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_provider_output_source(self, provider, source_provider, config_timestamp)
     }
 
-    fn randr_list_provider_properties(&self, provider: PROVIDER) -> Result<Cookie<'_, Self, ListProviderPropertiesReply>, ConnectionError>
+    fn randr_list_provider_properties(&self, provider: Provider) -> Result<Cookie<'_, Self, ListProviderPropertiesReply>, ConnectionError>
     {
         list_provider_properties(self, provider)
     }
 
-    fn randr_query_provider_property(&self, provider: PROVIDER, property: ATOM) -> Result<Cookie<'_, Self, QueryProviderPropertyReply>, ConnectionError>
+    fn randr_query_provider_property(&self, provider: Provider, property: Atom) -> Result<Cookie<'_, Self, QueryProviderPropertyReply>, ConnectionError>
     {
         query_provider_property(self, provider, property)
     }
 
-    fn randr_configure_provider_property<'c>(&'c self, provider: PROVIDER, property: ATOM, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_configure_provider_property<'c>(&'c self, provider: Provider, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_provider_property(self, provider, property, pending, range, values)
     }
 
-    fn randr_change_provider_property<'c>(&'c self, provider: PROVIDER, property: ATOM, type_: ATOM, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_change_provider_property<'c>(&'c self, provider: Provider, property: Atom, type_: Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_provider_property(self, provider, property, type_, format, mode, num_items, data)
     }
 
-    fn randr_delete_provider_property(&self, provider: PROVIDER, property: ATOM) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_delete_provider_property(&self, provider: Provider, property: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_provider_property(self, provider, property)
     }
 
-    fn randr_get_provider_property(&self, provider: PROVIDER, property: ATOM, type_: ATOM, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetProviderPropertyReply>, ConnectionError>
+    fn randr_get_provider_property(&self, provider: Provider, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetProviderPropertyReply>, ConnectionError>
     {
         get_provider_property(self, provider, property, type_, long_offset, long_length, delete, pending)
     }
 
-    fn randr_get_monitors(&self, window: WINDOW, get_active: bool) -> Result<Cookie<'_, Self, GetMonitorsReply>, ConnectionError>
+    fn randr_get_monitors(&self, window: Window, get_active: bool) -> Result<Cookie<'_, Self, GetMonitorsReply>, ConnectionError>
     {
         get_monitors(self, window, get_active)
     }
 
-    fn randr_set_monitor(&self, window: WINDOW, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_monitor(&self, window: Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_monitor(self, window, monitorinfo)
     }
 
-    fn randr_delete_monitor(&self, window: WINDOW, name: ATOM) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_delete_monitor(&self, window: Window, name: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_monitor(self, window, name)
     }
 
-    fn randr_create_lease<'c>(&'c self, window: WINDOW, lid: LEASE, crtcs: &[CRTC], outputs: &[OUTPUT]) -> Result<CookieWithFds<'c, Self, CreateLeaseReply>, ConnectionError>
+    fn randr_create_lease<'c>(&'c self, window: Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Self, CreateLeaseReply>, ConnectionError>
     {
         create_lease(self, window, lid, crtcs, outputs)
     }
 
-    fn randr_free_lease(&self, lid: LEASE, terminate: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_free_lease(&self, lid: Lease, terminate: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_lease(self, lid, terminate)
     }

--- a/src/generated/record.rs
+++ b/src/generated/record.rs
@@ -35,7 +35,7 @@ pub const X11_EXTENSION_NAME: &str = "RECORD";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 13);
 
-pub type CONTEXT = u32;
+pub type Context = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Range8 {
@@ -517,7 +517,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 1;
-pub fn create_context<'c, Conn>(conn: &'c Conn, context: CONTEXT, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_context<'c, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -565,7 +565,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the RegisterClients request
 pub const REGISTER_CLIENTS_REQUEST: u8 = 2;
-pub fn register_clients<'c, Conn>(conn: &'c Conn, context: CONTEXT, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn register_clients<'c, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -613,7 +613,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the UnregisterClients request
 pub const UNREGISTER_CLIENTS_REQUEST: u8 = 3;
-pub fn unregister_clients<'c, Conn>(conn: &'c Conn, context: CONTEXT, client_specs: &[ClientSpec]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn unregister_clients<'c, Conn>(conn: &'c Conn, context: Context, client_specs: &[ClientSpec]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -648,7 +648,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetContext request
 pub const GET_CONTEXT_REQUEST: u8 = 4;
-pub fn get_context<Conn>(conn: &Conn, context: CONTEXT) -> Result<Cookie<'_, Conn, GetContextReply>, ConnectionError>
+pub fn get_context<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, GetContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -703,7 +703,7 @@ impl TryFrom<&[u8]> for GetContextReply {
 
 /// Opcode for the EnableContext request
 pub const ENABLE_CONTEXT_REQUEST: u8 = 5;
-pub fn enable_context<Conn>(conn: &Conn, context: CONTEXT) -> Result<Cookie<'_, Conn, EnableContextReply>, ConnectionError>
+pub fn enable_context<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, EnableContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -764,7 +764,7 @@ impl TryFrom<&[u8]> for EnableContextReply {
 
 /// Opcode for the DisableContext request
 pub const DISABLE_CONTEXT_REQUEST: u8 = 6;
-pub fn disable_context<Conn>(conn: &Conn, context: CONTEXT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn disable_context<Conn>(conn: &Conn, context: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -789,7 +789,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the FreeContext request
 pub const FREE_CONTEXT_REQUEST: u8 = 7;
-pub fn free_context<Conn>(conn: &Conn, context: CONTEXT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_context<Conn>(conn: &Conn, context: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -819,37 +819,37 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn record_create_context<'c>(&'c self, context: CONTEXT, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn record_create_context<'c>(&'c self, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_context(self, context, element_header, client_specs, ranges)
     }
 
-    fn record_register_clients<'c>(&'c self, context: CONTEXT, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn record_register_clients<'c>(&'c self, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         register_clients(self, context, element_header, client_specs, ranges)
     }
 
-    fn record_unregister_clients<'c>(&'c self, context: CONTEXT, client_specs: &[ClientSpec]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn record_unregister_clients<'c>(&'c self, context: Context, client_specs: &[ClientSpec]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         unregister_clients(self, context, client_specs)
     }
 
-    fn record_get_context(&self, context: CONTEXT) -> Result<Cookie<'_, Self, GetContextReply>, ConnectionError>
+    fn record_get_context(&self, context: Context) -> Result<Cookie<'_, Self, GetContextReply>, ConnectionError>
     {
         get_context(self, context)
     }
 
-    fn record_enable_context(&self, context: CONTEXT) -> Result<Cookie<'_, Self, EnableContextReply>, ConnectionError>
+    fn record_enable_context(&self, context: Context) -> Result<Cookie<'_, Self, EnableContextReply>, ConnectionError>
     {
         enable_context(self, context)
     }
 
-    fn record_disable_context(&self, context: CONTEXT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn record_disable_context(&self, context: Context) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         disable_context(self, context)
     }
 
-    fn record_free_context(&self, context: CONTEXT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn record_free_context(&self, context: Context) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_context(self, context)
     }

--- a/src/generated/render.rs
+++ b/src/generated/render.rs
@@ -101,57 +101,57 @@ impl TryFrom<u32> for PictType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Picture {
+pub enum PictureEnum {
     None = 0,
 }
-impl From<Picture> for u8 {
-    fn from(input: Picture) -> Self {
+impl From<PictureEnum> for u8 {
+    fn from(input: PictureEnum) -> Self {
         match input {
-            Picture::None => 0,
+            PictureEnum::None => 0,
         }
     }
 }
-impl From<Picture> for Option<u8> {
-    fn from(input: Picture) -> Self {
+impl From<PictureEnum> for Option<u8> {
+    fn from(input: PictureEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Picture> for u16 {
-    fn from(input: Picture) -> Self {
+impl From<PictureEnum> for u16 {
+    fn from(input: PictureEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Picture> for Option<u16> {
-    fn from(input: Picture) -> Self {
+impl From<PictureEnum> for Option<u16> {
+    fn from(input: PictureEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Picture> for u32 {
-    fn from(input: Picture) -> Self {
+impl From<PictureEnum> for u32 {
+    fn from(input: PictureEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Picture> for Option<u32> {
-    fn from(input: Picture) -> Self {
+impl From<PictureEnum> for Option<u32> {
+    fn from(input: PictureEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Picture {
+impl TryFrom<u8> for PictureEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Picture::None),
+            0 => Ok(PictureEnum::None),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Picture {
+impl TryFrom<u16> for PictureEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Picture {
+impl TryFrom<u32> for PictureEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -719,15 +719,15 @@ impl TryFrom<u32> for Repeat {
     }
 }
 
-pub type GLYPH = u32;
+pub type Glyph = u32;
 
-pub type GLYPHSET = u32;
+pub type Glyphset = u32;
 
-pub type PICTURE = u32;
+pub type Picture = u32;
 
-pub type PICTFORMAT = u32;
+pub type Pictformat = u32;
 
-pub type FIXED = i32;
+pub type Fixed = i32;
 
 /// Opcode for the PictFormat error
 pub const PICT_FORMAT_ERROR: u8 = 0;
@@ -1065,20 +1065,20 @@ impl Serialize for Directformat {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pictforminfo {
-    pub id: PICTFORMAT,
+    pub id: Pictformat,
     pub type_: PictType,
     pub depth: u8,
     pub direct: Directformat,
-    pub colormap: COLORMAP,
+    pub colormap: Colormap,
 }
 impl TryParse for Pictforminfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (id, remaining) = PICTFORMAT::try_parse(remaining)?;
+        let (id, remaining) = Pictformat::try_parse(remaining)?;
         let (type_, remaining) = u8::try_parse(remaining)?;
         let (depth, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (direct, remaining) = Directformat::try_parse(remaining)?;
-        let (colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let (colormap, remaining) = Colormap::try_parse(remaining)?;
         let type_ = type_.try_into()?;
         let result = Pictforminfo { id, type_, depth, direct, colormap };
         Ok((result, remaining))
@@ -1142,13 +1142,13 @@ impl Serialize for Pictforminfo {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pictvisual {
-    pub visual: VISUALID,
-    pub format: PICTFORMAT,
+    pub visual: Visualid,
+    pub format: Pictformat,
 }
 impl TryParse for Pictvisual {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (visual, remaining) = VISUALID::try_parse(remaining)?;
-        let (format, remaining) = PICTFORMAT::try_parse(remaining)?;
+        let (visual, remaining) = Visualid::try_parse(remaining)?;
+        let (format, remaining) = Pictformat::try_parse(remaining)?;
         let result = Pictvisual { visual, format };
         Ok((result, remaining))
     }
@@ -1224,13 +1224,13 @@ impl Serialize for Pictdepth {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pictscreen {
-    pub fallback: PICTFORMAT,
+    pub fallback: Pictformat,
     pub depths: Vec<Pictdepth>,
 }
 impl TryParse for Pictscreen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_depths, remaining) = u32::try_parse(remaining)?;
-        let (fallback, remaining) = PICTFORMAT::try_parse(remaining)?;
+        let (fallback, remaining) = Pictformat::try_parse(remaining)?;
         let (depths, remaining) = crate::x11_utils::parse_list::<Pictdepth>(remaining, num_depths as usize)?;
         let result = Pictscreen { fallback, depths };
         Ok((result, remaining))
@@ -1368,13 +1368,13 @@ impl Serialize for Color {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pointfix {
-    pub x: FIXED,
-    pub y: FIXED,
+    pub x: Fixed,
+    pub y: Fixed,
 }
 impl TryParse for Pointfix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (x, remaining) = FIXED::try_parse(remaining)?;
-        let (y, remaining) = FIXED::try_parse(remaining)?;
+        let (x, remaining) = Fixed::try_parse(remaining)?;
+        let (y, remaining) = Fixed::try_parse(remaining)?;
         let result = Pointfix { x, y };
         Ok((result, remaining))
     }
@@ -1522,15 +1522,15 @@ impl Serialize for Triangle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Trapezoid {
-    pub top: FIXED,
-    pub bottom: FIXED,
+    pub top: Fixed,
+    pub bottom: Fixed,
     pub left: Linefix,
     pub right: Linefix,
 }
 impl TryParse for Trapezoid {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (top, remaining) = FIXED::try_parse(remaining)?;
-        let (bottom, remaining) = FIXED::try_parse(remaining)?;
+        let (top, remaining) = Fixed::try_parse(remaining)?;
+        let (bottom, remaining) = Fixed::try_parse(remaining)?;
         let (left, remaining) = Linefix::try_parse(remaining)?;
         let (right, remaining) = Linefix::try_parse(remaining)?;
         let result = Trapezoid { top, bottom, left, right };
@@ -1779,7 +1779,7 @@ impl TryFrom<&[u8]> for QueryPictFormatsReply {
 
 /// Opcode for the QueryPictIndexValues request
 pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
-pub fn query_pict_index_values<Conn>(conn: &Conn, format: PICTFORMAT) -> Result<Cookie<'_, Conn, QueryPictIndexValuesReply>, ConnectionError>
+pub fn query_pict_index_values<Conn>(conn: &Conn, format: Pictformat) -> Result<Cookie<'_, Conn, QueryPictIndexValuesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1834,17 +1834,17 @@ pub const CREATE_PICTURE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreatePictureAux {
     pub repeat: Option<u32>,
-    pub alphamap: Option<PICTURE>,
+    pub alphamap: Option<Picture>,
     pub alphaxorigin: Option<i32>,
     pub alphayorigin: Option<i32>,
     pub clipxorigin: Option<i32>,
     pub clipyorigin: Option<i32>,
-    pub clipmask: Option<PIXMAP>,
+    pub clipmask: Option<Pixmap>,
     pub graphicsexposure: Option<u32>,
     pub subwindowmode: Option<u32>,
     pub polyedge: Option<u32>,
     pub polymode: Option<u32>,
-    pub dither: Option<ATOM>,
+    pub dither: Option<Atom>,
     pub componentalpha: Option<u32>,
 }
 impl CreatePictureAux {
@@ -1901,7 +1901,7 @@ impl CreatePictureAux {
         self
     }
     /// Set the alphamap field of this structure.
-    pub fn alphamap<I>(mut self, value: I) -> Self where I: Into<Option<PICTURE>> {
+    pub fn alphamap<I>(mut self, value: I) -> Self where I: Into<Option<Picture>> {
         self.alphamap = value.into();
         self
     }
@@ -1926,7 +1926,7 @@ impl CreatePictureAux {
         self
     }
     /// Set the clipmask field of this structure.
-    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.clipmask = value.into();
         self
     }
@@ -1951,7 +1951,7 @@ impl CreatePictureAux {
         self
     }
     /// Set the dither field of this structure.
-    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.dither = value.into();
         self
     }
@@ -2010,7 +2010,7 @@ impl Serialize for CreatePictureAux {
         }
     }
 }
-pub fn create_picture<'c, Conn>(conn: &'c Conn, pid: PICTURE, drawable: DRAWABLE, format: PICTFORMAT, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_picture<'c, Conn>(conn: &'c Conn, pid: Picture, drawable: Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2059,17 +2059,17 @@ pub const CHANGE_PICTURE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangePictureAux {
     pub repeat: Option<u32>,
-    pub alphamap: Option<PICTURE>,
+    pub alphamap: Option<Picture>,
     pub alphaxorigin: Option<i32>,
     pub alphayorigin: Option<i32>,
     pub clipxorigin: Option<i32>,
     pub clipyorigin: Option<i32>,
-    pub clipmask: Option<PIXMAP>,
+    pub clipmask: Option<Pixmap>,
     pub graphicsexposure: Option<u32>,
     pub subwindowmode: Option<u32>,
     pub polyedge: Option<u32>,
     pub polymode: Option<u32>,
-    pub dither: Option<ATOM>,
+    pub dither: Option<Atom>,
     pub componentalpha: Option<u32>,
 }
 impl ChangePictureAux {
@@ -2126,7 +2126,7 @@ impl ChangePictureAux {
         self
     }
     /// Set the alphamap field of this structure.
-    pub fn alphamap<I>(mut self, value: I) -> Self where I: Into<Option<PICTURE>> {
+    pub fn alphamap<I>(mut self, value: I) -> Self where I: Into<Option<Picture>> {
         self.alphamap = value.into();
         self
     }
@@ -2151,7 +2151,7 @@ impl ChangePictureAux {
         self
     }
     /// Set the clipmask field of this structure.
-    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.clipmask = value.into();
         self
     }
@@ -2176,7 +2176,7 @@ impl ChangePictureAux {
         self
     }
     /// Set the dither field of this structure.
-    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.dither = value.into();
         self
     }
@@ -2235,7 +2235,7 @@ impl Serialize for ChangePictureAux {
         }
     }
 }
-pub fn change_picture<'c, Conn>(conn: &'c Conn, picture: PICTURE, value_list: &ChangePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_picture<'c, Conn>(conn: &'c Conn, picture: Picture, value_list: &ChangePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2270,7 +2270,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetPictureClipRectangles request
 pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
-pub fn set_picture_clip_rectangles<'c, Conn>(conn: &'c Conn, picture: PICTURE, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_picture_clip_rectangles<'c, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2305,7 +2305,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the FreePicture request
 pub const FREE_PICTURE_REQUEST: u8 = 7;
-pub fn free_picture<Conn>(conn: &Conn, picture: PICTURE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_picture<Conn>(conn: &Conn, picture: Picture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2330,7 +2330,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the Composite request
 pub const COMPOSITE_REQUEST: u8 = 8;
-pub fn composite<Conn, A>(conn: &Conn, op: A, src: PICTURE, mask: PICTURE, dst: PICTURE, src_x: i16, src_y: i16, mask_x: i16, mask_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn composite<Conn, A>(conn: &Conn, op: A, src: Picture, mask: Picture, dst: Picture, src_x: i16, src_y: i16, mask_x: i16, mask_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2395,7 +2395,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the Trapezoids request
 pub const TRAPEZOIDS_REQUEST: u8 = 10;
-pub fn trapezoids<'c, Conn, A>(conn: &'c Conn, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, traps: &[Trapezoid]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn trapezoids<'c, Conn, A>(conn: &'c Conn, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &[Trapezoid]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2446,7 +2446,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the Triangles request
 pub const TRIANGLES_REQUEST: u8 = 11;
-pub fn triangles<'c, Conn, A>(conn: &'c Conn, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, triangles: &[Triangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn triangles<'c, Conn, A>(conn: &'c Conn, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &[Triangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2497,7 +2497,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the TriStrip request
 pub const TRI_STRIP_REQUEST: u8 = 12;
-pub fn tri_strip<'c, Conn, A>(conn: &'c Conn, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn tri_strip<'c, Conn, A>(conn: &'c Conn, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2548,7 +2548,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the TriFan request
 pub const TRI_FAN_REQUEST: u8 = 13;
-pub fn tri_fan<'c, Conn, A>(conn: &'c Conn, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn tri_fan<'c, Conn, A>(conn: &'c Conn, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2599,7 +2599,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the CreateGlyphSet request
 pub const CREATE_GLYPH_SET_REQUEST: u8 = 17;
-pub fn create_glyph_set<Conn>(conn: &Conn, gsid: GLYPHSET, format: PICTFORMAT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_glyph_set<Conn>(conn: &Conn, gsid: Glyphset, format: Pictformat) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2629,7 +2629,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ReferenceGlyphSet request
 pub const REFERENCE_GLYPH_SET_REQUEST: u8 = 18;
-pub fn reference_glyph_set<Conn>(conn: &Conn, gsid: GLYPHSET, existing: GLYPHSET) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn reference_glyph_set<Conn>(conn: &Conn, gsid: Glyphset, existing: Glyphset) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2659,7 +2659,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the FreeGlyphSet request
 pub const FREE_GLYPH_SET_REQUEST: u8 = 19;
-pub fn free_glyph_set<Conn>(conn: &Conn, glyphset: GLYPHSET) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_glyph_set<Conn>(conn: &Conn, glyphset: Glyphset) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2684,7 +2684,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the AddGlyphs request
 pub const ADD_GLYPHS_REQUEST: u8 = 20;
-pub fn add_glyphs<'c, Conn>(conn: &'c Conn, glyphset: GLYPHSET, glyphs_len: u32, glyphids: &[u32], glyphs: &[Glyphinfo], data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn add_glyphs<'c, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphs_len: u32, glyphids: &[u32], glyphs: &[Glyphinfo], data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2723,7 +2723,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the FreeGlyphs request
 pub const FREE_GLYPHS_REQUEST: u8 = 22;
-pub fn free_glyphs<'c, Conn>(conn: &'c Conn, glyphset: GLYPHSET, glyphs: &[GLYPH]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn free_glyphs<'c, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphs: &[Glyph]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2752,7 +2752,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CompositeGlyphs8 request
 pub const COMPOSITE_GLYPHS8_REQUEST: u8 = 23;
-pub fn composite_glyphs8<'c, Conn, A>(conn: &'c Conn, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, glyphset: GLYPHSET, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn composite_glyphs8<'c, Conn, A>(conn: &'c Conn, op: A, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2807,7 +2807,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the CompositeGlyphs16 request
 pub const COMPOSITE_GLYPHS16_REQUEST: u8 = 24;
-pub fn composite_glyphs16<'c, Conn, A>(conn: &'c Conn, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, glyphset: GLYPHSET, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn composite_glyphs16<'c, Conn, A>(conn: &'c Conn, op: A, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2862,7 +2862,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the CompositeGlyphs32 request
 pub const COMPOSITE_GLYPHS32_REQUEST: u8 = 25;
-pub fn composite_glyphs32<'c, Conn, A>(conn: &'c Conn, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, glyphset: GLYPHSET, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn composite_glyphs32<'c, Conn, A>(conn: &'c Conn, op: A, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2917,7 +2917,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the FillRectangles request
 pub const FILL_RECTANGLES_REQUEST: u8 = 26;
-pub fn fill_rectangles<'c, Conn, A>(conn: &'c Conn, op: A, dst: PICTURE, color: Color, rects: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn fill_rectangles<'c, Conn, A>(conn: &'c Conn, op: A, dst: Picture, color: Color, rects: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2961,7 +2961,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 27;
-pub fn create_cursor<Conn>(conn: &Conn, cid: CURSOR, source: PICTURE, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_cursor<Conn>(conn: &Conn, cid: Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2997,27 +2997,27 @@ where Conn: RequestConnection + ?Sized
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Transform {
-    pub matrix11: FIXED,
-    pub matrix12: FIXED,
-    pub matrix13: FIXED,
-    pub matrix21: FIXED,
-    pub matrix22: FIXED,
-    pub matrix23: FIXED,
-    pub matrix31: FIXED,
-    pub matrix32: FIXED,
-    pub matrix33: FIXED,
+    pub matrix11: Fixed,
+    pub matrix12: Fixed,
+    pub matrix13: Fixed,
+    pub matrix21: Fixed,
+    pub matrix22: Fixed,
+    pub matrix23: Fixed,
+    pub matrix31: Fixed,
+    pub matrix32: Fixed,
+    pub matrix33: Fixed,
 }
 impl TryParse for Transform {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (matrix11, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix12, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix13, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix21, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix22, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix23, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix31, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix32, remaining) = FIXED::try_parse(remaining)?;
-        let (matrix33, remaining) = FIXED::try_parse(remaining)?;
+        let (matrix11, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix12, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix13, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix21, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix22, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix23, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix31, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix32, remaining) = Fixed::try_parse(remaining)?;
+        let (matrix33, remaining) = Fixed::try_parse(remaining)?;
         let result = Transform { matrix11, matrix12, matrix13, matrix21, matrix22, matrix23, matrix31, matrix32, matrix33 };
         Ok((result, remaining))
     }
@@ -3095,7 +3095,7 @@ impl Serialize for Transform {
 
 /// Opcode for the SetPictureTransform request
 pub const SET_PICTURE_TRANSFORM_REQUEST: u8 = 28;
-pub fn set_picture_transform<Conn>(conn: &Conn, picture: PICTURE, transform: Transform) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_picture_transform<Conn>(conn: &Conn, picture: Picture, transform: Transform) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3157,7 +3157,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the QueryFilters request
 pub const QUERY_FILTERS_REQUEST: u8 = 29;
-pub fn query_filters<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<Cookie<'_, Conn, QueryFiltersReply>, ConnectionError>
+pub fn query_filters<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, QueryFiltersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3211,7 +3211,7 @@ impl TryFrom<&[u8]> for QueryFiltersReply {
 
 /// Opcode for the SetPictureFilter request
 pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
-pub fn set_picture_filter<'c, Conn>(conn: &'c Conn, picture: PICTURE, filter: &[u8], values: &[FIXED]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_picture_filter<'c, Conn>(conn: &'c Conn, picture: Picture, filter: &[u8], values: &[Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3249,12 +3249,12 @@ where Conn: RequestConnection + ?Sized
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Animcursorelt {
-    pub cursor: CURSOR,
+    pub cursor: Cursor,
     pub delay: u32,
 }
 impl TryParse for Animcursorelt {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (cursor, remaining) = CURSOR::try_parse(remaining)?;
+        let (cursor, remaining) = Cursor::try_parse(remaining)?;
         let (delay, remaining) = u32::try_parse(remaining)?;
         let result = Animcursorelt { cursor, delay };
         Ok((result, remaining))
@@ -3291,7 +3291,7 @@ impl Serialize for Animcursorelt {
 
 /// Opcode for the CreateAnimCursor request
 pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
-pub fn create_anim_cursor<'c, Conn>(conn: &'c Conn, cid: CURSOR, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_anim_cursor<'c, Conn>(conn: &'c Conn, cid: Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3320,15 +3320,15 @@ where Conn: RequestConnection + ?Sized
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Spanfix {
-    pub l: FIXED,
-    pub r: FIXED,
-    pub y: FIXED,
+    pub l: Fixed,
+    pub r: Fixed,
+    pub y: Fixed,
 }
 impl TryParse for Spanfix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (l, remaining) = FIXED::try_parse(remaining)?;
-        let (r, remaining) = FIXED::try_parse(remaining)?;
-        let (y, remaining) = FIXED::try_parse(remaining)?;
+        let (l, remaining) = Fixed::try_parse(remaining)?;
+        let (r, remaining) = Fixed::try_parse(remaining)?;
+        let (y, remaining) = Fixed::try_parse(remaining)?;
         let result = Spanfix { l, r, y };
         Ok((result, remaining))
     }
@@ -3428,7 +3428,7 @@ impl Serialize for Trap {
 
 /// Opcode for the AddTraps request
 pub const ADD_TRAPS_REQUEST: u8 = 32;
-pub fn add_traps<'c, Conn>(conn: &'c Conn, picture: PICTURE, x_off: i16, y_off: i16, traps: &[Trap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn add_traps<'c, Conn>(conn: &'c Conn, picture: Picture, x_off: i16, y_off: i16, traps: &[Trap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3463,7 +3463,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateSolidFill request
 pub const CREATE_SOLID_FILL_REQUEST: u8 = 33;
-pub fn create_solid_fill<Conn>(conn: &Conn, picture: PICTURE, color: Color) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_solid_fill<Conn>(conn: &Conn, picture: Picture, color: Color) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3497,7 +3497,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateLinearGradient request
 pub const CREATE_LINEAR_GRADIENT_REQUEST: u8 = 34;
-pub fn create_linear_gradient<'c, Conn>(conn: &'c Conn, picture: PICTURE, p1: Pointfix, p2: Pointfix, num_stops: u32, stops: &[FIXED], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_linear_gradient<'c, Conn>(conn: &'c Conn, picture: Picture, p1: Pointfix, p2: Pointfix, num_stops: u32, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3553,7 +3553,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateRadialGradient request
 pub const CREATE_RADIAL_GRADIENT_REQUEST: u8 = 35;
-pub fn create_radial_gradient<'c, Conn>(conn: &'c Conn, picture: PICTURE, inner: Pointfix, outer: Pointfix, inner_radius: FIXED, outer_radius: FIXED, num_stops: u32, stops: &[FIXED], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_radial_gradient<'c, Conn>(conn: &'c Conn, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, num_stops: u32, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3619,7 +3619,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateConicalGradient request
 pub const CREATE_CONICAL_GRADIENT_REQUEST: u8 = 36;
-pub fn create_conical_gradient<'c, Conn>(conn: &'c Conn, picture: PICTURE, center: Pointfix, angle: FIXED, num_stops: u32, stops: &[FIXED], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_conical_gradient<'c, Conn>(conn: &'c Conn, picture: Picture, center: Pointfix, angle: Fixed, num_stops: u32, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3681,156 +3681,156 @@ pub trait ConnectionExt: RequestConnection {
         query_pict_formats(self)
     }
 
-    fn render_query_pict_index_values(&self, format: PICTFORMAT) -> Result<Cookie<'_, Self, QueryPictIndexValuesReply>, ConnectionError>
+    fn render_query_pict_index_values(&self, format: Pictformat) -> Result<Cookie<'_, Self, QueryPictIndexValuesReply>, ConnectionError>
     {
         query_pict_index_values(self, format)
     }
 
-    fn render_create_picture<'c>(&'c self, pid: PICTURE, drawable: DRAWABLE, format: PICTFORMAT, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_picture<'c>(&'c self, pid: Picture, drawable: Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_picture(self, pid, drawable, format, value_list)
     }
 
-    fn render_change_picture<'c>(&'c self, picture: PICTURE, value_list: &ChangePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_change_picture<'c>(&'c self, picture: Picture, value_list: &ChangePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_picture(self, picture, value_list)
     }
 
-    fn render_set_picture_clip_rectangles<'c>(&'c self, picture: PICTURE, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_set_picture_clip_rectangles<'c>(&'c self, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_picture_clip_rectangles(self, picture, clip_x_origin, clip_y_origin, rectangles)
     }
 
-    fn render_free_picture(&self, picture: PICTURE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_free_picture(&self, picture: Picture) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_picture(self, picture)
     }
 
-    fn render_composite<A>(&self, op: A, src: PICTURE, mask: PICTURE, dst: PICTURE, src_x: i16, src_y: i16, mask_x: i16, mask_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_composite<A>(&self, op: A, src: Picture, mask: Picture, dst: Picture, src_x: i16, src_y: i16, mask_x: i16, mask_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         composite(self, op, src, mask, dst, src_x, src_y, mask_x, mask_y, dst_x, dst_y, width, height)
     }
 
-    fn render_trapezoids<'c, A>(&'c self, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, traps: &[Trapezoid]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_trapezoids<'c, A>(&'c self, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &[Trapezoid]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         trapezoids(self, op, src, dst, mask_format, src_x, src_y, traps)
     }
 
-    fn render_triangles<'c, A>(&'c self, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, triangles: &[Triangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_triangles<'c, A>(&'c self, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &[Triangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         self::triangles(self, op, src, dst, mask_format, src_x, src_y, triangles)
     }
 
-    fn render_tri_strip<'c, A>(&'c self, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_tri_strip<'c, A>(&'c self, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         tri_strip(self, op, src, dst, mask_format, src_x, src_y, points)
     }
 
-    fn render_tri_fan<'c, A>(&'c self, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_tri_fan<'c, A>(&'c self, op: A, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         tri_fan(self, op, src, dst, mask_format, src_x, src_y, points)
     }
 
-    fn render_create_glyph_set(&self, gsid: GLYPHSET, format: PICTFORMAT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_create_glyph_set(&self, gsid: Glyphset, format: Pictformat) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_glyph_set(self, gsid, format)
     }
 
-    fn render_reference_glyph_set(&self, gsid: GLYPHSET, existing: GLYPHSET) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_reference_glyph_set(&self, gsid: Glyphset, existing: Glyphset) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         reference_glyph_set(self, gsid, existing)
     }
 
-    fn render_free_glyph_set(&self, glyphset: GLYPHSET) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_free_glyph_set(&self, glyphset: Glyphset) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_glyph_set(self, glyphset)
     }
 
-    fn render_add_glyphs<'c>(&'c self, glyphset: GLYPHSET, glyphs_len: u32, glyphids: &[u32], glyphs: &[Glyphinfo], data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_add_glyphs<'c>(&'c self, glyphset: Glyphset, glyphs_len: u32, glyphids: &[u32], glyphs: &[Glyphinfo], data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         add_glyphs(self, glyphset, glyphs_len, glyphids, glyphs, data)
     }
 
-    fn render_free_glyphs<'c>(&'c self, glyphset: GLYPHSET, glyphs: &[GLYPH]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_free_glyphs<'c>(&'c self, glyphset: Glyphset, glyphs: &[Glyph]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         free_glyphs(self, glyphset, glyphs)
     }
 
-    fn render_composite_glyphs8<'c, A>(&'c self, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, glyphset: GLYPHSET, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_composite_glyphs8<'c, A>(&'c self, op: A, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         composite_glyphs8(self, op, src, dst, mask_format, glyphset, src_x, src_y, glyphcmds)
     }
 
-    fn render_composite_glyphs16<'c, A>(&'c self, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, glyphset: GLYPHSET, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_composite_glyphs16<'c, A>(&'c self, op: A, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         composite_glyphs16(self, op, src, dst, mask_format, glyphset, src_x, src_y, glyphcmds)
     }
 
-    fn render_composite_glyphs32<'c, A>(&'c self, op: A, src: PICTURE, dst: PICTURE, mask_format: PICTFORMAT, glyphset: GLYPHSET, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_composite_glyphs32<'c, A>(&'c self, op: A, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         composite_glyphs32(self, op, src, dst, mask_format, glyphset, src_x, src_y, glyphcmds)
     }
 
-    fn render_fill_rectangles<'c, A>(&'c self, op: A, dst: PICTURE, color: Color, rects: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_fill_rectangles<'c, A>(&'c self, op: A, dst: Picture, color: Color, rects: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         fill_rectangles(self, op, dst, color, rects)
     }
 
-    fn render_create_cursor(&self, cid: CURSOR, source: PICTURE, x: u16, y: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_create_cursor(&self, cid: Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_cursor(self, cid, source, x, y)
     }
 
-    fn render_set_picture_transform(&self, picture: PICTURE, transform: Transform) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_set_picture_transform(&self, picture: Picture, transform: Transform) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_picture_transform(self, picture, transform)
     }
 
-    fn render_query_filters(&self, drawable: DRAWABLE) -> Result<Cookie<'_, Self, QueryFiltersReply>, ConnectionError>
+    fn render_query_filters(&self, drawable: Drawable) -> Result<Cookie<'_, Self, QueryFiltersReply>, ConnectionError>
     {
         query_filters(self, drawable)
     }
 
-    fn render_set_picture_filter<'c>(&'c self, picture: PICTURE, filter: &[u8], values: &[FIXED]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_set_picture_filter<'c>(&'c self, picture: Picture, filter: &[u8], values: &[Fixed]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_picture_filter(self, picture, filter, values)
     }
 
-    fn render_create_anim_cursor<'c>(&'c self, cid: CURSOR, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_anim_cursor<'c>(&'c self, cid: Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_anim_cursor(self, cid, cursors)
     }
 
-    fn render_add_traps<'c>(&'c self, picture: PICTURE, x_off: i16, y_off: i16, traps: &[Trap]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_add_traps<'c>(&'c self, picture: Picture, x_off: i16, y_off: i16, traps: &[Trap]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         add_traps(self, picture, x_off, y_off, traps)
     }
 
-    fn render_create_solid_fill(&self, picture: PICTURE, color: Color) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_create_solid_fill(&self, picture: Picture, color: Color) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_solid_fill(self, picture, color)
     }
 
-    fn render_create_linear_gradient<'c>(&'c self, picture: PICTURE, p1: Pointfix, p2: Pointfix, num_stops: u32, stops: &[FIXED], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_linear_gradient<'c>(&'c self, picture: Picture, p1: Pointfix, p2: Pointfix, num_stops: u32, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_linear_gradient(self, picture, p1, p2, num_stops, stops, colors)
     }
 
-    fn render_create_radial_gradient<'c>(&'c self, picture: PICTURE, inner: Pointfix, outer: Pointfix, inner_radius: FIXED, outer_radius: FIXED, num_stops: u32, stops: &[FIXED], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_radial_gradient<'c>(&'c self, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, num_stops: u32, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_radial_gradient(self, picture, inner, outer, inner_radius, outer_radius, num_stops, stops, colors)
     }
 
-    fn render_create_conical_gradient<'c>(&'c self, picture: PICTURE, center: Pointfix, angle: FIXED, num_stops: u32, stops: &[FIXED], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_conical_gradient<'c>(&'c self, picture: Picture, center: Pointfix, angle: Fixed, num_stops: u32, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_conical_gradient(self, picture, center, angle, num_stops, stops, colors)
     }

--- a/src/generated/res.rs
+++ b/src/generated/res.rs
@@ -81,12 +81,12 @@ impl Serialize for Client {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Type {
-    pub resource_type: ATOM,
+    pub resource_type: Atom,
     pub count: u32,
 }
 impl TryParse for Type {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (resource_type, remaining) = ATOM::try_parse(remaining)?;
+        let (resource_type, remaining) = Atom::try_parse(remaining)?;
         let (count, remaining) = u32::try_parse(remaining)?;
         let result = Type { resource_type, count };
         Ok((result, remaining))

--- a/src/generated/screensaver.rs
+++ b/src/generated/screensaver.rs
@@ -288,7 +288,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the QueryInfo request
 pub const QUERY_INFO_REQUEST: u8 = 1;
-pub fn query_info<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<Cookie<'_, Conn, QueryInfoReply>, ConnectionError>
+pub fn query_info<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, QueryInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -316,7 +316,7 @@ pub struct QueryInfoReply {
     pub state: u8,
     pub sequence: u16,
     pub length: u32,
-    pub saver_window: WINDOW,
+    pub saver_window: Window,
     pub ms_until_server: u32,
     pub ms_since_user_input: u32,
     pub event_mask: u32,
@@ -328,7 +328,7 @@ impl QueryInfoReply {
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (saver_window, remaining) = WINDOW::try_parse(remaining)?;
+        let (saver_window, remaining) = Window::try_parse(remaining)?;
         let (ms_until_server, remaining) = u32::try_parse(remaining)?;
         let (ms_since_user_input, remaining) = u32::try_parse(remaining)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
@@ -348,7 +348,7 @@ impl TryFrom<&[u8]> for QueryInfoReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 2;
-pub fn select_input<Conn>(conn: &Conn, drawable: DRAWABLE, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, drawable: Drawable, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -381,21 +381,21 @@ pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
 /// Auxiliary and optional information for the set_attributes function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SetAttributesAux {
-    pub background_pixmap: Option<PIXMAP>,
+    pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
-    pub border_pixmap: Option<PIXMAP>,
+    pub border_pixmap: Option<Pixmap>,
     pub border_pixel: Option<u32>,
     pub bit_gravity: Option<u32>,
     pub win_gravity: Option<u32>,
     pub backing_store: Option<u32>,
     pub backing_planes: Option<u32>,
     pub backing_pixel: Option<u32>,
-    pub override_redirect: Option<BOOL32>,
-    pub save_under: Option<BOOL32>,
+    pub override_redirect: Option<Bool32>,
+    pub save_under: Option<Bool32>,
     pub event_mask: Option<u32>,
     pub do_not_propogate_mask: Option<u32>,
-    pub colormap: Option<COLORMAP>,
-    pub cursor: Option<CURSOR>,
+    pub colormap: Option<Colormap>,
+    pub cursor: Option<Cursor>,
 }
 impl SetAttributesAux {
     /// Create a new instance with all fields unset / not present.
@@ -452,7 +452,7 @@ impl SetAttributesAux {
         mask
     }
     /// Set the background_pixmap field of this structure.
-    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.background_pixmap = value.into();
         self
     }
@@ -462,7 +462,7 @@ impl SetAttributesAux {
         self
     }
     /// Set the border_pixmap field of this structure.
-    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.border_pixmap = value.into();
         self
     }
@@ -497,12 +497,12 @@ impl SetAttributesAux {
         self
     }
     /// Set the override_redirect field of this structure.
-    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.override_redirect = value.into();
         self
     }
     /// Set the save_under field of this structure.
-    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.save_under = value.into();
         self
     }
@@ -517,12 +517,12 @@ impl SetAttributesAux {
         self
     }
     /// Set the colormap field of this structure.
-    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<COLORMAP>> {
+    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<Colormap>> {
         self.colormap = value.into();
         self
     }
     /// Set the cursor field of this structure.
-    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<CURSOR>> {
+    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<Cursor>> {
         self.cursor = value.into();
         self
     }
@@ -582,7 +582,7 @@ impl Serialize for SetAttributesAux {
         }
     }
 }
-pub fn set_attributes<'c, Conn, A>(conn: &'c Conn, drawable: DRAWABLE, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: VISUALID, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_attributes<'c, Conn, A>(conn: &'c Conn, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -642,7 +642,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the UnsetAttributes request
 pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
-pub fn unset_attributes<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unset_attributes<Conn>(conn: &Conn, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -697,9 +697,9 @@ pub struct NotifyEvent {
     pub response_type: u8,
     pub state: State,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub window: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub window: Window,
     pub kind: Kind,
     pub forced: bool,
 }
@@ -708,9 +708,9 @@ impl NotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (forced, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
@@ -767,23 +767,23 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn screensaver_query_info(&self, drawable: DRAWABLE) -> Result<Cookie<'_, Self, QueryInfoReply>, ConnectionError>
+    fn screensaver_query_info(&self, drawable: Drawable) -> Result<Cookie<'_, Self, QueryInfoReply>, ConnectionError>
     {
         query_info(self, drawable)
     }
 
-    fn screensaver_select_input(&self, drawable: DRAWABLE, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn screensaver_select_input(&self, drawable: Drawable, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, drawable, event_mask)
     }
 
-    fn screensaver_set_attributes<'c, A>(&'c self, drawable: DRAWABLE, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: VISUALID, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn screensaver_set_attributes<'c, A>(&'c self, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         set_attributes(self, drawable, x, y, width, height, border_width, class, depth, visual, value_list)
     }
 
-    fn screensaver_unset_attributes(&self, drawable: DRAWABLE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn screensaver_unset_attributes(&self, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         unset_attributes(self, drawable)
     }

--- a/src/generated/shape.rs
+++ b/src/generated/shape.rs
@@ -37,9 +37,9 @@ pub const X11_EXTENSION_NAME: &str = "SHAPE";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
-pub type OP = u8;
+pub type Op = u8;
 
-pub type KIND = u8;
+pub type Kind = u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -184,25 +184,25 @@ pub struct NotifyEvent {
     pub response_type: u8,
     pub shape_kind: SK,
     pub sequence: u16,
-    pub affected_window: WINDOW,
+    pub affected_window: Window,
     pub extents_x: i16,
     pub extents_y: i16,
     pub extents_width: u16,
     pub extents_height: u16,
-    pub server_time: TIMESTAMP,
+    pub server_time: Timestamp,
     pub shaped: bool,
 }
 impl NotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
-        let (shape_kind, remaining) = KIND::try_parse(remaining)?;
+        let (shape_kind, remaining) = Kind::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (affected_window, remaining) = WINDOW::try_parse(remaining)?;
+        let (affected_window, remaining) = Window::try_parse(remaining)?;
         let (extents_x, remaining) = i16::try_parse(remaining)?;
         let (extents_y, remaining) = i16::try_parse(remaining)?;
         let (extents_width, remaining) = u16::try_parse(remaining)?;
         let (extents_height, remaining) = u16::try_parse(remaining)?;
-        let (server_time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (server_time, remaining) = Timestamp::try_parse(remaining)?;
         let (shaped, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let shape_kind = shape_kind.try_into()?;
@@ -229,7 +229,7 @@ impl<B: AsRef<[u8]>> From<&GenericEvent<B>> for NotifyEvent {
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
         let response_type = input.response_type.serialize();
-        let shape_kind = Into::<KIND>::into(input.shape_kind).serialize();
+        let shape_kind = Into::<Kind>::into(input.shape_kind).serialize();
         let sequence = input.sequence.serialize();
         let affected_window = input.affected_window.serialize();
         let extents_x = input.extents_x.serialize();
@@ -300,8 +300,8 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Rectangles request
 pub const RECTANGLES_REQUEST: u8 = 1;
-pub fn rectangles<'c, Conn, A, B, C>(conn: &'c Conn, operation: A, destination_kind: B, ordering: C, destination_window: WINDOW, x_offset: i16, y_offset: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<OP>, B: Into<KIND>, C: Into<u8>
+pub fn rectangles<'c, Conn, A, B, C>(conn: &'c Conn, operation: A, destination_kind: B, ordering: C, destination_window: Window, x_offset: i16, y_offset: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>, C: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
         .ok_or(ConnectionError::UnsupportedExtension)?;
@@ -345,8 +345,8 @@ where Conn: RequestConnection + ?Sized, A: Into<OP>, B: Into<KIND>, C: Into<u8>
 
 /// Opcode for the Mask request
 pub const MASK_REQUEST: u8 = 2;
-pub fn mask<Conn, A, B>(conn: &Conn, operation: A, destination_kind: B, destination_window: WINDOW, x_offset: i16, y_offset: i16, source_bitmap: PIXMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<OP>, B: Into<KIND>
+pub fn mask<Conn, A, B>(conn: &Conn, operation: A, destination_kind: B, destination_window: Window, x_offset: i16, y_offset: i16, source_bitmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
         .ok_or(ConnectionError::UnsupportedExtension)?;
@@ -389,8 +389,8 @@ where Conn: RequestConnection + ?Sized, A: Into<OP>, B: Into<KIND>
 
 /// Opcode for the Combine request
 pub const COMBINE_REQUEST: u8 = 3;
-pub fn combine<Conn, A, B, C>(conn: &Conn, operation: A, destination_kind: B, source_kind: C, destination_window: WINDOW, x_offset: i16, y_offset: i16, source_window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<OP>, B: Into<KIND>, C: Into<KIND>
+pub fn combine<Conn, A, B, C>(conn: &Conn, operation: A, destination_kind: B, source_kind: C, destination_window: Window, x_offset: i16, y_offset: i16, source_window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>, C: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
         .ok_or(ConnectionError::UnsupportedExtension)?;
@@ -435,8 +435,8 @@ where Conn: RequestConnection + ?Sized, A: Into<OP>, B: Into<KIND>, C: Into<KIND
 
 /// Opcode for the Offset request
 pub const OFFSET_REQUEST: u8 = 4;
-pub fn offset<Conn, A>(conn: &Conn, destination_kind: A, destination_window: WINDOW, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<KIND>
+pub fn offset<Conn, A>(conn: &Conn, destination_kind: A, destination_window: Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
         .ok_or(ConnectionError::UnsupportedExtension)?;
@@ -472,7 +472,7 @@ where Conn: RequestConnection + ?Sized, A: Into<KIND>
 
 /// Opcode for the QueryExtents request
 pub const QUERY_EXTENTS_REQUEST: u8 = 5;
-pub fn query_extents<Conn>(conn: &Conn, destination_window: WINDOW) -> Result<Cookie<'_, Conn, QueryExtentsReply>, ConnectionError>
+pub fn query_extents<Conn>(conn: &Conn, destination_window: Window) -> Result<Cookie<'_, Conn, QueryExtentsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -540,7 +540,7 @@ impl TryFrom<&[u8]> for QueryExtentsReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 6;
-pub fn select_input<Conn>(conn: &Conn, destination_window: WINDOW, enable: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, destination_window: Window, enable: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -570,7 +570,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the InputSelected request
 pub const INPUT_SELECTED_REQUEST: u8 = 7;
-pub fn input_selected<Conn>(conn: &Conn, destination_window: WINDOW) -> Result<Cookie<'_, Conn, InputSelectedReply>, ConnectionError>
+pub fn input_selected<Conn>(conn: &Conn, destination_window: Window) -> Result<Cookie<'_, Conn, InputSelectedReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -618,8 +618,8 @@ impl TryFrom<&[u8]> for InputSelectedReply {
 
 /// Opcode for the GetRectangles request
 pub const GET_RECTANGLES_REQUEST: u8 = 8;
-pub fn get_rectangles<Conn, A>(conn: &Conn, window: WINDOW, source_kind: A) -> Result<Cookie<'_, Conn, GetRectanglesReply>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<KIND>
+pub fn get_rectangles<Conn, A>(conn: &Conn, window: Window, source_kind: A) -> Result<Cookie<'_, Conn, GetRectanglesReply>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
         .ok_or(ConnectionError::UnsupportedExtension)?;
@@ -682,47 +682,47 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self)
     }
 
-    fn shape_rectangles<'c, A, B, C>(&'c self, operation: A, destination_kind: B, ordering: C, destination_window: WINDOW, x_offset: i16, y_offset: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where A: Into<OP>, B: Into<KIND>, C: Into<u8>
+    fn shape_rectangles<'c, A, B, C>(&'c self, operation: A, destination_kind: B, ordering: C, destination_window: Window, x_offset: i16, y_offset: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    where A: Into<Op>, B: Into<Kind>, C: Into<u8>
     {
         self::rectangles(self, operation, destination_kind, ordering, destination_window, x_offset, y_offset, rectangles)
     }
 
-    fn shape_mask<A, B>(&self, operation: A, destination_kind: B, destination_window: WINDOW, x_offset: i16, y_offset: i16, source_bitmap: PIXMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where A: Into<OP>, B: Into<KIND>
+    fn shape_mask<A, B>(&self, operation: A, destination_kind: B, destination_window: Window, x_offset: i16, y_offset: i16, source_bitmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    where A: Into<Op>, B: Into<Kind>
     {
         mask(self, operation, destination_kind, destination_window, x_offset, y_offset, source_bitmap)
     }
 
-    fn shape_combine<A, B, C>(&self, operation: A, destination_kind: B, source_kind: C, destination_window: WINDOW, x_offset: i16, y_offset: i16, source_window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where A: Into<OP>, B: Into<KIND>, C: Into<KIND>
+    fn shape_combine<A, B, C>(&self, operation: A, destination_kind: B, source_kind: C, destination_window: Window, x_offset: i16, y_offset: i16, source_window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    where A: Into<Op>, B: Into<Kind>, C: Into<Kind>
     {
         combine(self, operation, destination_kind, source_kind, destination_window, x_offset, y_offset, source_window)
     }
 
-    fn shape_offset<A>(&self, destination_kind: A, destination_window: WINDOW, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where A: Into<KIND>
+    fn shape_offset<A>(&self, destination_kind: A, destination_window: Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    where A: Into<Kind>
     {
         offset(self, destination_kind, destination_window, x_offset, y_offset)
     }
 
-    fn shape_query_extents(&self, destination_window: WINDOW) -> Result<Cookie<'_, Self, QueryExtentsReply>, ConnectionError>
+    fn shape_query_extents(&self, destination_window: Window) -> Result<Cookie<'_, Self, QueryExtentsReply>, ConnectionError>
     {
         query_extents(self, destination_window)
     }
 
-    fn shape_select_input(&self, destination_window: WINDOW, enable: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shape_select_input(&self, destination_window: Window, enable: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, destination_window, enable)
     }
 
-    fn shape_input_selected(&self, destination_window: WINDOW) -> Result<Cookie<'_, Self, InputSelectedReply>, ConnectionError>
+    fn shape_input_selected(&self, destination_window: Window) -> Result<Cookie<'_, Self, InputSelectedReply>, ConnectionError>
     {
         input_selected(self, destination_window)
     }
 
-    fn shape_get_rectangles<A>(&self, window: WINDOW, source_kind: A) -> Result<Cookie<'_, Self, GetRectanglesReply>, ConnectionError>
-    where A: Into<KIND>
+    fn shape_get_rectangles<A>(&self, window: Window, source_kind: A) -> Result<Cookie<'_, Self, GetRectanglesReply>, ConnectionError>
+    where A: Into<Kind>
     {
         get_rectangles(self, window, source_kind)
     }

--- a/src/generated/shm.rs
+++ b/src/generated/shm.rs
@@ -37,7 +37,7 @@ pub const X11_EXTENSION_NAME: &str = "MIT-SHM";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
-pub type SEG = u32;
+pub type Seg = u32;
 
 /// Opcode for the Completion event
 pub const COMPLETION_EVENT: u8 = 0;
@@ -45,10 +45,10 @@ pub const COMPLETION_EVENT: u8 = 0;
 pub struct CompletionEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub drawable: DRAWABLE,
+    pub drawable: Drawable,
     pub minor_event: u16,
     pub major_event: u8,
-    pub shmseg: SEG,
+    pub shmseg: Seg,
     pub offset: u32,
 }
 impl CompletionEvent {
@@ -56,11 +56,11 @@ impl CompletionEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let (minor_event, remaining) = u16::try_parse(remaining)?;
         let (major_event, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (shmseg, remaining) = SEG::try_parse(remaining)?;
+        let (shmseg, remaining) = Seg::try_parse(remaining)?;
         let (offset, remaining) = u32::try_parse(remaining)?;
         let result = CompletionEvent { response_type, sequence, drawable, minor_event, major_event, shmseg, offset };
         Ok((result, remaining))
@@ -223,7 +223,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Attach request
 pub const ATTACH_REQUEST: u8 = 1;
-pub fn attach<Conn>(conn: &Conn, shmseg: SEG, shmid: u32, read_only: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn attach<Conn>(conn: &Conn, shmseg: Seg, shmid: u32, read_only: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -258,7 +258,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the Detach request
 pub const DETACH_REQUEST: u8 = 2;
-pub fn detach<Conn>(conn: &Conn, shmseg: SEG) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn detach<Conn>(conn: &Conn, shmseg: Seg) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -283,7 +283,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 3;
-pub fn put_image<Conn>(conn: &Conn, drawable: DRAWABLE, gc: GCONTEXT, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: SEG, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn put_image<Conn>(conn: &Conn, drawable: Drawable, gc: Gcontext, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -354,7 +354,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetImage request
 pub const GET_IMAGE_REQUEST: u8 = 4;
-pub fn get_image<Conn>(conn: &Conn, drawable: DRAWABLE, x: i16, y: i16, width: u16, height: u16, plane_mask: u32, format: u8, shmseg: SEG, offset: u32) -> Result<Cookie<'_, Conn, GetImageReply>, ConnectionError>
+pub fn get_image<Conn>(conn: &Conn, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, plane_mask: u32, format: u8, shmseg: Seg, offset: u32) -> Result<Cookie<'_, Conn, GetImageReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -414,7 +414,7 @@ pub struct GetImageReply {
     pub depth: u8,
     pub sequence: u16,
     pub length: u32,
-    pub visual: VISUALID,
+    pub visual: Visualid,
     pub size: u32,
 }
 impl GetImageReply {
@@ -423,7 +423,7 @@ impl GetImageReply {
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (visual, remaining) = Visualid::try_parse(remaining)?;
         let (size, remaining) = u32::try_parse(remaining)?;
         let result = GetImageReply { response_type, depth, sequence, length, visual, size };
         Ok((result, remaining))
@@ -438,7 +438,7 @@ impl TryFrom<&[u8]> for GetImageReply {
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 5;
-pub fn create_pixmap<Conn>(conn: &Conn, pid: PIXMAP, drawable: DRAWABLE, width: u16, height: u16, depth: u8, shmseg: SEG, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_pixmap<Conn>(conn: &Conn, pid: Pixmap, drawable: Drawable, width: u16, height: u16, depth: u8, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -489,7 +489,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the AttachFd request
 pub const ATTACH_FD_REQUEST: u8 = 6;
-pub fn attach_fd<Conn, A>(conn: &Conn, shmseg: SEG, shm_fd: A, read_only: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn attach_fd<Conn, A>(conn: &Conn, shmseg: Seg, shm_fd: A, read_only: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -520,7 +520,7 @@ where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 
 /// Opcode for the CreateSegment request
 pub const CREATE_SEGMENT_REQUEST: u8 = 7;
-pub fn create_segment<Conn>(conn: &Conn, shmseg: SEG, size: u32, read_only: bool) -> Result<CookieWithFds<'_, Conn, CreateSegmentReply>, ConnectionError>
+pub fn create_segment<Conn>(conn: &Conn, shmseg: Seg, size: u32, read_only: bool) -> Result<CookieWithFds<'_, Conn, CreateSegmentReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -588,38 +588,38 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self)
     }
 
-    fn shm_attach(&self, shmseg: SEG, shmid: u32, read_only: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shm_attach(&self, shmseg: Seg, shmid: u32, read_only: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         attach(self, shmseg, shmid, read_only)
     }
 
-    fn shm_detach(&self, shmseg: SEG) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shm_detach(&self, shmseg: Seg) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         detach(self, shmseg)
     }
 
-    fn shm_put_image(&self, drawable: DRAWABLE, gc: GCONTEXT, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: SEG, offset: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shm_put_image(&self, drawable: Drawable, gc: Gcontext, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         put_image(self, drawable, gc, total_width, total_height, src_x, src_y, src_width, src_height, dst_x, dst_y, depth, format, send_event, shmseg, offset)
     }
 
-    fn shm_get_image(&self, drawable: DRAWABLE, x: i16, y: i16, width: u16, height: u16, plane_mask: u32, format: u8, shmseg: SEG, offset: u32) -> Result<Cookie<'_, Self, GetImageReply>, ConnectionError>
+    fn shm_get_image(&self, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, plane_mask: u32, format: u8, shmseg: Seg, offset: u32) -> Result<Cookie<'_, Self, GetImageReply>, ConnectionError>
     {
         get_image(self, drawable, x, y, width, height, plane_mask, format, shmseg, offset)
     }
 
-    fn shm_create_pixmap(&self, pid: PIXMAP, drawable: DRAWABLE, width: u16, height: u16, depth: u8, shmseg: SEG, offset: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shm_create_pixmap(&self, pid: Pixmap, drawable: Drawable, width: u16, height: u16, depth: u8, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_pixmap(self, pid, drawable, width, height, depth, shmseg, offset)
     }
 
-    fn shm_attach_fd<A>(&self, shmseg: SEG, shm_fd: A, read_only: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shm_attach_fd<A>(&self, shmseg: Seg, shm_fd: A, read_only: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<RawFdContainer>
     {
         attach_fd(self, shmseg, shm_fd, read_only)
     }
 
-    fn shm_create_segment(&self, shmseg: SEG, size: u32, read_only: bool) -> Result<CookieWithFds<'_, Self, CreateSegmentReply>, ConnectionError>
+    fn shm_create_segment(&self, shmseg: Seg, size: u32, read_only: bool) -> Result<CookieWithFds<'_, Self, CreateSegmentReply>, ConnectionError>
     {
         create_segment(self, shmseg, size, read_only)
     }

--- a/src/generated/sync.rs
+++ b/src/generated/sync.rs
@@ -37,7 +37,7 @@ pub const X11_EXTENSION_NAME: &str = "SYNC";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (3, 1);
 
-pub type ALARM = u32;
+pub type Alarm = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -104,9 +104,9 @@ impl TryFrom<u32> for ALARMSTATE {
     }
 }
 
-pub type COUNTER = u32;
+pub type Counter = u32;
 
-pub type FENCE = u32;
+pub type Fence = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -357,14 +357,14 @@ impl Serialize for Int64 {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Systemcounter {
-    pub counter: COUNTER,
+    pub counter: Counter,
     pub resolution: Int64,
     pub name: Vec<u8>,
 }
 impl TryParse for Systemcounter {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (counter, remaining) = COUNTER::try_parse(remaining)?;
+        let (counter, remaining) = Counter::try_parse(remaining)?;
         let (resolution, remaining) = Int64::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
@@ -402,14 +402,14 @@ impl Serialize for Systemcounter {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Trigger {
-    pub counter: COUNTER,
+    pub counter: Counter,
     pub wait_type: VALUETYPE,
     pub wait_value: Int64,
     pub test_type: TESTTYPE,
 }
 impl TryParse for Trigger {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (counter, remaining) = COUNTER::try_parse(remaining)?;
+        let (counter, remaining) = Counter::try_parse(remaining)?;
         let (wait_type, remaining) = u32::try_parse(remaining)?;
         let (wait_value, remaining) = Int64::try_parse(remaining)?;
         let (test_type, remaining) = u32::try_parse(remaining)?;
@@ -749,7 +749,7 @@ impl TryFrom<&[u8]> for ListSystemCountersReply {
 
 /// Opcode for the CreateCounter request
 pub const CREATE_COUNTER_REQUEST: u8 = 2;
-pub fn create_counter<Conn>(conn: &Conn, id: COUNTER, initial_value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_counter<Conn>(conn: &Conn, id: Counter, initial_value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -783,7 +783,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyCounter request
 pub const DESTROY_COUNTER_REQUEST: u8 = 6;
-pub fn destroy_counter<Conn>(conn: &Conn, counter: COUNTER) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_counter<Conn>(conn: &Conn, counter: Counter) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -808,7 +808,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the QueryCounter request
 pub const QUERY_COUNTER_REQUEST: u8 = 5;
-pub fn query_counter<Conn>(conn: &Conn, counter: COUNTER) -> Result<Cookie<'_, Conn, QueryCounterReply>, ConnectionError>
+pub fn query_counter<Conn>(conn: &Conn, counter: Counter) -> Result<Cookie<'_, Conn, QueryCounterReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -881,7 +881,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ChangeCounter request
 pub const CHANGE_COUNTER_REQUEST: u8 = 4;
-pub fn change_counter<Conn>(conn: &Conn, counter: COUNTER, amount: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_counter<Conn>(conn: &Conn, counter: Counter, amount: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -915,7 +915,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetCounter request
 pub const SET_COUNTER_REQUEST: u8 = 3;
-pub fn set_counter<Conn>(conn: &Conn, counter: COUNTER, value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_counter<Conn>(conn: &Conn, counter: Counter, value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -952,7 +952,7 @@ pub const CREATE_ALARM_REQUEST: u8 = 8;
 /// Auxiliary and optional information for the create_alarm function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreateAlarmAux {
-    pub counter: Option<COUNTER>,
+    pub counter: Option<Counter>,
     pub value_type: Option<u32>,
     pub value: Option<Int64>,
     pub test_type: Option<u32>,
@@ -987,7 +987,7 @@ impl CreateAlarmAux {
         mask
     }
     /// Set the counter field of this structure.
-    pub fn counter<I>(mut self, value: I) -> Self where I: Into<Option<COUNTER>> {
+    pub fn counter<I>(mut self, value: I) -> Self where I: Into<Option<Counter>> {
         self.counter = value.into();
         self
     }
@@ -1045,7 +1045,7 @@ impl Serialize for CreateAlarmAux {
         }
     }
 }
-pub fn create_alarm<'c, Conn>(conn: &'c Conn, id: ALARM, value_list: &CreateAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_alarm<'c, Conn>(conn: &'c Conn, id: Alarm, value_list: &CreateAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1083,7 +1083,7 @@ pub const CHANGE_ALARM_REQUEST: u8 = 9;
 /// Auxiliary and optional information for the change_alarm function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangeAlarmAux {
-    pub counter: Option<COUNTER>,
+    pub counter: Option<Counter>,
     pub value_type: Option<u32>,
     pub value: Option<Int64>,
     pub test_type: Option<u32>,
@@ -1118,7 +1118,7 @@ impl ChangeAlarmAux {
         mask
     }
     /// Set the counter field of this structure.
-    pub fn counter<I>(mut self, value: I) -> Self where I: Into<Option<COUNTER>> {
+    pub fn counter<I>(mut self, value: I) -> Self where I: Into<Option<Counter>> {
         self.counter = value.into();
         self
     }
@@ -1176,7 +1176,7 @@ impl Serialize for ChangeAlarmAux {
         }
     }
 }
-pub fn change_alarm<'c, Conn>(conn: &'c Conn, id: ALARM, value_list: &ChangeAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_alarm<'c, Conn>(conn: &'c Conn, id: Alarm, value_list: &ChangeAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1211,7 +1211,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyAlarm request
 pub const DESTROY_ALARM_REQUEST: u8 = 11;
-pub fn destroy_alarm<Conn>(conn: &Conn, alarm: ALARM) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_alarm<Conn>(conn: &Conn, alarm: Alarm) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1236,7 +1236,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the QueryAlarm request
 pub const QUERY_ALARM_REQUEST: u8 = 10;
-pub fn query_alarm<Conn>(conn: &Conn, alarm: ALARM) -> Result<Cookie<'_, Conn, QueryAlarmReply>, ConnectionError>
+pub fn query_alarm<Conn>(conn: &Conn, alarm: Alarm) -> Result<Cookie<'_, Conn, QueryAlarmReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1372,7 +1372,7 @@ impl TryFrom<&[u8]> for GetPriorityReply {
 
 /// Opcode for the CreateFence request
 pub const CREATE_FENCE_REQUEST: u8 = 14;
-pub fn create_fence<Conn>(conn: &Conn, drawable: DRAWABLE, fence: FENCE, initially_triggered: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_fence<Conn>(conn: &Conn, drawable: Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1407,7 +1407,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the TriggerFence request
 pub const TRIGGER_FENCE_REQUEST: u8 = 15;
-pub fn trigger_fence<Conn>(conn: &Conn, fence: FENCE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn trigger_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1432,7 +1432,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ResetFence request
 pub const RESET_FENCE_REQUEST: u8 = 16;
-pub fn reset_fence<Conn>(conn: &Conn, fence: FENCE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn reset_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1457,7 +1457,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyFence request
 pub const DESTROY_FENCE_REQUEST: u8 = 17;
-pub fn destroy_fence<Conn>(conn: &Conn, fence: FENCE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1482,7 +1482,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the QueryFence request
 pub const QUERY_FENCE_REQUEST: u8 = 18;
-pub fn query_fence<Conn>(conn: &Conn, fence: FENCE) -> Result<Cookie<'_, Conn, QueryFenceReply>, ConnectionError>
+pub fn query_fence<Conn>(conn: &Conn, fence: Fence) -> Result<Cookie<'_, Conn, QueryFenceReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1532,7 +1532,7 @@ impl TryFrom<&[u8]> for QueryFenceReply {
 
 /// Opcode for the AwaitFence request
 pub const AWAIT_FENCE_REQUEST: u8 = 19;
-pub fn await_fence<'c, Conn>(conn: &'c Conn, fence_list: &[FENCE]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn await_fence<'c, Conn>(conn: &'c Conn, fence_list: &[Fence]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1561,10 +1561,10 @@ pub struct CounterNotifyEvent {
     pub response_type: u8,
     pub kind: u8,
     pub sequence: u16,
-    pub counter: COUNTER,
+    pub counter: Counter,
     pub wait_value: Int64,
     pub counter_value: Int64,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
     pub count: u16,
     pub destroyed: bool,
 }
@@ -1573,10 +1573,10 @@ impl CounterNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (counter, remaining) = COUNTER::try_parse(remaining)?;
+        let (counter, remaining) = Counter::try_parse(remaining)?;
         let (wait_value, remaining) = Int64::try_parse(remaining)?;
         let (counter_value, remaining) = Int64::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (count, remaining) = u16::try_parse(remaining)?;
         let (destroyed, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
@@ -1632,10 +1632,10 @@ pub struct AlarmNotifyEvent {
     pub response_type: u8,
     pub kind: u8,
     pub sequence: u16,
-    pub alarm: ALARM,
+    pub alarm: Alarm,
     pub counter_value: Int64,
     pub alarm_value: Int64,
-    pub timestamp: TIMESTAMP,
+    pub timestamp: Timestamp,
     pub state: ALARMSTATE,
 }
 impl AlarmNotifyEvent {
@@ -1643,10 +1643,10 @@ impl AlarmNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (alarm, remaining) = ALARM::try_parse(remaining)?;
+        let (alarm, remaining) = Alarm::try_parse(remaining)?;
         let (counter_value, remaining) = Int64::try_parse(remaining)?;
         let (alarm_value, remaining) = Int64::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
@@ -1706,17 +1706,17 @@ pub trait ConnectionExt: RequestConnection {
         list_system_counters(self)
     }
 
-    fn sync_create_counter(&self, id: COUNTER, initial_value: Int64) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_create_counter(&self, id: Counter, initial_value: Int64) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_counter(self, id, initial_value)
     }
 
-    fn sync_destroy_counter(&self, counter: COUNTER) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_destroy_counter(&self, counter: Counter) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_counter(self, counter)
     }
 
-    fn sync_query_counter(&self, counter: COUNTER) -> Result<Cookie<'_, Self, QueryCounterReply>, ConnectionError>
+    fn sync_query_counter(&self, counter: Counter) -> Result<Cookie<'_, Self, QueryCounterReply>, ConnectionError>
     {
         query_counter(self, counter)
     }
@@ -1726,32 +1726,32 @@ pub trait ConnectionExt: RequestConnection {
         await_(self, wait_list)
     }
 
-    fn sync_change_counter(&self, counter: COUNTER, amount: Int64) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_change_counter(&self, counter: Counter, amount: Int64) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         change_counter(self, counter, amount)
     }
 
-    fn sync_set_counter(&self, counter: COUNTER, value: Int64) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_set_counter(&self, counter: Counter, value: Int64) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_counter(self, counter, value)
     }
 
-    fn sync_create_alarm<'c>(&'c self, id: ALARM, value_list: &CreateAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn sync_create_alarm<'c>(&'c self, id: Alarm, value_list: &CreateAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_alarm(self, id, value_list)
     }
 
-    fn sync_change_alarm<'c>(&'c self, id: ALARM, value_list: &ChangeAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn sync_change_alarm<'c>(&'c self, id: Alarm, value_list: &ChangeAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_alarm(self, id, value_list)
     }
 
-    fn sync_destroy_alarm(&self, alarm: ALARM) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_destroy_alarm(&self, alarm: Alarm) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_alarm(self, alarm)
     }
 
-    fn sync_query_alarm(&self, alarm: ALARM) -> Result<Cookie<'_, Self, QueryAlarmReply>, ConnectionError>
+    fn sync_query_alarm(&self, alarm: Alarm) -> Result<Cookie<'_, Self, QueryAlarmReply>, ConnectionError>
     {
         query_alarm(self, alarm)
     }
@@ -1766,32 +1766,32 @@ pub trait ConnectionExt: RequestConnection {
         get_priority(self, id)
     }
 
-    fn sync_create_fence(&self, drawable: DRAWABLE, fence: FENCE, initially_triggered: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_create_fence(&self, drawable: Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_fence(self, drawable, fence, initially_triggered)
     }
 
-    fn sync_trigger_fence(&self, fence: FENCE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_trigger_fence(&self, fence: Fence) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         trigger_fence(self, fence)
     }
 
-    fn sync_reset_fence(&self, fence: FENCE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_reset_fence(&self, fence: Fence) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         reset_fence(self, fence)
     }
 
-    fn sync_destroy_fence(&self, fence: FENCE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_destroy_fence(&self, fence: Fence) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_fence(self, fence)
     }
 
-    fn sync_query_fence(&self, fence: FENCE) -> Result<Cookie<'_, Self, QueryFenceReply>, ConnectionError>
+    fn sync_query_fence(&self, fence: Fence) -> Result<Cookie<'_, Self, QueryFenceReply>, ConnectionError>
     {
         query_fence(self, fence)
     }
 
-    fn sync_await_fence<'c>(&'c self, fence_list: &[FENCE]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn sync_await_fence<'c>(&'c self, fence_list: &[Fence]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         await_fence(self, fence_list)
     }

--- a/src/generated/xf86vidmode.rs
+++ b/src/generated/xf86vidmode.rs
@@ -35,9 +35,9 @@ pub const X11_EXTENSION_NAME: &str = "XFree86-VidModeExtension";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (2, 2);
 
-pub type SYNCRANGE = u32;
+pub type Syncrange = u32;
 
-pub type DOTCLOCK = u32;
+pub type Dotclock = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
@@ -244,7 +244,7 @@ bitmask_binop!(Permission, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ModeInfo {
-    pub dotclock: DOTCLOCK,
+    pub dotclock: Dotclock,
     pub hdisplay: u16,
     pub hsyncstart: u16,
     pub hsyncend: u16,
@@ -259,7 +259,7 @@ pub struct ModeInfo {
 }
 impl TryParse for ModeInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (dotclock, remaining) = DOTCLOCK::try_parse(remaining)?;
+        let (dotclock, remaining) = Dotclock::try_parse(remaining)?;
         let (hdisplay, remaining) = u16::try_parse(remaining)?;
         let (hsyncstart, remaining) = u16::try_parse(remaining)?;
         let (hsyncend, remaining) = u16::try_parse(remaining)?;
@@ -443,7 +443,7 @@ pub struct GetModeLineReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub dotclock: DOTCLOCK,
+    pub dotclock: Dotclock,
     pub hdisplay: u16,
     pub hsyncstart: u16,
     pub hsyncend: u16,
@@ -462,7 +462,7 @@ impl GetModeLineReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (dotclock, remaining) = DOTCLOCK::try_parse(remaining)?;
+        let (dotclock, remaining) = Dotclock::try_parse(remaining)?;
         let (hdisplay, remaining) = u16::try_parse(remaining)?;
         let (hsyncstart, remaining) = u16::try_parse(remaining)?;
         let (hsyncend, remaining) = u16::try_parse(remaining)?;
@@ -623,8 +623,8 @@ pub struct GetMonitorReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub hsync: Vec<SYNCRANGE>,
-    pub vsync: Vec<SYNCRANGE>,
+    pub hsync: Vec<Syncrange>,
+    pub vsync: Vec<Syncrange>,
     pub vendor: Vec<u8>,
     pub alignment_pad: Vec<u8>,
     pub model: Vec<u8>,
@@ -640,8 +640,8 @@ impl GetMonitorReply {
         let (num_hsync, remaining) = u8::try_parse(remaining)?;
         let (num_vsync, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (hsync, remaining) = crate::x11_utils::parse_list::<SYNCRANGE>(remaining, num_hsync as usize)?;
-        let (vsync, remaining) = crate::x11_utils::parse_list::<SYNCRANGE>(remaining, num_vsync as usize)?;
+        let (hsync, remaining) = crate::x11_utils::parse_list::<Syncrange>(remaining, num_hsync as usize)?;
+        let (vsync, remaining) = crate::x11_utils::parse_list::<Syncrange>(remaining, num_vsync as usize)?;
         let (vendor, remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_length as usize)?;
         let (alignment_pad, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((vendor_length as usize) + (3)) & (!(3))) - (vendor_length as usize))?;
         let (model, remaining) = crate::x11_utils::parse_list::<u8>(remaining, model_length as usize)?;
@@ -735,7 +735,7 @@ impl TryFrom<&[u8]> for GetAllModeLinesReply {
 
 /// Opcode for the AddModeLine request
 pub const ADD_MODE_LINE_REQUEST: u8 = 7;
-pub fn add_mode_line<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, after_dotclock: DOTCLOCK, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn add_mode_line<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -871,7 +871,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeleteModeLine request
 pub const DELETE_MODE_LINE_REQUEST: u8 = 8;
-pub fn delete_mode_line<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn delete_mode_line<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -956,7 +956,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ValidateModeLine request
 pub const VALIDATE_MODE_LINE_REQUEST: u8 = 9;
-pub fn validate_mode_line<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
+pub fn validate_mode_line<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1066,7 +1066,7 @@ impl TryFrom<&[u8]> for ValidateModeLineReply {
 
 /// Opcode for the SwitchToMode request
 pub const SWITCH_TO_MODE_REQUEST: u8 = 10;
-pub fn switch_to_mode<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn switch_to_mode<'c, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2043,22 +2043,22 @@ pub trait ConnectionExt: RequestConnection {
         get_all_mode_lines(self, screen)
     }
 
-    fn xf86vidmode_add_mode_line<'c>(&'c self, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, after_dotclock: DOTCLOCK, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_add_mode_line<'c>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         add_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, after_dotclock, after_hdisplay, after_hsyncstart, after_hsyncend, after_htotal, after_hskew, after_vdisplay, after_vsyncstart, after_vsyncend, after_vtotal, after_flags, private)
     }
 
-    fn xf86vidmode_delete_mode_line<'c>(&'c self, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_delete_mode_line<'c>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         delete_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }
 
-    fn xf86vidmode_validate_mode_line<'c>(&'c self, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<Cookie<'c, Self, ValidateModeLineReply>, ConnectionError>
+    fn xf86vidmode_validate_mode_line<'c>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<Cookie<'c, Self, ValidateModeLineReply>, ConnectionError>
     {
         validate_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }
 
-    fn xf86vidmode_switch_to_mode<'c>(&'c self, screen: u32, dotclock: DOTCLOCK, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_switch_to_mode<'c>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: u32, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         switch_to_mode(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }

--- a/src/generated/xfixes.rs
+++ b/src/generated/xfixes.rs
@@ -286,7 +286,7 @@ impl TryFrom<u32> for SaveSetMapping {
 
 /// Opcode for the ChangeSaveSet request
 pub const CHANGE_SAVE_SET_REQUEST: u8 = 1;
-pub fn change_save_set<Conn, A, B, C>(conn: &Conn, mode: A, target: B, map: C, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_save_set<Conn, A, B, C>(conn: &Conn, mode: A, target: B, map: C, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>, C: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -457,22 +457,22 @@ pub struct SelectionNotifyEvent {
     pub response_type: u8,
     pub subtype: SelectionEvent,
     pub sequence: u16,
-    pub window: WINDOW,
-    pub owner: WINDOW,
-    pub selection: ATOM,
-    pub timestamp: TIMESTAMP,
-    pub selection_timestamp: TIMESTAMP,
+    pub window: Window,
+    pub owner: Window,
+    pub selection: Atom,
+    pub timestamp: Timestamp,
+    pub selection_timestamp: Timestamp,
 }
 impl SelectionNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (subtype, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (owner, remaining) = WINDOW::try_parse(remaining)?;
-        let (selection, remaining) = ATOM::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (selection_timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (owner, remaining) = Window::try_parse(remaining)?;
+        let (selection, remaining) = Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (selection_timestamp, remaining) = Timestamp::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let subtype = subtype.try_into()?;
         let result = SelectionNotifyEvent { response_type, subtype, sequence, window, owner, selection, timestamp, selection_timestamp };
@@ -521,7 +521,7 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectSelectionInput request
 pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
-pub fn select_selection_input<Conn>(conn: &Conn, window: WINDOW, selection: ATOM, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_selection_input<Conn>(conn: &Conn, window: Window, selection: Atom, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -680,20 +680,20 @@ pub struct CursorNotifyEvent {
     pub response_type: u8,
     pub subtype: CursorNotify,
     pub sequence: u16,
-    pub window: WINDOW,
+    pub window: Window,
     pub cursor_serial: u32,
-    pub timestamp: TIMESTAMP,
-    pub name: ATOM,
+    pub timestamp: Timestamp,
+    pub name: Atom,
 }
 impl CursorNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (subtype, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (cursor_serial, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (name, remaining) = Atom::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let subtype = subtype.try_into()?;
         let result = CursorNotifyEvent { response_type, subtype, sequence, window, cursor_serial, timestamp, name };
@@ -741,7 +741,7 @@ impl From<CursorNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectCursorInput request
 pub const SELECT_CURSOR_INPUT_REQUEST: u8 = 3;
-pub fn select_cursor_input<Conn>(conn: &Conn, window: WINDOW, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_cursor_input<Conn>(conn: &Conn, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -828,7 +828,7 @@ impl TryFrom<&[u8]> for GetCursorImageReply {
     }
 }
 
-pub type REGION = u32;
+pub type Region = u32;
 
 /// Opcode for the BadRegion error
 pub const BAD_REGION_ERROR: u8 = 0;
@@ -884,57 +884,57 @@ impl From<BadRegionError> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Region {
+pub enum RegionEnum {
     None = 0,
 }
-impl From<Region> for u8 {
-    fn from(input: Region) -> Self {
+impl From<RegionEnum> for u8 {
+    fn from(input: RegionEnum) -> Self {
         match input {
-            Region::None => 0,
+            RegionEnum::None => 0,
         }
     }
 }
-impl From<Region> for Option<u8> {
-    fn from(input: Region) -> Self {
+impl From<RegionEnum> for Option<u8> {
+    fn from(input: RegionEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Region> for u16 {
-    fn from(input: Region) -> Self {
+impl From<RegionEnum> for u16 {
+    fn from(input: RegionEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Region> for Option<u16> {
-    fn from(input: Region) -> Self {
+impl From<RegionEnum> for Option<u16> {
+    fn from(input: RegionEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Region> for u32 {
-    fn from(input: Region) -> Self {
+impl From<RegionEnum> for u32 {
+    fn from(input: RegionEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Region> for Option<u32> {
-    fn from(input: Region) -> Self {
+impl From<RegionEnum> for Option<u32> {
+    fn from(input: RegionEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Region {
+impl TryFrom<u8> for RegionEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Region::None),
+            0 => Ok(RegionEnum::None),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Region {
+impl TryFrom<u16> for RegionEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Region {
+impl TryFrom<u32> for RegionEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -943,7 +943,7 @@ impl TryFrom<u32> for Region {
 
 /// Opcode for the CreateRegion request
 pub const CREATE_REGION_REQUEST: u8 = 5;
-pub fn create_region<'c, Conn>(conn: &'c Conn, region: REGION, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -972,7 +972,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateRegionFromBitmap request
 pub const CREATE_REGION_FROM_BITMAP_REQUEST: u8 = 6;
-pub fn create_region_from_bitmap<Conn>(conn: &Conn, region: REGION, bitmap: PIXMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_bitmap<Conn>(conn: &Conn, region: Region, bitmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1002,8 +1002,8 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateRegionFromWindow request
 pub const CREATE_REGION_FROM_WINDOW_REQUEST: u8 = 7;
-pub fn create_region_from_window<Conn, A>(conn: &Conn, region: REGION, window: WINDOW, kind: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<shape::KIND>
+pub fn create_region_from_window<Conn, A>(conn: &Conn, region: Region, window: Window, kind: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<shape::Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
         .ok_or(ConnectionError::UnsupportedExtension)?;
@@ -1038,7 +1038,7 @@ where Conn: RequestConnection + ?Sized, A: Into<shape::KIND>
 
 /// Opcode for the CreateRegionFromGC request
 pub const CREATE_REGION_FROM_GC_REQUEST: u8 = 8;
-pub fn create_region_from_gc<Conn>(conn: &Conn, region: REGION, gc: GCONTEXT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_gc<Conn>(conn: &Conn, region: Region, gc: Gcontext) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1068,7 +1068,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateRegionFromPicture request
 pub const CREATE_REGION_FROM_PICTURE_REQUEST: u8 = 9;
-pub fn create_region_from_picture<Conn>(conn: &Conn, region: REGION, picture: render::PICTURE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_picture<Conn>(conn: &Conn, region: Region, picture: render::Picture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1098,7 +1098,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyRegion request
 pub const DESTROY_REGION_REQUEST: u8 = 10;
-pub fn destroy_region<Conn>(conn: &Conn, region: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_region<Conn>(conn: &Conn, region: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1123,7 +1123,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetRegion request
 pub const SET_REGION_REQUEST: u8 = 11;
-pub fn set_region<'c, Conn>(conn: &'c Conn, region: REGION, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1152,7 +1152,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 12;
-pub fn copy_region<Conn>(conn: &Conn, source: REGION, destination: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn copy_region<Conn>(conn: &Conn, source: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1182,7 +1182,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the UnionRegion request
 pub const UNION_REGION_REQUEST: u8 = 13;
-pub fn union_region<Conn>(conn: &Conn, source1: REGION, source2: REGION, destination: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn union_region<Conn>(conn: &Conn, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1217,7 +1217,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the IntersectRegion request
 pub const INTERSECT_REGION_REQUEST: u8 = 14;
-pub fn intersect_region<Conn>(conn: &Conn, source1: REGION, source2: REGION, destination: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn intersect_region<Conn>(conn: &Conn, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1252,7 +1252,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SubtractRegion request
 pub const SUBTRACT_REGION_REQUEST: u8 = 15;
-pub fn subtract_region<Conn>(conn: &Conn, source1: REGION, source2: REGION, destination: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn subtract_region<Conn>(conn: &Conn, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1287,7 +1287,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the InvertRegion request
 pub const INVERT_REGION_REQUEST: u8 = 16;
-pub fn invert_region<Conn>(conn: &Conn, source: REGION, bounds: Rectangle, destination: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn invert_region<Conn>(conn: &Conn, source: Region, bounds: Rectangle, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1326,7 +1326,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the TranslateRegion request
 pub const TRANSLATE_REGION_REQUEST: u8 = 17;
-pub fn translate_region<Conn>(conn: &Conn, region: REGION, dx: i16, dy: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn translate_region<Conn>(conn: &Conn, region: Region, dx: i16, dy: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1357,7 +1357,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the RegionExtents request
 pub const REGION_EXTENTS_REQUEST: u8 = 18;
-pub fn region_extents<Conn>(conn: &Conn, source: REGION, destination: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn region_extents<Conn>(conn: &Conn, source: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1387,7 +1387,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the FetchRegion request
 pub const FETCH_REGION_REQUEST: u8 = 19;
-pub fn fetch_region<Conn>(conn: &Conn, region: REGION) -> Result<Cookie<'_, Conn, FetchRegionReply>, ConnectionError>
+pub fn fetch_region<Conn>(conn: &Conn, region: Region) -> Result<Cookie<'_, Conn, FetchRegionReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1438,7 +1438,7 @@ impl TryFrom<&[u8]> for FetchRegionReply {
 
 /// Opcode for the SetGCClipRegion request
 pub const SET_GC_CLIP_REGION_REQUEST: u8 = 20;
-pub fn set_gc_clip_region<Conn>(conn: &Conn, gc: GCONTEXT, region: REGION, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_gc_clip_region<Conn>(conn: &Conn, gc: Gcontext, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1474,8 +1474,8 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetWindowShapeRegion request
 pub const SET_WINDOW_SHAPE_REGION_REQUEST: u8 = 21;
-pub fn set_window_shape_region<Conn, A>(conn: &Conn, dest: WINDOW, dest_kind: A, x_offset: i16, y_offset: i16, region: REGION) -> Result<VoidCookie<'_, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<shape::KIND>
+pub fn set_window_shape_region<Conn, A>(conn: &Conn, dest: Window, dest_kind: A, x_offset: i16, y_offset: i16, region: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<shape::Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
         .ok_or(ConnectionError::UnsupportedExtension)?;
@@ -1516,7 +1516,7 @@ where Conn: RequestConnection + ?Sized, A: Into<shape::KIND>
 
 /// Opcode for the SetPictureClipRegion request
 pub const SET_PICTURE_CLIP_REGION_REQUEST: u8 = 22;
-pub fn set_picture_clip_region<Conn>(conn: &Conn, picture: render::PICTURE, region: REGION, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_picture_clip_region<Conn>(conn: &Conn, picture: render::Picture, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1552,7 +1552,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetCursorName request
 pub const SET_CURSOR_NAME_REQUEST: u8 = 23;
-pub fn set_cursor_name<'c, Conn>(conn: &'c Conn, cursor: CURSOR, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_cursor_name<'c, Conn>(conn: &'c Conn, cursor: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1586,7 +1586,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetCursorName request
 pub const GET_CURSOR_NAME_REQUEST: u8 = 24;
-pub fn get_cursor_name<Conn>(conn: &Conn, cursor: CURSOR) -> Result<Cookie<'_, Conn, GetCursorNameReply>, ConnectionError>
+pub fn get_cursor_name<Conn>(conn: &Conn, cursor: Cursor) -> Result<Cookie<'_, Conn, GetCursorNameReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1613,7 +1613,7 @@ pub struct GetCursorNameReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atom: ATOM,
+    pub atom: Atom,
     pub name: Vec<u8>,
 }
 impl GetCursorNameReply {
@@ -1622,7 +1622,7 @@ impl GetCursorNameReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (atom, remaining) = ATOM::try_parse(remaining)?;
+        let (atom, remaining) = Atom::try_parse(remaining)?;
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
@@ -1668,7 +1668,7 @@ pub struct GetCursorImageAndNameReply {
     pub xhot: u16,
     pub yhot: u16,
     pub cursor_serial: u32,
-    pub cursor_atom: ATOM,
+    pub cursor_atom: Atom,
     pub cursor_image: Vec<u32>,
     pub name: Vec<u8>,
 }
@@ -1685,7 +1685,7 @@ impl GetCursorImageAndNameReply {
         let (xhot, remaining) = u16::try_parse(remaining)?;
         let (yhot, remaining) = u16::try_parse(remaining)?;
         let (cursor_serial, remaining) = u32::try_parse(remaining)?;
-        let (cursor_atom, remaining) = ATOM::try_parse(remaining)?;
+        let (cursor_atom, remaining) = Atom::try_parse(remaining)?;
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
@@ -1703,7 +1703,7 @@ impl TryFrom<&[u8]> for GetCursorImageAndNameReply {
 
 /// Opcode for the ChangeCursor request
 pub const CHANGE_CURSOR_REQUEST: u8 = 26;
-pub fn change_cursor<Conn>(conn: &Conn, source: CURSOR, destination: CURSOR) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_cursor<Conn>(conn: &Conn, source: Cursor, destination: Cursor) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1733,7 +1733,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ChangeCursorByName request
 pub const CHANGE_CURSOR_BY_NAME_REQUEST: u8 = 27;
-pub fn change_cursor_by_name<'c, Conn>(conn: &'c Conn, src: CURSOR, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_cursor_by_name<'c, Conn>(conn: &'c Conn, src: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1767,7 +1767,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ExpandRegion request
 pub const EXPAND_REGION_REQUEST: u8 = 28;
-pub fn expand_region<Conn>(conn: &Conn, source: REGION, destination: REGION, left: u16, right: u16, top: u16, bottom: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn expand_region<Conn>(conn: &Conn, source: Region, destination: Region, left: u16, right: u16, top: u16, bottom: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1809,7 +1809,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the HideCursor request
 pub const HIDE_CURSOR_REQUEST: u8 = 29;
-pub fn hide_cursor<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn hide_cursor<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1834,7 +1834,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ShowCursor request
 pub const SHOW_CURSOR_REQUEST: u8 = 30;
-pub fn show_cursor<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn show_cursor<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1857,7 +1857,7 @@ where Conn: RequestConnection + ?Sized
     Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], Vec::new())?)
 }
 
-pub type BARRIER = u32;
+pub type Barrier = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -1930,7 +1930,7 @@ bitmask_binop!(BarrierDirections, u8);
 
 /// Opcode for the CreatePointerBarrier request
 pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;
-pub fn create_pointer_barrier<'c, Conn>(conn: &'c Conn, barrier: BARRIER, window: WINDOW, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pointer_barrier<'c, Conn>(conn: &'c Conn, barrier: Barrier, window: Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1987,7 +1987,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeletePointerBarrier request
 pub const DELETE_POINTER_BARRIER_REQUEST: u8 = 32;
-pub fn delete_pointer_barrier<Conn>(conn: &Conn, barrier: BARRIER) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_pointer_barrier<Conn>(conn: &Conn, barrier: Barrier) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2017,18 +2017,18 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn xfixes_change_save_set<A, B, C>(&self, mode: A, target: B, map: C, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_change_save_set<A, B, C>(&self, mode: A, target: B, map: C, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>, B: Into<u8>, C: Into<u8>
     {
         change_save_set(self, mode, target, map, window)
     }
 
-    fn xfixes_select_selection_input(&self, window: WINDOW, selection: ATOM, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_select_selection_input(&self, window: Window, selection: Atom, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_selection_input(self, window, selection, event_mask)
     }
 
-    fn xfixes_select_cursor_input(&self, window: WINDOW, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_select_cursor_input(&self, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_cursor_input(self, window, event_mask)
     }
@@ -2038,104 +2038,104 @@ pub trait ConnectionExt: RequestConnection {
         get_cursor_image(self)
     }
 
-    fn xfixes_create_region<'c>(&'c self, region: REGION, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_create_region<'c>(&'c self, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_region(self, region, rectangles)
     }
 
-    fn xfixes_create_region_from_bitmap(&self, region: REGION, bitmap: PIXMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_create_region_from_bitmap(&self, region: Region, bitmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_region_from_bitmap(self, region, bitmap)
     }
 
-    fn xfixes_create_region_from_window<A>(&self, region: REGION, window: WINDOW, kind: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where A: Into<shape::KIND>
+    fn xfixes_create_region_from_window<A>(&self, region: Region, window: Window, kind: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    where A: Into<shape::Kind>
     {
         create_region_from_window(self, region, window, kind)
     }
 
-    fn xfixes_create_region_from_gc(&self, region: REGION, gc: GCONTEXT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_create_region_from_gc(&self, region: Region, gc: Gcontext) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_region_from_gc(self, region, gc)
     }
 
-    fn xfixes_create_region_from_picture(&self, region: REGION, picture: render::PICTURE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_create_region_from_picture(&self, region: Region, picture: render::Picture) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_region_from_picture(self, region, picture)
     }
 
-    fn xfixes_destroy_region(&self, region: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_destroy_region(&self, region: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_region(self, region)
     }
 
-    fn xfixes_set_region<'c>(&'c self, region: REGION, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_set_region<'c>(&'c self, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_region(self, region, rectangles)
     }
 
-    fn xfixes_copy_region(&self, source: REGION, destination: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_copy_region(&self, source: Region, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         copy_region(self, source, destination)
     }
 
-    fn xfixes_union_region(&self, source1: REGION, source2: REGION, destination: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_union_region(&self, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         union_region(self, source1, source2, destination)
     }
 
-    fn xfixes_intersect_region(&self, source1: REGION, source2: REGION, destination: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_intersect_region(&self, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         intersect_region(self, source1, source2, destination)
     }
 
-    fn xfixes_subtract_region(&self, source1: REGION, source2: REGION, destination: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_subtract_region(&self, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         subtract_region(self, source1, source2, destination)
     }
 
-    fn xfixes_invert_region(&self, source: REGION, bounds: Rectangle, destination: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_invert_region(&self, source: Region, bounds: Rectangle, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         invert_region(self, source, bounds, destination)
     }
 
-    fn xfixes_translate_region(&self, region: REGION, dx: i16, dy: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_translate_region(&self, region: Region, dx: i16, dy: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         translate_region(self, region, dx, dy)
     }
 
-    fn xfixes_region_extents(&self, source: REGION, destination: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_region_extents(&self, source: Region, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         region_extents(self, source, destination)
     }
 
-    fn xfixes_fetch_region(&self, region: REGION) -> Result<Cookie<'_, Self, FetchRegionReply>, ConnectionError>
+    fn xfixes_fetch_region(&self, region: Region) -> Result<Cookie<'_, Self, FetchRegionReply>, ConnectionError>
     {
         fetch_region(self, region)
     }
 
-    fn xfixes_set_gc_clip_region(&self, gc: GCONTEXT, region: REGION, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_set_gc_clip_region(&self, gc: Gcontext, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_gc_clip_region(self, gc, region, x_origin, y_origin)
     }
 
-    fn xfixes_set_window_shape_region<A>(&self, dest: WINDOW, dest_kind: A, x_offset: i16, y_offset: i16, region: REGION) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where A: Into<shape::KIND>
+    fn xfixes_set_window_shape_region<A>(&self, dest: Window, dest_kind: A, x_offset: i16, y_offset: i16, region: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    where A: Into<shape::Kind>
     {
         set_window_shape_region(self, dest, dest_kind, x_offset, y_offset, region)
     }
 
-    fn xfixes_set_picture_clip_region(&self, picture: render::PICTURE, region: REGION, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_set_picture_clip_region(&self, picture: render::Picture, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_picture_clip_region(self, picture, region, x_origin, y_origin)
     }
 
-    fn xfixes_set_cursor_name<'c>(&'c self, cursor: CURSOR, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_set_cursor_name<'c>(&'c self, cursor: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_cursor_name(self, cursor, name)
     }
 
-    fn xfixes_get_cursor_name(&self, cursor: CURSOR) -> Result<Cookie<'_, Self, GetCursorNameReply>, ConnectionError>
+    fn xfixes_get_cursor_name(&self, cursor: Cursor) -> Result<Cookie<'_, Self, GetCursorNameReply>, ConnectionError>
     {
         get_cursor_name(self, cursor)
     }
@@ -2145,37 +2145,37 @@ pub trait ConnectionExt: RequestConnection {
         get_cursor_image_and_name(self)
     }
 
-    fn xfixes_change_cursor(&self, source: CURSOR, destination: CURSOR) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_change_cursor(&self, source: Cursor, destination: Cursor) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         change_cursor(self, source, destination)
     }
 
-    fn xfixes_change_cursor_by_name<'c>(&'c self, src: CURSOR, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_change_cursor_by_name<'c>(&'c self, src: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_cursor_by_name(self, src, name)
     }
 
-    fn xfixes_expand_region(&self, source: REGION, destination: REGION, left: u16, right: u16, top: u16, bottom: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_expand_region(&self, source: Region, destination: Region, left: u16, right: u16, top: u16, bottom: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         expand_region(self, source, destination, left, right, top, bottom)
     }
 
-    fn xfixes_hide_cursor(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_hide_cursor(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         hide_cursor(self, window)
     }
 
-    fn xfixes_show_cursor(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_show_cursor(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         show_cursor(self, window)
     }
 
-    fn xfixes_create_pointer_barrier<'c>(&'c self, barrier: BARRIER, window: WINDOW, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_create_pointer_barrier<'c>(&'c self, barrier: Barrier, window: Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pointer_barrier(self, barrier, window, x1, y1, x2, y2, directions, devices)
     }
 
-    fn xfixes_delete_pointer_barrier(&self, barrier: BARRIER) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_delete_pointer_barrier(&self, barrier: Barrier) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_pointer_barrier(self, barrier)
     }

--- a/src/generated/xinerama.rs
+++ b/src/generated/xinerama.rs
@@ -141,7 +141,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 1;
-pub fn get_state<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
+pub fn get_state<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -169,7 +169,7 @@ pub struct GetStateReply {
     pub state: u8,
     pub sequence: u16,
     pub length: u32,
-    pub window: WINDOW,
+    pub window: Window,
 }
 impl GetStateReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -177,7 +177,7 @@ impl GetStateReply {
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let result = GetStateReply { response_type, state, sequence, length, window };
         Ok((result, remaining))
     }
@@ -191,7 +191,7 @@ impl TryFrom<&[u8]> for GetStateReply {
 
 /// Opcode for the GetScreenCount request
 pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
-pub fn get_screen_count<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetScreenCountReply>, ConnectionError>
+pub fn get_screen_count<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenCountReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -219,7 +219,7 @@ pub struct GetScreenCountReply {
     pub screen_count: u8,
     pub sequence: u16,
     pub length: u32,
-    pub window: WINDOW,
+    pub window: Window,
 }
 impl GetScreenCountReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -227,7 +227,7 @@ impl GetScreenCountReply {
         let (screen_count, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let result = GetScreenCountReply { response_type, screen_count, sequence, length, window };
         Ok((result, remaining))
     }
@@ -241,7 +241,7 @@ impl TryFrom<&[u8]> for GetScreenCountReply {
 
 /// Opcode for the GetScreenSize request
 pub const GET_SCREEN_SIZE_REQUEST: u8 = 3;
-pub fn get_screen_size<Conn>(conn: &Conn, window: WINDOW, screen: u32) -> Result<Cookie<'_, Conn, GetScreenSizeReply>, ConnectionError>
+pub fn get_screen_size<Conn>(conn: &Conn, window: Window, screen: u32) -> Result<Cookie<'_, Conn, GetScreenSizeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -275,7 +275,7 @@ pub struct GetScreenSizeReply {
     pub length: u32,
     pub width: u32,
     pub height: u32,
-    pub window: WINDOW,
+    pub window: Window,
     pub screen: u32,
 }
 impl GetScreenSizeReply {
@@ -286,7 +286,7 @@ impl GetScreenSizeReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (width, remaining) = u32::try_parse(remaining)?;
         let (height, remaining) = u32::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (screen, remaining) = u32::try_parse(remaining)?;
         let result = GetScreenSizeReply { response_type, sequence, length, width, height, window, screen };
         Ok((result, remaining))
@@ -396,17 +396,17 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major, minor)
     }
 
-    fn xinerama_get_state(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetStateReply>, ConnectionError>
+    fn xinerama_get_state(&self, window: Window) -> Result<Cookie<'_, Self, GetStateReply>, ConnectionError>
     {
         get_state(self, window)
     }
 
-    fn xinerama_get_screen_count(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetScreenCountReply>, ConnectionError>
+    fn xinerama_get_screen_count(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenCountReply>, ConnectionError>
     {
         get_screen_count(self, window)
     }
 
-    fn xinerama_get_screen_size(&self, window: WINDOW, screen: u32) -> Result<Cookie<'_, Self, GetScreenSizeReply>, ConnectionError>
+    fn xinerama_get_screen_size(&self, window: Window, screen: u32) -> Result<Cookie<'_, Self, GetScreenSizeReply>, ConnectionError>
     {
         get_screen_size(self, window, screen)
     }

--- a/src/generated/xinput.rs
+++ b/src/generated/xinput.rs
@@ -49,7 +49,7 @@ pub type KeyCode = u8;
 
 pub type DeviceId = u16;
 
-pub type FP1616 = i32;
+pub type Fp1616 = i32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Fp3232 {
@@ -364,14 +364,14 @@ impl TryFrom<u32> for ValuatorMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeviceInfo {
-    pub device_type: ATOM,
+    pub device_type: Atom,
     pub device_id: u8,
     pub num_class_info: u8,
     pub device_use: DeviceUse,
 }
 impl TryParse for DeviceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (device_type, remaining) = ATOM::try_parse(remaining)?;
+        let (device_type, remaining) = Atom::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (num_class_info, remaining) = u8::try_parse(remaining)?;
         let (device_use, remaining) = u8::try_parse(remaining)?;
@@ -1070,7 +1070,7 @@ impl TryFrom<&[u8]> for SetDeviceModeReply {
 
 /// Opcode for the SelectExtensionEvent request
 pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
-pub fn select_extension_event<'c, Conn>(conn: &'c Conn, window: WINDOW, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn select_extension_event<'c, Conn>(conn: &'c Conn, window: Window, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1105,7 +1105,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetSelectedExtensionEvents request
 pub const GET_SELECTED_EXTENSION_EVENTS_REQUEST: u8 = 7;
-pub fn get_selected_extension_events<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetSelectedExtensionEventsReply>, ConnectionError>
+pub fn get_selected_extension_events<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetSelectedExtensionEventsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1222,7 +1222,7 @@ impl TryFrom<u32> for PropagateMode {
 
 /// Opcode for the ChangeDeviceDontPropagateList request
 pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
-pub fn change_device_dont_propagate_list<'c, Conn, A>(conn: &'c Conn, window: WINDOW, mode: A, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_device_dont_propagate_list<'c, Conn, A>(conn: &'c Conn, window: Window, mode: A, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1259,7 +1259,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the GetDeviceDontPropagateList request
 pub const GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 9;
-pub fn get_device_dont_propagate_list<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetDeviceDontPropagateListReply>, ConnectionError>
+pub fn get_device_dont_propagate_list<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetDeviceDontPropagateListReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1311,12 +1311,12 @@ impl TryFrom<&[u8]> for GetDeviceDontPropagateListReply {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeviceTimeCoord {
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub axisvalues: Vec<i32>,
 }
 impl DeviceTimeCoord {
     pub fn try_parse(remaining: &[u8], num_axes: u8) -> Result<(Self, &[u8]), ParseError> {
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (axisvalues, remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_axes as usize)?;
         let result = DeviceTimeCoord { time, axisvalues };
         Ok((result, remaining))
@@ -1341,7 +1341,7 @@ impl Serialize for DeviceTimeCoord {
 
 /// Opcode for the GetDeviceMotionEvents request
 pub const GET_DEVICE_MOTION_EVENTS_REQUEST: u8 = 10;
-pub fn get_device_motion_events<Conn>(conn: &Conn, start: TIMESTAMP, stop: TIMESTAMP, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceMotionEventsReply>, ConnectionError>
+pub fn get_device_motion_events<Conn>(conn: &Conn, start: Timestamp, stop: Timestamp, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceMotionEventsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1521,7 +1521,7 @@ impl TryFrom<&[u8]> for ChangePointerDeviceReply {
 
 /// Opcode for the GrabDevice request
 pub const GRAB_DEVICE_REQUEST: u8 = 13;
-pub fn grab_device<'c, Conn, A, B>(conn: &'c Conn, grab_window: WINDOW, time: TIMESTAMP, this_device_mode: A, other_device_mode: B, owner_events: bool, device_id: u8, classes: &[EventClass]) -> Result<Cookie<'c, Conn, GrabDeviceReply>, ConnectionError>
+pub fn grab_device<'c, Conn, A, B>(conn: &'c Conn, grab_window: Window, time: Timestamp, this_device_mode: A, other_device_mode: B, owner_events: bool, device_id: u8, classes: &[EventClass]) -> Result<Cookie<'c, Conn, GrabDeviceReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1598,7 +1598,7 @@ impl TryFrom<&[u8]> for GrabDeviceReply {
 
 /// Opcode for the UngrabDevice request
 pub const UNGRAB_DEVICE_REQUEST: u8 = 14;
-pub fn ungrab_device<Conn>(conn: &Conn, time: TIMESTAMP, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_device<Conn>(conn: &Conn, time: Timestamp, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1687,7 +1687,7 @@ impl TryFrom<u32> for ModifierDevice {
 
 /// Opcode for the GrabDeviceKey request
 pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
-pub fn grab_device_key<'c, Conn, A, B>(conn: &'c Conn, grab_window: WINDOW, modifiers: u16, modifier_device: u8, grabbed_device: u8, key: u8, this_device_mode: A, other_device_mode: B, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn grab_device_key<'c, Conn, A, B>(conn: &'c Conn, grab_window: Window, modifiers: u16, modifier_device: u8, grabbed_device: u8, key: u8, this_device_mode: A, other_device_mode: B, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1739,7 +1739,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 
 /// Opcode for the UngrabDeviceKey request
 pub const UNGRAB_DEVICE_KEY_REQUEST: u8 = 16;
-pub fn ungrab_device_key<Conn>(conn: &Conn, grab_window: WINDOW, modifiers: u16, modifier_device: u8, key: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_device_key<Conn>(conn: &Conn, grab_window: Window, modifiers: u16, modifier_device: u8, key: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1776,7 +1776,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GrabDeviceButton request
 pub const GRAB_DEVICE_BUTTON_REQUEST: u8 = 17;
-pub fn grab_device_button<'c, Conn, A, B>(conn: &'c Conn, grab_window: WINDOW, grabbed_device: u8, modifier_device: u8, modifiers: u16, this_device_mode: A, other_device_mode: B, button: u8, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn grab_device_button<'c, Conn, A, B>(conn: &'c Conn, grab_window: Window, grabbed_device: u8, modifier_device: u8, modifiers: u16, this_device_mode: A, other_device_mode: B, button: u8, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1828,7 +1828,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 
 /// Opcode for the UngrabDeviceButton request
 pub const UNGRAB_DEVICE_BUTTON_REQUEST: u8 = 18;
-pub fn ungrab_device_button<Conn>(conn: &Conn, grab_window: WINDOW, modifiers: u16, modifier_device: u8, button: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_device_button<Conn>(conn: &Conn, grab_window: Window, modifiers: u16, modifier_device: u8, button: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1939,7 +1939,7 @@ impl TryFrom<u32> for DeviceInputMode {
 
 /// Opcode for the AllowDeviceEvents request
 pub const ALLOW_DEVICE_EVENTS_REQUEST: u8 = 19;
-pub fn allow_device_events<Conn, A>(conn: &Conn, time: TIMESTAMP, mode: A, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn allow_device_events<Conn, A>(conn: &Conn, time: Timestamp, mode: A, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1999,8 +1999,8 @@ pub struct GetDeviceFocusReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub focus: WINDOW,
-    pub time: TIMESTAMP,
+    pub focus: Window,
+    pub time: Timestamp,
     pub revert_to: InputFocus,
 }
 impl GetDeviceFocusReply {
@@ -2009,8 +2009,8 @@ impl GetDeviceFocusReply {
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (focus, remaining) = WINDOW::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (focus, remaining) = Window::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (revert_to, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
         let revert_to = revert_to.try_into()?;
@@ -2027,7 +2027,7 @@ impl TryFrom<&[u8]> for GetDeviceFocusReply {
 
 /// Opcode for the SetDeviceFocus request
 pub const SET_DEVICE_FOCUS_REQUEST: u8 = 21;
-pub fn set_device_focus<Conn, A>(conn: &Conn, focus: WINDOW, time: TIMESTAMP, revert_to: A, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_device_focus<Conn, A>(conn: &Conn, focus: Window, time: Timestamp, revert_to: A, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2463,7 +2463,7 @@ pub struct StringFeedbackState {
     pub feedback_id: u8,
     pub len: u16,
     pub max_symbols: u16,
-    pub keysyms: Vec<KEYSYM>,
+    pub keysyms: Vec<Keysym>,
 }
 impl TryParse for StringFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2472,7 +2472,7 @@ impl TryParse for StringFeedbackState {
         let (len, remaining) = u16::try_parse(remaining)?;
         let (max_symbols, remaining) = u16::try_parse(remaining)?;
         let (num_keysyms, remaining) = u16::try_parse(remaining)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, num_keysyms as usize)?;
         let class_id = class_id.try_into()?;
         let result = StringFeedbackState { class_id, feedback_id, len, max_symbols, keysyms };
         Ok((result, remaining))
@@ -2848,13 +2848,13 @@ impl Serialize for FeedbackStateDataPointer {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FeedbackStateDataString {
     pub max_symbols: u16,
-    pub keysyms: Vec<KEYSYM>,
+    pub keysyms: Vec<Keysym>,
 }
 impl TryParse for FeedbackStateDataString {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (max_symbols, remaining) = u16::try_parse(remaining)?;
         let (num_keysyms, remaining) = u16::try_parse(remaining)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, num_keysyms as usize)?;
         let result = FeedbackStateDataString { max_symbols, keysyms };
         Ok((result, remaining))
     }
@@ -3435,7 +3435,7 @@ pub struct StringFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
     pub len: u16,
-    pub keysyms: Vec<KEYSYM>,
+    pub keysyms: Vec<Keysym>,
 }
 impl TryParse for StringFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3444,7 +3444,7 @@ impl TryParse for StringFeedbackCtl {
         let (len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (num_keysyms, remaining) = u16::try_parse(remaining)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, num_keysyms as usize)?;
         let class_id = class_id.try_into()?;
         let result = StringFeedbackCtl { class_id, feedback_id, len, keysyms };
         Ok((result, remaining))
@@ -3721,13 +3721,13 @@ impl Serialize for FeedbackCtlDataPointer {
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FeedbackCtlDataString {
-    pub keysyms: Vec<KEYSYM>,
+    pub keysyms: Vec<Keysym>,
 }
 impl TryParse for FeedbackCtlDataString {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (num_keysyms, remaining) = u16::try_parse(remaining)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, num_keysyms as usize)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, num_keysyms as usize)?;
         let result = FeedbackCtlDataString { keysyms };
         Ok((result, remaining))
     }
@@ -4125,7 +4125,7 @@ pub struct GetDeviceKeyMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub keysyms_per_keycode: u8,
-    pub keysyms: Vec<KEYSYM>,
+    pub keysyms: Vec<Keysym>,
 }
 impl GetDeviceKeyMappingReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4135,7 +4135,7 @@ impl GetDeviceKeyMappingReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (keysyms_per_keycode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, length as usize)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, length as usize)?;
         let result = GetDeviceKeyMappingReply { response_type, xi_reply_type, sequence, keysyms_per_keycode, keysyms };
         Ok((result, remaining))
     }
@@ -4149,7 +4149,7 @@ impl TryFrom<&[u8]> for GetDeviceKeyMappingReply {
 
 /// Opcode for the ChangeDeviceKeyMapping request
 pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
-pub fn change_device_key_mapping<'c, Conn>(conn: &'c Conn, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &[KEYSYM]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_device_key_mapping<'c, Conn>(conn: &'c Conn, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &[Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -6946,7 +6946,7 @@ pub struct ListDevicePropertiesReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atoms: Vec<ATOM>,
+    pub atoms: Vec<Atom>,
 }
 impl ListDevicePropertiesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6956,7 +6956,7 @@ impl ListDevicePropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_atoms, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_atoms as usize)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_atoms as usize)?;
         let result = ListDevicePropertiesReply { response_type, xi_reply_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -7067,7 +7067,7 @@ impl ChangeDevicePropertyAux {
         }
     }
 }
-pub fn change_device_property<'c, Conn, A>(conn: &'c Conn, property: ATOM, type_: ATOM, device_id: u8, mode: A, num_items: u32, items: &ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_device_property<'c, Conn, A>(conn: &'c Conn, property: Atom, type_: Atom, device_id: u8, mode: A, num_items: u32, items: &ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7115,7 +7115,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the DeleteDeviceProperty request
 pub const DELETE_DEVICE_PROPERTY_REQUEST: u8 = 38;
-pub fn delete_device_property<Conn>(conn: &Conn, property: ATOM, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_device_property<Conn>(conn: &Conn, property: Atom, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7145,7 +7145,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetDeviceProperty request
 pub const GET_DEVICE_PROPERTY_REQUEST: u8 = 39;
-pub fn get_device_property<Conn>(conn: &Conn, property: ATOM, type_: ATOM, offset: u32, len: u32, device_id: u8, delete: bool) -> Result<Cookie<'_, Conn, GetDevicePropertyReply>, ConnectionError>
+pub fn get_device_property<Conn>(conn: &Conn, property: Atom, type_: Atom, offset: u32, len: u32, device_id: u8, delete: bool) -> Result<Cookie<'_, Conn, GetDevicePropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7276,7 +7276,7 @@ pub struct GetDevicePropertyReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub type_: ATOM,
+    pub type_: Atom,
     pub bytes_after: u32,
     pub num_items: u32,
     pub format: PropertyFormat,
@@ -7289,7 +7289,7 @@ impl GetDevicePropertyReply {
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (type_, remaining) = Atom::try_parse(remaining)?;
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
@@ -7476,7 +7476,7 @@ impl Serialize for ModifierInfo {
 
 /// Opcode for the XIQueryPointer request
 pub const XI_QUERY_POINTER_REQUEST: u8 = 40;
-pub fn xi_query_pointer<Conn>(conn: &Conn, window: WINDOW, deviceid: DeviceId) -> Result<Cookie<'_, Conn, XIQueryPointerReply>, ConnectionError>
+pub fn xi_query_pointer<Conn>(conn: &Conn, window: Window, deviceid: DeviceId) -> Result<Cookie<'_, Conn, XIQueryPointerReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7508,12 +7508,12 @@ pub struct XIQueryPointerReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub root: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub win_x: FP1616,
-    pub win_y: FP1616,
+    pub root: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub win_x: Fp1616,
+    pub win_y: Fp1616,
     pub same_screen: bool,
     pub mods: ModifierInfo,
     pub group: GroupInfo,
@@ -7525,12 +7525,12 @@ impl XIQueryPointerReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (win_x, remaining) = FP1616::try_parse(remaining)?;
-        let (win_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (win_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (win_y, remaining) = Fp1616::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
@@ -7550,7 +7550,7 @@ impl TryFrom<&[u8]> for XIQueryPointerReply {
 
 /// Opcode for the XIWarpPointer request
 pub const XI_WARP_POINTER_REQUEST: u8 = 41;
-pub fn xi_warp_pointer<Conn>(conn: &Conn, src_win: WINDOW, dst_win: WINDOW, src_x: FP1616, src_y: FP1616, src_width: u16, src_height: u16, dst_x: FP1616, dst_y: FP1616, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn xi_warp_pointer<Conn>(conn: &Conn, src_win: Window, dst_win: Window, src_x: Fp1616, src_y: Fp1616, src_width: u16, src_height: u16, dst_x: Fp1616, dst_y: Fp1616, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7611,7 +7611,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the XIChangeCursor request
 pub const XI_CHANGE_CURSOR_REQUEST: u8 = 42;
-pub fn xi_change_cursor<Conn>(conn: &Conn, window: WINDOW, cursor: CURSOR, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn xi_change_cursor<Conn>(conn: &Conn, window: Window, cursor: Cursor, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8280,7 +8280,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the XISetClientPointer request
 pub const XI_SET_CLIENT_POINTER_REQUEST: u8 = 44;
-pub fn xi_set_client_pointer<Conn>(conn: &Conn, window: WINDOW, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn xi_set_client_pointer<Conn>(conn: &Conn, window: Window, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8310,7 +8310,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the XIGetClientPointer request
 pub const XI_GET_CLIENT_POINTER_REQUEST: u8 = 45;
-pub fn xi_get_client_pointer<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, XIGetClientPointerReply>, ConnectionError>
+pub fn xi_get_client_pointer<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, XIGetClientPointerReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8502,7 +8502,7 @@ impl Serialize for EventMask {
 
 /// Opcode for the XISelectEvents request
 pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
-pub fn xi_select_events<'c, Conn>(conn: &'c Conn, window: WINDOW, masks: &[EventMask]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_select_events<'c, Conn>(conn: &'c Conn, window: Window, masks: &[EventMask]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8924,7 +8924,7 @@ pub struct ButtonClass {
     pub sourceid: DeviceId,
     pub num_buttons: u16,
     pub state: Vec<u32>,
-    pub labels: Vec<ATOM>,
+    pub labels: Vec<Atom>,
 }
 impl TryParse for ButtonClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8933,7 +8933,7 @@ impl TryParse for ButtonClass {
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (num_buttons, remaining) = u16::try_parse(remaining)?;
         let (state, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((num_buttons as usize) + (31)) / (32))?;
-        let (labels, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_buttons as usize)?;
+        let (labels, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_buttons as usize)?;
         let type_ = type_.try_into()?;
         let result = ButtonClass { type_, len, sourceid, num_buttons, state, labels };
         Ok((result, remaining))
@@ -9150,7 +9150,7 @@ pub struct ValuatorClass {
     pub len: u16,
     pub sourceid: DeviceId,
     pub number: u16,
-    pub label: ATOM,
+    pub label: Atom,
     pub min: Fp3232,
     pub max: Fp3232,
     pub value: Fp3232,
@@ -9163,7 +9163,7 @@ impl TryParse for ValuatorClass {
         let (len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (number, remaining) = u16::try_parse(remaining)?;
-        let (label, remaining) = ATOM::try_parse(remaining)?;
+        let (label, remaining) = Atom::try_parse(remaining)?;
         let (min, remaining) = Fp3232::try_parse(remaining)?;
         let (max, remaining) = Fp3232::try_parse(remaining)?;
         let (value, remaining) = Fp3232::try_parse(remaining)?;
@@ -9294,13 +9294,13 @@ impl Serialize for DeviceClassDataKey {
 pub struct DeviceClassDataButton {
     pub num_buttons: u16,
     pub state: Vec<u32>,
-    pub labels: Vec<ATOM>,
+    pub labels: Vec<Atom>,
 }
 impl TryParse for DeviceClassDataButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_buttons, remaining) = u16::try_parse(remaining)?;
         let (state, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ((num_buttons as usize) + (31)) / (32))?;
-        let (labels, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_buttons as usize)?;
+        let (labels, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_buttons as usize)?;
         let result = DeviceClassDataButton { num_buttons, state, labels };
         Ok((result, remaining))
     }
@@ -9328,7 +9328,7 @@ impl Serialize for DeviceClassDataButton {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeviceClassDataValuator {
     pub number: u16,
-    pub label: ATOM,
+    pub label: Atom,
     pub min: Fp3232,
     pub max: Fp3232,
     pub value: Fp3232,
@@ -9338,7 +9338,7 @@ pub struct DeviceClassDataValuator {
 impl TryParse for DeviceClassDataValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (number, remaining) = u16::try_parse(remaining)?;
-        let (label, remaining) = ATOM::try_parse(remaining)?;
+        let (label, remaining) = Atom::try_parse(remaining)?;
         let (min, remaining) = Fp3232::try_parse(remaining)?;
         let (max, remaining) = Fp3232::try_parse(remaining)?;
         let (value, remaining) = Fp3232::try_parse(remaining)?;
@@ -9769,7 +9769,7 @@ impl TryFrom<&[u8]> for XIQueryDeviceReply {
 
 /// Opcode for the XISetFocus request
 pub const XI_SET_FOCUS_REQUEST: u8 = 49;
-pub fn xi_set_focus<Conn>(conn: &Conn, window: WINDOW, time: TIMESTAMP, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn xi_set_focus<Conn>(conn: &Conn, window: Window, time: Timestamp, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -9831,7 +9831,7 @@ pub struct XIGetFocusReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub focus: WINDOW,
+    pub focus: Window,
 }
 impl XIGetFocusReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9839,7 +9839,7 @@ impl XIGetFocusReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (focus, remaining) = WINDOW::try_parse(remaining)?;
+        let (focus, remaining) = Window::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = XIGetFocusReply { response_type, sequence, length, focus };
         Ok((result, remaining))
@@ -9916,7 +9916,7 @@ impl TryFrom<u32> for GrabOwner {
 
 /// Opcode for the XIGrabDevice request
 pub const XI_GRAB_DEVICE_REQUEST: u8 = 51;
-pub fn xi_grab_device<'c, Conn, A, B, C>(conn: &'c Conn, window: WINDOW, time: TIMESTAMP, cursor: CURSOR, deviceid: DeviceId, mode: A, paired_device_mode: B, owner_events: C, mask: &[u32]) -> Result<Cookie<'c, Conn, XIGrabDeviceReply>, ConnectionError>
+pub fn xi_grab_device<'c, Conn, A, B, C>(conn: &'c Conn, window: Window, time: Timestamp, cursor: Cursor, deviceid: DeviceId, mode: A, paired_device_mode: B, owner_events: C, mask: &[u32]) -> Result<Cookie<'c, Conn, XIGrabDeviceReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>, C: Into<bool>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -9998,7 +9998,7 @@ impl TryFrom<&[u8]> for XIGrabDeviceReply {
 
 /// Opcode for the XIUngrabDevice request
 pub const XI_UNGRAB_DEVICE_REQUEST: u8 = 52;
-pub fn xi_ungrab_device<Conn>(conn: &Conn, time: TIMESTAMP, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn xi_ungrab_device<Conn>(conn: &Conn, time: Timestamp, deviceid: DeviceId) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10108,7 +10108,7 @@ impl TryFrom<u32> for EventMode {
 
 /// Opcode for the XIAllowEvents request
 pub const XI_ALLOW_EVENTS_REQUEST: u8 = 53;
-pub fn xi_allow_events<Conn, A>(conn: &Conn, time: TIMESTAMP, deviceid: DeviceId, event_mode: A, touchid: u32, grab_window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn xi_allow_events<Conn, A>(conn: &Conn, time: Timestamp, deviceid: DeviceId, event_mode: A, touchid: u32, grab_window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10359,7 +10359,7 @@ impl Serialize for GrabModifierInfo {
 
 /// Opcode for the XIPassiveGrabDevice request
 pub const XI_PASSIVE_GRAB_DEVICE_REQUEST: u8 = 54;
-pub fn xi_passive_grab_device<'c, Conn, A, B, C, D>(conn: &'c Conn, time: TIMESTAMP, grab_window: WINDOW, cursor: CURSOR, detail: u32, deviceid: DeviceId, grab_type: A, grab_mode: B, paired_device_mode: C, owner_events: D, mask: &[u32], modifiers: &[u32]) -> Result<Cookie<'c, Conn, XIPassiveGrabDeviceReply>, ConnectionError>
+pub fn xi_passive_grab_device<'c, Conn, A, B, C, D>(conn: &'c Conn, time: Timestamp, grab_window: Window, cursor: Cursor, detail: u32, deviceid: DeviceId, grab_type: A, grab_mode: B, paired_device_mode: C, owner_events: D, mask: &[u32], modifiers: &[u32]) -> Result<Cookie<'c, Conn, XIPassiveGrabDeviceReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>, C: Into<u8>, D: Into<bool>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10456,7 +10456,7 @@ impl TryFrom<&[u8]> for XIPassiveGrabDeviceReply {
 
 /// Opcode for the XIPassiveUngrabDevice request
 pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
-pub fn xi_passive_ungrab_device<'c, Conn, A>(conn: &'c Conn, grab_window: WINDOW, detail: u32, deviceid: DeviceId, grab_type: A, modifiers: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_passive_ungrab_device<'c, Conn, A>(conn: &'c Conn, grab_window: Window, detail: u32, deviceid: DeviceId, grab_type: A, modifiers: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10530,7 +10530,7 @@ pub struct XIListPropertiesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub properties: Vec<ATOM>,
+    pub properties: Vec<Atom>,
 }
 impl XIListPropertiesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10540,7 +10540,7 @@ impl XIListPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_properties, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (properties, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, num_properties as usize)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_properties as usize)?;
         let result = XIListPropertiesReply { response_type, sequence, length, properties };
         Ok((result, remaining))
     }
@@ -10586,7 +10586,7 @@ impl XIChangePropertyAux {
         }
     }
 }
-pub fn xi_change_property<'c, Conn, A>(conn: &'c Conn, deviceid: DeviceId, mode: A, property: ATOM, type_: ATOM, num_items: u32, items: &XIChangePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_change_property<'c, Conn, A>(conn: &'c Conn, deviceid: DeviceId, mode: A, property: Atom, type_: Atom, num_items: u32, items: &XIChangePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10634,7 +10634,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the XIDeleteProperty request
 pub const XI_DELETE_PROPERTY_REQUEST: u8 = 58;
-pub fn xi_delete_property<Conn>(conn: &Conn, deviceid: DeviceId, property: ATOM) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn xi_delete_property<Conn>(conn: &Conn, deviceid: DeviceId, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10664,7 +10664,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the XIGetProperty request
 pub const XI_GET_PROPERTY_REQUEST: u8 = 59;
-pub fn xi_get_property<Conn>(conn: &Conn, deviceid: DeviceId, delete: bool, property: ATOM, type_: ATOM, offset: u32, len: u32) -> Result<Cookie<'_, Conn, XIGetPropertyReply>, ConnectionError>
+pub fn xi_get_property<Conn>(conn: &Conn, deviceid: DeviceId, delete: bool, property: Atom, type_: Atom, offset: u32, len: u32) -> Result<Cookie<'_, Conn, XIGetPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10794,7 +10794,7 @@ pub struct XIGetPropertyReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub type_: ATOM,
+    pub type_: Atom,
     pub bytes_after: u32,
     pub num_items: u32,
     pub format: PropertyFormat,
@@ -10806,7 +10806,7 @@ impl XIGetPropertyReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (type_, remaining) = Atom::try_parse(remaining)?;
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
@@ -10826,7 +10826,7 @@ impl TryFrom<&[u8]> for XIGetPropertyReply {
 
 /// Opcode for the XIGetSelectedEvents request
 pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
-pub fn xi_get_selected_events<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, XIGetSelectedEventsReply>, ConnectionError>
+pub fn xi_get_selected_events<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, XIGetSelectedEventsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -10878,14 +10878,14 @@ impl TryFrom<&[u8]> for XIGetSelectedEventsReply {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BarrierReleasePointerInfo {
     pub deviceid: DeviceId,
-    pub barrier: xfixes::BARRIER,
+    pub barrier: xfixes::Barrier,
     pub eventid: u32,
 }
 impl TryParse for BarrierReleasePointerInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (barrier, remaining) = xfixes::BARRIER::try_parse(remaining)?;
+        let (barrier, remaining) = xfixes::Barrier::try_parse(remaining)?;
         let (eventid, remaining) = u32::try_parse(remaining)?;
         let result = BarrierReleasePointerInfo { deviceid, barrier, eventid };
         Ok((result, remaining))
@@ -11106,10 +11106,10 @@ pub struct DeviceKeyPressEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -11123,10 +11123,10 @@ impl DeviceKeyPressEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -11191,10 +11191,10 @@ pub struct DeviceKeyReleaseEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -11208,10 +11208,10 @@ impl DeviceKeyReleaseEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -11276,10 +11276,10 @@ pub struct DeviceButtonPressEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -11293,10 +11293,10 @@ impl DeviceButtonPressEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -11361,10 +11361,10 @@ pub struct DeviceButtonReleaseEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -11378,10 +11378,10 @@ impl DeviceButtonReleaseEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -11446,10 +11446,10 @@ pub struct DeviceMotionNotifyEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -11463,10 +11463,10 @@ impl DeviceMotionNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -11531,8 +11531,8 @@ pub struct DeviceFocusInEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub window: WINDOW,
+    pub time: Timestamp,
+    pub window: Window,
     pub mode: NotifyMode,
     pub device_id: u8,
 }
@@ -11541,8 +11541,8 @@ impl DeviceFocusInEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
@@ -11598,8 +11598,8 @@ pub struct DeviceFocusOutEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub window: WINDOW,
+    pub time: Timestamp,
+    pub window: Window,
     pub mode: NotifyMode,
     pub device_id: u8,
 }
@@ -11608,8 +11608,8 @@ impl DeviceFocusOutEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
@@ -11665,10 +11665,10 @@ pub struct ProximityInEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -11682,10 +11682,10 @@ impl ProximityInEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -11750,10 +11750,10 @@ pub struct ProximityOutEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -11767,10 +11767,10 @@ impl ProximityOutEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -11907,7 +11907,7 @@ pub struct DeviceStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub num_keys: u8,
     pub num_buttons: u8,
     pub num_valuators: u8,
@@ -11921,7 +11921,7 @@ impl DeviceStateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (num_keys, remaining) = u8::try_parse(remaining)?;
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
         let (num_valuators, remaining) = u8::try_parse(remaining)?;
@@ -12011,7 +12011,7 @@ pub struct DeviceMappingNotifyEvent {
     pub request: Mapping,
     pub first_keycode: KeyCode,
     pub count: u8,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
 }
 impl DeviceMappingNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12022,7 +12022,7 @@ impl DeviceMappingNotifyEvent {
         let (first_keycode, remaining) = KeyCode::try_parse(remaining)?;
         let (count, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let request = request.try_into()?;
         let result = DeviceMappingNotifyEvent { response_type, device_id, sequence, request, first_keycode, count, time };
@@ -12137,7 +12137,7 @@ pub struct ChangeDeviceNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub request: ChangeDevice,
 }
 impl ChangeDeviceNotifyEvent {
@@ -12145,7 +12145,7 @@ impl ChangeDeviceNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (request, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let request = request.try_into()?;
@@ -12492,7 +12492,7 @@ pub const DEVICE_PRESENCE_NOTIFY_EVENT: u8 = 15;
 pub struct DevicePresenceNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub devchange: DeviceChange,
     pub device_id: u8,
     pub control: u16,
@@ -12502,7 +12502,7 @@ impl DevicePresenceNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (devchange, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (control, remaining) = u16::try_parse(remaining)?;
@@ -12557,8 +12557,8 @@ pub struct DevicePropertyNotifyEvent {
     pub response_type: u8,
     pub state: Property,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub property: ATOM,
+    pub time: Timestamp,
+    pub property: Atom,
     pub device_id: u8,
 }
 impl DevicePropertyNotifyEvent {
@@ -12566,8 +12566,8 @@ impl DevicePropertyNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (property, remaining) = ATOM::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (property, remaining) = Atom::try_parse(remaining)?;
         let remaining = remaining.get(19..).ok_or(ParseError::ParseError)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let state = state.try_into()?;
@@ -12685,7 +12685,7 @@ pub struct DeviceChangedEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub sourceid: DeviceId,
     pub reason: ChangeReason,
     pub classes: Vec<DeviceClass>,
@@ -12698,7 +12698,7 @@ impl DeviceChangedEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (num_classes, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (reason, remaining) = u8::try_parse(remaining)?;
@@ -12766,15 +12766,15 @@ pub struct KeyPressEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -12791,15 +12791,15 @@ impl KeyPressEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -12843,15 +12843,15 @@ pub struct KeyReleaseEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -12868,15 +12868,15 @@ impl KeyReleaseEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -12948,15 +12948,15 @@ pub struct ButtonPressEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -12973,15 +12973,15 @@ impl ButtonPressEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -13025,15 +13025,15 @@ pub struct ButtonReleaseEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -13050,15 +13050,15 @@ impl ButtonReleaseEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -13102,15 +13102,15 @@ pub struct MotionEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -13127,15 +13127,15 @@ impl MotionEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -13333,17 +13333,17 @@ pub struct EnterEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub sourceid: DeviceId,
     pub mode: NotifyMode,
     pub detail: NotifyDetail,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub same_screen: bool,
     pub focus: bool,
     pub mods: ModifierInfo,
@@ -13358,17 +13358,17 @@ impl EnterEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (focus, remaining) = bool::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
@@ -13410,17 +13410,17 @@ pub struct LeaveEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub sourceid: DeviceId,
     pub mode: NotifyMode,
     pub detail: NotifyDetail,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub same_screen: bool,
     pub focus: bool,
     pub mods: ModifierInfo,
@@ -13435,17 +13435,17 @@ impl LeaveEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (focus, remaining) = bool::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
@@ -13487,17 +13487,17 @@ pub struct FocusInEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub sourceid: DeviceId,
     pub mode: NotifyMode,
     pub detail: NotifyDetail,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub same_screen: bool,
     pub focus: bool,
     pub mods: ModifierInfo,
@@ -13512,17 +13512,17 @@ impl FocusInEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (focus, remaining) = bool::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
@@ -13564,17 +13564,17 @@ pub struct FocusOutEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub sourceid: DeviceId,
     pub mode: NotifyMode,
     pub detail: NotifyDetail,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub same_screen: bool,
     pub focus: bool,
     pub mods: ModifierInfo,
@@ -13589,17 +13589,17 @@ impl FocusOutEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (focus, remaining) = bool::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
@@ -13783,7 +13783,7 @@ pub struct HierarchyEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub flags: u32,
     pub infos: Vec<HierarchyInfo>,
 }
@@ -13795,7 +13795,7 @@ impl HierarchyEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
         let (num_infos, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
@@ -13898,8 +13898,8 @@ pub struct PropertyEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
-    pub property: ATOM,
+    pub time: Timestamp,
+    pub property: Atom,
     pub what: PropertyFlag,
 }
 impl PropertyEvent {
@@ -13910,8 +13910,8 @@ impl PropertyEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (property, remaining) = ATOM::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (property, remaining) = Atom::try_parse(remaining)?;
         let (what, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let what = what.try_into()?;
@@ -13948,7 +13948,7 @@ pub struct RawKeyPressEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -13964,7 +13964,7 @@ impl RawKeyPressEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14006,7 +14006,7 @@ pub struct RawKeyReleaseEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -14022,7 +14022,7 @@ impl RawKeyReleaseEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14064,7 +14064,7 @@ pub struct RawButtonPressEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -14080,7 +14080,7 @@ impl RawButtonPressEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14122,7 +14122,7 @@ pub struct RawButtonReleaseEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -14138,7 +14138,7 @@ impl RawButtonReleaseEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14180,7 +14180,7 @@ pub struct RawMotionEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -14196,7 +14196,7 @@ impl RawMotionEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14269,15 +14269,15 @@ pub struct TouchBeginEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -14294,15 +14294,15 @@ impl TouchBeginEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -14346,15 +14346,15 @@ pub struct TouchUpdateEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -14371,15 +14371,15 @@ impl TouchUpdateEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -14423,15 +14423,15 @@ pub struct TouchEndEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
-    pub event_x: FP1616,
-    pub event_y: FP1616,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
+    pub event_x: Fp1616,
+    pub event_y: Fp1616,
     pub sourceid: DeviceId,
     pub flags: u32,
     pub mods: ModifierInfo,
@@ -14448,15 +14448,15 @@ impl TouchEndEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
-        let (event_x, remaining) = FP1616::try_parse(remaining)?;
-        let (event_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
         let (buttons_len, remaining) = u16::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -14559,11 +14559,11 @@ pub struct TouchOwnershipEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub touchid: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub sourceid: DeviceId,
     pub flags: TouchOwnershipFlags,
 }
@@ -14575,11 +14575,11 @@ impl TouchOwnershipEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (touchid, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
@@ -14618,7 +14618,7 @@ pub struct RawTouchBeginEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -14634,7 +14634,7 @@ impl RawTouchBeginEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14676,7 +14676,7 @@ pub struct RawTouchUpdateEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -14692,7 +14692,7 @@ impl RawTouchUpdateEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14734,7 +14734,7 @@ pub struct RawTouchEndEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
     pub flags: u32,
@@ -14750,7 +14750,7 @@ impl RawTouchEndEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (detail, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let (valuators_len, remaining) = u16::try_parse(remaining)?;
@@ -14855,16 +14855,16 @@ pub struct BarrierHitEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub eventid: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub barrier: xfixes::BARRIER,
+    pub root: Window,
+    pub event: Window,
+    pub barrier: xfixes::Barrier,
     pub dtime: u32,
     pub flags: u32,
     pub sourceid: DeviceId,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
     pub dx: Fp3232,
     pub dy: Fp3232,
 }
@@ -14876,17 +14876,17 @@ impl BarrierHitEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (eventid, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (barrier, remaining) = xfixes::BARRIER::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (barrier, remaining) = xfixes::Barrier::try_parse(remaining)?;
         let (dtime, remaining) = u32::try_parse(remaining)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
         let (dx, remaining) = Fp3232::try_parse(remaining)?;
         let (dy, remaining) = Fp3232::try_parse(remaining)?;
         let result = BarrierHitEvent { response_type, extension, sequence, length, event_type, deviceid, time, eventid, root, event, barrier, dtime, flags, sourceid, root_x, root_y, dx, dy };
@@ -14922,16 +14922,16 @@ pub struct BarrierLeaveEvent {
     pub length: u32,
     pub event_type: u16,
     pub deviceid: DeviceId,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub eventid: u32,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub barrier: xfixes::BARRIER,
+    pub root: Window,
+    pub event: Window,
+    pub barrier: xfixes::Barrier,
     pub dtime: u32,
     pub flags: u32,
     pub sourceid: DeviceId,
-    pub root_x: FP1616,
-    pub root_y: FP1616,
+    pub root_x: Fp1616,
+    pub root_y: Fp1616,
     pub dx: Fp3232,
     pub dy: Fp3232,
 }
@@ -14943,17 +14943,17 @@ impl BarrierLeaveEvent {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (eventid, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (barrier, remaining) = xfixes::BARRIER::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (barrier, remaining) = xfixes::Barrier::try_parse(remaining)?;
         let (dtime, remaining) = u32::try_parse(remaining)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (root_x, remaining) = FP1616::try_parse(remaining)?;
-        let (root_y, remaining) = FP1616::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
         let (dx, remaining) = Fp3232::try_parse(remaining)?;
         let (dy, remaining) = Fp3232::try_parse(remaining)?;
         let result = BarrierLeaveEvent { response_type, extension, sequence, length, event_type, deviceid, time, eventid, root, event, barrier, dtime, flags, sourceid, root_x, root_y, dx, dy };
@@ -15178,7 +15178,7 @@ impl From<DevicePresenceNotifyEvent> for EventForSend {
 
 /// Opcode for the SendExtensionEvent request
 pub const SEND_EXTENSION_EVENT_REQUEST: u8 = 31;
-pub fn send_extension_event<'c, Conn>(conn: &'c Conn, destination: WINDOW, device_id: u8, propagate: bool, events: &[EventForSend], classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn send_extension_event<'c, Conn>(conn: &'c Conn, destination: Window, device_id: u8, propagate: bool, events: &[EventForSend], classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -15509,28 +15509,28 @@ pub trait ConnectionExt: RequestConnection {
         set_device_mode(self, device_id, mode)
     }
 
-    fn xinput_select_extension_event<'c>(&'c self, window: WINDOW, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_select_extension_event<'c>(&'c self, window: Window, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         select_extension_event(self, window, classes)
     }
 
-    fn xinput_get_selected_extension_events(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetSelectedExtensionEventsReply>, ConnectionError>
+    fn xinput_get_selected_extension_events(&self, window: Window) -> Result<Cookie<'_, Self, GetSelectedExtensionEventsReply>, ConnectionError>
     {
         get_selected_extension_events(self, window)
     }
 
-    fn xinput_change_device_dont_propagate_list<'c, A>(&'c self, window: WINDOW, mode: A, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_change_device_dont_propagate_list<'c, A>(&'c self, window: Window, mode: A, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         change_device_dont_propagate_list(self, window, mode, classes)
     }
 
-    fn xinput_get_device_dont_propagate_list(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetDeviceDontPropagateListReply>, ConnectionError>
+    fn xinput_get_device_dont_propagate_list(&self, window: Window) -> Result<Cookie<'_, Self, GetDeviceDontPropagateListReply>, ConnectionError>
     {
         get_device_dont_propagate_list(self, window)
     }
 
-    fn xinput_get_device_motion_events(&self, start: TIMESTAMP, stop: TIMESTAMP, device_id: u8) -> Result<Cookie<'_, Self, GetDeviceMotionEventsReply>, ConnectionError>
+    fn xinput_get_device_motion_events(&self, start: Timestamp, stop: Timestamp, device_id: u8) -> Result<Cookie<'_, Self, GetDeviceMotionEventsReply>, ConnectionError>
     {
         get_device_motion_events(self, start, stop, device_id)
     }
@@ -15545,40 +15545,40 @@ pub trait ConnectionExt: RequestConnection {
         change_pointer_device(self, x_axis, y_axis, device_id)
     }
 
-    fn xinput_grab_device<'c, A, B>(&'c self, grab_window: WINDOW, time: TIMESTAMP, this_device_mode: A, other_device_mode: B, owner_events: bool, device_id: u8, classes: &[EventClass]) -> Result<Cookie<'c, Self, GrabDeviceReply>, ConnectionError>
+    fn xinput_grab_device<'c, A, B>(&'c self, grab_window: Window, time: Timestamp, this_device_mode: A, other_device_mode: B, owner_events: bool, device_id: u8, classes: &[EventClass]) -> Result<Cookie<'c, Self, GrabDeviceReply>, ConnectionError>
     where A: Into<u8>, B: Into<u8>
     {
         grab_device(self, grab_window, time, this_device_mode, other_device_mode, owner_events, device_id, classes)
     }
 
-    fn xinput_ungrab_device(&self, time: TIMESTAMP, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_ungrab_device(&self, time: Timestamp, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_device(self, time, device_id)
     }
 
-    fn xinput_grab_device_key<'c, A, B>(&'c self, grab_window: WINDOW, modifiers: u16, modifier_device: u8, grabbed_device: u8, key: u8, this_device_mode: A, other_device_mode: B, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_grab_device_key<'c, A, B>(&'c self, grab_window: Window, modifiers: u16, modifier_device: u8, grabbed_device: u8, key: u8, this_device_mode: A, other_device_mode: B, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>, B: Into<u8>
     {
         grab_device_key(self, grab_window, modifiers, modifier_device, grabbed_device, key, this_device_mode, other_device_mode, owner_events, classes)
     }
 
-    fn xinput_ungrab_device_key(&self, grab_window: WINDOW, modifiers: u16, modifier_device: u8, key: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_ungrab_device_key(&self, grab_window: Window, modifiers: u16, modifier_device: u8, key: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_device_key(self, grab_window, modifiers, modifier_device, key, grabbed_device)
     }
 
-    fn xinput_grab_device_button<'c, A, B>(&'c self, grab_window: WINDOW, grabbed_device: u8, modifier_device: u8, modifiers: u16, this_device_mode: A, other_device_mode: B, button: u8, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_grab_device_button<'c, A, B>(&'c self, grab_window: Window, grabbed_device: u8, modifier_device: u8, modifiers: u16, this_device_mode: A, other_device_mode: B, button: u8, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>, B: Into<u8>
     {
         grab_device_button(self, grab_window, grabbed_device, modifier_device, modifiers, this_device_mode, other_device_mode, button, owner_events, classes)
     }
 
-    fn xinput_ungrab_device_button(&self, grab_window: WINDOW, modifiers: u16, modifier_device: u8, button: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_ungrab_device_button(&self, grab_window: Window, modifiers: u16, modifier_device: u8, button: u8, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_device_button(self, grab_window, modifiers, modifier_device, button, grabbed_device)
     }
 
-    fn xinput_allow_device_events<A>(&self, time: TIMESTAMP, mode: A, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_allow_device_events<A>(&self, time: Timestamp, mode: A, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         allow_device_events(self, time, mode, device_id)
@@ -15589,7 +15589,7 @@ pub trait ConnectionExt: RequestConnection {
         get_device_focus(self, device_id)
     }
 
-    fn xinput_set_device_focus<A>(&self, focus: WINDOW, time: TIMESTAMP, revert_to: A, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_set_device_focus<A>(&self, focus: Window, time: Timestamp, revert_to: A, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         set_device_focus(self, focus, time, revert_to, device_id)
@@ -15610,7 +15610,7 @@ pub trait ConnectionExt: RequestConnection {
         get_device_key_mapping(self, device_id, first_keycode, count)
     }
 
-    fn xinput_change_device_key_mapping<'c>(&'c self, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &[KEYSYM]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_change_device_key_mapping<'c>(&'c self, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &[Keysym]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_device_key_mapping(self, device_id, first_keycode, keysyms_per_keycode, keycode_count, keysyms)
     }
@@ -15667,33 +15667,33 @@ pub trait ConnectionExt: RequestConnection {
         list_device_properties(self, device_id)
     }
 
-    fn xinput_change_device_property<'c, A>(&'c self, property: ATOM, type_: ATOM, device_id: u8, mode: A, num_items: u32, items: &ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_change_device_property<'c, A>(&'c self, property: Atom, type_: Atom, device_id: u8, mode: A, num_items: u32, items: &ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         change_device_property(self, property, type_, device_id, mode, num_items, items)
     }
 
-    fn xinput_delete_device_property(&self, property: ATOM, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_delete_device_property(&self, property: Atom, device_id: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_device_property(self, property, device_id)
     }
 
-    fn xinput_get_device_property(&self, property: ATOM, type_: ATOM, offset: u32, len: u32, device_id: u8, delete: bool) -> Result<Cookie<'_, Self, GetDevicePropertyReply>, ConnectionError>
+    fn xinput_get_device_property(&self, property: Atom, type_: Atom, offset: u32, len: u32, device_id: u8, delete: bool) -> Result<Cookie<'_, Self, GetDevicePropertyReply>, ConnectionError>
     {
         get_device_property(self, property, type_, offset, len, device_id, delete)
     }
 
-    fn xinput_xi_query_pointer(&self, window: WINDOW, deviceid: DeviceId) -> Result<Cookie<'_, Self, XIQueryPointerReply>, ConnectionError>
+    fn xinput_xi_query_pointer(&self, window: Window, deviceid: DeviceId) -> Result<Cookie<'_, Self, XIQueryPointerReply>, ConnectionError>
     {
         xi_query_pointer(self, window, deviceid)
     }
 
-    fn xinput_xi_warp_pointer(&self, src_win: WINDOW, dst_win: WINDOW, src_x: FP1616, src_y: FP1616, src_width: u16, src_height: u16, dst_x: FP1616, dst_y: FP1616, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_xi_warp_pointer(&self, src_win: Window, dst_win: Window, src_x: Fp1616, src_y: Fp1616, src_width: u16, src_height: u16, dst_x: Fp1616, dst_y: Fp1616, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         xi_warp_pointer(self, src_win, dst_win, src_x, src_y, src_width, src_height, dst_x, dst_y, deviceid)
     }
 
-    fn xinput_xi_change_cursor(&self, window: WINDOW, cursor: CURSOR, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_xi_change_cursor(&self, window: Window, cursor: Cursor, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         xi_change_cursor(self, window, cursor, deviceid)
     }
@@ -15703,17 +15703,17 @@ pub trait ConnectionExt: RequestConnection {
         xi_change_hierarchy(self, changes)
     }
 
-    fn xinput_xi_set_client_pointer(&self, window: WINDOW, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_xi_set_client_pointer(&self, window: Window, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         xi_set_client_pointer(self, window, deviceid)
     }
 
-    fn xinput_xi_get_client_pointer(&self, window: WINDOW) -> Result<Cookie<'_, Self, XIGetClientPointerReply>, ConnectionError>
+    fn xinput_xi_get_client_pointer(&self, window: Window) -> Result<Cookie<'_, Self, XIGetClientPointerReply>, ConnectionError>
     {
         xi_get_client_pointer(self, window)
     }
 
-    fn xinput_xi_select_events<'c>(&'c self, window: WINDOW, masks: &[EventMask]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_select_events<'c>(&'c self, window: Window, masks: &[EventMask]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         xi_select_events(self, window, masks)
     }
@@ -15728,7 +15728,7 @@ pub trait ConnectionExt: RequestConnection {
         xi_query_device(self, deviceid)
     }
 
-    fn xinput_xi_set_focus(&self, window: WINDOW, time: TIMESTAMP, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_xi_set_focus(&self, window: Window, time: Timestamp, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         xi_set_focus(self, window, time, deviceid)
     }
@@ -15738,30 +15738,30 @@ pub trait ConnectionExt: RequestConnection {
         xi_get_focus(self, deviceid)
     }
 
-    fn xinput_xi_grab_device<'c, A, B, C>(&'c self, window: WINDOW, time: TIMESTAMP, cursor: CURSOR, deviceid: DeviceId, mode: A, paired_device_mode: B, owner_events: C, mask: &[u32]) -> Result<Cookie<'c, Self, XIGrabDeviceReply>, ConnectionError>
+    fn xinput_xi_grab_device<'c, A, B, C>(&'c self, window: Window, time: Timestamp, cursor: Cursor, deviceid: DeviceId, mode: A, paired_device_mode: B, owner_events: C, mask: &[u32]) -> Result<Cookie<'c, Self, XIGrabDeviceReply>, ConnectionError>
     where A: Into<u8>, B: Into<u8>, C: Into<bool>
     {
         xi_grab_device(self, window, time, cursor, deviceid, mode, paired_device_mode, owner_events, mask)
     }
 
-    fn xinput_xi_ungrab_device(&self, time: TIMESTAMP, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_xi_ungrab_device(&self, time: Timestamp, deviceid: DeviceId) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         xi_ungrab_device(self, time, deviceid)
     }
 
-    fn xinput_xi_allow_events<A>(&self, time: TIMESTAMP, deviceid: DeviceId, event_mode: A, touchid: u32, grab_window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_xi_allow_events<A>(&self, time: Timestamp, deviceid: DeviceId, event_mode: A, touchid: u32, grab_window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         xi_allow_events(self, time, deviceid, event_mode, touchid, grab_window)
     }
 
-    fn xinput_xi_passive_grab_device<'c, A, B, C, D>(&'c self, time: TIMESTAMP, grab_window: WINDOW, cursor: CURSOR, detail: u32, deviceid: DeviceId, grab_type: A, grab_mode: B, paired_device_mode: C, owner_events: D, mask: &[u32], modifiers: &[u32]) -> Result<Cookie<'c, Self, XIPassiveGrabDeviceReply>, ConnectionError>
+    fn xinput_xi_passive_grab_device<'c, A, B, C, D>(&'c self, time: Timestamp, grab_window: Window, cursor: Cursor, detail: u32, deviceid: DeviceId, grab_type: A, grab_mode: B, paired_device_mode: C, owner_events: D, mask: &[u32], modifiers: &[u32]) -> Result<Cookie<'c, Self, XIPassiveGrabDeviceReply>, ConnectionError>
     where A: Into<u8>, B: Into<u8>, C: Into<u8>, D: Into<bool>
     {
         xi_passive_grab_device(self, time, grab_window, cursor, detail, deviceid, grab_type, grab_mode, paired_device_mode, owner_events, mask, modifiers)
     }
 
-    fn xinput_xi_passive_ungrab_device<'c, A>(&'c self, grab_window: WINDOW, detail: u32, deviceid: DeviceId, grab_type: A, modifiers: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_passive_ungrab_device<'c, A>(&'c self, grab_window: Window, detail: u32, deviceid: DeviceId, grab_type: A, modifiers: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         xi_passive_ungrab_device(self, grab_window, detail, deviceid, grab_type, modifiers)
@@ -15772,23 +15772,23 @@ pub trait ConnectionExt: RequestConnection {
         xi_list_properties(self, deviceid)
     }
 
-    fn xinput_xi_change_property<'c, A>(&'c self, deviceid: DeviceId, mode: A, property: ATOM, type_: ATOM, num_items: u32, items: &XIChangePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_change_property<'c, A>(&'c self, deviceid: DeviceId, mode: A, property: Atom, type_: Atom, num_items: u32, items: &XIChangePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         xi_change_property(self, deviceid, mode, property, type_, num_items, items)
     }
 
-    fn xinput_xi_delete_property(&self, deviceid: DeviceId, property: ATOM) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_xi_delete_property(&self, deviceid: DeviceId, property: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         xi_delete_property(self, deviceid, property)
     }
 
-    fn xinput_xi_get_property(&self, deviceid: DeviceId, delete: bool, property: ATOM, type_: ATOM, offset: u32, len: u32) -> Result<Cookie<'_, Self, XIGetPropertyReply>, ConnectionError>
+    fn xinput_xi_get_property(&self, deviceid: DeviceId, delete: bool, property: Atom, type_: Atom, offset: u32, len: u32) -> Result<Cookie<'_, Self, XIGetPropertyReply>, ConnectionError>
     {
         xi_get_property(self, deviceid, delete, property, type_, offset, len)
     }
 
-    fn xinput_xi_get_selected_events(&self, window: WINDOW) -> Result<Cookie<'_, Self, XIGetSelectedEventsReply>, ConnectionError>
+    fn xinput_xi_get_selected_events(&self, window: Window) -> Result<Cookie<'_, Self, XIGetSelectedEventsReply>, ConnectionError>
     {
         xi_get_selected_events(self, window)
     }
@@ -15798,7 +15798,7 @@ pub trait ConnectionExt: RequestConnection {
         xi_barrier_release_pointer(self, barriers)
     }
 
-    fn xinput_send_extension_event<'c>(&'c self, destination: WINDOW, device_id: u8, propagate: bool, events: &[EventForSend], classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_send_extension_event<'c>(&'c self, destination: Window, device_id: u8, propagate: bool, events: &[EventForSend], classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         send_extension_event(self, destination, device_id, propagate, events, classes)
     }

--- a/src/generated/xkb.rs
+++ b/src/generated/xkb.rs
@@ -2778,7 +2778,7 @@ pub struct KeySymMap {
     pub kt_index: [u8; 4],
     pub group_info: u8,
     pub width: u8,
-    pub syms: Vec<KEYSYM>,
+    pub syms: Vec<Keysym>,
 }
 impl TryParse for KeySymMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2795,7 +2795,7 @@ impl TryParse for KeySymMap {
         let (group_info, remaining) = u8::try_parse(remaining)?;
         let (width, remaining) = u8::try_parse(remaining)?;
         let (n_syms, remaining) = u16::try_parse(remaining)?;
-        let (syms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, n_syms as usize)?;
+        let (syms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, n_syms as usize)?;
         let result = KeySymMap { kt_index, group_info, width, syms };
         Ok((result, remaining))
     }
@@ -2967,12 +2967,12 @@ impl Serialize for RadioGroupBehavior {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OverlayBehavior {
     pub type_: u8,
-    pub key: KEYCODE,
+    pub key: Keycode,
 }
 impl TryParse for OverlayBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (key, remaining) = Keycode::try_parse(remaining)?;
         let result = OverlayBehavior { type_, key };
         Ok((result, remaining))
     }
@@ -3073,12 +3073,12 @@ impl Serialize for PermamentRadioGroupBehavior {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PermamentOverlayBehavior {
     pub type_: u8,
-    pub key: KEYCODE,
+    pub key: Keycode,
 }
 impl TryParse for PermamentOverlayBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (key, remaining) = Keycode::try_parse(remaining)?;
         let result = PermamentOverlayBehavior { type_, key };
         Ok((result, remaining))
     }
@@ -3332,12 +3332,12 @@ impl TryFrom<u32> for BehaviorType {
 
 #[derive(Debug, Clone, Copy)]
 pub struct SetBehavior {
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub behavior: Behavior,
 }
 impl TryParse for SetBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let (behavior, remaining) = Behavior::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = SetBehavior { keycode, behavior };
@@ -3372,12 +3372,12 @@ impl Serialize for SetBehavior {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetExplicit {
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub explicit: u8,
 }
 impl TryParse for SetExplicit {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let (explicit, remaining) = u8::try_parse(remaining)?;
         let result = SetExplicit { keycode, explicit };
         Ok((result, remaining))
@@ -3408,12 +3408,12 @@ impl Serialize for SetExplicit {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyModMap {
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub mods: u8,
 }
 impl TryParse for KeyModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let result = KeyModMap { keycode, mods };
         Ok((result, remaining))
@@ -3444,12 +3444,12 @@ impl Serialize for KeyModMap {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyVModMap {
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub vmods: u16,
 }
 impl TryParse for KeyVModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (vmods, remaining) = u16::try_parse(remaining)?;
         let result = KeyVModMap { keycode, vmods };
@@ -3577,7 +3577,7 @@ impl Serialize for SetKeyType {
     }
 }
 
-pub type STRING8 = u8;
+pub type String8 = u8;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Outline {
@@ -3619,14 +3619,14 @@ impl Serialize for Outline {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Shape {
-    pub name: ATOM,
+    pub name: Atom,
     pub primary_ndx: u8,
     pub approx_ndx: u8,
     pub outlines: Vec<Outline>,
 }
 impl TryParse for Shape {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (name, remaining) = Atom::try_parse(remaining)?;
         let (n_outlines, remaining) = u8::try_parse(remaining)?;
         let (primary_ndx, remaining) = u8::try_parse(remaining)?;
         let (approx_ndx, remaining) = u8::try_parse(remaining)?;
@@ -3663,17 +3663,17 @@ impl Serialize for Shape {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Key {
-    pub name: [STRING8; 4],
+    pub name: [String8; 4],
     pub gap: i16,
     pub shape_ndx: u8,
     pub color_ndx: u8,
 }
 impl TryParse for Key {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name_0, remaining) = STRING8::try_parse(remaining)?;
-        let (name_1, remaining) = STRING8::try_parse(remaining)?;
-        let (name_2, remaining) = STRING8::try_parse(remaining)?;
-        let (name_3, remaining) = STRING8::try_parse(remaining)?;
+        let (name_0, remaining) = String8::try_parse(remaining)?;
+        let (name_1, remaining) = String8::try_parse(remaining)?;
+        let (name_2, remaining) = String8::try_parse(remaining)?;
+        let (name_3, remaining) = String8::try_parse(remaining)?;
         let name = [
             name_0,
             name_1,
@@ -3721,25 +3721,25 @@ impl Serialize for Key {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OverlayKey {
-    pub over: [STRING8; 4],
-    pub under: [STRING8; 4],
+    pub over: [String8; 4],
+    pub under: [String8; 4],
 }
 impl TryParse for OverlayKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (over_0, remaining) = STRING8::try_parse(remaining)?;
-        let (over_1, remaining) = STRING8::try_parse(remaining)?;
-        let (over_2, remaining) = STRING8::try_parse(remaining)?;
-        let (over_3, remaining) = STRING8::try_parse(remaining)?;
+        let (over_0, remaining) = String8::try_parse(remaining)?;
+        let (over_1, remaining) = String8::try_parse(remaining)?;
+        let (over_2, remaining) = String8::try_parse(remaining)?;
+        let (over_3, remaining) = String8::try_parse(remaining)?;
         let over = [
             over_0,
             over_1,
             over_2,
             over_3,
         ];
-        let (under_0, remaining) = STRING8::try_parse(remaining)?;
-        let (under_1, remaining) = STRING8::try_parse(remaining)?;
-        let (under_2, remaining) = STRING8::try_parse(remaining)?;
-        let (under_3, remaining) = STRING8::try_parse(remaining)?;
+        let (under_0, remaining) = String8::try_parse(remaining)?;
+        let (under_1, remaining) = String8::try_parse(remaining)?;
+        let (under_2, remaining) = String8::try_parse(remaining)?;
+        let (under_3, remaining) = String8::try_parse(remaining)?;
         let under = [
             under_0,
             under_1,
@@ -3817,12 +3817,12 @@ impl Serialize for OverlayRow {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Overlay {
-    pub name: ATOM,
+    pub name: Atom,
     pub rows: Vec<OverlayRow>,
 }
 impl TryParse for Overlay {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (name, remaining) = Atom::try_parse(remaining)?;
         let (n_rows, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let (rows, remaining) = crate::x11_utils::parse_list::<OverlayRow>(remaining, n_rows as usize)?;
@@ -3971,14 +3971,14 @@ impl TryFrom<u32> for DoodadType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Listing {
     pub flags: u16,
-    pub string: Vec<STRING8>,
+    pub string: Vec<String8>,
 }
 impl TryParse for Listing {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
         let (flags, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, length as usize)?;
+        let (string, remaining) = crate::x11_utils::parse_list::<String8>(remaining, length as usize)?;
         // Align offset to multiple of 2
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (2 - (offset % 2)) % 2;
@@ -4018,7 +4018,7 @@ pub struct DeviceLedInfo {
     pub maps_present: u32,
     pub phys_indicators: u32,
     pub state: u32,
-    pub names: Vec<ATOM>,
+    pub names: Vec<Atom>,
     pub maps: Vec<IndicatorMap>,
 }
 impl TryParse for DeviceLedInfo {
@@ -4029,7 +4029,7 @@ impl TryParse for DeviceLedInfo {
         let (maps_present, remaining) = u32::try_parse(remaining)?;
         let (phys_indicators, remaining) = u32::try_parse(remaining)?;
         let (state, remaining) = u32::try_parse(remaining)?;
-        let (names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(names_present.count_ones()).unwrap())?;
+        let (names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(names_present.count_ones()).unwrap())?;
         let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, TryInto::<usize>::try_into(maps_present.count_ones()).unwrap())?;
         let led_class = led_class.try_into()?;
         let result = DeviceLedInfo { led_class, led_id, names_present, maps_present, phys_indicators, state, names, maps };
@@ -5788,7 +5788,7 @@ impl Serialize for SAActionMessage {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SARedirectKey {
     pub type_: SAType,
-    pub newkey: KEYCODE,
+    pub newkey: Keycode,
     pub mask: u8,
     pub real_modifiers: u8,
     pub vmods_mask_high: u8,
@@ -5799,7 +5799,7 @@ pub struct SARedirectKey {
 impl TryParse for SARedirectKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (newkey, remaining) = KEYCODE::try_parse(remaining)?;
+        let (newkey, remaining) = Keycode::try_parse(remaining)?;
         let (mask, remaining) = u8::try_parse(remaining)?;
         let (real_modifiers, remaining) = u8::try_parse(remaining)?;
         let (vmods_mask_high, remaining) = u8::try_parse(remaining)?;
@@ -6229,7 +6229,7 @@ impl Serialize for SIAction {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SymInterpret {
-    pub sym: KEYSYM,
+    pub sym: Keysym,
     pub mods: u8,
     pub match_: u8,
     pub virtual_mod: u8,
@@ -6238,7 +6238,7 @@ pub struct SymInterpret {
 }
 impl TryParse for SymInterpret {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (sym, remaining) = KEYSYM::try_parse(remaining)?;
+        let (sym, remaining) = Keysym::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let (match_, remaining) = u8::try_parse(remaining)?;
         let (virtual_mod, remaining) = u8::try_parse(remaining)?;
@@ -7097,7 +7097,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 3;
-pub fn bell<Conn>(conn: &Conn, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: ATOM, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn bell<Conn>(conn: &Conn, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: Atom, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7553,7 +7553,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetMap request
 pub const GET_MAP_REQUEST: u8 = 8;
-pub fn get_map<Conn>(conn: &Conn, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: KEYCODE, n_key_syms: u8, first_key_action: KEYCODE, n_key_actions: u8, first_key_behavior: KEYCODE, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: KEYCODE, n_key_explicit: u8, first_mod_map_key: KEYCODE, n_mod_map_keys: u8, first_v_mod_map_key: KEYCODE, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
+pub fn get_map<Conn>(conn: &Conn, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, first_key_action: Keycode, n_key_actions: u8, first_key_behavior: Keycode, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: Keycode, n_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7747,28 +7747,28 @@ pub struct GetMapReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub min_key_code: KEYCODE,
-    pub max_key_code: KEYCODE,
+    pub min_key_code: Keycode,
+    pub max_key_code: Keycode,
     pub present: u16,
     pub first_type: u8,
     pub n_types: u8,
     pub total_types: u8,
-    pub first_key_sym: KEYCODE,
+    pub first_key_sym: Keycode,
     pub total_syms: u16,
     pub n_key_syms: u8,
-    pub first_key_action: KEYCODE,
+    pub first_key_action: Keycode,
     pub total_actions: u16,
     pub n_key_actions: u8,
-    pub first_key_behavior: KEYCODE,
+    pub first_key_behavior: Keycode,
     pub n_key_behaviors: u8,
     pub total_key_behaviors: u8,
-    pub first_key_explicit: KEYCODE,
+    pub first_key_explicit: Keycode,
     pub n_key_explicit: u8,
     pub total_key_explicit: u8,
-    pub first_mod_map_key: KEYCODE,
+    pub first_mod_map_key: Keycode,
     pub n_mod_map_keys: u8,
     pub total_mod_map_keys: u8,
-    pub first_v_mod_map_key: KEYCODE,
+    pub first_v_mod_map_key: Keycode,
     pub n_v_mod_map_keys: u8,
     pub total_v_mod_map_keys: u8,
     pub virtual_mods: u16,
@@ -7781,28 +7781,28 @@ impl GetMapReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
-        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
         let (present, remaining) = u16::try_parse(remaining)?;
         let (first_type, remaining) = u8::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
         let (total_types, remaining) = u8::try_parse(remaining)?;
-        let (first_key_sym, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_sym, remaining) = Keycode::try_parse(remaining)?;
         let (total_syms, remaining) = u16::try_parse(remaining)?;
         let (n_key_syms, remaining) = u8::try_parse(remaining)?;
-        let (first_key_action, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_action, remaining) = Keycode::try_parse(remaining)?;
         let (total_actions, remaining) = u16::try_parse(remaining)?;
         let (n_key_actions, remaining) = u8::try_parse(remaining)?;
-        let (first_key_behavior, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_behavior, remaining) = Keycode::try_parse(remaining)?;
         let (n_key_behaviors, remaining) = u8::try_parse(remaining)?;
         let (total_key_behaviors, remaining) = u8::try_parse(remaining)?;
-        let (first_key_explicit, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_explicit, remaining) = Keycode::try_parse(remaining)?;
         let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
         let (total_key_explicit, remaining) = u8::try_parse(remaining)?;
-        let (first_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
         let (n_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (total_mod_map_keys, remaining) = u8::try_parse(remaining)?;
-        let (first_v_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_v_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
         let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (total_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
@@ -7960,7 +7960,7 @@ impl Serialize for SetMapAux {
         }
     }
 }
-pub fn set_map<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, flags: u16, min_key_code: KEYCODE, max_key_code: KEYCODE, first_type: u8, n_types: u8, first_key_sym: KEYCODE, n_key_syms: u8, total_syms: u16, first_key_action: KEYCODE, n_key_actions: u8, total_actions: u16, first_key_behavior: KEYCODE, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: KEYCODE, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: KEYCODE, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: KEYCODE, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_map<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, flags: u16, min_key_code: Keycode, max_key_code: Keycode, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, total_syms: u16, first_key_action: Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8306,7 +8306,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetNamedIndicator request
 pub const GET_NAMED_INDICATOR_REQUEST: u8 = 15;
-pub fn get_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: ATOM) -> Result<Cookie<'_, Conn, GetNamedIndicatorReply>, ConnectionError>
+pub fn get_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom) -> Result<Cookie<'_, Conn, GetNamedIndicatorReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<LedClassSpec>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8346,7 +8346,7 @@ pub struct GetNamedIndicatorReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub indicator: ATOM,
+    pub indicator: Atom,
     pub found: bool,
     pub on: bool,
     pub real_indicator: bool,
@@ -8367,7 +8367,7 @@ impl GetNamedIndicatorReply {
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (indicator, remaining) = ATOM::try_parse(remaining)?;
+        let (indicator, remaining) = Atom::try_parse(remaining)?;
         let (found, remaining) = bool::try_parse(remaining)?;
         let (on, remaining) = bool::try_parse(remaining)?;
         let (real_indicator, remaining) = bool::try_parse(remaining)?;
@@ -8395,7 +8395,7 @@ impl TryFrom<&[u8]> for GetNamedIndicatorReply {
 
 /// Opcode for the SetNamedIndicator request
 pub const SET_NAMED_INDICATOR_REQUEST: u8 = 16;
-pub fn set_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: ATOM, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<LedClassSpec>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8489,7 +8489,7 @@ where Conn: RequestConnection + ?Sized
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetNamesValueListBitcase8 {
     pub n_levels_per_type: Vec<u8>,
-    pub kt_level_names: Vec<ATOM>,
+    pub kt_level_names: Vec<Atom>,
 }
 impl GetNamesValueListBitcase8 {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -8499,7 +8499,7 @@ impl GetNamesValueListBitcase8 {
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_levels_per_type.iter().map(|x| TryInto::<usize>::try_into(*x).unwrap()).sum())?;
+        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, n_levels_per_type.iter().map(|x| TryInto::<usize>::try_into(*x).unwrap()).sum())?;
         let result = GetNamesValueListBitcase8 { n_levels_per_type, kt_level_names };
         Ok((result, remaining))
     }
@@ -8521,27 +8521,27 @@ impl Serialize for GetNamesValueListBitcase8 {
 }
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GetNamesValueList {
-    pub keycodes_name: Option<ATOM>,
-    pub geometry_name: Option<ATOM>,
-    pub symbols_name: Option<ATOM>,
-    pub phys_symbols_name: Option<ATOM>,
-    pub types_name: Option<ATOM>,
-    pub compat_name: Option<ATOM>,
-    pub type_names: Option<Vec<ATOM>>,
+    pub keycodes_name: Option<Atom>,
+    pub geometry_name: Option<Atom>,
+    pub symbols_name: Option<Atom>,
+    pub phys_symbols_name: Option<Atom>,
+    pub types_name: Option<Atom>,
+    pub compat_name: Option<Atom>,
+    pub type_names: Option<Vec<Atom>>,
     pub bitcase8: Option<GetNamesValueListBitcase8>,
-    pub indicator_names: Option<Vec<ATOM>>,
-    pub virtual_mod_names: Option<Vec<ATOM>>,
-    pub groups: Option<Vec<ATOM>>,
+    pub indicator_names: Option<Vec<Atom>>,
+    pub virtual_mod_names: Option<Vec<Atom>>,
+    pub groups: Option<Vec<Atom>>,
     pub key_names: Option<Vec<KeyName>>,
     pub key_aliases: Option<Vec<KeyAlias>>,
-    pub radio_group_names: Option<Vec<ATOM>>,
+    pub radio_group_names: Option<Vec<Atom>>,
 }
 impl GetNamesValueList {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
         let mut outer_remaining = value;
         let keycodes_name = if which & Into::<u32>::into(NameDetail::Keycodes) != 0 {
             let remaining = outer_remaining;
-            let (keycodes_name, remaining) = ATOM::try_parse(remaining)?;
+            let (keycodes_name, remaining) = Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(keycodes_name)
         } else {
@@ -8549,7 +8549,7 @@ impl GetNamesValueList {
         };
         let geometry_name = if which & Into::<u32>::into(NameDetail::Geometry) != 0 {
             let remaining = outer_remaining;
-            let (geometry_name, remaining) = ATOM::try_parse(remaining)?;
+            let (geometry_name, remaining) = Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(geometry_name)
         } else {
@@ -8557,7 +8557,7 @@ impl GetNamesValueList {
         };
         let symbols_name = if which & Into::<u32>::into(NameDetail::Symbols) != 0 {
             let remaining = outer_remaining;
-            let (symbols_name, remaining) = ATOM::try_parse(remaining)?;
+            let (symbols_name, remaining) = Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(symbols_name)
         } else {
@@ -8565,7 +8565,7 @@ impl GetNamesValueList {
         };
         let phys_symbols_name = if which & Into::<u32>::into(NameDetail::PhysSymbols) != 0 {
             let remaining = outer_remaining;
-            let (phys_symbols_name, remaining) = ATOM::try_parse(remaining)?;
+            let (phys_symbols_name, remaining) = Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(phys_symbols_name)
         } else {
@@ -8573,7 +8573,7 @@ impl GetNamesValueList {
         };
         let types_name = if which & Into::<u32>::into(NameDetail::Types) != 0 {
             let remaining = outer_remaining;
-            let (types_name, remaining) = ATOM::try_parse(remaining)?;
+            let (types_name, remaining) = Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(types_name)
         } else {
@@ -8581,7 +8581,7 @@ impl GetNamesValueList {
         };
         let compat_name = if which & Into::<u32>::into(NameDetail::Compat) != 0 {
             let remaining = outer_remaining;
-            let (compat_name, remaining) = ATOM::try_parse(remaining)?;
+            let (compat_name, remaining) = Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(compat_name)
         } else {
@@ -8589,7 +8589,7 @@ impl GetNamesValueList {
         };
         let type_names = if which & Into::<u32>::into(NameDetail::KeyTypeNames) != 0 {
             let remaining = outer_remaining;
-            let (type_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_types as usize)?;
+            let (type_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, n_types as usize)?;
             outer_remaining = remaining;
             Some(type_names)
         } else {
@@ -8604,7 +8604,7 @@ impl GetNamesValueList {
         };
         let indicator_names = if which & Into::<u32>::into(NameDetail::IndicatorNames) != 0 {
             let remaining = outer_remaining;
-            let (indicator_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(indicators.count_ones()).unwrap())?;
+            let (indicator_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(indicators.count_ones()).unwrap())?;
             outer_remaining = remaining;
             Some(indicator_names)
         } else {
@@ -8612,7 +8612,7 @@ impl GetNamesValueList {
         };
         let virtual_mod_names = if which & Into::<u32>::into(NameDetail::VirtualModNames) != 0 {
             let remaining = outer_remaining;
-            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
+            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
             outer_remaining = remaining;
             Some(virtual_mod_names)
         } else {
@@ -8620,7 +8620,7 @@ impl GetNamesValueList {
         };
         let groups = if which & Into::<u32>::into(NameDetail::GroupNames) != 0 {
             let remaining = outer_remaining;
-            let (groups, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, TryInto::<usize>::try_into(group_names.count_ones()).unwrap())?;
+            let (groups, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(group_names.count_ones()).unwrap())?;
             outer_remaining = remaining;
             Some(groups)
         } else {
@@ -8644,7 +8644,7 @@ impl GetNamesValueList {
         };
         let radio_group_names = if which & Into::<u32>::into(NameDetail::RGNames) != 0 {
             let remaining = outer_remaining;
-            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, n_radio_groups as usize)?;
+            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, n_radio_groups as usize)?;
             outer_remaining = remaining;
             Some(radio_group_names)
         } else {
@@ -8661,12 +8661,12 @@ pub struct GetNamesReply {
     pub sequence: u16,
     pub length: u32,
     pub which: u32,
-    pub min_key_code: KEYCODE,
-    pub max_key_code: KEYCODE,
+    pub min_key_code: Keycode,
+    pub max_key_code: Keycode,
     pub n_types: u8,
     pub group_names: u8,
     pub virtual_mods: u16,
-    pub first_key: KEYCODE,
+    pub first_key: Keycode,
     pub n_keys: u8,
     pub indicators: u32,
     pub n_radio_groups: u8,
@@ -8681,12 +8681,12 @@ impl GetNamesReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let (which, remaining) = u32::try_parse(remaining)?;
-        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
-        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
         let (group_names, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
-        let (first_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key, remaining) = Keycode::try_parse(remaining)?;
         let (n_keys, remaining) = u8::try_parse(remaining)?;
         let (indicators, remaining) = u32::try_parse(remaining)?;
         let (n_radio_groups, remaining) = u8::try_parse(remaining)?;
@@ -8710,7 +8710,7 @@ pub const SET_NAMES_REQUEST: u8 = 18;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetNamesAuxBitcase8 {
     pub n_levels_per_type: Vec<u8>,
-    pub kt_level_names: Vec<ATOM>,
+    pub kt_level_names: Vec<Atom>,
 }
 impl Serialize for SetNamesAuxBitcase8 {
     type Bytes = Vec<u8>;
@@ -8729,20 +8729,20 @@ impl Serialize for SetNamesAuxBitcase8 {
 /// Auxiliary and optional information for the set_names function.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SetNamesAux {
-    pub keycodes_name: Option<ATOM>,
-    pub geometry_name: Option<ATOM>,
-    pub symbols_name: Option<ATOM>,
-    pub phys_symbols_name: Option<ATOM>,
-    pub types_name: Option<ATOM>,
-    pub compat_name: Option<ATOM>,
-    pub type_names: Option<Vec<ATOM>>,
+    pub keycodes_name: Option<Atom>,
+    pub geometry_name: Option<Atom>,
+    pub symbols_name: Option<Atom>,
+    pub phys_symbols_name: Option<Atom>,
+    pub types_name: Option<Atom>,
+    pub compat_name: Option<Atom>,
+    pub type_names: Option<Vec<Atom>>,
     pub bitcase8: Option<SetNamesAuxBitcase8>,
-    pub indicator_names: Option<Vec<ATOM>>,
-    pub virtual_mod_names: Option<Vec<ATOM>>,
-    pub groups: Option<Vec<ATOM>>,
+    pub indicator_names: Option<Vec<Atom>>,
+    pub virtual_mod_names: Option<Vec<Atom>>,
+    pub groups: Option<Vec<Atom>>,
     pub key_names: Option<Vec<KeyName>>,
     pub key_aliases: Option<Vec<KeyAlias>>,
-    pub radio_group_names: Option<Vec<ATOM>>,
+    pub radio_group_names: Option<Vec<Atom>>,
 }
 impl SetNamesAux {
     /// Create a new instance with all fields unset / not present.
@@ -8796,37 +8796,37 @@ impl SetNamesAux {
         mask
     }
     /// Set the keycodesName field of this structure.
-    pub fn keycodes_name<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn keycodes_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.keycodes_name = value.into();
         self
     }
     /// Set the geometryName field of this structure.
-    pub fn geometry_name<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn geometry_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.geometry_name = value.into();
         self
     }
     /// Set the symbolsName field of this structure.
-    pub fn symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.symbols_name = value.into();
         self
     }
     /// Set the physSymbolsName field of this structure.
-    pub fn phys_symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn phys_symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.phys_symbols_name = value.into();
         self
     }
     /// Set the typesName field of this structure.
-    pub fn types_name<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn types_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.types_name = value.into();
         self
     }
     /// Set the compatName field of this structure.
-    pub fn compat_name<I>(mut self, value: I) -> Self where I: Into<Option<ATOM>> {
+    pub fn compat_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
         self.compat_name = value.into();
         self
     }
     /// Set the typeNames field of this structure.
-    pub fn type_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<ATOM>>> {
+    pub fn type_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
         self.type_names = value.into();
         self
     }
@@ -8836,17 +8836,17 @@ impl SetNamesAux {
         self
     }
     /// Set the indicatorNames field of this structure.
-    pub fn indicator_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<ATOM>>> {
+    pub fn indicator_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
         self.indicator_names = value.into();
         self
     }
     /// Set the virtualModNames field of this structure.
-    pub fn virtual_mod_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<ATOM>>> {
+    pub fn virtual_mod_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
         self.virtual_mod_names = value.into();
         self
     }
     /// Set the groups field of this structure.
-    pub fn groups<I>(mut self, value: I) -> Self where I: Into<Option<Vec<ATOM>>> {
+    pub fn groups<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
         self.groups = value.into();
         self
     }
@@ -8861,7 +8861,7 @@ impl SetNamesAux {
         self
     }
     /// Set the radioGroupNames field of this structure.
-    pub fn radio_group_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<ATOM>>> {
+    pub fn radio_group_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
         self.radio_group_names = value.into();
         self
     }
@@ -8918,7 +8918,7 @@ impl Serialize for SetNamesAux {
         }
     }
 }
-pub fn set_names<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: KEYCODE, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_names<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -9190,8 +9190,8 @@ pub struct GetDeviceInfoReply {
     pub has_own_state: bool,
     pub dflt_kbd_fb: u16,
     pub dflt_led_fb: u16,
-    pub dev_type: ATOM,
-    pub name: Vec<STRING8>,
+    pub dev_type: Atom,
+    pub name: Vec<String8>,
     pub btn_actions: Vec<Action>,
     pub leds: Vec<DeviceLedInfo>,
 }
@@ -9215,9 +9215,9 @@ impl GetDeviceInfoReply {
         let (dflt_kbd_fb, remaining) = u16::try_parse(remaining)?;
         let (dflt_led_fb, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (dev_type, remaining) = ATOM::try_parse(remaining)?;
+        let (dev_type, remaining) = Atom::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<String8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -9278,7 +9278,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetDebuggingFlags request
 pub const SET_DEBUGGING_FLAGS_REQUEST: u8 = 101;
-pub fn set_debugging_flags<'c, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &[STRING8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>
+pub fn set_debugging_flags<'c, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &[String8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -9363,13 +9363,13 @@ pub struct NewKeyboardNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub old_device_id: u8,
-    pub min_key_code: KEYCODE,
-    pub max_key_code: KEYCODE,
-    pub old_min_key_code: KEYCODE,
-    pub old_max_key_code: KEYCODE,
+    pub min_key_code: Keycode,
+    pub max_key_code: Keycode,
+    pub old_min_key_code: Keycode,
+    pub old_max_key_code: Keycode,
     pub request_major: u8,
     pub request_minor: u8,
     pub changed: u16,
@@ -9379,13 +9379,13 @@ impl NewKeyboardNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (old_device_id, remaining) = u8::try_parse(remaining)?;
-        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
-        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
-        let (old_min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
-        let (old_max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (old_min_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (old_max_key_code, remaining) = Keycode::try_parse(remaining)?;
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
@@ -9446,25 +9446,25 @@ pub struct MapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub ptr_btn_actions: u8,
     pub changed: u16,
-    pub min_key_code: KEYCODE,
-    pub max_key_code: KEYCODE,
+    pub min_key_code: Keycode,
+    pub max_key_code: Keycode,
     pub first_type: u8,
     pub n_types: u8,
-    pub first_key_sym: KEYCODE,
+    pub first_key_sym: Keycode,
     pub n_key_syms: u8,
-    pub first_key_act: KEYCODE,
+    pub first_key_act: Keycode,
     pub n_key_acts: u8,
-    pub first_key_behavior: KEYCODE,
+    pub first_key_behavior: Keycode,
     pub n_key_behavior: u8,
-    pub first_key_explicit: KEYCODE,
+    pub first_key_explicit: Keycode,
     pub n_key_explicit: u8,
-    pub first_mod_map_key: KEYCODE,
+    pub first_mod_map_key: Keycode,
     pub n_mod_map_keys: u8,
-    pub first_v_mod_map_key: KEYCODE,
+    pub first_v_mod_map_key: Keycode,
     pub n_v_mod_map_keys: u8,
     pub virtual_mods: u16,
 }
@@ -9473,25 +9473,25 @@ impl MapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (ptr_btn_actions, remaining) = u8::try_parse(remaining)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
-        let (min_key_code, remaining) = KEYCODE::try_parse(remaining)?;
-        let (max_key_code, remaining) = KEYCODE::try_parse(remaining)?;
+        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
         let (first_type, remaining) = u8::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
-        let (first_key_sym, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_sym, remaining) = Keycode::try_parse(remaining)?;
         let (n_key_syms, remaining) = u8::try_parse(remaining)?;
-        let (first_key_act, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_act, remaining) = Keycode::try_parse(remaining)?;
         let (n_key_acts, remaining) = u8::try_parse(remaining)?;
-        let (first_key_behavior, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_behavior, remaining) = Keycode::try_parse(remaining)?;
         let (n_key_behavior, remaining) = u8::try_parse(remaining)?;
-        let (first_key_explicit, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key_explicit, remaining) = Keycode::try_parse(remaining)?;
         let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
-        let (first_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
         let (n_mod_map_keys, remaining) = u8::try_parse(remaining)?;
-        let (first_v_mod_map_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_v_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
         let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
@@ -9562,7 +9562,7 @@ pub struct StateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub mods: u8,
     pub base_mods: u8,
@@ -9579,7 +9579,7 @@ pub struct StateNotifyEvent {
     pub compat_loockup_mods: u8,
     pub ptr_btn_state: u16,
     pub changed: u16,
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub event_type: u8,
     pub request_major: u8,
     pub request_minor: u8,
@@ -9589,7 +9589,7 @@ impl StateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let (base_mods, remaining) = u8::try_parse(remaining)?;
@@ -9606,7 +9606,7 @@ impl StateNotifyEvent {
         let (compat_loockup_mods, remaining) = u8::try_parse(remaining)?;
         let (ptr_btn_state, remaining) = u16::try_parse(remaining)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let (event_type, remaining) = u8::try_parse(remaining)?;
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
@@ -9679,13 +9679,13 @@ pub struct ControlsNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub num_groups: u8,
     pub changed_controls: u32,
     pub enabled_controls: u32,
     pub enabled_control_changes: u32,
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub event_type: u8,
     pub request_major: u8,
     pub request_minor: u8,
@@ -9695,14 +9695,14 @@ impl ControlsNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (num_groups, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (changed_controls, remaining) = u32::try_parse(remaining)?;
         let (enabled_controls, remaining) = u32::try_parse(remaining)?;
         let (enabled_control_changes, remaining) = u32::try_parse(remaining)?;
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let (event_type, remaining) = u8::try_parse(remaining)?;
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
@@ -9763,7 +9763,7 @@ pub struct IndicatorStateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub state: u32,
     pub state_changed: u32,
@@ -9773,7 +9773,7 @@ impl IndicatorStateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let (state, remaining) = u32::try_parse(remaining)?;
@@ -9829,7 +9829,7 @@ pub struct IndicatorMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub state: u32,
     pub map_changed: u32,
@@ -9839,7 +9839,7 @@ impl IndicatorMapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let (state, remaining) = u32::try_parse(remaining)?;
@@ -9895,7 +9895,7 @@ pub struct NamesNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub changed: u16,
     pub first_type: u8,
@@ -9906,7 +9906,7 @@ pub struct NamesNotifyEvent {
     pub n_key_aliases: u8,
     pub changed_group_names: u8,
     pub changed_virtual_mods: u16,
-    pub first_key: KEYCODE,
+    pub first_key: Keycode,
     pub n_keys: u8,
     pub changed_indicators: u32,
 }
@@ -9915,7 +9915,7 @@ impl NamesNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
@@ -9928,7 +9928,7 @@ impl NamesNotifyEvent {
         let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
         let (changed_group_names, remaining) = u8::try_parse(remaining)?;
         let (changed_virtual_mods, remaining) = u16::try_parse(remaining)?;
-        let (first_key, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_key, remaining) = Keycode::try_parse(remaining)?;
         let (n_keys, remaining) = u8::try_parse(remaining)?;
         let (changed_indicators, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
@@ -9992,7 +9992,7 @@ pub struct CompatMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub changed_groups: u8,
     pub first_si: u16,
@@ -10004,7 +10004,7 @@ impl CompatMapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (changed_groups, remaining) = u8::try_parse(remaining)?;
         let (first_si, remaining) = u16::try_parse(remaining)?;
@@ -10063,15 +10063,15 @@ pub struct BellNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub bell_class: BellClassResult,
     pub bell_id: u8,
     pub percent: u8,
     pub pitch: u16,
     pub duration: u16,
-    pub name: ATOM,
-    pub window: WINDOW,
+    pub name: Atom,
+    pub window: Window,
     pub event_only: bool,
 }
 impl BellNotifyEvent {
@@ -10079,15 +10079,15 @@ impl BellNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (bell_class, remaining) = u8::try_parse(remaining)?;
         let (bell_id, remaining) = u8::try_parse(remaining)?;
         let (percent, remaining) = u8::try_parse(remaining)?;
         let (pitch, remaining) = u16::try_parse(remaining)?;
         let (duration, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = ATOM::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (name, remaining) = Atom::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (event_only, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
         let bell_class = bell_class.try_into()?;
@@ -10147,35 +10147,35 @@ pub struct ActionMessageEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub press: bool,
     pub key_event_follows: bool,
     pub mods: u8,
     pub group: Group,
-    pub message: [STRING8; 8],
+    pub message: [String8; 8],
 }
 impl ActionMessageEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let (press, remaining) = bool::try_parse(remaining)?;
         let (key_event_follows, remaining) = bool::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let (group, remaining) = u8::try_parse(remaining)?;
-        let (message_0, remaining) = STRING8::try_parse(remaining)?;
-        let (message_1, remaining) = STRING8::try_parse(remaining)?;
-        let (message_2, remaining) = STRING8::try_parse(remaining)?;
-        let (message_3, remaining) = STRING8::try_parse(remaining)?;
-        let (message_4, remaining) = STRING8::try_parse(remaining)?;
-        let (message_5, remaining) = STRING8::try_parse(remaining)?;
-        let (message_6, remaining) = STRING8::try_parse(remaining)?;
-        let (message_7, remaining) = STRING8::try_parse(remaining)?;
+        let (message_0, remaining) = String8::try_parse(remaining)?;
+        let (message_1, remaining) = String8::try_parse(remaining)?;
+        let (message_2, remaining) = String8::try_parse(remaining)?;
+        let (message_3, remaining) = String8::try_parse(remaining)?;
+        let (message_4, remaining) = String8::try_parse(remaining)?;
+        let (message_5, remaining) = String8::try_parse(remaining)?;
+        let (message_6, remaining) = String8::try_parse(remaining)?;
+        let (message_7, remaining) = String8::try_parse(remaining)?;
         let message = [
             message_0,
             message_1,
@@ -10241,9 +10241,9 @@ pub struct AccessXNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
-    pub keycode: KEYCODE,
+    pub keycode: Keycode,
     pub detailt: u16,
     pub slow_keys_delay: u16,
     pub debounce_delay: u16,
@@ -10253,9 +10253,9 @@ impl AccessXNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
-        let (keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (keycode, remaining) = Keycode::try_parse(remaining)?;
         let (detailt, remaining) = u16::try_parse(remaining)?;
         let (slow_keys_delay, remaining) = u16::try_parse(remaining)?;
         let (debounce_delay, remaining) = u16::try_parse(remaining)?;
@@ -10312,7 +10312,7 @@ pub struct ExtensionDeviceNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub device_id: u8,
     pub reason: u16,
     pub led_class: LedClassResult,
@@ -10329,7 +10329,7 @@ impl ExtensionDeviceNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (reason, remaining) = u16::try_parse(remaining)?;
@@ -10405,7 +10405,7 @@ pub trait ConnectionExt: RequestConnection {
         select_events(self, device_spec, affect_which, clear, select_all, affect_map, map, details)
     }
 
-    fn xkb_bell(&self, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: ATOM, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xkb_bell(&self, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: Atom, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         bell(self, device_spec, bell_class, bell_id, percent, force_sound, event_only, pitch, duration, name, window)
     }
@@ -10431,12 +10431,12 @@ pub trait ConnectionExt: RequestConnection {
         set_controls(self, device_spec, affect_internal_real_mods, internal_real_mods, affect_ignore_lock_real_mods, ignore_lock_real_mods, affect_internal_virtual_mods, internal_virtual_mods, affect_ignore_lock_virtual_mods, ignore_lock_virtual_mods, mouse_keys_dflt_btn, groups_wrap, access_x_options, affect_enabled_controls, enabled_controls, change_controls, repeat_delay, repeat_interval, slow_keys_delay, debounce_delay, mouse_keys_delay, mouse_keys_interval, mouse_keys_time_to_max, mouse_keys_max_speed, mouse_keys_curve, access_x_timeout, access_x_timeout_mask, access_x_timeout_values, access_x_timeout_options_mask, access_x_timeout_options_values, per_key_repeat)
     }
 
-    fn xkb_get_map(&self, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: KEYCODE, n_key_syms: u8, first_key_action: KEYCODE, n_key_actions: u8, first_key_behavior: KEYCODE, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: KEYCODE, n_key_explicit: u8, first_mod_map_key: KEYCODE, n_mod_map_keys: u8, first_v_mod_map_key: KEYCODE, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Self, GetMapReply>, ConnectionError>
+    fn xkb_get_map(&self, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, first_key_action: Keycode, n_key_actions: u8, first_key_behavior: Keycode, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: Keycode, n_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Self, GetMapReply>, ConnectionError>
     {
         get_map(self, device_spec, full, partial, first_type, n_types, first_key_sym, n_key_syms, first_key_action, n_key_actions, first_key_behavior, n_key_behaviors, virtual_mods, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys)
     }
 
-    fn xkb_set_map<'c>(&'c self, device_spec: DeviceSpec, flags: u16, min_key_code: KEYCODE, max_key_code: KEYCODE, first_type: u8, n_types: u8, first_key_sym: KEYCODE, n_key_syms: u8, total_syms: u16, first_key_action: KEYCODE, n_key_actions: u8, total_actions: u16, first_key_behavior: KEYCODE, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: KEYCODE, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: KEYCODE, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: KEYCODE, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_map<'c>(&'c self, device_spec: DeviceSpec, flags: u16, min_key_code: Keycode, max_key_code: Keycode, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, total_syms: u16, first_key_action: Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_map(self, device_spec, flags, min_key_code, max_key_code, first_type, n_types, first_key_sym, n_key_syms, total_syms, first_key_action, n_key_actions, total_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, values)
     }
@@ -10466,13 +10466,13 @@ pub trait ConnectionExt: RequestConnection {
         set_indicator_map(self, device_spec, which, maps)
     }
 
-    fn xkb_get_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: ATOM) -> Result<Cookie<'_, Self, GetNamedIndicatorReply>, ConnectionError>
+    fn xkb_get_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom) -> Result<Cookie<'_, Self, GetNamedIndicatorReply>, ConnectionError>
     where A: Into<LedClassSpec>
     {
         get_named_indicator(self, device_spec, led_class, led_id, indicator)
     }
 
-    fn xkb_set_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: ATOM, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xkb_set_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<LedClassSpec>
     {
         set_named_indicator(self, device_spec, led_class, led_id, indicator, set_state, on, set_map, create_map, map_flags, map_which_groups, map_groups, map_which_mods, map_real_mods, map_vmods, map_ctrls)
@@ -10483,7 +10483,7 @@ pub trait ConnectionExt: RequestConnection {
         get_names(self, device_spec, which)
     }
 
-    fn xkb_set_names<'c>(&'c self, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: KEYCODE, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_names<'c>(&'c self, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_names(self, device_spec, virtual_mods, first_type, n_types, first_kt_levelt, n_kt_levels, indicators, group_names, n_radio_groups, first_key, n_keys, n_key_aliases, total_kt_level_names, values)
     }
@@ -10510,7 +10510,7 @@ pub trait ConnectionExt: RequestConnection {
         set_device_info(self, device_spec, first_btn, change, btn_actions, leds)
     }
 
-    fn xkb_set_debugging_flags<'c>(&'c self, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &[STRING8]) -> Result<Cookie<'c, Self, SetDebuggingFlagsReply>, ConnectionError>
+    fn xkb_set_debugging_flags<'c>(&'c self, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &[String8]) -> Result<Cookie<'c, Self, SetDebuggingFlagsReply>, ConnectionError>
     {
         set_debugging_flags(self, affect_flags, flags, affect_ctrls, ctrls, message)
     }

--- a/src/generated/xprint.rs
+++ b/src/generated/xprint.rs
@@ -37,24 +37,24 @@ pub const X11_EXTENSION_NAME: &str = "XpExtension";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
-pub type STRING8 = u8;
+pub type String8 = u8;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Printer {
-    pub name: Vec<STRING8>,
-    pub description: Vec<STRING8>,
+    pub name: Vec<String8>,
+    pub description: Vec<String8>,
 }
 impl TryParse for Printer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
         let (name_len, remaining) = u32::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_list::<String8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let (desc_len, remaining) = u32::try_parse(remaining)?;
-        let (description, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, desc_len as usize)?;
+        let (description, remaining) = crate::x11_utils::parse_list::<String8>(remaining, desc_len as usize)?;
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -89,7 +89,7 @@ impl Serialize for Printer {
     }
 }
 
-pub type PCONTEXT = u32;
+pub type Pcontext = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -418,7 +418,7 @@ impl TryFrom<&[u8]> for PrintQueryVersionReply {
 
 /// Opcode for the PrintGetPrinterList request
 pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
-pub fn print_get_printer_list<'c, Conn>(conn: &'c Conn, printer_name: &[STRING8], locale: &[STRING8]) -> Result<Cookie<'c, Conn, PrintGetPrinterListReply>, ConnectionError>
+pub fn print_get_printer_list<'c, Conn>(conn: &'c Conn, printer_name: &[String8], locale: &[String8]) -> Result<Cookie<'c, Conn, PrintGetPrinterListReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -500,7 +500,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
-pub fn create_context<'c, Conn>(conn: &'c Conn, context_id: u32, printer_name: &[STRING8], locale: &[STRING8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_context<'c, Conn>(conn: &'c Conn, context_id: u32, printer_name: &[String8], locale: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -657,7 +657,7 @@ pub struct PrintGetScreenOfContextReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub root: WINDOW,
+    pub root: Window,
 }
 impl PrintGetScreenOfContextReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -665,7 +665,7 @@ impl PrintGetScreenOfContextReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
         let result = PrintGetScreenOfContextReply { response_type, sequence, length, root };
         Ok((result, remaining))
     }
@@ -779,7 +779,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PrintPutDocumentData request
 pub const PRINT_PUT_DOCUMENT_DATA_REQUEST: u8 = 11;
-pub fn print_put_document_data<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, data: &[u8], doc_format: &[STRING8], options: &[STRING8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn print_put_document_data<'c, Conn>(conn: &'c Conn, drawable: Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -823,7 +823,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PrintGetDocumentData request
 pub const PRINT_GET_DOCUMENT_DATA_REQUEST: u8 = 12;
-pub fn print_get_document_data<Conn>(conn: &Conn, context: PCONTEXT, max_bytes: u32) -> Result<Cookie<'_, Conn, PrintGetDocumentDataReply>, ConnectionError>
+pub fn print_get_document_data<Conn>(conn: &Conn, context: Pcontext, max_bytes: u32) -> Result<Cookie<'_, Conn, PrintGetDocumentDataReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -883,7 +883,7 @@ impl TryFrom<&[u8]> for PrintGetDocumentDataReply {
 
 /// Opcode for the PrintStartPage request
 pub const PRINT_START_PAGE_REQUEST: u8 = 13;
-pub fn print_start_page<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn print_start_page<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -933,7 +933,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PrintSelectInput request
 pub const PRINT_SELECT_INPUT_REQUEST: u8 = 15;
-pub fn print_select_input<Conn>(conn: &Conn, context: PCONTEXT, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn print_select_input<Conn>(conn: &Conn, context: Pcontext, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -963,7 +963,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PrintInputSelected request
 pub const PRINT_INPUT_SELECTED_REQUEST: u8 = 16;
-pub fn print_input_selected<Conn>(conn: &Conn, context: PCONTEXT) -> Result<Cookie<'_, Conn, PrintInputSelectedReply>, ConnectionError>
+pub fn print_input_selected<Conn>(conn: &Conn, context: Pcontext) -> Result<Cookie<'_, Conn, PrintInputSelectedReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1014,7 +1014,7 @@ impl TryFrom<&[u8]> for PrintInputSelectedReply {
 
 /// Opcode for the PrintGetAttributes request
 pub const PRINT_GET_ATTRIBUTES_REQUEST: u8 = 17;
-pub fn print_get_attributes<Conn>(conn: &Conn, context: PCONTEXT, pool: u8) -> Result<Cookie<'_, Conn, PrintGetAttributesReply>, ConnectionError>
+pub fn print_get_attributes<Conn>(conn: &Conn, context: Pcontext, pool: u8) -> Result<Cookie<'_, Conn, PrintGetAttributesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1046,7 +1046,7 @@ pub struct PrintGetAttributesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub attributes: Vec<STRING8>,
+    pub attributes: Vec<String8>,
 }
 impl PrintGetAttributesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1056,7 +1056,7 @@ impl PrintGetAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (string_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attributes, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, string_len as usize)?;
+        let (attributes, remaining) = crate::x11_utils::parse_list::<String8>(remaining, string_len as usize)?;
         let result = PrintGetAttributesReply { response_type, sequence, length, attributes };
         Ok((result, remaining))
     }
@@ -1070,7 +1070,7 @@ impl TryFrom<&[u8]> for PrintGetAttributesReply {
 
 /// Opcode for the PrintGetOneAttributes request
 pub const PRINT_GET_ONE_ATTRIBUTES_REQUEST: u8 = 19;
-pub fn print_get_one_attributes<'c, Conn>(conn: &'c Conn, context: PCONTEXT, pool: u8, name: &[STRING8]) -> Result<Cookie<'c, Conn, PrintGetOneAttributesReply>, ConnectionError>
+pub fn print_get_one_attributes<'c, Conn>(conn: &'c Conn, context: Pcontext, pool: u8, name: &[String8]) -> Result<Cookie<'c, Conn, PrintGetOneAttributesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1111,7 +1111,7 @@ pub struct PrintGetOneAttributesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub value: Vec<STRING8>,
+    pub value: Vec<String8>,
 }
 impl PrintGetOneAttributesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1121,7 +1121,7 @@ impl PrintGetOneAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (value, remaining) = crate::x11_utils::parse_list::<STRING8>(remaining, value_len as usize)?;
+        let (value, remaining) = crate::x11_utils::parse_list::<String8>(remaining, value_len as usize)?;
         let result = PrintGetOneAttributesReply { response_type, sequence, length, value };
         Ok((result, remaining))
     }
@@ -1135,7 +1135,7 @@ impl TryFrom<&[u8]> for PrintGetOneAttributesReply {
 
 /// Opcode for the PrintSetAttributes request
 pub const PRINT_SET_ATTRIBUTES_REQUEST: u8 = 18;
-pub fn print_set_attributes<'c, Conn>(conn: &'c Conn, context: PCONTEXT, string_len: u32, pool: u8, rule: u8, attributes: &[STRING8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn print_set_attributes<'c, Conn>(conn: &'c Conn, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1174,7 +1174,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PrintGetPageDimensions request
 pub const PRINT_GET_PAGE_DIMENSIONS_REQUEST: u8 = 21;
-pub fn print_get_page_dimensions<Conn>(conn: &Conn, context: PCONTEXT) -> Result<Cookie<'_, Conn, PrintGetPageDimensionsReply>, ConnectionError>
+pub fn print_get_page_dimensions<Conn>(conn: &Conn, context: Pcontext) -> Result<Cookie<'_, Conn, PrintGetPageDimensionsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1255,7 +1255,7 @@ pub struct PrintQueryScreensReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub roots: Vec<WINDOW>,
+    pub roots: Vec<Window>,
 }
 impl PrintQueryScreensReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1265,7 +1265,7 @@ impl PrintQueryScreensReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (list_count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (roots, remaining) = crate::x11_utils::parse_list::<WINDOW>(remaining, list_count as usize)?;
+        let (roots, remaining) = crate::x11_utils::parse_list::<Window>(remaining, list_count as usize)?;
         let result = PrintQueryScreensReply { response_type, sequence, length, roots };
         Ok((result, remaining))
     }
@@ -1279,7 +1279,7 @@ impl TryFrom<&[u8]> for PrintQueryScreensReply {
 
 /// Opcode for the PrintSetImageResolution request
 pub const PRINT_SET_IMAGE_RESOLUTION_REQUEST: u8 = 23;
-pub fn print_set_image_resolution<Conn>(conn: &Conn, context: PCONTEXT, image_resolution: u16) -> Result<Cookie<'_, Conn, PrintSetImageResolutionReply>, ConnectionError>
+pub fn print_set_image_resolution<Conn>(conn: &Conn, context: Pcontext, image_resolution: u16) -> Result<Cookie<'_, Conn, PrintSetImageResolutionReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1334,7 +1334,7 @@ impl TryFrom<&[u8]> for PrintSetImageResolutionReply {
 
 /// Opcode for the PrintGetImageResolution request
 pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
-pub fn print_get_image_resolution<Conn>(conn: &Conn, context: PCONTEXT) -> Result<Cookie<'_, Conn, PrintGetImageResolutionReply>, ConnectionError>
+pub fn print_get_image_resolution<Conn>(conn: &Conn, context: Pcontext) -> Result<Cookie<'_, Conn, PrintGetImageResolutionReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1388,7 +1388,7 @@ pub struct NotifyEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub context: PCONTEXT,
+    pub context: Pcontext,
     pub cancel: bool,
 }
 impl NotifyEvent {
@@ -1396,7 +1396,7 @@ impl NotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (context, remaining) = PCONTEXT::try_parse(remaining)?;
+        let (context, remaining) = Pcontext::try_parse(remaining)?;
         let (cancel, remaining) = bool::try_parse(remaining)?;
         let result = NotifyEvent { response_type, detail, sequence, context, cancel };
         Ok((result, remaining))
@@ -1446,14 +1446,14 @@ pub struct AttributNotifyEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
-    pub context: PCONTEXT,
+    pub context: Pcontext,
 }
 impl AttributNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (context, remaining) = PCONTEXT::try_parse(remaining)?;
+        let (context, remaining) = Pcontext::try_parse(remaining)?;
         let result = AttributNotifyEvent { response_type, detail, sequence, context };
         Ok((result, remaining))
     }
@@ -1605,7 +1605,7 @@ pub trait ConnectionExt: RequestConnection {
         print_query_version(self)
     }
 
-    fn xprint_print_get_printer_list<'c>(&'c self, printer_name: &[STRING8], locale: &[STRING8]) -> Result<Cookie<'c, Self, PrintGetPrinterListReply>, ConnectionError>
+    fn xprint_print_get_printer_list<'c>(&'c self, printer_name: &[String8], locale: &[String8]) -> Result<Cookie<'c, Self, PrintGetPrinterListReply>, ConnectionError>
     {
         print_get_printer_list(self, printer_name, locale)
     }
@@ -1615,7 +1615,7 @@ pub trait ConnectionExt: RequestConnection {
         print_rehash_printer_list(self)
     }
 
-    fn xprint_create_context<'c>(&'c self, context_id: u32, printer_name: &[STRING8], locale: &[STRING8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xprint_create_context<'c>(&'c self, context_id: u32, printer_name: &[String8], locale: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_context(self, context_id, printer_name, locale)
     }
@@ -1660,17 +1660,17 @@ pub trait ConnectionExt: RequestConnection {
         print_end_doc(self, cancel)
     }
 
-    fn xprint_print_put_document_data<'c>(&'c self, drawable: DRAWABLE, data: &[u8], doc_format: &[STRING8], options: &[STRING8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xprint_print_put_document_data<'c>(&'c self, drawable: Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         print_put_document_data(self, drawable, data, doc_format, options)
     }
 
-    fn xprint_print_get_document_data(&self, context: PCONTEXT, max_bytes: u32) -> Result<Cookie<'_, Self, PrintGetDocumentDataReply>, ConnectionError>
+    fn xprint_print_get_document_data(&self, context: Pcontext, max_bytes: u32) -> Result<Cookie<'_, Self, PrintGetDocumentDataReply>, ConnectionError>
     {
         print_get_document_data(self, context, max_bytes)
     }
 
-    fn xprint_print_start_page(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xprint_print_start_page(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         print_start_page(self, window)
     }
@@ -1680,32 +1680,32 @@ pub trait ConnectionExt: RequestConnection {
         print_end_page(self, cancel)
     }
 
-    fn xprint_print_select_input(&self, context: PCONTEXT, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xprint_print_select_input(&self, context: Pcontext, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         print_select_input(self, context, event_mask)
     }
 
-    fn xprint_print_input_selected(&self, context: PCONTEXT) -> Result<Cookie<'_, Self, PrintInputSelectedReply>, ConnectionError>
+    fn xprint_print_input_selected(&self, context: Pcontext) -> Result<Cookie<'_, Self, PrintInputSelectedReply>, ConnectionError>
     {
         print_input_selected(self, context)
     }
 
-    fn xprint_print_get_attributes(&self, context: PCONTEXT, pool: u8) -> Result<Cookie<'_, Self, PrintGetAttributesReply>, ConnectionError>
+    fn xprint_print_get_attributes(&self, context: Pcontext, pool: u8) -> Result<Cookie<'_, Self, PrintGetAttributesReply>, ConnectionError>
     {
         print_get_attributes(self, context, pool)
     }
 
-    fn xprint_print_get_one_attributes<'c>(&'c self, context: PCONTEXT, pool: u8, name: &[STRING8]) -> Result<Cookie<'c, Self, PrintGetOneAttributesReply>, ConnectionError>
+    fn xprint_print_get_one_attributes<'c>(&'c self, context: Pcontext, pool: u8, name: &[String8]) -> Result<Cookie<'c, Self, PrintGetOneAttributesReply>, ConnectionError>
     {
         print_get_one_attributes(self, context, pool, name)
     }
 
-    fn xprint_print_set_attributes<'c>(&'c self, context: PCONTEXT, string_len: u32, pool: u8, rule: u8, attributes: &[STRING8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xprint_print_set_attributes<'c>(&'c self, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         print_set_attributes(self, context, string_len, pool, rule, attributes)
     }
 
-    fn xprint_print_get_page_dimensions(&self, context: PCONTEXT) -> Result<Cookie<'_, Self, PrintGetPageDimensionsReply>, ConnectionError>
+    fn xprint_print_get_page_dimensions(&self, context: Pcontext) -> Result<Cookie<'_, Self, PrintGetPageDimensionsReply>, ConnectionError>
     {
         print_get_page_dimensions(self, context)
     }
@@ -1715,12 +1715,12 @@ pub trait ConnectionExt: RequestConnection {
         print_query_screens(self)
     }
 
-    fn xprint_print_set_image_resolution(&self, context: PCONTEXT, image_resolution: u16) -> Result<Cookie<'_, Self, PrintSetImageResolutionReply>, ConnectionError>
+    fn xprint_print_set_image_resolution(&self, context: Pcontext, image_resolution: u16) -> Result<Cookie<'_, Self, PrintSetImageResolutionReply>, ConnectionError>
     {
         print_set_image_resolution(self, context, image_resolution)
     }
 
-    fn xprint_print_get_image_resolution(&self, context: PCONTEXT) -> Result<Cookie<'_, Self, PrintGetImageResolutionReply>, ConnectionError>
+    fn xprint_print_get_image_resolution(&self, context: Pcontext) -> Result<Cookie<'_, Self, PrintGetImageResolutionReply>, ConnectionError>
     {
         print_get_image_resolution(self, context)
     }

--- a/src/generated/xproto.rs
+++ b/src/generated/xproto.rs
@@ -61,37 +61,37 @@ impl Serialize for Char2b {
     }
 }
 
-pub type WINDOW = u32;
+pub type Window = u32;
 
-pub type PIXMAP = u32;
+pub type Pixmap = u32;
 
-pub type CURSOR = u32;
+pub type Cursor = u32;
 
-pub type FONT = u32;
+pub type Font = u32;
 
-pub type GCONTEXT = u32;
+pub type Gcontext = u32;
 
-pub type COLORMAP = u32;
+pub type Colormap = u32;
 
-pub type ATOM = u32;
+pub type Atom = u32;
 
-pub type DRAWABLE = u32;
+pub type Drawable = u32;
 
-pub type FONTABLE = u32;
+pub type Fontable = u32;
 
-pub type BOOL32 = u32;
+pub type Bool32 = u32;
 
-pub type VISUALID = u32;
+pub type Visualid = u32;
 
-pub type TIMESTAMP = u32;
+pub type Timestamp = u32;
 
-pub type KEYSYM = u32;
+pub type Keysym = u32;
 
-pub type KEYCODE = u8;
+pub type Keycode = u8;
 
-pub type KEYCODE32 = u32;
+pub type Keycode32 = u32;
 
-pub type BUTTON = u8;
+pub type Button = u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Point {
@@ -367,7 +367,7 @@ impl TryFrom<u32> for VisualClass {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Visualtype {
-    pub visual_id: VISUALID,
+    pub visual_id: Visualid,
     pub class: VisualClass,
     pub bits_per_rgb_value: u8,
     pub colormap_entries: u16,
@@ -377,7 +377,7 @@ pub struct Visualtype {
 }
 impl TryParse for Visualtype {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (visual_id, remaining) = VISUALID::try_parse(remaining)?;
+        let (visual_id, remaining) = Visualid::try_parse(remaining)?;
         let (class, remaining) = u8::try_parse(remaining)?;
         let (bits_per_rgb_value, remaining) = u8::try_parse(remaining)?;
         let (colormap_entries, remaining) = u16::try_parse(remaining)?;
@@ -656,8 +656,8 @@ impl TryFrom<u32> for BackingStore {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Screen {
-    pub root: WINDOW,
-    pub default_colormap: COLORMAP,
+    pub root: Window,
+    pub default_colormap: Colormap,
     pub white_pixel: u32,
     pub black_pixel: u32,
     pub current_input_masks: u32,
@@ -667,7 +667,7 @@ pub struct Screen {
     pub height_in_millimeters: u16,
     pub min_installed_maps: u16,
     pub max_installed_maps: u16,
-    pub root_visual: VISUALID,
+    pub root_visual: Visualid,
     pub backing_stores: BackingStore,
     pub save_unders: bool,
     pub root_depth: u8,
@@ -675,8 +675,8 @@ pub struct Screen {
 }
 impl TryParse for Screen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (default_colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (default_colormap, remaining) = Colormap::try_parse(remaining)?;
         let (white_pixel, remaining) = u32::try_parse(remaining)?;
         let (black_pixel, remaining) = u32::try_parse(remaining)?;
         let (current_input_masks, remaining) = u32::try_parse(remaining)?;
@@ -686,7 +686,7 @@ impl TryParse for Screen {
         let (height_in_millimeters, remaining) = u16::try_parse(remaining)?;
         let (min_installed_maps, remaining) = u16::try_parse(remaining)?;
         let (max_installed_maps, remaining) = u16::try_parse(remaining)?;
-        let (root_visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (root_visual, remaining) = Visualid::try_parse(remaining)?;
         let (backing_stores, remaining) = u8::try_parse(remaining)?;
         let (save_unders, remaining) = bool::try_parse(remaining)?;
         let (root_depth, remaining) = u8::try_parse(remaining)?;
@@ -957,8 +957,8 @@ pub struct Setup {
     pub bitmap_format_bit_order: ImageOrder,
     pub bitmap_format_scanline_unit: u8,
     pub bitmap_format_scanline_pad: u8,
-    pub min_keycode: KEYCODE,
-    pub max_keycode: KEYCODE,
+    pub min_keycode: Keycode,
+    pub max_keycode: Keycode,
     pub vendor: Vec<u8>,
     pub pixmap_formats: Vec<Format>,
     pub roots: Vec<Screen>,
@@ -983,8 +983,8 @@ impl TryParse for Setup {
         let (bitmap_format_bit_order, remaining) = u8::try_parse(remaining)?;
         let (bitmap_format_scanline_unit, remaining) = u8::try_parse(remaining)?;
         let (bitmap_format_scanline_pad, remaining) = u8::try_parse(remaining)?;
-        let (min_keycode, remaining) = KEYCODE::try_parse(remaining)?;
-        let (max_keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (min_keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (max_keycode, remaining) = Keycode::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (vendor, remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_len as usize)?;
         // Align offset to multiple of 4
@@ -1194,57 +1194,57 @@ bitmask_binop!(KeyButMask, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Window {
+pub enum WindowEnum {
     None = 0,
 }
-impl From<Window> for u8 {
-    fn from(input: Window) -> Self {
+impl From<WindowEnum> for u8 {
+    fn from(input: WindowEnum) -> Self {
         match input {
-            Window::None => 0,
+            WindowEnum::None => 0,
         }
     }
 }
-impl From<Window> for Option<u8> {
-    fn from(input: Window) -> Self {
+impl From<WindowEnum> for Option<u8> {
+    fn from(input: WindowEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Window> for u16 {
-    fn from(input: Window) -> Self {
+impl From<WindowEnum> for u16 {
+    fn from(input: WindowEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Window> for Option<u16> {
-    fn from(input: Window) -> Self {
+impl From<WindowEnum> for Option<u16> {
+    fn from(input: WindowEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Window> for u32 {
-    fn from(input: Window) -> Self {
+impl From<WindowEnum> for u32 {
+    fn from(input: WindowEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Window> for Option<u32> {
-    fn from(input: Window) -> Self {
+impl From<WindowEnum> for Option<u32> {
+    fn from(input: WindowEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Window {
+impl TryFrom<u8> for WindowEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Window::None),
+            0 => Ok(WindowEnum::None),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Window {
+impl TryFrom<u16> for WindowEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Window {
+impl TryFrom<u32> for WindowEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -1281,12 +1281,12 @@ pub const KEY_PRESS_EVENT: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyPressEvent {
     pub response_type: u8,
-    pub detail: KEYCODE,
+    pub detail: Keycode,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -1297,12 +1297,12 @@ pub struct KeyPressEvent {
 impl KeyPressEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
-        let (detail, remaining) = KEYCODE::try_parse(remaining)?;
+        let (detail, remaining) = Keycode::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -1389,12 +1389,12 @@ pub const KEY_RELEASE_EVENT: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyReleaseEvent {
     pub response_type: u8,
-    pub detail: KEYCODE,
+    pub detail: Keycode,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -1405,12 +1405,12 @@ pub struct KeyReleaseEvent {
 impl KeyReleaseEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
-        let (detail, remaining) = KEYCODE::try_parse(remaining)?;
+        let (detail, remaining) = Keycode::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -1556,12 +1556,12 @@ pub const BUTTON_PRESS_EVENT: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ButtonPressEvent {
     pub response_type: u8,
-    pub detail: BUTTON,
+    pub detail: Button,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -1572,12 +1572,12 @@ pub struct ButtonPressEvent {
 impl ButtonPressEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
-        let (detail, remaining) = BUTTON::try_parse(remaining)?;
+        let (detail, remaining) = Button::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -1664,12 +1664,12 @@ pub const BUTTON_RELEASE_EVENT: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ButtonReleaseEvent {
     pub response_type: u8,
-    pub detail: BUTTON,
+    pub detail: Button,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -1680,12 +1680,12 @@ pub struct ButtonReleaseEvent {
 impl ButtonReleaseEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
-        let (detail, remaining) = BUTTON::try_parse(remaining)?;
+        let (detail, remaining) = Button::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -1836,10 +1836,10 @@ pub struct MotionNotifyEvent {
     pub response_type: u8,
     pub detail: Motion,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -1852,10 +1852,10 @@ impl MotionNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -2083,10 +2083,10 @@ pub struct EnterNotifyEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -2100,10 +2100,10 @@ impl EnterNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -2185,10 +2185,10 @@ pub struct LeaveNotifyEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub root: WINDOW,
-    pub event: WINDOW,
-    pub child: WINDOW,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub event_x: i16,
@@ -2202,10 +2202,10 @@ impl LeaveNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (event_x, remaining) = i16::try_parse(remaining)?;
@@ -2279,7 +2279,7 @@ pub struct FocusInEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
     pub sequence: u16,
-    pub event: WINDOW,
+    pub event: Window,
     pub mode: NotifyMode,
 }
 impl FocusInEvent {
@@ -2287,7 +2287,7 @@ impl FocusInEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let detail = detail.try_into()?;
@@ -2347,7 +2347,7 @@ pub struct FocusOutEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
     pub sequence: u16,
-    pub event: WINDOW,
+    pub event: Window,
     pub mode: NotifyMode,
 }
 impl FocusOutEvent {
@@ -2355,7 +2355,7 @@ impl FocusOutEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let detail = detail.try_into()?;
@@ -2534,7 +2534,7 @@ pub const EXPOSE_EVENT: u8 = 12;
 pub struct ExposeEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub window: WINDOW,
+    pub window: Window,
     pub x: u16,
     pub y: u16,
     pub width: u16,
@@ -2546,7 +2546,7 @@ impl ExposeEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = u16::try_parse(remaining)?;
         let (y, remaining) = u16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -2603,7 +2603,7 @@ pub const GRAPHICS_EXPOSURE_EVENT: u8 = 13;
 pub struct GraphicsExposureEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub drawable: DRAWABLE,
+    pub drawable: Drawable,
     pub x: u16,
     pub y: u16,
     pub width: u16,
@@ -2617,7 +2617,7 @@ impl GraphicsExposureEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let (x, remaining) = u16::try_parse(remaining)?;
         let (y, remaining) = u16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -2678,7 +2678,7 @@ pub const NO_EXPOSURE_EVENT: u8 = 14;
 pub struct NoExposureEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub drawable: DRAWABLE,
+    pub drawable: Drawable,
     pub minor_opcode: u16,
     pub major_opcode: u8,
 }
@@ -2687,7 +2687,7 @@ impl NoExposureEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let (minor_opcode, remaining) = u16::try_parse(remaining)?;
         let (major_opcode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
@@ -2803,7 +2803,7 @@ pub const VISIBILITY_NOTIFY_EVENT: u8 = 15;
 pub struct VisibilityNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub window: WINDOW,
+    pub window: Window,
     pub state: Visibility,
 }
 impl VisibilityNotifyEvent {
@@ -2811,7 +2811,7 @@ impl VisibilityNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
@@ -2861,8 +2861,8 @@ pub const CREATE_NOTIFY_EVENT: u8 = 16;
 pub struct CreateNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub parent: WINDOW,
-    pub window: WINDOW,
+    pub parent: Window,
+    pub window: Window,
     pub x: i16,
     pub y: i16,
     pub width: u16,
@@ -2875,8 +2875,8 @@ impl CreateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (parent, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -2948,16 +2948,16 @@ pub const DESTROY_NOTIFY_EVENT: u8 = 17;
 pub struct DestroyNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
+    pub event: Window,
+    pub window: Window,
 }
 impl DestroyNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let result = DestroyNotifyEvent { response_type, sequence, event, window };
         Ok((result, remaining))
     }
@@ -3018,8 +3018,8 @@ pub const UNMAP_NOTIFY_EVENT: u8 = 18;
 pub struct UnmapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
+    pub event: Window,
+    pub window: Window,
     pub from_configure: bool,
 }
 impl UnmapNotifyEvent {
@@ -3027,8 +3027,8 @@ impl UnmapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (from_configure, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = UnmapNotifyEvent { response_type, sequence, event, window, from_configure };
@@ -3091,8 +3091,8 @@ pub const MAP_NOTIFY_EVENT: u8 = 19;
 pub struct MapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
+    pub event: Window,
+    pub window: Window,
     pub override_redirect: bool,
 }
 impl MapNotifyEvent {
@@ -3100,8 +3100,8 @@ impl MapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (override_redirect, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = MapNotifyEvent { response_type, sequence, event, window, override_redirect };
@@ -3162,16 +3162,16 @@ pub const MAP_REQUEST_EVENT: u8 = 20;
 pub struct MapRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub parent: WINDOW,
-    pub window: WINDOW,
+    pub parent: Window,
+    pub window: Window,
 }
 impl MapRequestEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (parent, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let result = MapRequestEvent { response_type, sequence, parent, window };
         Ok((result, remaining))
     }
@@ -3218,9 +3218,9 @@ pub const REPARENT_NOTIFY_EVENT: u8 = 21;
 pub struct ReparentNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
-    pub parent: WINDOW,
+    pub event: Window,
+    pub window: Window,
+    pub parent: Window,
     pub x: i16,
     pub y: i16,
     pub override_redirect: bool,
@@ -3230,9 +3230,9 @@ impl ReparentNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (parent, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (override_redirect, remaining) = bool::try_parse(remaining)?;
@@ -3310,9 +3310,9 @@ pub const CONFIGURE_NOTIFY_EVENT: u8 = 22;
 pub struct ConfigureNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
-    pub above_sibling: WINDOW,
+    pub event: Window,
+    pub window: Window,
+    pub above_sibling: Window,
     pub x: i16,
     pub y: i16,
     pub width: u16,
@@ -3325,9 +3325,9 @@ impl ConfigureNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (above_sibling, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (above_sibling, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -3389,9 +3389,9 @@ pub struct ConfigureRequestEvent {
     pub response_type: u8,
     pub stack_mode: StackMode,
     pub sequence: u16,
-    pub parent: WINDOW,
-    pub window: WINDOW,
-    pub sibling: WINDOW,
+    pub parent: Window,
+    pub window: Window,
+    pub sibling: Window,
     pub x: i16,
     pub y: i16,
     pub width: u16,
@@ -3404,9 +3404,9 @@ impl ConfigureRequestEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (stack_mode, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (parent, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (sibling, remaining) = WINDOW::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (sibling, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -3468,8 +3468,8 @@ pub const GRAVITY_NOTIFY_EVENT: u8 = 24;
 pub struct GravityNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
+    pub event: Window,
+    pub window: Window,
     pub x: i16,
     pub y: i16,
 }
@@ -3478,8 +3478,8 @@ impl GravityNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let result = GravityNotifyEvent { response_type, sequence, event, window, x, y };
@@ -3530,7 +3530,7 @@ pub const RESIZE_REQUEST_EVENT: u8 = 25;
 pub struct ResizeRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub window: WINDOW,
+    pub window: Window,
     pub width: u16,
     pub height: u16,
 }
@@ -3539,7 +3539,7 @@ impl ResizeRequestEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
         let (height, remaining) = u16::try_parse(remaining)?;
         let result = ResizeRequestEvent { response_type, sequence, window, width, height };
@@ -3670,8 +3670,8 @@ pub const CIRCULATE_NOTIFY_EVENT: u8 = 26;
 pub struct CirculateNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
+    pub event: Window,
+    pub window: Window,
     pub place: Place,
 }
 impl CirculateNotifyEvent {
@@ -3679,8 +3679,8 @@ impl CirculateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (place, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
@@ -3744,8 +3744,8 @@ pub const CIRCULATE_REQUEST_EVENT: u8 = 27;
 pub struct CirculateRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub event: WINDOW,
-    pub window: WINDOW,
+    pub event: Window,
+    pub window: Window,
     pub place: Place,
 }
 impl CirculateRequestEvent {
@@ -3753,8 +3753,8 @@ impl CirculateRequestEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (event, remaining) = WINDOW::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (place, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
@@ -3880,9 +3880,9 @@ pub const PROPERTY_NOTIFY_EVENT: u8 = 28;
 pub struct PropertyNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub window: WINDOW,
-    pub atom: ATOM,
-    pub time: TIMESTAMP,
+    pub window: Window,
+    pub atom: Atom,
+    pub time: Timestamp,
     pub state: Property,
 }
 impl PropertyNotifyEvent {
@@ -3890,9 +3890,9 @@ impl PropertyNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (atom, remaining) = ATOM::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (atom, remaining) = Atom::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
@@ -3944,18 +3944,18 @@ pub const SELECTION_CLEAR_EVENT: u8 = 29;
 pub struct SelectionClearEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub owner: WINDOW,
-    pub selection: ATOM,
+    pub time: Timestamp,
+    pub owner: Window,
+    pub selection: Atom,
 }
 impl SelectionClearEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (owner, remaining) = WINDOW::try_parse(remaining)?;
-        let (selection, remaining) = ATOM::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (owner, remaining) = Window::try_parse(remaining)?;
+        let (selection, remaining) = Atom::try_parse(remaining)?;
         let result = SelectionClearEvent { response_type, sequence, time, owner, selection };
         Ok((result, remaining))
     }
@@ -4058,7 +4058,7 @@ impl TryFrom<u32> for Time {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
-pub enum Atom {
+pub enum AtomEnum {
     None,
     Any,
     PRIMARY,
@@ -4130,104 +4130,104 @@ pub enum Atom {
     WM_CLASS,
     WM_TRANSIENT_FOR,
 }
-impl From<Atom> for u8 {
-    fn from(input: Atom) -> Self {
+impl From<AtomEnum> for u8 {
+    fn from(input: AtomEnum) -> Self {
         match input {
-            Atom::None => 0,
-            Atom::Any => 0,
-            Atom::PRIMARY => 1,
-            Atom::SECONDARY => 2,
-            Atom::ARC => 3,
-            Atom::ATOM => 4,
-            Atom::BITMAP => 5,
-            Atom::CARDINAL => 6,
-            Atom::COLORMAP => 7,
-            Atom::CURSOR => 8,
-            Atom::CUT_BUFFER0 => 9,
-            Atom::CUT_BUFFER1 => 10,
-            Atom::CUT_BUFFER2 => 11,
-            Atom::CUT_BUFFER3 => 12,
-            Atom::CUT_BUFFER4 => 13,
-            Atom::CUT_BUFFER5 => 14,
-            Atom::CUT_BUFFER6 => 15,
-            Atom::CUT_BUFFER7 => 16,
-            Atom::DRAWABLE => 17,
-            Atom::FONT => 18,
-            Atom::INTEGER => 19,
-            Atom::PIXMAP => 20,
-            Atom::POINT => 21,
-            Atom::RECTANGLE => 22,
-            Atom::RESOURCE_MANAGER => 23,
-            Atom::RGB_COLOR_MAP => 24,
-            Atom::RGB_BEST_MAP => 25,
-            Atom::RGB_BLUE_MAP => 26,
-            Atom::RGB_DEFAULT_MAP => 27,
-            Atom::RGB_GRAY_MAP => 28,
-            Atom::RGB_GREEN_MAP => 29,
-            Atom::RGB_RED_MAP => 30,
-            Atom::STRING => 31,
-            Atom::VISUALID => 32,
-            Atom::WINDOW => 33,
-            Atom::WM_COMMAND => 34,
-            Atom::WM_HINTS => 35,
-            Atom::WM_CLIENT_MACHINE => 36,
-            Atom::WM_ICON_NAME => 37,
-            Atom::WM_ICON_SIZE => 38,
-            Atom::WM_NAME => 39,
-            Atom::WM_NORMAL_HINTS => 40,
-            Atom::WM_SIZE_HINTS => 41,
-            Atom::WM_ZOOM_HINTS => 42,
-            Atom::MIN_SPACE => 43,
-            Atom::NORM_SPACE => 44,
-            Atom::MAX_SPACE => 45,
-            Atom::END_SPACE => 46,
-            Atom::SUPERSCRIPT_X => 47,
-            Atom::SUPERSCRIPT_Y => 48,
-            Atom::SUBSCRIPT_X => 49,
-            Atom::SUBSCRIPT_Y => 50,
-            Atom::UNDERLINE_POSITION => 51,
-            Atom::UNDERLINE_THICKNESS => 52,
-            Atom::STRIKEOUT_ASCENT => 53,
-            Atom::STRIKEOUT_DESCENT => 54,
-            Atom::ITALIC_ANGLE => 55,
-            Atom::X_HEIGHT => 56,
-            Atom::QUAD_WIDTH => 57,
-            Atom::WEIGHT => 58,
-            Atom::POINT_SIZE => 59,
-            Atom::RESOLUTION => 60,
-            Atom::COPYRIGHT => 61,
-            Atom::NOTICE => 62,
-            Atom::FONT_NAME => 63,
-            Atom::FAMILY_NAME => 64,
-            Atom::FULL_NAME => 65,
-            Atom::CAP_HEIGHT => 66,
-            Atom::WM_CLASS => 67,
-            Atom::WM_TRANSIENT_FOR => 68,
+            AtomEnum::None => 0,
+            AtomEnum::Any => 0,
+            AtomEnum::PRIMARY => 1,
+            AtomEnum::SECONDARY => 2,
+            AtomEnum::ARC => 3,
+            AtomEnum::ATOM => 4,
+            AtomEnum::BITMAP => 5,
+            AtomEnum::CARDINAL => 6,
+            AtomEnum::COLORMAP => 7,
+            AtomEnum::CURSOR => 8,
+            AtomEnum::CUT_BUFFER0 => 9,
+            AtomEnum::CUT_BUFFER1 => 10,
+            AtomEnum::CUT_BUFFER2 => 11,
+            AtomEnum::CUT_BUFFER3 => 12,
+            AtomEnum::CUT_BUFFER4 => 13,
+            AtomEnum::CUT_BUFFER5 => 14,
+            AtomEnum::CUT_BUFFER6 => 15,
+            AtomEnum::CUT_BUFFER7 => 16,
+            AtomEnum::DRAWABLE => 17,
+            AtomEnum::FONT => 18,
+            AtomEnum::INTEGER => 19,
+            AtomEnum::PIXMAP => 20,
+            AtomEnum::POINT => 21,
+            AtomEnum::RECTANGLE => 22,
+            AtomEnum::RESOURCE_MANAGER => 23,
+            AtomEnum::RGB_COLOR_MAP => 24,
+            AtomEnum::RGB_BEST_MAP => 25,
+            AtomEnum::RGB_BLUE_MAP => 26,
+            AtomEnum::RGB_DEFAULT_MAP => 27,
+            AtomEnum::RGB_GRAY_MAP => 28,
+            AtomEnum::RGB_GREEN_MAP => 29,
+            AtomEnum::RGB_RED_MAP => 30,
+            AtomEnum::STRING => 31,
+            AtomEnum::VISUALID => 32,
+            AtomEnum::WINDOW => 33,
+            AtomEnum::WM_COMMAND => 34,
+            AtomEnum::WM_HINTS => 35,
+            AtomEnum::WM_CLIENT_MACHINE => 36,
+            AtomEnum::WM_ICON_NAME => 37,
+            AtomEnum::WM_ICON_SIZE => 38,
+            AtomEnum::WM_NAME => 39,
+            AtomEnum::WM_NORMAL_HINTS => 40,
+            AtomEnum::WM_SIZE_HINTS => 41,
+            AtomEnum::WM_ZOOM_HINTS => 42,
+            AtomEnum::MIN_SPACE => 43,
+            AtomEnum::NORM_SPACE => 44,
+            AtomEnum::MAX_SPACE => 45,
+            AtomEnum::END_SPACE => 46,
+            AtomEnum::SUPERSCRIPT_X => 47,
+            AtomEnum::SUPERSCRIPT_Y => 48,
+            AtomEnum::SUBSCRIPT_X => 49,
+            AtomEnum::SUBSCRIPT_Y => 50,
+            AtomEnum::UNDERLINE_POSITION => 51,
+            AtomEnum::UNDERLINE_THICKNESS => 52,
+            AtomEnum::STRIKEOUT_ASCENT => 53,
+            AtomEnum::STRIKEOUT_DESCENT => 54,
+            AtomEnum::ITALIC_ANGLE => 55,
+            AtomEnum::X_HEIGHT => 56,
+            AtomEnum::QUAD_WIDTH => 57,
+            AtomEnum::WEIGHT => 58,
+            AtomEnum::POINT_SIZE => 59,
+            AtomEnum::RESOLUTION => 60,
+            AtomEnum::COPYRIGHT => 61,
+            AtomEnum::NOTICE => 62,
+            AtomEnum::FONT_NAME => 63,
+            AtomEnum::FAMILY_NAME => 64,
+            AtomEnum::FULL_NAME => 65,
+            AtomEnum::CAP_HEIGHT => 66,
+            AtomEnum::WM_CLASS => 67,
+            AtomEnum::WM_TRANSIENT_FOR => 68,
         }
     }
 }
-impl From<Atom> for Option<u8> {
-    fn from(input: Atom) -> Self {
+impl From<AtomEnum> for Option<u8> {
+    fn from(input: AtomEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Atom> for u16 {
-    fn from(input: Atom) -> Self {
+impl From<AtomEnum> for u16 {
+    fn from(input: AtomEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Atom> for Option<u16> {
-    fn from(input: Atom) -> Self {
+impl From<AtomEnum> for Option<u16> {
+    fn from(input: AtomEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Atom> for u32 {
-    fn from(input: Atom) -> Self {
+impl From<AtomEnum> for u32 {
+    fn from(input: AtomEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Atom> for Option<u32> {
-    fn from(input: Atom) -> Self {
+impl From<AtomEnum> for Option<u32> {
+    fn from(input: AtomEnum) -> Self {
         Some(u32::from(input))
     }
 }
@@ -4238,24 +4238,24 @@ pub const SELECTION_REQUEST_EVENT: u8 = 30;
 pub struct SelectionRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub owner: WINDOW,
-    pub requestor: WINDOW,
-    pub selection: ATOM,
-    pub target: ATOM,
-    pub property: ATOM,
+    pub time: Timestamp,
+    pub owner: Window,
+    pub requestor: Window,
+    pub selection: Atom,
+    pub target: Atom,
+    pub property: Atom,
 }
 impl SelectionRequestEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (owner, remaining) = WINDOW::try_parse(remaining)?;
-        let (requestor, remaining) = WINDOW::try_parse(remaining)?;
-        let (selection, remaining) = ATOM::try_parse(remaining)?;
-        let (target, remaining) = ATOM::try_parse(remaining)?;
-        let (property, remaining) = ATOM::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (owner, remaining) = Window::try_parse(remaining)?;
+        let (requestor, remaining) = Window::try_parse(remaining)?;
+        let (selection, remaining) = Atom::try_parse(remaining)?;
+        let (target, remaining) = Atom::try_parse(remaining)?;
+        let (property, remaining) = Atom::try_parse(remaining)?;
         let result = SelectionRequestEvent { response_type, sequence, time, owner, requestor, selection, target, property };
         Ok((result, remaining))
     }
@@ -4306,22 +4306,22 @@ pub const SELECTION_NOTIFY_EVENT: u8 = 31;
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub requestor: WINDOW,
-    pub selection: ATOM,
-    pub target: ATOM,
-    pub property: ATOM,
+    pub time: Timestamp,
+    pub requestor: Window,
+    pub selection: Atom,
+    pub target: Atom,
+    pub property: Atom,
 }
 impl SelectionNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (requestor, remaining) = WINDOW::try_parse(remaining)?;
-        let (selection, remaining) = ATOM::try_parse(remaining)?;
-        let (target, remaining) = ATOM::try_parse(remaining)?;
-        let (property, remaining) = ATOM::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (requestor, remaining) = Window::try_parse(remaining)?;
+        let (selection, remaining) = Atom::try_parse(remaining)?;
+        let (target, remaining) = Atom::try_parse(remaining)?;
+        let (property, remaining) = Atom::try_parse(remaining)?;
         let result = SelectionNotifyEvent { response_type, sequence, time, requestor, selection, target, property };
         Ok((result, remaining))
     }
@@ -4436,57 +4436,57 @@ impl TryFrom<u32> for ColormapState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Colormap {
+pub enum ColormapEnum {
     None = 0,
 }
-impl From<Colormap> for u8 {
-    fn from(input: Colormap) -> Self {
+impl From<ColormapEnum> for u8 {
+    fn from(input: ColormapEnum) -> Self {
         match input {
-            Colormap::None => 0,
+            ColormapEnum::None => 0,
         }
     }
 }
-impl From<Colormap> for Option<u8> {
-    fn from(input: Colormap) -> Self {
+impl From<ColormapEnum> for Option<u8> {
+    fn from(input: ColormapEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Colormap> for u16 {
-    fn from(input: Colormap) -> Self {
+impl From<ColormapEnum> for u16 {
+    fn from(input: ColormapEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Colormap> for Option<u16> {
-    fn from(input: Colormap) -> Self {
+impl From<ColormapEnum> for Option<u16> {
+    fn from(input: ColormapEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Colormap> for u32 {
-    fn from(input: Colormap) -> Self {
+impl From<ColormapEnum> for u32 {
+    fn from(input: ColormapEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Colormap> for Option<u32> {
-    fn from(input: Colormap) -> Self {
+impl From<ColormapEnum> for Option<u32> {
+    fn from(input: ColormapEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Colormap {
+impl TryFrom<u8> for ColormapEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Colormap::None),
+            0 => Ok(ColormapEnum::None),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Colormap {
+impl TryFrom<u16> for ColormapEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Colormap {
+impl TryFrom<u32> for ColormapEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -4512,8 +4512,8 @@ pub const COLORMAP_NOTIFY_EVENT: u8 = 32;
 pub struct ColormapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub window: WINDOW,
-    pub colormap: COLORMAP,
+    pub window: Window,
+    pub colormap: Colormap,
     pub new: bool,
     pub state: ColormapState,
 }
@@ -4522,8 +4522,8 @@ impl ColormapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (colormap, remaining) = Colormap::try_parse(remaining)?;
         let (new, remaining) = bool::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
@@ -4789,8 +4789,8 @@ pub struct ClientMessageEvent {
     pub response_type: u8,
     pub format: u8,
     pub sequence: u16,
-    pub window: WINDOW,
-    pub type_: ATOM,
+    pub window: Window,
+    pub type_: Atom,
     pub data: ClientMessageData,
 }
 impl ClientMessageEvent {
@@ -4798,8 +4798,8 @@ impl ClientMessageEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = WINDOW::try_parse(remaining)?;
-        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (type_, remaining) = Atom::try_parse(remaining)?;
         let (data, remaining) = ClientMessageData::try_parse(remaining)?;
         let result = ClientMessageEvent { response_type, format, sequence, window, type_, data };
         Ok((result, remaining))
@@ -4922,7 +4922,7 @@ pub struct MappingNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub request: Mapping,
-    pub first_keycode: KEYCODE,
+    pub first_keycode: Keycode,
     pub count: u8,
 }
 impl MappingNotifyEvent {
@@ -4931,7 +4931,7 @@ impl MappingNotifyEvent {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (request, remaining) = u8::try_parse(remaining)?;
-        let (first_keycode, remaining) = KEYCODE::try_parse(remaining)?;
+        let (first_keycode, remaining) = Keycode::try_parse(remaining)?;
         let (count, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let request = request.try_into()?;
@@ -6429,21 +6429,21 @@ pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// Auxiliary and optional information for the create_window function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreateWindowAux {
-    pub background_pixmap: Option<PIXMAP>,
+    pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
-    pub border_pixmap: Option<PIXMAP>,
+    pub border_pixmap: Option<Pixmap>,
     pub border_pixel: Option<u32>,
     pub bit_gravity: Option<u32>,
     pub win_gravity: Option<u32>,
     pub backing_store: Option<u32>,
     pub backing_planes: Option<u32>,
     pub backing_pixel: Option<u32>,
-    pub override_redirect: Option<BOOL32>,
-    pub save_under: Option<BOOL32>,
+    pub override_redirect: Option<Bool32>,
+    pub save_under: Option<Bool32>,
     pub event_mask: Option<u32>,
     pub do_not_propogate_mask: Option<u32>,
-    pub colormap: Option<COLORMAP>,
-    pub cursor: Option<CURSOR>,
+    pub colormap: Option<Colormap>,
+    pub cursor: Option<Cursor>,
 }
 impl CreateWindowAux {
     /// Create a new instance with all fields unset / not present.
@@ -6500,7 +6500,7 @@ impl CreateWindowAux {
         mask
     }
     /// Set the background_pixmap field of this structure.
-    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.background_pixmap = value.into();
         self
     }
@@ -6510,7 +6510,7 @@ impl CreateWindowAux {
         self
     }
     /// Set the border_pixmap field of this structure.
-    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.border_pixmap = value.into();
         self
     }
@@ -6545,12 +6545,12 @@ impl CreateWindowAux {
         self
     }
     /// Set the override_redirect field of this structure.
-    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.override_redirect = value.into();
         self
     }
     /// Set the save_under field of this structure.
-    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.save_under = value.into();
         self
     }
@@ -6565,12 +6565,12 @@ impl CreateWindowAux {
         self
     }
     /// Set the colormap field of this structure.
-    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<COLORMAP>> {
+    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<Colormap>> {
         self.colormap = value.into();
         self
     }
     /// Set the cursor field of this structure.
-    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<CURSOR>> {
+    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<Cursor>> {
         self.cursor = value.into();
         self
     }
@@ -6683,7 +6683,7 @@ impl Serialize for CreateWindowAux {
 /// * CreateNotify: event
 /// * MapWindow: request
 /// * xcb_generate_id: function
-pub fn create_window<'c, Conn, A>(conn: &'c Conn, depth: u8, wid: WINDOW, parent: WINDOW, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, visual: VISUALID, value_list: &CreateWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_window<'c, Conn, A>(conn: &'c Conn, depth: u8, wid: Window, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, visual: Visualid, value_list: &CreateWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u16>
 {
     let value_mask = value_list.value_mask();
@@ -6749,21 +6749,21 @@ pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// Auxiliary and optional information for the change_window_attributes function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangeWindowAttributesAux {
-    pub background_pixmap: Option<PIXMAP>,
+    pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
-    pub border_pixmap: Option<PIXMAP>,
+    pub border_pixmap: Option<Pixmap>,
     pub border_pixel: Option<u32>,
     pub bit_gravity: Option<u32>,
     pub win_gravity: Option<u32>,
     pub backing_store: Option<u32>,
     pub backing_planes: Option<u32>,
     pub backing_pixel: Option<u32>,
-    pub override_redirect: Option<BOOL32>,
-    pub save_under: Option<BOOL32>,
+    pub override_redirect: Option<Bool32>,
+    pub save_under: Option<Bool32>,
     pub event_mask: Option<u32>,
     pub do_not_propogate_mask: Option<u32>,
-    pub colormap: Option<COLORMAP>,
-    pub cursor: Option<CURSOR>,
+    pub colormap: Option<Colormap>,
+    pub cursor: Option<Cursor>,
 }
 impl ChangeWindowAttributesAux {
     /// Create a new instance with all fields unset / not present.
@@ -6820,7 +6820,7 @@ impl ChangeWindowAttributesAux {
         mask
     }
     /// Set the background_pixmap field of this structure.
-    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.background_pixmap = value.into();
         self
     }
@@ -6830,7 +6830,7 @@ impl ChangeWindowAttributesAux {
         self
     }
     /// Set the border_pixmap field of this structure.
-    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.border_pixmap = value.into();
         self
     }
@@ -6865,12 +6865,12 @@ impl ChangeWindowAttributesAux {
         self
     }
     /// Set the override_redirect field of this structure.
-    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.override_redirect = value.into();
         self
     }
     /// Set the save_under field of this structure.
-    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.save_under = value.into();
         self
     }
@@ -6885,12 +6885,12 @@ impl ChangeWindowAttributesAux {
         self
     }
     /// Set the colormap field of this structure.
-    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<COLORMAP>> {
+    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<Colormap>> {
         self.colormap = value.into();
         self
     }
     /// Set the cursor field of this structure.
-    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<CURSOR>> {
+    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<Cursor>> {
         self.cursor = value.into();
         self
     }
@@ -6970,7 +6970,7 @@ impl Serialize for ChangeWindowAttributesAux {
 /// * `Pixmap` - TODO: reasons?
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
-pub fn change_window_attributes<'c, Conn>(conn: &'c Conn, window: WINDOW, value_list: &ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_window_attributes<'c, Conn>(conn: &'c Conn, window: Window, value_list: &ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let value_mask = value_list.value_mask();
@@ -7080,7 +7080,7 @@ pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
 ///
 /// * `Drawable` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
-pub fn get_window_attributes<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetWindowAttributesReply>, ConnectionError>
+pub fn get_window_attributes<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetWindowAttributesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -7120,7 +7120,7 @@ pub struct GetWindowAttributesReply {
     pub backing_store: BackingStore,
     pub sequence: u16,
     pub length: u32,
-    pub visual: VISUALID,
+    pub visual: Visualid,
     pub class: WindowClass,
     pub bit_gravity: u8,
     pub win_gravity: u8,
@@ -7130,7 +7130,7 @@ pub struct GetWindowAttributesReply {
     pub map_is_installed: bool,
     pub map_state: MapState,
     pub override_redirect: bool,
-    pub colormap: COLORMAP,
+    pub colormap: Colormap,
     pub all_event_masks: u32,
     pub your_event_mask: u32,
     pub do_not_propagate_mask: u16,
@@ -7141,7 +7141,7 @@ impl GetWindowAttributesReply {
         let (backing_store, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (visual, remaining) = Visualid::try_parse(remaining)?;
         let (class, remaining) = u16::try_parse(remaining)?;
         let (bit_gravity, remaining) = u8::try_parse(remaining)?;
         let (win_gravity, remaining) = u8::try_parse(remaining)?;
@@ -7151,7 +7151,7 @@ impl GetWindowAttributesReply {
         let (map_is_installed, remaining) = bool::try_parse(remaining)?;
         let (map_state, remaining) = u8::try_parse(remaining)?;
         let (override_redirect, remaining) = bool::try_parse(remaining)?;
-        let (colormap, remaining) = COLORMAP::try_parse(remaining)?;
+        let (colormap, remaining) = Colormap::try_parse(remaining)?;
         let (all_event_masks, remaining) = u32::try_parse(remaining)?;
         let (your_event_mask, remaining) = u32::try_parse(remaining)?;
         let (do_not_propagate_mask, remaining) = u16::try_parse(remaining)?;
@@ -7194,7 +7194,7 @@ pub const DESTROY_WINDOW_REQUEST: u8 = 4;
 /// * DestroyNotify: event
 /// * MapWindow: request
 /// * UnmapWindow: request
-pub fn destroy_window<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -7217,7 +7217,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroySubwindows request
 pub const DESTROY_SUBWINDOWS_REQUEST: u8 = 5;
-pub fn destroy_subwindows<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -7324,7 +7324,7 @@ pub const CHANGE_SAVE_SET_REQUEST: u8 = 6;
 /// # See
 ///
 /// * ReparentWindow: request
-pub fn change_save_set<Conn, A>(conn: &Conn, mode: A, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_save_set<Conn, A>(conn: &Conn, mode: A, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (8) / 4;
@@ -7381,7 +7381,7 @@ pub const REPARENT_WINDOW_REQUEST: u8 = 7;
 /// * MapWindow: request
 /// * ReparentNotify: event
 /// * UnmapWindow: request
-pub fn reparent_window<Conn>(conn: &Conn, window: WINDOW, parent: WINDOW, x: i16, y: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn reparent_window<Conn>(conn: &Conn, window: Window, parent: Window, x: i16, y: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -7450,7 +7450,7 @@ pub const MAP_WINDOW_REQUEST: u8 = 8;
 /// * Expose: event
 /// * MapNotify: event
 /// * UnmapWindow: request
-pub fn map_window<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn map_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -7473,7 +7473,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the MapSubwindows request
 pub const MAP_SUBWINDOWS_REQUEST: u8 = 9;
-pub fn map_subwindows<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn map_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -7517,7 +7517,7 @@ pub const UNMAP_WINDOW_REQUEST: u8 = 10;
 /// * Expose: event
 /// * MapWindow: request
 /// * UnmapNotify: event
-pub fn unmap_window<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unmap_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -7540,7 +7540,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the UnmapSubwindows request
 pub const UNMAP_SUBWINDOWS_REQUEST: u8 = 11;
-pub fn unmap_subwindows<Conn>(conn: &Conn, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unmap_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -7720,7 +7720,7 @@ pub struct ConfigureWindowAux {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub border_width: Option<u32>,
-    pub sibling: Option<WINDOW>,
+    pub sibling: Option<Window>,
     pub stack_mode: Option<u32>,
 }
 impl ConfigureWindowAux {
@@ -7779,7 +7779,7 @@ impl ConfigureWindowAux {
         self
     }
     /// Set the sibling field of this structure.
-    pub fn sibling<I>(mut self, value: I) -> Self where I: Into<Option<WINDOW>> {
+    pub fn sibling<I>(mut self, value: I) -> Self where I: Into<Option<Window>> {
         self.sibling = value.into();
         self
     }
@@ -7870,7 +7870,7 @@ impl Serialize for ConfigureWindowAux {
 ///     xcb_flush(c);
 /// }
 /// ```
-pub fn configure_window<'c, Conn>(conn: &'c Conn, window: WINDOW, value_list: &ConfigureWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_window<'c, Conn>(conn: &'c Conn, window: Window, value_list: &ConfigureWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let value_mask = value_list.value_mask();
@@ -7981,7 +7981,7 @@ pub const CIRCULATE_WINDOW_REQUEST: u8 = 13;
 ///
 /// * `Value` - The specified `direction` is invalid.
 /// * `Window` - The specified `window` does not exist.
-pub fn circulate_window<Conn, A>(conn: &Conn, direction: A, window: WINDOW) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn circulate_window<Conn, A>(conn: &Conn, direction: A, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (8) / 4;
@@ -8042,7 +8042,7 @@ pub const GET_GEOMETRY_REQUEST: u8 = 14;
 ///     free(reply);
 /// }
 /// ```
-pub fn get_geometry<Conn>(conn: &Conn, drawable: DRAWABLE) -> Result<Cookie<'_, Conn, GetGeometryReply>, ConnectionError>
+pub fn get_geometry<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, GetGeometryReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -8084,7 +8084,7 @@ pub struct GetGeometryReply {
     pub depth: u8,
     pub sequence: u16,
     pub length: u32,
-    pub root: WINDOW,
+    pub root: Window,
     pub x: i16,
     pub y: i16,
     pub width: u16,
@@ -8097,7 +8097,7 @@ impl GetGeometryReply {
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -8154,7 +8154,7 @@ pub const QUERY_TREE_REQUEST: u8 = 15;
 ///     }
 /// }
 /// ```
-pub fn query_tree<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, QueryTreeReply>, ConnectionError>
+pub fn query_tree<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, QueryTreeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -8187,9 +8187,9 @@ pub struct QueryTreeReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub root: WINDOW,
-    pub parent: WINDOW,
-    pub children: Vec<WINDOW>,
+    pub root: Window,
+    pub parent: Window,
+    pub children: Vec<Window>,
 }
 impl QueryTreeReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8197,11 +8197,11 @@ impl QueryTreeReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (parent, remaining) = WINDOW::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
         let (children_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
-        let (children, remaining) = crate::x11_utils::parse_list::<WINDOW>(remaining, children_len as usize)?;
+        let (children, remaining) = crate::x11_utils::parse_list::<Window>(remaining, children_len as usize)?;
         let result = QueryTreeReply { response_type, sequence, length, root, parent, children };
         Ok((result, remaining))
     }
@@ -8290,7 +8290,7 @@ pub struct InternAtomReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atom: ATOM,
+    pub atom: Atom,
 }
 impl InternAtomReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8298,7 +8298,7 @@ impl InternAtomReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (atom, remaining) = ATOM::try_parse(remaining)?;
+        let (atom, remaining) = Atom::try_parse(remaining)?;
         let result = InternAtomReply { response_type, sequence, length, atom };
         Ok((result, remaining))
     }
@@ -8312,7 +8312,7 @@ impl TryFrom<&[u8]> for InternAtomReply {
 
 /// Opcode for the GetAtomName request
 pub const GET_ATOM_NAME_REQUEST: u8 = 17;
-pub fn get_atom_name<Conn>(conn: &Conn, atom: ATOM) -> Result<Cookie<'_, Conn, GetAtomNameReply>, ConnectionError>
+pub fn get_atom_name<Conn>(conn: &Conn, atom: Atom) -> Result<Cookie<'_, Conn, GetAtomNameReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -8488,8 +8488,8 @@ pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 ///     xcb_flush(conn);
 /// }
 /// ```
-pub fn change_property<'c, Conn, A, B, C>(conn: &'c Conn, mode: A, window: WINDOW, property: B, type_: C, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
-where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<ATOM>, C: Into<ATOM>
+pub fn change_property<'c, Conn, A, B, C>(conn: &'c Conn, mode: A, window: Window, property: B, type_: C, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<Atom>, C: Into<Atom>
 {
     let length: usize = (24 + 1 * data.len() + 3) / 4;
     let mode = mode.into();
@@ -8539,7 +8539,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<ATOM>, C: Into<ATOM
 
 /// Opcode for the DeleteProperty request
 pub const DELETE_PROPERTY_REQUEST: u8 = 19;
-pub fn delete_property<Conn>(conn: &Conn, window: WINDOW, property: ATOM) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_property<Conn>(conn: &Conn, window: Window, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12) / 4;
@@ -8859,7 +8859,7 @@ impl GetPropertyReply {
 ///     free(reply);
 /// }
 /// ```
-pub fn get_property<Conn>(conn: &Conn, delete: bool, window: WINDOW, property: ATOM, type_: ATOM, long_offset: u32, long_length: u32) -> Result<Cookie<'_, Conn, GetPropertyReply>, ConnectionError>
+pub fn get_property<Conn>(conn: &Conn, delete: bool, window: Window, property: Atom, type_: Atom, long_offset: u32, long_length: u32) -> Result<Cookie<'_, Conn, GetPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (24) / 4;
@@ -8919,7 +8919,7 @@ pub struct GetPropertyReply {
     pub format: u8,
     pub sequence: u16,
     pub length: u32,
-    pub type_: ATOM,
+    pub type_: Atom,
     pub bytes_after: u32,
     pub value_len: u32,
     pub value: Vec<u8>,
@@ -8930,7 +8930,7 @@ impl GetPropertyReply {
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (type_, remaining) = ATOM::try_parse(remaining)?;
+        let (type_, remaining) = Atom::try_parse(remaining)?;
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
@@ -8948,7 +8948,7 @@ impl TryFrom<&[u8]> for GetPropertyReply {
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 21;
-pub fn list_properties<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
+pub fn list_properties<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -8973,7 +8973,7 @@ pub struct ListPropertiesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atoms: Vec<ATOM>,
+    pub atoms: Vec<Atom>,
 }
 impl ListPropertiesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8983,7 +8983,7 @@ impl ListPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (atoms_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<ATOM>(remaining, atoms_len as usize)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, atoms_len as usize)?;
         let result = ListPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -9026,7 +9026,7 @@ pub const SET_SELECTION_OWNER_REQUEST: u8 = 22;
 /// # See
 ///
 /// * SetSelectionOwner: request
-pub fn set_selection_owner<Conn>(conn: &Conn, owner: WINDOW, selection: ATOM, time: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_selection_owner<Conn>(conn: &Conn, owner: Window, selection: Atom, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -9076,7 +9076,7 @@ pub const GET_SELECTION_OWNER_REQUEST: u8 = 23;
 /// # See
 ///
 /// * SetSelectionOwner: request
-pub fn get_selection_owner<Conn>(conn: &Conn, selection: ATOM) -> Result<Cookie<'_, Conn, GetSelectionOwnerReply>, ConnectionError>
+pub fn get_selection_owner<Conn>(conn: &Conn, selection: Atom) -> Result<Cookie<'_, Conn, GetSelectionOwnerReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -9107,7 +9107,7 @@ pub struct GetSelectionOwnerReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub owner: WINDOW,
+    pub owner: Window,
 }
 impl GetSelectionOwnerReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9115,7 +9115,7 @@ impl GetSelectionOwnerReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (owner, remaining) = WINDOW::try_parse(remaining)?;
+        let (owner, remaining) = Window::try_parse(remaining)?;
         let result = GetSelectionOwnerReply { response_type, sequence, length, owner };
         Ok((result, remaining))
     }
@@ -9129,7 +9129,7 @@ impl TryFrom<&[u8]> for GetSelectionOwnerReply {
 
 /// Opcode for the ConvertSelection request
 pub const CONVERT_SELECTION_REQUEST: u8 = 24;
-pub fn convert_selection<Conn>(conn: &Conn, requestor: WINDOW, selection: ATOM, target: ATOM, property: ATOM, time: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn convert_selection<Conn>(conn: &Conn, requestor: Window, selection: Atom, target: Atom, property: Atom, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (24) / 4;
@@ -9307,7 +9307,7 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 ///     free(event);
 /// }
 /// ```
-pub fn send_event<Conn, A>(conn: &Conn, propagate: bool, destination: WINDOW, event_mask: u32, event: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn send_event<Conn, A>(conn: &Conn, propagate: bool, destination: Window, event_mask: u32, event: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<[u8; 32]>
 {
     let length: usize = (44) / 4;
@@ -9481,57 +9481,57 @@ impl TryFrom<u32> for GrabStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Cursor {
+pub enum CursorEnum {
     None = 0,
 }
-impl From<Cursor> for u8 {
-    fn from(input: Cursor) -> Self {
+impl From<CursorEnum> for u8 {
+    fn from(input: CursorEnum) -> Self {
         match input {
-            Cursor::None => 0,
+            CursorEnum::None => 0,
         }
     }
 }
-impl From<Cursor> for Option<u8> {
-    fn from(input: Cursor) -> Self {
+impl From<CursorEnum> for Option<u8> {
+    fn from(input: CursorEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Cursor> for u16 {
-    fn from(input: Cursor) -> Self {
+impl From<CursorEnum> for u16 {
+    fn from(input: CursorEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Cursor> for Option<u16> {
-    fn from(input: Cursor) -> Self {
+impl From<CursorEnum> for Option<u16> {
+    fn from(input: CursorEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Cursor> for u32 {
-    fn from(input: Cursor) -> Self {
+impl From<CursorEnum> for u32 {
+    fn from(input: CursorEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Cursor> for Option<u32> {
-    fn from(input: Cursor) -> Self {
+impl From<CursorEnum> for Option<u32> {
+    fn from(input: CursorEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Cursor {
+impl TryFrom<u8> for CursorEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Cursor::None),
+            0 => Ok(CursorEnum::None),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Cursor {
+impl TryFrom<u16> for CursorEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Cursor {
+impl TryFrom<u32> for CursorEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -9609,7 +9609,7 @@ pub const GRAB_POINTER_REQUEST: u8 = 26;
 ///     }
 /// }
 /// ```
-pub fn grab_pointer<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: WINDOW, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: WINDOW, cursor: CURSOR, time: TIMESTAMP) -> Result<Cookie<'_, Conn, GrabPointerReply>, ConnectionError>
+pub fn grab_pointer<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: Window, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: Window, cursor: Cursor, time: Timestamp) -> Result<Cookie<'_, Conn, GrabPointerReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 {
     let length: usize = (24) / 4;
@@ -9704,7 +9704,7 @@ pub const UNGRAB_POINTER_REQUEST: u8 = 27;
 /// * GrabButton: request
 /// * GrabPointer: request
 /// * LeaveNotify: event
-pub fn ungrab_pointer<Conn>(conn: &Conn, time: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_pointer<Conn>(conn: &Conn, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -9876,7 +9876,7 @@ pub const GRAB_BUTTON_REQUEST: u8 = 28;
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
-pub fn grab_button<Conn, A, B, C>(conn: &Conn, owner_events: bool, grab_window: WINDOW, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: WINDOW, cursor: CURSOR, button: C, modifiers: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn grab_button<Conn, A, B, C>(conn: &Conn, owner_events: bool, grab_window: Window, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: Window, cursor: Cursor, button: C, modifiers: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>, C: Into<u8>
 {
     let length: usize = (24) / 4;
@@ -9926,7 +9926,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>, C: Into<u8>
 
 /// Opcode for the UngrabButton request
 pub const UNGRAB_BUTTON_REQUEST: u8 = 29;
-pub fn ungrab_button<Conn, A>(conn: &Conn, button: A, grab_window: WINDOW, modifiers: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_button<Conn, A>(conn: &Conn, button: A, grab_window: Window, modifiers: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (12) / 4;
@@ -9956,7 +9956,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the ChangeActivePointerGrab request
 pub const CHANGE_ACTIVE_POINTER_GRAB_REQUEST: u8 = 30;
-pub fn change_active_pointer_grab<Conn>(conn: &Conn, cursor: CURSOR, time: TIMESTAMP, event_mask: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_active_pointer_grab<Conn>(conn: &Conn, cursor: Cursor, time: Timestamp, event_mask: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -10049,7 +10049,7 @@ pub const GRAB_KEYBOARD_REQUEST: u8 = 31;
 ///     }
 /// }
 /// ```
-pub fn grab_keyboard<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: WINDOW, time: TIMESTAMP, pointer_mode: A, keyboard_mode: B) -> Result<Cookie<'_, Conn, GrabKeyboardReply>, ConnectionError>
+pub fn grab_keyboard<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: Window, time: Timestamp, pointer_mode: A, keyboard_mode: B) -> Result<Cookie<'_, Conn, GrabKeyboardReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 {
     let length: usize = (16) / 4;
@@ -10110,7 +10110,7 @@ impl TryFrom<&[u8]> for GrabKeyboardReply {
 
 /// Opcode for the UngrabKeyboard request
 pub const UNGRAB_KEYBOARD_REQUEST: u8 = 32;
-pub fn ungrab_keyboard<Conn>(conn: &Conn, time: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_keyboard<Conn>(conn: &Conn, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -10250,7 +10250,7 @@ pub const GRAB_KEY_REQUEST: u8 = 33;
 /// # See
 ///
 /// * GrabKeyboard: request
-pub fn grab_key<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: WINDOW, modifiers: u16, key: KEYCODE, pointer_mode: A, keyboard_mode: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn grab_key<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: Window, modifiers: u16, key: Keycode, pointer_mode: A, keyboard_mode: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 {
     let length: usize = (16) / 4;
@@ -10313,7 +10313,7 @@ pub const UNGRAB_KEY_REQUEST: u8 = 34;
 ///
 /// * GrabKey: request
 /// * xev: program
-pub fn ungrab_key<Conn>(conn: &Conn, key: KEYCODE, grab_window: WINDOW, modifiers: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_key<Conn>(conn: &Conn, key: Keycode, grab_window: Window, modifiers: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12) / 4;
@@ -10501,7 +10501,7 @@ pub const ALLOW_EVENTS_REQUEST: u8 = 35;
 /// # Errors
 ///
 /// * `Value` - You specified an invalid `mode`.
-pub fn allow_events<Conn, A>(conn: &Conn, mode: A, time: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn allow_events<Conn, A>(conn: &Conn, mode: A, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (8) / 4;
@@ -10575,7 +10575,7 @@ pub const QUERY_POINTER_REQUEST: u8 = 38;
 /// # Errors
 ///
 /// * `Window` - The specified `window` does not exist.
-pub fn query_pointer<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, QueryPointerReply>, ConnectionError>
+pub fn query_pointer<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, QueryPointerReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -10623,8 +10623,8 @@ pub struct QueryPointerReply {
     pub same_screen: bool,
     pub sequence: u16,
     pub length: u32,
-    pub root: WINDOW,
-    pub child: WINDOW,
+    pub root: Window,
+    pub child: Window,
     pub root_x: i16,
     pub root_y: i16,
     pub win_x: i16,
@@ -10637,8 +10637,8 @@ impl QueryPointerReply {
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = WINDOW::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (root_x, remaining) = i16::try_parse(remaining)?;
         let (root_y, remaining) = i16::try_parse(remaining)?;
         let (win_x, remaining) = i16::try_parse(remaining)?;
@@ -10658,13 +10658,13 @@ impl TryFrom<&[u8]> for QueryPointerReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Timecoord {
-    pub time: TIMESTAMP,
+    pub time: Timestamp,
     pub x: i16,
     pub y: i16,
 }
 impl TryParse for Timecoord {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let result = Timecoord { time, x, y };
@@ -10704,7 +10704,7 @@ impl Serialize for Timecoord {
 
 /// Opcode for the GetMotionEvents request
 pub const GET_MOTION_EVENTS_REQUEST: u8 = 39;
-pub fn get_motion_events<Conn>(conn: &Conn, window: WINDOW, start: TIMESTAMP, stop: TIMESTAMP) -> Result<Cookie<'_, Conn, GetMotionEventsReply>, ConnectionError>
+pub fn get_motion_events<Conn>(conn: &Conn, window: Window, start: Timestamp, stop: Timestamp) -> Result<Cookie<'_, Conn, GetMotionEventsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -10763,7 +10763,7 @@ impl TryFrom<&[u8]> for GetMotionEventsReply {
 
 /// Opcode for the TranslateCoordinates request
 pub const TRANSLATE_COORDINATES_REQUEST: u8 = 40;
-pub fn translate_coordinates<Conn>(conn: &Conn, src_window: WINDOW, dst_window: WINDOW, src_x: i16, src_y: i16) -> Result<Cookie<'_, Conn, TranslateCoordinatesReply>, ConnectionError>
+pub fn translate_coordinates<Conn>(conn: &Conn, src_window: Window, dst_window: Window, src_x: i16, src_y: i16) -> Result<Cookie<'_, Conn, TranslateCoordinatesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -10800,7 +10800,7 @@ pub struct TranslateCoordinatesReply {
     pub same_screen: bool,
     pub sequence: u16,
     pub length: u32,
-    pub child: WINDOW,
+    pub child: Window,
     pub dst_x: i16,
     pub dst_y: i16,
 }
@@ -10810,7 +10810,7 @@ impl TranslateCoordinatesReply {
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (child, remaining) = WINDOW::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
         let (dst_x, remaining) = i16::try_parse(remaining)?;
         let (dst_y, remaining) = i16::try_parse(remaining)?;
         let result = TranslateCoordinatesReply { response_type, same_screen, sequence, length, child, dst_x, dst_y };
@@ -10858,7 +10858,7 @@ pub const WARP_POINTER_REQUEST: u8 = 41;
 /// # See
 ///
 /// * SetInputFocus: request
-pub fn warp_pointer<Conn>(conn: &Conn, src_window: WINDOW, dst_window: WINDOW, src_x: i16, src_y: i16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn warp_pointer<Conn>(conn: &Conn, src_window: Window, dst_window: Window, src_x: i16, src_y: i16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (24) / 4;
@@ -11019,7 +11019,7 @@ pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
 ///
 /// * FocusIn: event
 /// * FocusOut: event
-pub fn set_input_focus<Conn, A>(conn: &Conn, revert_to: A, focus: WINDOW, time: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_input_focus<Conn, A>(conn: &Conn, revert_to: A, focus: Window, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (12) / 4;
@@ -11070,7 +11070,7 @@ pub struct GetInputFocusReply {
     pub revert_to: InputFocus,
     pub sequence: u16,
     pub length: u32,
-    pub focus: WINDOW,
+    pub focus: Window,
 }
 impl GetInputFocusReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11078,7 +11078,7 @@ impl GetInputFocusReply {
         let (revert_to, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (focus, remaining) = WINDOW::try_parse(remaining)?;
+        let (focus, remaining) = Window::try_parse(remaining)?;
         let revert_to = revert_to.try_into()?;
         let result = GetInputFocusReply { response_type, revert_to, sequence, length, focus };
         Ok((result, remaining))
@@ -11220,7 +11220,7 @@ pub const OPEN_FONT_REQUEST: u8 = 45;
 /// # See
 ///
 /// * xcb_generate_id: function
-pub fn open_font<'c, Conn>(conn: &'c Conn, fid: FONT, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn open_font<'c, Conn>(conn: &'c Conn, fid: Font, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 1 * name.len() + 3) / 4;
@@ -11252,7 +11252,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CloseFont request
 pub const CLOSE_FONT_REQUEST: u8 = 46;
-pub fn close_font<Conn>(conn: &Conn, font: FONT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn close_font<Conn>(conn: &Conn, font: Font) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -11337,12 +11337,12 @@ impl TryFrom<u32> for FontDraw {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Fontprop {
-    pub name: ATOM,
+    pub name: Atom,
     pub value: u32,
 }
 impl TryParse for Fontprop {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (name, remaining) = Atom::try_parse(remaining)?;
         let (value, remaining) = u32::try_parse(remaining)?;
         let result = Fontprop { name, value };
         Ok((result, remaining))
@@ -11448,7 +11448,7 @@ pub const QUERY_FONT_REQUEST: u8 = 47;
 /// # Fields
 ///
 /// * `font` - The fontable (Font or Graphics Context) to query.
-pub fn query_font<Conn>(conn: &Conn, font: FONTABLE) -> Result<Cookie<'_, Conn, QueryFontReply>, ConnectionError>
+pub fn query_font<Conn>(conn: &Conn, font: Fontable) -> Result<Cookie<'_, Conn, QueryFontReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -11572,7 +11572,7 @@ pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
 ///
 /// * `Font` - The specified `font` does not exist.
 /// * `GContext` - The specified graphics context does not exist.
-pub fn query_text_extents<'c, Conn>(conn: &'c Conn, font: FONTABLE, string: &[Char2b]) -> Result<Cookie<'c, Conn, QueryTextExtentsReply>, ConnectionError>
+pub fn query_text_extents<'c, Conn>(conn: &'c Conn, font: Fontable, string: &[Char2b]) -> Result<Cookie<'c, Conn, QueryTextExtentsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8 + 2 * string.len() + 3) / 4;
@@ -11956,7 +11956,7 @@ pub const CREATE_PIXMAP_REQUEST: u8 = 53;
 /// # See
 ///
 /// * xcb_generate_id: function
-pub fn create_pixmap<Conn>(conn: &Conn, depth: u8, pid: PIXMAP, drawable: DRAWABLE, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_pixmap<Conn>(conn: &Conn, depth: u8, pid: Pixmap, drawable: Drawable, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -12003,7 +12003,7 @@ pub const FREE_PIXMAP_REQUEST: u8 = 54;
 /// # Errors
 ///
 /// * `Pixmap` - The specified pixmap does not exist.
-pub fn free_pixmap<Conn>(conn: &Conn, pixmap: PIXMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_pixmap<Conn>(conn: &Conn, pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -12793,16 +12793,16 @@ pub struct CreateGCAux {
     pub join_style: Option<u32>,
     pub fill_style: Option<u32>,
     pub fill_rule: Option<u32>,
-    pub tile: Option<PIXMAP>,
-    pub stipple: Option<PIXMAP>,
+    pub tile: Option<Pixmap>,
+    pub stipple: Option<Pixmap>,
     pub tile_stipple_x_origin: Option<i32>,
     pub tile_stipple_y_origin: Option<i32>,
-    pub font: Option<FONT>,
+    pub font: Option<Font>,
     pub subwindow_mode: Option<u32>,
-    pub graphics_exposures: Option<BOOL32>,
+    pub graphics_exposures: Option<Bool32>,
     pub clip_x_origin: Option<i32>,
     pub clip_y_origin: Option<i32>,
-    pub clip_mask: Option<PIXMAP>,
+    pub clip_mask: Option<Pixmap>,
     pub dash_offset: Option<u32>,
     pub dashes: Option<u32>,
     pub arc_mode: Option<u32>,
@@ -12936,12 +12936,12 @@ impl CreateGCAux {
         self
     }
     /// Set the tile field of this structure.
-    pub fn tile<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn tile<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.tile = value.into();
         self
     }
     /// Set the stipple field of this structure.
-    pub fn stipple<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn stipple<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.stipple = value.into();
         self
     }
@@ -12956,7 +12956,7 @@ impl CreateGCAux {
         self
     }
     /// Set the font field of this structure.
-    pub fn font<I>(mut self, value: I) -> Self where I: Into<Option<FONT>> {
+    pub fn font<I>(mut self, value: I) -> Self where I: Into<Option<Font>> {
         self.font = value.into();
         self
     }
@@ -12966,7 +12966,7 @@ impl CreateGCAux {
         self
     }
     /// Set the graphics_exposures field of this structure.
-    pub fn graphics_exposures<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn graphics_exposures<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.graphics_exposures = value.into();
         self
     }
@@ -12981,7 +12981,7 @@ impl CreateGCAux {
         self
     }
     /// Set the clip_mask field of this structure.
-    pub fn clip_mask<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn clip_mask<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.clip_mask = value.into();
         self
     }
@@ -13103,7 +13103,7 @@ impl Serialize for CreateGCAux {
 /// # See
 ///
 /// * xcb_generate_id: function
-pub fn create_gc<'c, Conn>(conn: &'c Conn, cid: GCONTEXT, drawable: DRAWABLE, value_list: &CreateGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_gc<'c, Conn>(conn: &'c Conn, cid: Gcontext, drawable: Drawable, value_list: &CreateGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let value_mask = value_list.value_mask();
@@ -13154,16 +13154,16 @@ pub struct ChangeGCAux {
     pub join_style: Option<u32>,
     pub fill_style: Option<u32>,
     pub fill_rule: Option<u32>,
-    pub tile: Option<PIXMAP>,
-    pub stipple: Option<PIXMAP>,
+    pub tile: Option<Pixmap>,
+    pub stipple: Option<Pixmap>,
     pub tile_stipple_x_origin: Option<i32>,
     pub tile_stipple_y_origin: Option<i32>,
-    pub font: Option<FONT>,
+    pub font: Option<Font>,
     pub subwindow_mode: Option<u32>,
-    pub graphics_exposures: Option<BOOL32>,
+    pub graphics_exposures: Option<Bool32>,
     pub clip_x_origin: Option<i32>,
     pub clip_y_origin: Option<i32>,
-    pub clip_mask: Option<PIXMAP>,
+    pub clip_mask: Option<Pixmap>,
     pub dash_offset: Option<u32>,
     pub dashes: Option<u32>,
     pub arc_mode: Option<u32>,
@@ -13297,12 +13297,12 @@ impl ChangeGCAux {
         self
     }
     /// Set the tile field of this structure.
-    pub fn tile<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn tile<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.tile = value.into();
         self
     }
     /// Set the stipple field of this structure.
-    pub fn stipple<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn stipple<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.stipple = value.into();
         self
     }
@@ -13317,7 +13317,7 @@ impl ChangeGCAux {
         self
     }
     /// Set the font field of this structure.
-    pub fn font<I>(mut self, value: I) -> Self where I: Into<Option<FONT>> {
+    pub fn font<I>(mut self, value: I) -> Self where I: Into<Option<Font>> {
         self.font = value.into();
         self
     }
@@ -13327,7 +13327,7 @@ impl ChangeGCAux {
         self
     }
     /// Set the graphics_exposures field of this structure.
-    pub fn graphics_exposures<I>(mut self, value: I) -> Self where I: Into<Option<BOOL32>> {
+    pub fn graphics_exposures<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
         self.graphics_exposures = value.into();
         self
     }
@@ -13342,7 +13342,7 @@ impl ChangeGCAux {
         self
     }
     /// Set the clip_mask field of this structure.
-    pub fn clip_mask<I>(mut self, value: I) -> Self where I: Into<Option<PIXMAP>> {
+    pub fn clip_mask<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
         self.clip_mask = value.into();
         self
     }
@@ -13485,7 +13485,7 @@ impl Serialize for ChangeGCAux {
 ///     xcb_flush(conn);
 /// }
 /// ```
-pub fn change_gc<'c, Conn>(conn: &'c Conn, gc: GCONTEXT, value_list: &ChangeGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_gc<'c, Conn>(conn: &'c Conn, gc: Gcontext, value_list: &ChangeGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let value_mask = value_list.value_mask();
@@ -13518,7 +13518,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CopyGC request
 pub const COPY_GC_REQUEST: u8 = 57;
-pub fn copy_gc<Conn>(conn: &Conn, src_gc: GCONTEXT, dst_gc: GCONTEXT, value_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn copy_gc<Conn>(conn: &Conn, src_gc: Gcontext, dst_gc: Gcontext, value_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -13551,7 +13551,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetDashes request
 pub const SET_DASHES_REQUEST: u8 = 58;
-pub fn set_dashes<'c, Conn>(conn: &'c Conn, gc: GCONTEXT, dash_offset: u16, dashes: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_dashes<'c, Conn>(conn: &'c Conn, gc: Gcontext, dash_offset: u16, dashes: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 1 * dashes.len() + 3) / 4;
@@ -13652,7 +13652,7 @@ impl TryFrom<u32> for ClipOrdering {
 
 /// Opcode for the SetClipRectangles request
 pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
-pub fn set_clip_rectangles<'c, Conn, A>(conn: &'c Conn, ordering: A, gc: GCONTEXT, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_clip_rectangles<'c, Conn, A>(conn: &'c Conn, ordering: A, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (12 + 8 * rectangles.len() + 3) / 4;
@@ -13698,7 +13698,7 @@ pub const FREE_GC_REQUEST: u8 = 60;
 /// # Errors
 ///
 /// * `GContext` - The specified graphics context does not exist.
-pub fn free_gc<Conn>(conn: &Conn, gc: GCONTEXT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_gc<Conn>(conn: &Conn, gc: Gcontext) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -13721,7 +13721,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ClearArea request
 pub const CLEAR_AREA_REQUEST: u8 = 61;
-pub fn clear_area<Conn>(conn: &Conn, exposures: bool, window: WINDOW, x: i16, y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn clear_area<Conn>(conn: &Conn, exposures: bool, window: Window, x: i16, y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -13778,7 +13778,7 @@ pub const COPY_AREA_REQUEST: u8 = 62;
 /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - `src_drawable` has a different root or depth than `dst_drawable`.
-pub fn copy_area<Conn>(conn: &Conn, src_drawable: DRAWABLE, dst_drawable: DRAWABLE, gc: GCONTEXT, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn copy_area<Conn>(conn: &Conn, src_drawable: Drawable, dst_drawable: Drawable, gc: Gcontext, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (28) / 4;
@@ -13829,7 +13829,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CopyPlane request
 pub const COPY_PLANE_REQUEST: u8 = 63;
-pub fn copy_plane<Conn>(conn: &Conn, src_drawable: DRAWABLE, dst_drawable: DRAWABLE, gc: GCONTEXT, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16, bit_plane: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn copy_plane<Conn>(conn: &Conn, src_drawable: Drawable, dst_drawable: Drawable, gc: Gcontext, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16, bit_plane: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (32) / 4;
@@ -13954,7 +13954,7 @@ impl TryFrom<u32> for CoordMode {
 
 /// Opcode for the PolyPoint request
 pub const POLY_POINT_REQUEST: u8 = 64;
-pub fn poly_point<'c, Conn, A>(conn: &'c Conn, coordinate_mode: A, drawable: DRAWABLE, gc: GCONTEXT, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_point<'c, Conn, A>(conn: &'c Conn, coordinate_mode: A, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (12 + 4 * points.len() + 3) / 4;
@@ -14026,7 +14026,7 @@ pub const POLY_LINE_REQUEST: u8 = 65;
 ///     xcb_flush(conn);
 /// }
 /// ```
-pub fn poly_line<'c, Conn, A>(conn: &'c Conn, coordinate_mode: A, drawable: DRAWABLE, gc: GCONTEXT, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_line<'c, Conn, A>(conn: &'c Conn, coordinate_mode: A, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (12 + 4 * points.len() + 3) / 4;
@@ -14136,7 +14136,7 @@ pub const POLY_SEGMENT_REQUEST: u8 = 66;
 /// * `Drawable` - The specified `drawable` does not exist.
 /// * `GContext` - The specified `gc` does not exist.
 /// * `Match` - TODO: reasons?
-pub fn poly_segment<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, segments: &[Segment]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_segment<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, segments: &[Segment]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 8 * segments.len() + 3) / 4;
@@ -14168,7 +14168,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PolyRectangle request
 pub const POLY_RECTANGLE_REQUEST: u8 = 67;
-pub fn poly_rectangle<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_rectangle<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 8 * rectangles.len() + 3) / 4;
@@ -14200,7 +14200,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PolyArc request
 pub const POLY_ARC_REQUEST: u8 = 68;
-pub fn poly_arc<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, arcs: &[Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_arc<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 12 * arcs.len() + 3) / 4;
@@ -14297,7 +14297,7 @@ impl TryFrom<u32> for PolyShape {
 
 /// Opcode for the FillPoly request
 pub const FILL_POLY_REQUEST: u8 = 69;
-pub fn fill_poly<'c, Conn, A, B>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, shape: A, coordinate_mode: B, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn fill_poly<'c, Conn, A, B>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, shape: A, coordinate_mode: B, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>
 {
     let length: usize = (16 + 4 * points.len() + 3) / 4;
@@ -14362,7 +14362,7 @@ pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - TODO: reasons?
-pub fn poly_fill_rectangle<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_fill_rectangle<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 8 * rectangles.len() + 3) / 4;
@@ -14394,7 +14394,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PolyFillArc request
 pub const POLY_FILL_ARC_REQUEST: u8 = 71;
-pub fn poly_fill_arc<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, arcs: &[Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_fill_arc<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 12 * arcs.len() + 3) / 4;
@@ -14491,7 +14491,7 @@ impl TryFrom<u32> for ImageFormat {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 72;
-pub fn put_image<'c, Conn, A>(conn: &'c Conn, format: A, drawable: DRAWABLE, gc: GCONTEXT, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn put_image<'c, Conn, A>(conn: &'c Conn, format: A, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (24 + 1 * data.len() + 3) / 4;
@@ -14542,7 +14542,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the GetImage request
 pub const GET_IMAGE_REQUEST: u8 = 73;
-pub fn get_image<Conn, A>(conn: &Conn, format: A, drawable: DRAWABLE, x: i16, y: i16, width: u16, height: u16, plane_mask: u32) -> Result<Cookie<'_, Conn, GetImageReply>, ConnectionError>
+pub fn get_image<Conn, A>(conn: &Conn, format: A, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, plane_mask: u32) -> Result<Cookie<'_, Conn, GetImageReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (20) / 4;
@@ -14586,7 +14586,7 @@ pub struct GetImageReply {
     pub response_type: u8,
     pub depth: u8,
     pub sequence: u16,
-    pub visual: VISUALID,
+    pub visual: Visualid,
     pub data: Vec<u8>,
 }
 impl GetImageReply {
@@ -14595,7 +14595,7 @@ impl GetImageReply {
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (visual, remaining) = Visualid::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * (4))?;
         let result = GetImageReply { response_type, depth, sequence, visual, data };
@@ -14611,7 +14611,7 @@ impl TryFrom<&[u8]> for GetImageReply {
 
 /// Opcode for the PolyText8 request
 pub const POLY_TEXT8_REQUEST: u8 = 74;
-pub fn poly_text8<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_text8<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16 + 1 * items.len() + 3) / 4;
@@ -14648,7 +14648,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PolyText16 request
 pub const POLY_TEXT16_REQUEST: u8 = 75;
-pub fn poly_text16<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_text16<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16 + 1 * items.len() + 3) / 4;
@@ -14719,7 +14719,7 @@ pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 /// # See
 ///
 /// * ImageText16: request
-pub fn image_text8<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, string: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn image_text8<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16 + 1 * string.len() + 3) / 4;
@@ -14793,7 +14793,7 @@ pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 /// # See
 ///
 /// * ImageText8: request
-pub fn image_text16<'c, Conn>(conn: &'c Conn, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, string: &[Char2b]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn image_text16<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[Char2b]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16 + 2 * string.len() + 3) / 4;
@@ -14895,7 +14895,7 @@ impl TryFrom<u32> for ColormapAlloc {
 
 /// Opcode for the CreateColormap request
 pub const CREATE_COLORMAP_REQUEST: u8 = 78;
-pub fn create_colormap<Conn, A>(conn: &Conn, alloc: A, mid: COLORMAP, window: WINDOW, visual: VISUALID) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_colormap<Conn, A>(conn: &Conn, alloc: A, mid: Colormap, window: Window, visual: Visualid) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (16) / 4;
@@ -14930,7 +14930,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the FreeColormap request
 pub const FREE_COLORMAP_REQUEST: u8 = 79;
-pub fn free_colormap<Conn>(conn: &Conn, cmap: COLORMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -14953,7 +14953,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CopyColormapAndFree request
 pub const COPY_COLORMAP_AND_FREE_REQUEST: u8 = 80;
-pub fn copy_colormap_and_free<Conn>(conn: &Conn, mid: COLORMAP, src_cmap: COLORMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn copy_colormap_and_free<Conn>(conn: &Conn, mid: Colormap, src_cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12) / 4;
@@ -14981,7 +14981,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the InstallColormap request
 pub const INSTALL_COLORMAP_REQUEST: u8 = 81;
-pub fn install_colormap<Conn>(conn: &Conn, cmap: COLORMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn install_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -15004,7 +15004,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the UninstallColormap request
 pub const UNINSTALL_COLORMAP_REQUEST: u8 = 82;
-pub fn uninstall_colormap<Conn>(conn: &Conn, cmap: COLORMAP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn uninstall_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -15027,7 +15027,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ListInstalledColormaps request
 pub const LIST_INSTALLED_COLORMAPS_REQUEST: u8 = 83;
-pub fn list_installed_colormaps<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, ListInstalledColormapsReply>, ConnectionError>
+pub fn list_installed_colormaps<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListInstalledColormapsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -15052,7 +15052,7 @@ pub struct ListInstalledColormapsReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub cmaps: Vec<COLORMAP>,
+    pub cmaps: Vec<Colormap>,
 }
 impl ListInstalledColormapsReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15062,7 +15062,7 @@ impl ListInstalledColormapsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (cmaps_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (cmaps, remaining) = crate::x11_utils::parse_list::<COLORMAP>(remaining, cmaps_len as usize)?;
+        let (cmaps, remaining) = crate::x11_utils::parse_list::<Colormap>(remaining, cmaps_len as usize)?;
         let result = ListInstalledColormapsReply { response_type, sequence, length, cmaps };
         Ok((result, remaining))
     }
@@ -15094,7 +15094,7 @@ pub const ALLOC_COLOR_REQUEST: u8 = 84;
 /// # Errors
 ///
 /// * `Colormap` - The specified colormap `cmap` does not exist.
-pub fn alloc_color<Conn>(conn: &Conn, cmap: COLORMAP, red: u16, green: u16, blue: u16) -> Result<Cookie<'_, Conn, AllocColorReply>, ConnectionError>
+pub fn alloc_color<Conn>(conn: &Conn, cmap: Colormap, red: u16, green: u16, blue: u16) -> Result<Cookie<'_, Conn, AllocColorReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -15159,7 +15159,7 @@ impl TryFrom<&[u8]> for AllocColorReply {
 
 /// Opcode for the AllocNamedColor request
 pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
-pub fn alloc_named_color<'c, Conn>(conn: &'c Conn, cmap: COLORMAP, name: &[u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
+pub fn alloc_named_color<'c, Conn>(conn: &'c Conn, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 1 * name.len() + 3) / 4;
@@ -15227,7 +15227,7 @@ impl TryFrom<&[u8]> for AllocNamedColorReply {
 
 /// Opcode for the AllocColorCells request
 pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
-pub fn alloc_color_cells<Conn>(conn: &Conn, contiguous: bool, cmap: COLORMAP, colors: u16, planes: u16) -> Result<Cookie<'_, Conn, AllocColorCellsReply>, ConnectionError>
+pub fn alloc_color_cells<Conn>(conn: &Conn, contiguous: bool, cmap: Colormap, colors: u16, planes: u16) -> Result<Cookie<'_, Conn, AllocColorCellsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12) / 4;
@@ -15286,7 +15286,7 @@ impl TryFrom<&[u8]> for AllocColorCellsReply {
 
 /// Opcode for the AllocColorPlanes request
 pub const ALLOC_COLOR_PLANES_REQUEST: u8 = 87;
-pub fn alloc_color_planes<Conn>(conn: &Conn, contiguous: bool, cmap: COLORMAP, colors: u16, reds: u16, greens: u16, blues: u16) -> Result<Cookie<'_, Conn, AllocColorPlanesReply>, ConnectionError>
+pub fn alloc_color_planes<Conn>(conn: &Conn, contiguous: bool, cmap: Colormap, colors: u16, reds: u16, greens: u16, blues: u16) -> Result<Cookie<'_, Conn, AllocColorPlanesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16) / 4;
@@ -15355,7 +15355,7 @@ impl TryFrom<&[u8]> for AllocColorPlanesReply {
 
 /// Opcode for the FreeColors request
 pub const FREE_COLORS_REQUEST: u8 = 88;
-pub fn free_colors<'c, Conn>(conn: &'c Conn, cmap: COLORMAP, plane_mask: u32, pixels: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn free_colors<'c, Conn>(conn: &'c Conn, cmap: Colormap, plane_mask: u32, pixels: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 4 * pixels.len() + 3) / 4;
@@ -15513,7 +15513,7 @@ impl Serialize for Coloritem {
 
 /// Opcode for the StoreColors request
 pub const STORE_COLORS_REQUEST: u8 = 89;
-pub fn store_colors<'c, Conn>(conn: &'c Conn, cmap: COLORMAP, items: &[Coloritem]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn store_colors<'c, Conn>(conn: &'c Conn, cmap: Colormap, items: &[Coloritem]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8 + 12 * items.len() + 3) / 4;
@@ -15540,7 +15540,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the StoreNamedColor request
 pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
-pub fn store_named_color<'c, Conn>(conn: &'c Conn, flags: u8, cmap: COLORMAP, pixel: u32, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn store_named_color<'c, Conn>(conn: &'c Conn, flags: u8, cmap: Colormap, pixel: u32, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (16 + 1 * name.len() + 3) / 4;
@@ -15626,7 +15626,7 @@ impl Serialize for Rgb {
 
 /// Opcode for the QueryColors request
 pub const QUERY_COLORS_REQUEST: u8 = 91;
-pub fn query_colors<'c, Conn>(conn: &'c Conn, cmap: COLORMAP, pixels: &[u32]) -> Result<Cookie<'c, Conn, QueryColorsReply>, ConnectionError>
+pub fn query_colors<'c, Conn>(conn: &'c Conn, cmap: Colormap, pixels: &[u32]) -> Result<Cookie<'c, Conn, QueryColorsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8 + 4 * pixels.len() + 3) / 4;
@@ -15679,7 +15679,7 @@ impl TryFrom<&[u8]> for QueryColorsReply {
 
 /// Opcode for the LookupColor request
 pub const LOOKUP_COLOR_REQUEST: u8 = 92;
-pub fn lookup_color<'c, Conn>(conn: &'c Conn, cmap: COLORMAP, name: &[u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
+pub fn lookup_color<'c, Conn>(conn: &'c Conn, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 1 * name.len() + 3) / 4;
@@ -15745,57 +15745,57 @@ impl TryFrom<&[u8]> for LookupColorReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Pixmap {
+pub enum PixmapEnum {
     None = 0,
 }
-impl From<Pixmap> for u8 {
-    fn from(input: Pixmap) -> Self {
+impl From<PixmapEnum> for u8 {
+    fn from(input: PixmapEnum) -> Self {
         match input {
-            Pixmap::None => 0,
+            PixmapEnum::None => 0,
         }
     }
 }
-impl From<Pixmap> for Option<u8> {
-    fn from(input: Pixmap) -> Self {
+impl From<PixmapEnum> for Option<u8> {
+    fn from(input: PixmapEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Pixmap> for u16 {
-    fn from(input: Pixmap) -> Self {
+impl From<PixmapEnum> for u16 {
+    fn from(input: PixmapEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Pixmap> for Option<u16> {
-    fn from(input: Pixmap) -> Self {
+impl From<PixmapEnum> for Option<u16> {
+    fn from(input: PixmapEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Pixmap> for u32 {
-    fn from(input: Pixmap) -> Self {
+impl From<PixmapEnum> for u32 {
+    fn from(input: PixmapEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Pixmap> for Option<u32> {
-    fn from(input: Pixmap) -> Self {
+impl From<PixmapEnum> for Option<u32> {
+    fn from(input: PixmapEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Pixmap {
+impl TryFrom<u8> for PixmapEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Pixmap::None),
+            0 => Ok(PixmapEnum::None),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Pixmap {
+impl TryFrom<u16> for PixmapEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Pixmap {
+impl TryFrom<u32> for PixmapEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -15804,7 +15804,7 @@ impl TryFrom<u32> for Pixmap {
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 93;
-pub fn create_cursor<Conn>(conn: &Conn, cid: CURSOR, source: PIXMAP, mask: PIXMAP, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_cursor<Conn>(conn: &Conn, cid: Cursor, source: Pixmap, mask: Pixmap, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (32) / 4;
@@ -15861,57 +15861,57 @@ where Conn: RequestConnection + ?Sized
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum Font {
+pub enum FontEnum {
     None = 0,
 }
-impl From<Font> for u8 {
-    fn from(input: Font) -> Self {
+impl From<FontEnum> for u8 {
+    fn from(input: FontEnum) -> Self {
         match input {
-            Font::None => 0,
+            FontEnum::None => 0,
         }
     }
 }
-impl From<Font> for Option<u8> {
-    fn from(input: Font) -> Self {
+impl From<FontEnum> for Option<u8> {
+    fn from(input: FontEnum) -> Self {
         Some(u8::from(input))
     }
 }
-impl From<Font> for u16 {
-    fn from(input: Font) -> Self {
+impl From<FontEnum> for u16 {
+    fn from(input: FontEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Font> for Option<u16> {
-    fn from(input: Font) -> Self {
+impl From<FontEnum> for Option<u16> {
+    fn from(input: FontEnum) -> Self {
         Some(u16::from(input))
     }
 }
-impl From<Font> for u32 {
-    fn from(input: Font) -> Self {
+impl From<FontEnum> for u32 {
+    fn from(input: FontEnum) -> Self {
         Self::from(u8::from(input))
     }
 }
-impl From<Font> for Option<u32> {
-    fn from(input: Font) -> Self {
+impl From<FontEnum> for Option<u32> {
+    fn from(input: FontEnum) -> Self {
         Some(u32::from(input))
     }
 }
-impl TryFrom<u8> for Font {
+impl TryFrom<u8> for FontEnum {
     type Error = ParseError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Font::None),
+            0 => Ok(FontEnum::None),
             _ => Err(ParseError::ParseError)
         }
     }
 }
-impl TryFrom<u16> for Font {
+impl TryFrom<u16> for FontEnum {
     type Error = ParseError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
     }
 }
-impl TryFrom<u32> for Font {
+impl TryFrom<u32> for FontEnum {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::try_from(u8::try_from(value).or(Err(ParseError::ParseError))?)
@@ -15953,7 +15953,7 @@ pub const CREATE_GLYPH_CURSOR_REQUEST: u8 = 94;
 /// * `Alloc` - The X server could not allocate the requested resources (no memory?).
 /// * `Font` - The specified `source_font` or `mask_font` does not exist.
 /// * `Value` - Either `source_char` or `mask_char` are not defined in `source_font` or `mask_font`, respectively.
-pub fn create_glyph_cursor<Conn>(conn: &Conn, cid: CURSOR, source_font: FONT, mask_font: FONT, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_glyph_cursor<Conn>(conn: &Conn, cid: Cursor, source_font: Font, mask_font: Font, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (32) / 4;
@@ -16022,7 +16022,7 @@ pub const FREE_CURSOR_REQUEST: u8 = 95;
 /// # Errors
 ///
 /// * `Cursor` - The specified cursor does not exist.
-pub fn free_cursor<Conn>(conn: &Conn, cursor: CURSOR) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn free_cursor<Conn>(conn: &Conn, cursor: Cursor) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -16045,7 +16045,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the RecolorCursor request
 pub const RECOLOR_CURSOR_REQUEST: u8 = 96;
-pub fn recolor_cursor<Conn>(conn: &Conn, cursor: CURSOR, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn recolor_cursor<Conn>(conn: &Conn, cursor: Cursor, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (20) / 4;
@@ -16151,7 +16151,7 @@ impl TryFrom<u32> for QueryShapeOf {
 
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 97;
-pub fn query_best_size<Conn, A>(conn: &Conn, class: A, drawable: DRAWABLE, width: u16, height: u16) -> Result<Cookie<'_, Conn, QueryBestSizeReply>, ConnectionError>
+pub fn query_best_size<Conn, A>(conn: &Conn, class: A, drawable: Drawable, width: u16, height: u16) -> Result<Cookie<'_, Conn, QueryBestSizeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let length: usize = (12) / 4;
@@ -16339,7 +16339,7 @@ impl TryFrom<&[u8]> for ListExtensionsReply {
 
 /// Opcode for the ChangeKeyboardMapping request
 pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
-pub fn change_keyboard_mapping<'c, Conn>(conn: &'c Conn, keycode_count: u8, first_keycode: KEYCODE, keysyms_per_keycode: u8, keysyms: &[KEYSYM]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_keyboard_mapping<'c, Conn>(conn: &'c Conn, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &[Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8 + 4 * keysyms.len() + 3) / 4;
@@ -16369,7 +16369,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetKeyboardMapping request
 pub const GET_KEYBOARD_MAPPING_REQUEST: u8 = 101;
-pub fn get_keyboard_mapping<Conn>(conn: &Conn, first_keycode: KEYCODE, count: u8) -> Result<Cookie<'_, Conn, GetKeyboardMappingReply>, ConnectionError>
+pub fn get_keyboard_mapping<Conn>(conn: &Conn, first_keycode: Keycode, count: u8) -> Result<Cookie<'_, Conn, GetKeyboardMappingReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (8) / 4;
@@ -16395,7 +16395,7 @@ pub struct GetKeyboardMappingReply {
     pub response_type: u8,
     pub keysyms_per_keycode: u8,
     pub sequence: u16,
-    pub keysyms: Vec<KEYSYM>,
+    pub keysyms: Vec<Keysym>,
 }
 impl GetKeyboardMappingReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -16404,7 +16404,7 @@ impl GetKeyboardMappingReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<KEYSYM>(remaining, length as usize)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, length as usize)?;
         let result = GetKeyboardMappingReply { response_type, keysyms_per_keycode, sequence, keysyms };
         Ok((result, remaining))
     }
@@ -16635,7 +16635,7 @@ pub struct ChangeKeyboardControlAux {
     pub bell_duration: Option<i32>,
     pub led: Option<u32>,
     pub led_mode: Option<u32>,
-    pub key: Option<KEYCODE32>,
+    pub key: Option<Keycode32>,
     pub auto_repeat_mode: Option<u32>,
 }
 impl ChangeKeyboardControlAux {
@@ -16702,7 +16702,7 @@ impl ChangeKeyboardControlAux {
         self
     }
     /// Set the key field of this structure.
-    pub fn key<I>(mut self, value: I) -> Self where I: Into<Option<KEYCODE32>> {
+    pub fn key<I>(mut self, value: I) -> Self where I: Into<Option<Keycode32>> {
         self.key = value.into();
         self
     }
@@ -17727,7 +17727,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the RotateProperties request
 pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
-pub fn rotate_properties<'c, Conn>(conn: &'c Conn, window: WINDOW, delta: i16, atoms: &[ATOM]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn rotate_properties<'c, Conn>(conn: &'c Conn, window: Window, delta: i16, atoms: &[Atom]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (12 + 4 * atoms.len() + 3) / 4;
@@ -18078,7 +18078,7 @@ impl TryFrom<u32> for MapIndex {
 
 /// Opcode for the SetModifierMapping request
 pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
-pub fn set_modifier_mapping<'c, Conn>(conn: &'c Conn, keycodes: &[KEYCODE]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>
+pub fn set_modifier_mapping<'c, Conn>(conn: &'c Conn, keycodes: &[Keycode]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let length: usize = (4 + 1 * keycodes.len() + 3) / 4;
@@ -18146,7 +18146,7 @@ pub struct GetModifierMappingReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub keycodes: Vec<KEYCODE>,
+    pub keycodes: Vec<Keycode>,
 }
 impl GetModifierMappingReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -18155,7 +18155,7 @@ impl GetModifierMappingReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (keycodes, remaining) = crate::x11_utils::parse_list::<KEYCODE>(remaining, (keycodes_per_modifier as usize) * (8))?;
+        let (keycodes, remaining) = crate::x11_utils::parse_list::<Keycode>(remaining, (keycodes_per_modifier as usize) * (8))?;
         let result = GetModifierMappingReply { response_type, sequence, length, keycodes };
         Ok((result, remaining))
     }
@@ -18240,7 +18240,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * CreateNotify: event
     /// * MapWindow: request
     /// * xcb_generate_id: function
-    fn create_window<'c, A>(&'c self, depth: u8, wid: WINDOW, parent: WINDOW, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, visual: VISUALID, value_list: &CreateWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn create_window<'c, A>(&'c self, depth: u8, wid: Window, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, visual: Visualid, value_list: &CreateWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u16>
     {
         create_window(self, depth, wid, parent, x, y, width, height, border_width, class, visual, value_list)
@@ -18266,7 +18266,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Pixmap` - TODO: reasons?
     /// * `Value` - TODO: reasons?
     /// * `Window` - The specified `window` does not exist.
-    fn change_window_attributes<'c>(&'c self, window: WINDOW, value_list: &ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_window_attributes<'c>(&'c self, window: Window, value_list: &ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_window_attributes(self, window, value_list)
     }
@@ -18283,7 +18283,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `Drawable` - TODO: reasons?
     /// * `Window` - The specified `window` does not exist.
-    fn get_window_attributes(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetWindowAttributesReply>, ConnectionError>
+    fn get_window_attributes(&self, window: Window) -> Result<Cookie<'_, Self, GetWindowAttributesReply>, ConnectionError>
     {
         get_window_attributes(self, window)
     }
@@ -18310,12 +18310,12 @@ pub trait ConnectionExt: RequestConnection {
     /// * DestroyNotify: event
     /// * MapWindow: request
     /// * UnmapWindow: request
-    fn destroy_window(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn destroy_window(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_window(self, window)
     }
 
-    fn destroy_subwindows(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn destroy_subwindows(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_subwindows(self, window)
     }
@@ -18342,7 +18342,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * ReparentWindow: request
-    fn change_save_set<A>(&self, mode: A, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn change_save_set<A>(&self, mode: A, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         change_save_set(self, mode, window)
@@ -18380,7 +18380,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * MapWindow: request
     /// * ReparentNotify: event
     /// * UnmapWindow: request
-    fn reparent_window(&self, window: WINDOW, parent: WINDOW, x: i16, y: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn reparent_window(&self, window: Window, parent: Window, x: i16, y: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         reparent_window(self, window, parent, x, y)
     }
@@ -18420,12 +18420,12 @@ pub trait ConnectionExt: RequestConnection {
     /// * Expose: event
     /// * MapNotify: event
     /// * UnmapWindow: request
-    fn map_window(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn map_window(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         map_window(self, window)
     }
 
-    fn map_subwindows(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn map_subwindows(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         map_subwindows(self, window)
     }
@@ -18451,12 +18451,12 @@ pub trait ConnectionExt: RequestConnection {
     /// * Expose: event
     /// * MapWindow: request
     /// * UnmapNotify: event
-    fn unmap_window(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn unmap_window(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         unmap_window(self, window)
     }
 
-    fn unmap_subwindows(&self, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn unmap_subwindows(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         unmap_subwindows(self, window)
     }
@@ -18511,7 +18511,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(c);
     /// }
     /// ```
-    fn configure_window<'c>(&'c self, window: WINDOW, value_list: &ConfigureWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn configure_window<'c>(&'c self, window: Window, value_list: &ConfigureWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_window(self, window, value_list)
     }
@@ -18532,7 +18532,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `Value` - The specified `direction` is invalid.
     /// * `Window` - The specified `window` does not exist.
-    fn circulate_window<A>(&self, direction: A, window: WINDOW) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn circulate_window<A>(&self, direction: A, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         circulate_window(self, direction, window)
@@ -18574,7 +18574,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     free(reply);
     /// }
     /// ```
-    fn get_geometry(&self, drawable: DRAWABLE) -> Result<Cookie<'_, Self, GetGeometryReply>, ConnectionError>
+    fn get_geometry(&self, drawable: Drawable) -> Result<Cookie<'_, Self, GetGeometryReply>, ConnectionError>
     {
         get_geometry(self, drawable)
     }
@@ -18616,7 +18616,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     }
     /// }
     /// ```
-    fn query_tree(&self, window: WINDOW) -> Result<Cookie<'_, Self, QueryTreeReply>, ConnectionError>
+    fn query_tree(&self, window: Window) -> Result<Cookie<'_, Self, QueryTreeReply>, ConnectionError>
     {
         query_tree(self, window)
     }
@@ -18671,7 +18671,7 @@ pub trait ConnectionExt: RequestConnection {
         intern_atom(self, only_if_exists, name)
     }
 
-    fn get_atom_name(&self, atom: ATOM) -> Result<Cookie<'_, Self, GetAtomNameReply>, ConnectionError>
+    fn get_atom_name(&self, atom: Atom) -> Result<Cookie<'_, Self, GetAtomNameReply>, ConnectionError>
     {
         get_atom_name(self, atom)
     }
@@ -18726,13 +18726,13 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(conn);
     /// }
     /// ```
-    fn change_property<'c, A, B, C>(&'c self, mode: A, window: WINDOW, property: B, type_: C, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where A: Into<u8>, B: Into<ATOM>, C: Into<ATOM>
+    fn change_property<'c, A, B, C>(&'c self, mode: A, window: Window, property: B, type_: C, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    where A: Into<u8>, B: Into<Atom>, C: Into<Atom>
     {
         change_property(self, mode, window, property, type_, format, data_len, data)
     }
 
-    fn delete_property(&self, window: WINDOW, property: ATOM) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn delete_property(&self, window: Window, property: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_property(self, window, property)
     }
@@ -18805,12 +18805,12 @@ pub trait ConnectionExt: RequestConnection {
     ///     free(reply);
     /// }
     /// ```
-    fn get_property(&self, delete: bool, window: WINDOW, property: ATOM, type_: ATOM, long_offset: u32, long_length: u32) -> Result<Cookie<'_, Self, GetPropertyReply>, ConnectionError>
+    fn get_property(&self, delete: bool, window: Window, property: Atom, type_: Atom, long_offset: u32, long_length: u32) -> Result<Cookie<'_, Self, GetPropertyReply>, ConnectionError>
     {
         get_property(self, delete, window, property, type_, long_offset, long_length)
     }
 
-    fn list_properties(&self, window: WINDOW) -> Result<Cookie<'_, Self, ListPropertiesReply>, ConnectionError>
+    fn list_properties(&self, window: Window) -> Result<Cookie<'_, Self, ListPropertiesReply>, ConnectionError>
     {
         list_properties(self, window)
     }
@@ -18844,7 +18844,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * SetSelectionOwner: request
-    fn set_selection_owner(&self, owner: WINDOW, selection: ATOM, time: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn set_selection_owner(&self, owner: Window, selection: Atom, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_selection_owner(self, owner, selection, time)
     }
@@ -18866,12 +18866,12 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * SetSelectionOwner: request
-    fn get_selection_owner(&self, selection: ATOM) -> Result<Cookie<'_, Self, GetSelectionOwnerReply>, ConnectionError>
+    fn get_selection_owner(&self, selection: Atom) -> Result<Cookie<'_, Self, GetSelectionOwnerReply>, ConnectionError>
     {
         get_selection_owner(self, selection)
     }
 
-    fn convert_selection(&self, requestor: WINDOW, selection: ATOM, target: ATOM, property: ATOM, time: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn convert_selection(&self, requestor: Window, selection: Atom, target: Atom, property: Atom, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         convert_selection(self, requestor, selection, target, property, time)
     }
@@ -18949,7 +18949,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     free(event);
     /// }
     /// ```
-    fn send_event<A>(&self, propagate: bool, destination: WINDOW, event_mask: u32, event: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn send_event<A>(&self, propagate: bool, destination: Window, event_mask: u32, event: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<[u8; 32]>
     {
         send_event(self, propagate, destination, event_mask, event)
@@ -19024,7 +19024,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     }
     /// }
     /// ```
-    fn grab_pointer<A, B>(&self, owner_events: bool, grab_window: WINDOW, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: WINDOW, cursor: CURSOR, time: TIMESTAMP) -> Result<Cookie<'_, Self, GrabPointerReply>, ConnectionError>
+    fn grab_pointer<A, B>(&self, owner_events: bool, grab_window: Window, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: Window, cursor: Cursor, time: Timestamp) -> Result<Cookie<'_, Self, GrabPointerReply>, ConnectionError>
     where A: Into<u8>, B: Into<u8>
     {
         grab_pointer(self, owner_events, grab_window, event_mask, pointer_mode, keyboard_mode, confine_to, cursor, time)
@@ -19053,7 +19053,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * GrabButton: request
     /// * GrabPointer: request
     /// * LeaveNotify: event
-    fn ungrab_pointer(&self, time: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn ungrab_pointer(&self, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_pointer(self, time)
     }
@@ -19122,19 +19122,19 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Cursor` - The specified `cursor` does not exist.
     /// * `Value` - TODO: reasons?
     /// * `Window` - The specified `window` does not exist.
-    fn grab_button<A, B, C>(&self, owner_events: bool, grab_window: WINDOW, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: WINDOW, cursor: CURSOR, button: C, modifiers: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn grab_button<A, B, C>(&self, owner_events: bool, grab_window: Window, event_mask: u16, pointer_mode: A, keyboard_mode: B, confine_to: Window, cursor: Cursor, button: C, modifiers: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>, B: Into<u8>, C: Into<u8>
     {
         grab_button(self, owner_events, grab_window, event_mask, pointer_mode, keyboard_mode, confine_to, cursor, button, modifiers)
     }
 
-    fn ungrab_button<A>(&self, button: A, grab_window: WINDOW, modifiers: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn ungrab_button<A>(&self, button: A, grab_window: Window, modifiers: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         ungrab_button(self, button, grab_window, modifiers)
     }
 
-    fn change_active_pointer_grab(&self, cursor: CURSOR, time: TIMESTAMP, event_mask: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn change_active_pointer_grab(&self, cursor: Cursor, time: Timestamp, event_mask: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         change_active_pointer_grab(self, cursor, time, event_mask)
     }
@@ -19199,13 +19199,13 @@ pub trait ConnectionExt: RequestConnection {
     ///     }
     /// }
     /// ```
-    fn grab_keyboard<A, B>(&self, owner_events: bool, grab_window: WINDOW, time: TIMESTAMP, pointer_mode: A, keyboard_mode: B) -> Result<Cookie<'_, Self, GrabKeyboardReply>, ConnectionError>
+    fn grab_keyboard<A, B>(&self, owner_events: bool, grab_window: Window, time: Timestamp, pointer_mode: A, keyboard_mode: B) -> Result<Cookie<'_, Self, GrabKeyboardReply>, ConnectionError>
     where A: Into<u8>, B: Into<u8>
     {
         grab_keyboard(self, owner_events, grab_window, time, pointer_mode, keyboard_mode)
     }
 
-    fn ungrab_keyboard(&self, time: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn ungrab_keyboard(&self, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_keyboard(self, time)
     }
@@ -19268,7 +19268,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * GrabKeyboard: request
-    fn grab_key<A, B>(&self, owner_events: bool, grab_window: WINDOW, modifiers: u16, key: KEYCODE, pointer_mode: A, keyboard_mode: B) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn grab_key<A, B>(&self, owner_events: bool, grab_window: Window, modifiers: u16, key: Keycode, pointer_mode: A, keyboard_mode: B) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>, B: Into<u8>
     {
         grab_key(self, owner_events, grab_window, modifiers, key, pointer_mode, keyboard_mode)
@@ -19299,7 +19299,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * GrabKey: request
     /// * xev: program
-    fn ungrab_key(&self, key: KEYCODE, grab_window: WINDOW, modifiers: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn ungrab_key(&self, key: Keycode, grab_window: Window, modifiers: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_key(self, key, grab_window, modifiers)
     }
@@ -19321,7 +19321,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Value` - You specified an invalid `mode`.
-    fn allow_events<A>(&self, mode: A, time: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn allow_events<A>(&self, mode: A, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         allow_events(self, mode, time)
@@ -19350,17 +19350,17 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Window` - The specified `window` does not exist.
-    fn query_pointer(&self, window: WINDOW) -> Result<Cookie<'_, Self, QueryPointerReply>, ConnectionError>
+    fn query_pointer(&self, window: Window) -> Result<Cookie<'_, Self, QueryPointerReply>, ConnectionError>
     {
         query_pointer(self, window)
     }
 
-    fn get_motion_events(&self, window: WINDOW, start: TIMESTAMP, stop: TIMESTAMP) -> Result<Cookie<'_, Self, GetMotionEventsReply>, ConnectionError>
+    fn get_motion_events(&self, window: Window, start: Timestamp, stop: Timestamp) -> Result<Cookie<'_, Self, GetMotionEventsReply>, ConnectionError>
     {
         get_motion_events(self, window, start, stop)
     }
 
-    fn translate_coordinates(&self, src_window: WINDOW, dst_window: WINDOW, src_x: i16, src_y: i16) -> Result<Cookie<'_, Self, TranslateCoordinatesReply>, ConnectionError>
+    fn translate_coordinates(&self, src_window: Window, dst_window: Window, src_x: i16, src_y: i16) -> Result<Cookie<'_, Self, TranslateCoordinatesReply>, ConnectionError>
     {
         translate_coordinates(self, src_window, dst_window, src_x, src_y)
     }
@@ -19397,7 +19397,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * SetInputFocus: request
-    fn warp_pointer(&self, src_window: WINDOW, dst_window: WINDOW, src_x: i16, src_y: i16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn warp_pointer(&self, src_window: Window, dst_window: Window, src_x: i16, src_y: i16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         warp_pointer(self, src_window, dst_window, src_x, src_y, src_width, src_height, dst_x, dst_y)
     }
@@ -19437,7 +19437,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * FocusIn: event
     /// * FocusOut: event
-    fn set_input_focus<A>(&self, revert_to: A, focus: WINDOW, time: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn set_input_focus<A>(&self, revert_to: A, focus: Window, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         set_input_focus(self, revert_to, focus, time)
@@ -19473,12 +19473,12 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * xcb_generate_id: function
-    fn open_font<'c>(&'c self, fid: FONT, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn open_font<'c>(&'c self, fid: Font, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         open_font(self, fid, name)
     }
 
-    fn close_font(&self, font: FONT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn close_font(&self, font: Font) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         close_font(self, font)
     }
@@ -19490,7 +19490,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `font` - The fontable (Font or Graphics Context) to query.
-    fn query_font(&self, font: FONTABLE) -> Result<Cookie<'_, Self, QueryFontReply>, ConnectionError>
+    fn query_font(&self, font: Fontable) -> Result<Cookie<'_, Self, QueryFontReply>, ConnectionError>
     {
         query_font(self, font)
     }
@@ -19529,7 +19529,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `Font` - The specified `font` does not exist.
     /// * `GContext` - The specified graphics context does not exist.
-    fn query_text_extents<'c>(&'c self, font: FONTABLE, string: &[Char2b]) -> Result<Cookie<'c, Self, QueryTextExtentsReply>, ConnectionError>
+    fn query_text_extents<'c>(&'c self, font: Fontable, string: &[Char2b]) -> Result<Cookie<'c, Self, QueryTextExtentsReply>, ConnectionError>
     {
         query_text_extents(self, font, string)
     }
@@ -19603,7 +19603,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * xcb_generate_id: function
-    fn create_pixmap(&self, depth: u8, pid: PIXMAP, drawable: DRAWABLE, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn create_pixmap(&self, depth: u8, pid: Pixmap, drawable: Drawable, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_pixmap(self, depth, pid, drawable, width, height)
     }
@@ -19620,7 +19620,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Pixmap` - The specified pixmap does not exist.
-    fn free_pixmap(&self, pixmap: PIXMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn free_pixmap(&self, pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_pixmap(self, pixmap)
     }
@@ -19648,7 +19648,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * xcb_generate_id: function
-    fn create_gc<'c>(&'c self, cid: GCONTEXT, drawable: DRAWABLE, value_list: &CreateGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn create_gc<'c>(&'c self, cid: Gcontext, drawable: Drawable, value_list: &CreateGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_gc(self, cid, drawable, value_list)
     }
@@ -19697,22 +19697,22 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(conn);
     /// }
     /// ```
-    fn change_gc<'c>(&'c self, gc: GCONTEXT, value_list: &ChangeGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_gc<'c>(&'c self, gc: Gcontext, value_list: &ChangeGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_gc(self, gc, value_list)
     }
 
-    fn copy_gc(&self, src_gc: GCONTEXT, dst_gc: GCONTEXT, value_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn copy_gc(&self, src_gc: Gcontext, dst_gc: Gcontext, value_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         copy_gc(self, src_gc, dst_gc, value_mask)
     }
 
-    fn set_dashes<'c>(&'c self, gc: GCONTEXT, dash_offset: u16, dashes: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn set_dashes<'c>(&'c self, gc: Gcontext, dash_offset: u16, dashes: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_dashes(self, gc, dash_offset, dashes)
     }
 
-    fn set_clip_rectangles<'c, A>(&'c self, ordering: A, gc: GCONTEXT, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn set_clip_rectangles<'c, A>(&'c self, ordering: A, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         set_clip_rectangles(self, ordering, gc, clip_x_origin, clip_y_origin, rectangles)
@@ -19729,12 +19729,12 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `GContext` - The specified graphics context does not exist.
-    fn free_gc(&self, gc: GCONTEXT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn free_gc(&self, gc: Gcontext) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_gc(self, gc)
     }
 
-    fn clear_area(&self, exposures: bool, window: WINDOW, x: i16, y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn clear_area(&self, exposures: bool, window: Window, x: i16, y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         clear_area(self, exposures, window, x, y, width, height)
     }
@@ -19760,17 +19760,17 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
     /// * `GContext` - The specified graphics context does not exist.
     /// * `Match` - `src_drawable` has a different root or depth than `dst_drawable`.
-    fn copy_area(&self, src_drawable: DRAWABLE, dst_drawable: DRAWABLE, gc: GCONTEXT, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn copy_area(&self, src_drawable: Drawable, dst_drawable: Drawable, gc: Gcontext, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         copy_area(self, src_drawable, dst_drawable, gc, src_x, src_y, dst_x, dst_y, width, height)
     }
 
-    fn copy_plane(&self, src_drawable: DRAWABLE, dst_drawable: DRAWABLE, gc: GCONTEXT, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16, bit_plane: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn copy_plane(&self, src_drawable: Drawable, dst_drawable: Drawable, gc: Gcontext, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16, bit_plane: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         copy_plane(self, src_drawable, dst_drawable, gc, src_x, src_y, dst_x, dst_y, width, height, bit_plane)
     }
 
-    fn poly_point<'c, A>(&'c self, coordinate_mode: A, drawable: DRAWABLE, gc: GCONTEXT, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_point<'c, A>(&'c self, coordinate_mode: A, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         poly_point(self, coordinate_mode, drawable, gc, points)
@@ -19814,7 +19814,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(conn);
     /// }
     /// ```
-    fn poly_line<'c, A>(&'c self, coordinate_mode: A, drawable: DRAWABLE, gc: GCONTEXT, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_line<'c, A>(&'c self, coordinate_mode: A, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         poly_line(self, coordinate_mode, drawable, gc, points)
@@ -19846,22 +19846,22 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Drawable` - The specified `drawable` does not exist.
     /// * `GContext` - The specified `gc` does not exist.
     /// * `Match` - TODO: reasons?
-    fn poly_segment<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, segments: &[Segment]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_segment<'c>(&'c self, drawable: Drawable, gc: Gcontext, segments: &[Segment]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_segment(self, drawable, gc, segments)
     }
 
-    fn poly_rectangle<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_rectangle<'c>(&'c self, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_rectangle(self, drawable, gc, rectangles)
     }
 
-    fn poly_arc<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, arcs: &[Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_arc<'c>(&'c self, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_arc(self, drawable, gc, arcs)
     }
 
-    fn fill_poly<'c, A, B>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, shape: A, coordinate_mode: B, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn fill_poly<'c, A, B>(&'c self, drawable: Drawable, gc: Gcontext, shape: A, coordinate_mode: B, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>, B: Into<u8>
     {
         fill_poly(self, drawable, gc, shape, coordinate_mode, points)
@@ -19892,34 +19892,34 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
     /// * `GContext` - The specified graphics context does not exist.
     /// * `Match` - TODO: reasons?
-    fn poly_fill_rectangle<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_fill_rectangle<'c>(&'c self, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_fill_rectangle(self, drawable, gc, rectangles)
     }
 
-    fn poly_fill_arc<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, arcs: &[Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_fill_arc<'c>(&'c self, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_fill_arc(self, drawable, gc, arcs)
     }
 
-    fn put_image<'c, A>(&'c self, format: A, drawable: DRAWABLE, gc: GCONTEXT, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn put_image<'c, A>(&'c self, format: A, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         put_image(self, format, drawable, gc, width, height, dst_x, dst_y, left_pad, depth, data)
     }
 
-    fn get_image<A>(&self, format: A, drawable: DRAWABLE, x: i16, y: i16, width: u16, height: u16, plane_mask: u32) -> Result<Cookie<'_, Self, GetImageReply>, ConnectionError>
+    fn get_image<A>(&self, format: A, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, plane_mask: u32) -> Result<Cookie<'_, Self, GetImageReply>, ConnectionError>
     where A: Into<u8>
     {
         get_image(self, format, drawable, x, y, width, height, plane_mask)
     }
 
-    fn poly_text8<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_text8<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_text8(self, drawable, gc, x, y, items)
     }
 
-    fn poly_text16<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_text16<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_text16(self, drawable, gc, x, y, items)
     }
@@ -19958,7 +19958,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * ImageText16: request
-    fn image_text8<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, string: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn image_text8<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         image_text8(self, drawable, gc, x, y, string)
     }
@@ -19998,38 +19998,38 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * ImageText8: request
-    fn image_text16<'c>(&'c self, drawable: DRAWABLE, gc: GCONTEXT, x: i16, y: i16, string: &[Char2b]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn image_text16<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[Char2b]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         image_text16(self, drawable, gc, x, y, string)
     }
 
-    fn create_colormap<A>(&self, alloc: A, mid: COLORMAP, window: WINDOW, visual: VISUALID) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn create_colormap<A>(&self, alloc: A, mid: Colormap, window: Window, visual: Visualid) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         create_colormap(self, alloc, mid, window, visual)
     }
 
-    fn free_colormap(&self, cmap: COLORMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn free_colormap(&self, cmap: Colormap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_colormap(self, cmap)
     }
 
-    fn copy_colormap_and_free(&self, mid: COLORMAP, src_cmap: COLORMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn copy_colormap_and_free(&self, mid: Colormap, src_cmap: Colormap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         copy_colormap_and_free(self, mid, src_cmap)
     }
 
-    fn install_colormap(&self, cmap: COLORMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn install_colormap(&self, cmap: Colormap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         install_colormap(self, cmap)
     }
 
-    fn uninstall_colormap(&self, cmap: COLORMAP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn uninstall_colormap(&self, cmap: Colormap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         uninstall_colormap(self, cmap)
     }
 
-    fn list_installed_colormaps(&self, window: WINDOW) -> Result<Cookie<'_, Self, ListInstalledColormapsReply>, ConnectionError>
+    fn list_installed_colormaps(&self, window: Window) -> Result<Cookie<'_, Self, ListInstalledColormapsReply>, ConnectionError>
     {
         list_installed_colormaps(self, window)
     }
@@ -20052,52 +20052,52 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Colormap` - The specified colormap `cmap` does not exist.
-    fn alloc_color(&self, cmap: COLORMAP, red: u16, green: u16, blue: u16) -> Result<Cookie<'_, Self, AllocColorReply>, ConnectionError>
+    fn alloc_color(&self, cmap: Colormap, red: u16, green: u16, blue: u16) -> Result<Cookie<'_, Self, AllocColorReply>, ConnectionError>
     {
         alloc_color(self, cmap, red, green, blue)
     }
 
-    fn alloc_named_color<'c>(&'c self, cmap: COLORMAP, name: &[u8]) -> Result<Cookie<'c, Self, AllocNamedColorReply>, ConnectionError>
+    fn alloc_named_color<'c>(&'c self, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Self, AllocNamedColorReply>, ConnectionError>
     {
         alloc_named_color(self, cmap, name)
     }
 
-    fn alloc_color_cells(&self, contiguous: bool, cmap: COLORMAP, colors: u16, planes: u16) -> Result<Cookie<'_, Self, AllocColorCellsReply>, ConnectionError>
+    fn alloc_color_cells(&self, contiguous: bool, cmap: Colormap, colors: u16, planes: u16) -> Result<Cookie<'_, Self, AllocColorCellsReply>, ConnectionError>
     {
         alloc_color_cells(self, contiguous, cmap, colors, planes)
     }
 
-    fn alloc_color_planes(&self, contiguous: bool, cmap: COLORMAP, colors: u16, reds: u16, greens: u16, blues: u16) -> Result<Cookie<'_, Self, AllocColorPlanesReply>, ConnectionError>
+    fn alloc_color_planes(&self, contiguous: bool, cmap: Colormap, colors: u16, reds: u16, greens: u16, blues: u16) -> Result<Cookie<'_, Self, AllocColorPlanesReply>, ConnectionError>
     {
         alloc_color_planes(self, contiguous, cmap, colors, reds, greens, blues)
     }
 
-    fn free_colors<'c>(&'c self, cmap: COLORMAP, plane_mask: u32, pixels: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn free_colors<'c>(&'c self, cmap: Colormap, plane_mask: u32, pixels: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         free_colors(self, cmap, plane_mask, pixels)
     }
 
-    fn store_colors<'c>(&'c self, cmap: COLORMAP, items: &[Coloritem]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn store_colors<'c>(&'c self, cmap: Colormap, items: &[Coloritem]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         store_colors(self, cmap, items)
     }
 
-    fn store_named_color<'c>(&'c self, flags: u8, cmap: COLORMAP, pixel: u32, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn store_named_color<'c>(&'c self, flags: u8, cmap: Colormap, pixel: u32, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         store_named_color(self, flags, cmap, pixel, name)
     }
 
-    fn query_colors<'c>(&'c self, cmap: COLORMAP, pixels: &[u32]) -> Result<Cookie<'c, Self, QueryColorsReply>, ConnectionError>
+    fn query_colors<'c>(&'c self, cmap: Colormap, pixels: &[u32]) -> Result<Cookie<'c, Self, QueryColorsReply>, ConnectionError>
     {
         query_colors(self, cmap, pixels)
     }
 
-    fn lookup_color<'c>(&'c self, cmap: COLORMAP, name: &[u8]) -> Result<Cookie<'c, Self, LookupColorReply>, ConnectionError>
+    fn lookup_color<'c>(&'c self, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Self, LookupColorReply>, ConnectionError>
     {
         lookup_color(self, cmap, name)
     }
 
-    fn create_cursor(&self, cid: CURSOR, source: PIXMAP, mask: PIXMAP, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn create_cursor(&self, cid: Cursor, source: Pixmap, mask: Pixmap, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_cursor(self, cid, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x, y)
     }
@@ -20135,7 +20135,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Alloc` - The X server could not allocate the requested resources (no memory?).
     /// * `Font` - The specified `source_font` or `mask_font` does not exist.
     /// * `Value` - Either `source_char` or `mask_char` are not defined in `source_font` or `mask_font`, respectively.
-    fn create_glyph_cursor(&self, cid: CURSOR, source_font: FONT, mask_font: FONT, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn create_glyph_cursor(&self, cid: Cursor, source_font: Font, mask_font: Font, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_glyph_cursor(self, cid, source_font, mask_font, source_char, mask_char, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)
     }
@@ -20152,17 +20152,17 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Cursor` - The specified cursor does not exist.
-    fn free_cursor(&self, cursor: CURSOR) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn free_cursor(&self, cursor: Cursor) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         free_cursor(self, cursor)
     }
 
-    fn recolor_cursor(&self, cursor: CURSOR, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn recolor_cursor(&self, cursor: Cursor, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         recolor_cursor(self, cursor, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)
     }
 
-    fn query_best_size<A>(&self, class: A, drawable: DRAWABLE, width: u16, height: u16) -> Result<Cookie<'_, Self, QueryBestSizeReply>, ConnectionError>
+    fn query_best_size<A>(&self, class: A, drawable: Drawable, width: u16, height: u16) -> Result<Cookie<'_, Self, QueryBestSizeReply>, ConnectionError>
     where A: Into<u8>
     {
         query_best_size(self, class, drawable, width, height)
@@ -20200,12 +20200,12 @@ pub trait ConnectionExt: RequestConnection {
         list_extensions(self)
     }
 
-    fn change_keyboard_mapping<'c>(&'c self, keycode_count: u8, first_keycode: KEYCODE, keysyms_per_keycode: u8, keysyms: &[KEYSYM]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_keyboard_mapping<'c>(&'c self, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &[Keysym]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_keyboard_mapping(self, keycode_count, first_keycode, keysyms_per_keycode, keysyms)
     }
 
-    fn get_keyboard_mapping(&self, first_keycode: KEYCODE, count: u8) -> Result<Cookie<'_, Self, GetKeyboardMappingReply>, ConnectionError>
+    fn get_keyboard_mapping(&self, first_keycode: Keycode, count: u8) -> Result<Cookie<'_, Self, GetKeyboardMappingReply>, ConnectionError>
     {
         get_keyboard_mapping(self, first_keycode, count)
     }
@@ -20293,7 +20293,7 @@ pub trait ConnectionExt: RequestConnection {
         kill_client(self, resource)
     }
 
-    fn rotate_properties<'c>(&'c self, window: WINDOW, delta: i16, atoms: &[ATOM]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn rotate_properties<'c>(&'c self, window: Window, delta: i16, atoms: &[Atom]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         rotate_properties(self, window, delta, atoms)
     }
@@ -20314,7 +20314,7 @@ pub trait ConnectionExt: RequestConnection {
         get_pointer_mapping(self)
     }
 
-    fn set_modifier_mapping<'c>(&'c self, keycodes: &[KEYCODE]) -> Result<Cookie<'c, Self, SetModifierMappingReply>, ConnectionError>
+    fn set_modifier_mapping<'c>(&'c self, keycodes: &[Keycode]) -> Result<Cookie<'c, Self, SetModifierMappingReply>, ConnectionError>
     {
         set_modifier_mapping(self, keycodes)
     }

--- a/src/generated/xselinux.rs
+++ b/src/generated/xselinux.rs
@@ -326,7 +326,7 @@ impl TryFrom<&[u8]> for GetWindowCreateContextReply {
 
 /// Opcode for the GetWindowContext request
 pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
-pub fn get_window_context<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, GetWindowContextReply>, ConnectionError>
+pub fn get_window_context<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetWindowContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -377,14 +377,14 @@ impl TryFrom<&[u8]> for GetWindowContextReply {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListItem {
-    pub name: ATOM,
+    pub name: Atom,
     pub object_context: Vec<u8>,
     pub data_context: Vec<u8>,
 }
 impl TryParse for ListItem {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (name, remaining) = ATOM::try_parse(remaining)?;
+        let (name, remaining) = Atom::try_parse(remaining)?;
         let (object_context_len, remaining) = u32::try_parse(remaining)?;
         let (data_context_len, remaining) = u32::try_parse(remaining)?;
         let (object_context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, object_context_len as usize)?;
@@ -580,7 +580,7 @@ impl TryFrom<&[u8]> for GetPropertyUseContextReply {
 
 /// Opcode for the GetPropertyContext request
 pub const GET_PROPERTY_CONTEXT_REQUEST: u8 = 12;
-pub fn get_property_context<Conn>(conn: &Conn, window: WINDOW, property: ATOM) -> Result<Cookie<'_, Conn, GetPropertyContextReply>, ConnectionError>
+pub fn get_property_context<Conn>(conn: &Conn, window: Window, property: Atom) -> Result<Cookie<'_, Conn, GetPropertyContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -636,7 +636,7 @@ impl TryFrom<&[u8]> for GetPropertyContextReply {
 
 /// Opcode for the GetPropertyDataContext request
 pub const GET_PROPERTY_DATA_CONTEXT_REQUEST: u8 = 13;
-pub fn get_property_data_context<Conn>(conn: &Conn, window: WINDOW, property: ATOM) -> Result<Cookie<'_, Conn, GetPropertyDataContextReply>, ConnectionError>
+pub fn get_property_data_context<Conn>(conn: &Conn, window: Window, property: Atom) -> Result<Cookie<'_, Conn, GetPropertyDataContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -692,7 +692,7 @@ impl TryFrom<&[u8]> for GetPropertyDataContextReply {
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 14;
-pub fn list_properties<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
+pub fn list_properties<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -893,7 +893,7 @@ impl TryFrom<&[u8]> for GetSelectionUseContextReply {
 
 /// Opcode for the GetSelectionContext request
 pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
-pub fn get_selection_context<Conn>(conn: &Conn, selection: ATOM) -> Result<Cookie<'_, Conn, GetSelectionContextReply>, ConnectionError>
+pub fn get_selection_context<Conn>(conn: &Conn, selection: Atom) -> Result<Cookie<'_, Conn, GetSelectionContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -944,7 +944,7 @@ impl TryFrom<&[u8]> for GetSelectionContextReply {
 
 /// Opcode for the GetSelectionDataContext request
 pub const GET_SELECTION_DATA_CONTEXT_REQUEST: u8 = 20;
-pub fn get_selection_data_context<Conn>(conn: &Conn, selection: ATOM) -> Result<Cookie<'_, Conn, GetSelectionDataContextReply>, ConnectionError>
+pub fn get_selection_data_context<Conn>(conn: &Conn, selection: Atom) -> Result<Cookie<'_, Conn, GetSelectionDataContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1127,7 +1127,7 @@ pub trait ConnectionExt: RequestConnection {
         get_window_create_context(self)
     }
 
-    fn xselinux_get_window_context(&self, window: WINDOW) -> Result<Cookie<'_, Self, GetWindowContextReply>, ConnectionError>
+    fn xselinux_get_window_context(&self, window: Window) -> Result<Cookie<'_, Self, GetWindowContextReply>, ConnectionError>
     {
         get_window_context(self, window)
     }
@@ -1152,17 +1152,17 @@ pub trait ConnectionExt: RequestConnection {
         get_property_use_context(self)
     }
 
-    fn xselinux_get_property_context(&self, window: WINDOW, property: ATOM) -> Result<Cookie<'_, Self, GetPropertyContextReply>, ConnectionError>
+    fn xselinux_get_property_context(&self, window: Window, property: Atom) -> Result<Cookie<'_, Self, GetPropertyContextReply>, ConnectionError>
     {
         get_property_context(self, window, property)
     }
 
-    fn xselinux_get_property_data_context(&self, window: WINDOW, property: ATOM) -> Result<Cookie<'_, Self, GetPropertyDataContextReply>, ConnectionError>
+    fn xselinux_get_property_data_context(&self, window: Window, property: Atom) -> Result<Cookie<'_, Self, GetPropertyDataContextReply>, ConnectionError>
     {
         get_property_data_context(self, window, property)
     }
 
-    fn xselinux_list_properties(&self, window: WINDOW) -> Result<Cookie<'_, Self, ListPropertiesReply>, ConnectionError>
+    fn xselinux_list_properties(&self, window: Window) -> Result<Cookie<'_, Self, ListPropertiesReply>, ConnectionError>
     {
         list_properties(self, window)
     }
@@ -1187,12 +1187,12 @@ pub trait ConnectionExt: RequestConnection {
         get_selection_use_context(self)
     }
 
-    fn xselinux_get_selection_context(&self, selection: ATOM) -> Result<Cookie<'_, Self, GetSelectionContextReply>, ConnectionError>
+    fn xselinux_get_selection_context(&self, selection: Atom) -> Result<Cookie<'_, Self, GetSelectionContextReply>, ConnectionError>
     {
         get_selection_context(self, selection)
     }
 
-    fn xselinux_get_selection_data_context(&self, selection: ATOM) -> Result<Cookie<'_, Self, GetSelectionDataContextReply>, ConnectionError>
+    fn xselinux_get_selection_data_context(&self, selection: Atom) -> Result<Cookie<'_, Self, GetSelectionDataContextReply>, ConnectionError>
     {
         get_selection_data_context(self, selection)
     }

--- a/src/generated/xtest.rs
+++ b/src/generated/xtest.rs
@@ -152,7 +152,7 @@ impl TryFrom<u32> for Cursor {
 
 /// Opcode for the CompareCursor request
 pub const COMPARE_CURSOR_REQUEST: u8 = 1;
-pub fn compare_cursor<Conn>(conn: &Conn, window: WINDOW, cursor: CURSOR) -> Result<Cookie<'_, Conn, CompareCursorReply>, ConnectionError>
+pub fn compare_cursor<Conn>(conn: &Conn, window: Window, cursor: super::xproto::Cursor) -> Result<Cookie<'_, Conn, CompareCursorReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -205,7 +205,7 @@ impl TryFrom<&[u8]> for CompareCursorReply {
 
 /// Opcode for the FakeInput request
 pub const FAKE_INPUT_REQUEST: u8 = 2;
-pub fn fake_input<Conn>(conn: &Conn, type_: u8, detail: u8, time: u32, root: WINDOW, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn fake_input<Conn>(conn: &Conn, type_: u8, detail: u8, time: u32, root: Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -294,12 +294,12 @@ pub trait ConnectionExt: RequestConnection {
         get_version(self, major_version, minor_version)
     }
 
-    fn xtest_compare_cursor(&self, window: WINDOW, cursor: CURSOR) -> Result<Cookie<'_, Self, CompareCursorReply>, ConnectionError>
+    fn xtest_compare_cursor(&self, window: Window, cursor: super::xproto::Cursor) -> Result<Cookie<'_, Self, CompareCursorReply>, ConnectionError>
     {
         compare_cursor(self, window, cursor)
     }
 
-    fn xtest_fake_input(&self, type_: u8, detail: u8, time: u32, root: WINDOW, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xtest_fake_input(&self, type_: u8, detail: u8, time: u32, root: Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         fake_input(self, type_, detail, time, root, root_x, root_y, deviceid)
     }

--- a/src/generated/xv.rs
+++ b/src/generated/xv.rs
@@ -39,9 +39,9 @@ pub const X11_EXTENSION_NAME: &str = "XVideo";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (2, 2);
 
-pub type PORT = u32;
+pub type Port = u32;
 
-pub type ENCODING = u32;
+pub type Encoding = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -554,12 +554,12 @@ impl Serialize for Rational {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Format {
-    pub visual: VISUALID,
+    pub visual: Visualid,
     pub depth: u8,
 }
 impl TryParse for Format {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (visual, remaining) = VISUALID::try_parse(remaining)?;
+        let (visual, remaining) = Visualid::try_parse(remaining)?;
         let (depth, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = Format { visual, depth };
@@ -598,7 +598,7 @@ impl Serialize for Format {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdaptorInfo {
-    pub base_id: PORT,
+    pub base_id: Port,
     pub num_ports: u16,
     pub type_: u8,
     pub name: Vec<u8>,
@@ -607,7 +607,7 @@ pub struct AdaptorInfo {
 impl TryParse for AdaptorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (base_id, remaining) = PORT::try_parse(remaining)?;
+        let (base_id, remaining) = Port::try_parse(remaining)?;
         let (name_size, remaining) = u16::try_parse(remaining)?;
         let (num_ports, remaining) = u16::try_parse(remaining)?;
         let (num_formats, remaining) = u16::try_parse(remaining)?;
@@ -654,7 +654,7 @@ impl Serialize for AdaptorInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncodingInfo {
-    pub encoding: ENCODING,
+    pub encoding: Encoding,
     pub width: u16,
     pub height: u16,
     pub rate: Rational,
@@ -663,7 +663,7 @@ pub struct EncodingInfo {
 impl TryParse for EncodingInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (encoding, remaining) = ENCODING::try_parse(remaining)?;
+        let (encoding, remaining) = Encoding::try_parse(remaining)?;
         let (name_size, remaining) = u16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
         let (height, remaining) = u16::try_parse(remaining)?;
@@ -1319,18 +1319,18 @@ pub struct VideoNotifyEvent {
     pub response_type: u8,
     pub reason: VideoNotifyReason,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub drawable: DRAWABLE,
-    pub port: PORT,
+    pub time: Timestamp,
+    pub drawable: Drawable,
+    pub port: Port,
 }
 impl VideoNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (reason, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (drawable, remaining) = DRAWABLE::try_parse(remaining)?;
-        let (port, remaining) = PORT::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (port, remaining) = Port::try_parse(remaining)?;
         let reason = reason.try_into()?;
         let result = VideoNotifyEvent { response_type, reason, sequence, time, drawable, port };
         Ok((result, remaining))
@@ -1380,9 +1380,9 @@ pub const PORT_NOTIFY_EVENT: u8 = 1;
 pub struct PortNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub time: TIMESTAMP,
-    pub port: PORT,
-    pub attribute: ATOM,
+    pub time: Timestamp,
+    pub port: Port,
+    pub attribute: Atom,
     pub value: i32,
 }
 impl PortNotifyEvent {
@@ -1390,9 +1390,9 @@ impl PortNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = TIMESTAMP::try_parse(remaining)?;
-        let (port, remaining) = PORT::try_parse(remaining)?;
-        let (attribute, remaining) = ATOM::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (port, remaining) = Port::try_parse(remaining)?;
+        let (attribute, remaining) = Atom::try_parse(remaining)?;
         let (value, remaining) = i32::try_parse(remaining)?;
         let result = PortNotifyEvent { response_type, sequence, time, port, attribute, value };
         Ok((result, remaining))
@@ -1484,7 +1484,7 @@ impl TryFrom<&[u8]> for QueryExtensionReply {
 
 /// Opcode for the QueryAdaptors request
 pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
-pub fn query_adaptors<Conn>(conn: &Conn, window: WINDOW) -> Result<Cookie<'_, Conn, QueryAdaptorsReply>, ConnectionError>
+pub fn query_adaptors<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, QueryAdaptorsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1535,7 +1535,7 @@ impl TryFrom<&[u8]> for QueryAdaptorsReply {
 
 /// Opcode for the QueryEncodings request
 pub const QUERY_ENCODINGS_REQUEST: u8 = 2;
-pub fn query_encodings<Conn>(conn: &Conn, port: PORT) -> Result<Cookie<'_, Conn, QueryEncodingsReply>, ConnectionError>
+pub fn query_encodings<Conn>(conn: &Conn, port: Port) -> Result<Cookie<'_, Conn, QueryEncodingsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1586,7 +1586,7 @@ impl TryFrom<&[u8]> for QueryEncodingsReply {
 
 /// Opcode for the GrabPort request
 pub const GRAB_PORT_REQUEST: u8 = 3;
-pub fn grab_port<Conn>(conn: &Conn, port: PORT, time: TIMESTAMP) -> Result<Cookie<'_, Conn, GrabPortReply>, ConnectionError>
+pub fn grab_port<Conn>(conn: &Conn, port: Port, time: Timestamp) -> Result<Cookie<'_, Conn, GrabPortReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1640,7 +1640,7 @@ impl TryFrom<&[u8]> for GrabPortReply {
 
 /// Opcode for the UngrabPort request
 pub const UNGRAB_PORT_REQUEST: u8 = 4;
-pub fn ungrab_port<Conn>(conn: &Conn, port: PORT, time: TIMESTAMP) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_port<Conn>(conn: &Conn, port: Port, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1670,7 +1670,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PutVideo request
 pub const PUT_VIDEO_REQUEST: u8 = 5;
-pub fn put_video<Conn>(conn: &Conn, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn put_video<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1729,7 +1729,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PutStill request
 pub const PUT_STILL_REQUEST: u8 = 6;
-pub fn put_still<Conn>(conn: &Conn, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn put_still<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1788,7 +1788,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetVideo request
 pub const GET_VIDEO_REQUEST: u8 = 7;
-pub fn get_video<Conn>(conn: &Conn, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn get_video<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1847,7 +1847,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetStill request
 pub const GET_STILL_REQUEST: u8 = 8;
-pub fn get_still<Conn>(conn: &Conn, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn get_still<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1906,7 +1906,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the StopVideo request
 pub const STOP_VIDEO_REQUEST: u8 = 9;
-pub fn stop_video<Conn>(conn: &Conn, port: PORT, drawable: DRAWABLE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn stop_video<Conn>(conn: &Conn, port: Port, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1936,7 +1936,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SelectVideoNotify request
 pub const SELECT_VIDEO_NOTIFY_REQUEST: u8 = 10;
-pub fn select_video_notify<Conn>(conn: &Conn, drawable: DRAWABLE, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_video_notify<Conn>(conn: &Conn, drawable: Drawable, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1966,7 +1966,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SelectPortNotify request
 pub const SELECT_PORT_NOTIFY_REQUEST: u8 = 11;
-pub fn select_port_notify<Conn>(conn: &Conn, port: PORT, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_port_notify<Conn>(conn: &Conn, port: Port, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1996,7 +1996,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 12;
-pub fn query_best_size<Conn>(conn: &Conn, port: PORT, vid_w: u16, vid_h: u16, drw_w: u16, drw_h: u16, motion: bool) -> Result<Cookie<'_, Conn, QueryBestSizeReply>, ConnectionError>
+pub fn query_best_size<Conn>(conn: &Conn, port: Port, vid_w: u16, vid_h: u16, drw_w: u16, drw_h: u16, motion: bool) -> Result<Cookie<'_, Conn, QueryBestSizeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2064,7 +2064,7 @@ impl TryFrom<&[u8]> for QueryBestSizeReply {
 
 /// Opcode for the SetPortAttribute request
 pub const SET_PORT_ATTRIBUTE_REQUEST: u8 = 13;
-pub fn set_port_attribute<Conn>(conn: &Conn, port: PORT, attribute: ATOM, value: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_port_attribute<Conn>(conn: &Conn, port: Port, attribute: Atom, value: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2099,7 +2099,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetPortAttribute request
 pub const GET_PORT_ATTRIBUTE_REQUEST: u8 = 14;
-pub fn get_port_attribute<Conn>(conn: &Conn, port: PORT, attribute: ATOM) -> Result<Cookie<'_, Conn, GetPortAttributeReply>, ConnectionError>
+pub fn get_port_attribute<Conn>(conn: &Conn, port: Port, attribute: Atom) -> Result<Cookie<'_, Conn, GetPortAttributeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2153,7 +2153,7 @@ impl TryFrom<&[u8]> for GetPortAttributeReply {
 
 /// Opcode for the QueryPortAttributes request
 pub const QUERY_PORT_ATTRIBUTES_REQUEST: u8 = 15;
-pub fn query_port_attributes<Conn>(conn: &Conn, port: PORT) -> Result<Cookie<'_, Conn, QueryPortAttributesReply>, ConnectionError>
+pub fn query_port_attributes<Conn>(conn: &Conn, port: Port) -> Result<Cookie<'_, Conn, QueryPortAttributesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2206,7 +2206,7 @@ impl TryFrom<&[u8]> for QueryPortAttributesReply {
 
 /// Opcode for the ListImageFormats request
 pub const LIST_IMAGE_FORMATS_REQUEST: u8 = 16;
-pub fn list_image_formats<Conn>(conn: &Conn, port: PORT) -> Result<Cookie<'_, Conn, ListImageFormatsReply>, ConnectionError>
+pub fn list_image_formats<Conn>(conn: &Conn, port: Port) -> Result<Cookie<'_, Conn, ListImageFormatsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2257,7 +2257,7 @@ impl TryFrom<&[u8]> for ListImageFormatsReply {
 
 /// Opcode for the QueryImageAttributes request
 pub const QUERY_IMAGE_ATTRIBUTES_REQUEST: u8 = 17;
-pub fn query_image_attributes<Conn>(conn: &Conn, port: PORT, id: u32, width: u16, height: u16) -> Result<Cookie<'_, Conn, QueryImageAttributesReply>, ConnectionError>
+pub fn query_image_attributes<Conn>(conn: &Conn, port: Port, id: u32, width: u16, height: u16) -> Result<Cookie<'_, Conn, QueryImageAttributesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2328,7 +2328,7 @@ impl TryFrom<&[u8]> for QueryImageAttributesReply {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 18;
-pub fn put_image<'c, Conn>(conn: &'c Conn, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn put_image<'c, Conn>(conn: &'c Conn, port: Port, drawable: Drawable, gc: Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2401,7 +2401,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ShmPutImage request
 pub const SHM_PUT_IMAGE_REQUEST: u8 = 19;
-pub fn shm_put_image<Conn>(conn: &Conn, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, shmseg: shm::SEG, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn shm_put_image<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, shmseg: shm::Seg, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2491,97 +2491,97 @@ pub trait ConnectionExt: RequestConnection {
         query_extension(self)
     }
 
-    fn xv_query_adaptors(&self, window: WINDOW) -> Result<Cookie<'_, Self, QueryAdaptorsReply>, ConnectionError>
+    fn xv_query_adaptors(&self, window: Window) -> Result<Cookie<'_, Self, QueryAdaptorsReply>, ConnectionError>
     {
         query_adaptors(self, window)
     }
 
-    fn xv_query_encodings(&self, port: PORT) -> Result<Cookie<'_, Self, QueryEncodingsReply>, ConnectionError>
+    fn xv_query_encodings(&self, port: Port) -> Result<Cookie<'_, Self, QueryEncodingsReply>, ConnectionError>
     {
         query_encodings(self, port)
     }
 
-    fn xv_grab_port(&self, port: PORT, time: TIMESTAMP) -> Result<Cookie<'_, Self, GrabPortReply>, ConnectionError>
+    fn xv_grab_port(&self, port: Port, time: Timestamp) -> Result<Cookie<'_, Self, GrabPortReply>, ConnectionError>
     {
         grab_port(self, port, time)
     }
 
-    fn xv_ungrab_port(&self, port: PORT, time: TIMESTAMP) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_ungrab_port(&self, port: Port, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_port(self, port, time)
     }
 
-    fn xv_put_video(&self, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_put_video(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         put_video(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_put_still(&self, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_put_still(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         put_still(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_get_video(&self, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_get_video(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         get_video(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_get_still(&self, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_get_still(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         get_still(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_stop_video(&self, port: PORT, drawable: DRAWABLE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_stop_video(&self, port: Port, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         stop_video(self, port, drawable)
     }
 
-    fn xv_select_video_notify(&self, drawable: DRAWABLE, onoff: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_select_video_notify(&self, drawable: Drawable, onoff: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_video_notify(self, drawable, onoff)
     }
 
-    fn xv_select_port_notify(&self, port: PORT, onoff: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_select_port_notify(&self, port: Port, onoff: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_port_notify(self, port, onoff)
     }
 
-    fn xv_query_best_size(&self, port: PORT, vid_w: u16, vid_h: u16, drw_w: u16, drw_h: u16, motion: bool) -> Result<Cookie<'_, Self, QueryBestSizeReply>, ConnectionError>
+    fn xv_query_best_size(&self, port: Port, vid_w: u16, vid_h: u16, drw_w: u16, drw_h: u16, motion: bool) -> Result<Cookie<'_, Self, QueryBestSizeReply>, ConnectionError>
     {
         query_best_size(self, port, vid_w, vid_h, drw_w, drw_h, motion)
     }
 
-    fn xv_set_port_attribute(&self, port: PORT, attribute: ATOM, value: i32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_set_port_attribute(&self, port: Port, attribute: Atom, value: i32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_port_attribute(self, port, attribute, value)
     }
 
-    fn xv_get_port_attribute(&self, port: PORT, attribute: ATOM) -> Result<Cookie<'_, Self, GetPortAttributeReply>, ConnectionError>
+    fn xv_get_port_attribute(&self, port: Port, attribute: Atom) -> Result<Cookie<'_, Self, GetPortAttributeReply>, ConnectionError>
     {
         get_port_attribute(self, port, attribute)
     }
 
-    fn xv_query_port_attributes(&self, port: PORT) -> Result<Cookie<'_, Self, QueryPortAttributesReply>, ConnectionError>
+    fn xv_query_port_attributes(&self, port: Port) -> Result<Cookie<'_, Self, QueryPortAttributesReply>, ConnectionError>
     {
         query_port_attributes(self, port)
     }
 
-    fn xv_list_image_formats(&self, port: PORT) -> Result<Cookie<'_, Self, ListImageFormatsReply>, ConnectionError>
+    fn xv_list_image_formats(&self, port: Port) -> Result<Cookie<'_, Self, ListImageFormatsReply>, ConnectionError>
     {
         list_image_formats(self, port)
     }
 
-    fn xv_query_image_attributes(&self, port: PORT, id: u32, width: u16, height: u16) -> Result<Cookie<'_, Self, QueryImageAttributesReply>, ConnectionError>
+    fn xv_query_image_attributes(&self, port: Port, id: u32, width: u16, height: u16) -> Result<Cookie<'_, Self, QueryImageAttributesReply>, ConnectionError>
     {
         query_image_attributes(self, port, id, width, height)
     }
 
-    fn xv_put_image<'c>(&'c self, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xv_put_image<'c>(&'c self, port: Port, drawable: Drawable, gc: Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         put_image(self, port, drawable, gc, id, src_x, src_y, src_w, src_h, drw_x, drw_y, drw_w, drw_h, width, height, data)
     }
 
-    fn xv_shm_put_image(&self, port: PORT, drawable: DRAWABLE, gc: GCONTEXT, shmseg: shm::SEG, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_shm_put_image(&self, port: Port, drawable: Drawable, gc: Gcontext, shmseg: shm::Seg, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         shm_put_image(self, port, drawable, gc, shmseg, id, offset, src_x, src_y, src_w, src_h, drw_x, drw_y, drw_w, drw_h, width, height, send_event)
     }

--- a/src/generated/xvmc.rs
+++ b/src/generated/xvmc.rs
@@ -41,15 +41,15 @@ pub const X11_EXTENSION_NAME: &str = "XVideo-MotionCompensation";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
-pub type CONTEXT = u32;
+pub type Context = u32;
 
-pub type SURFACE = u32;
+pub type Surface = u32;
 
-pub type SUBPICTURE = u32;
+pub type Subpicture = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SurfaceInfo {
-    pub id: SURFACE,
+    pub id: Surface,
     pub chroma_format: u16,
     pub pad0: u16,
     pub max_width: u16,
@@ -61,7 +61,7 @@ pub struct SurfaceInfo {
 }
 impl TryParse for SurfaceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (id, remaining) = SURFACE::try_parse(remaining)?;
+        let (id, remaining) = Surface::try_parse(remaining)?;
         let (chroma_format, remaining) = u16::try_parse(remaining)?;
         let (pad0, remaining) = u16::try_parse(remaining)?;
         let (max_width, remaining) = u16::try_parse(remaining)?;
@@ -181,7 +181,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the ListSurfaceTypes request
 pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
-pub fn list_surface_types<Conn>(conn: &Conn, port_id: xv::PORT) -> Result<Cookie<'_, Conn, ListSurfaceTypesReply>, ConnectionError>
+pub fn list_surface_types<Conn>(conn: &Conn, port_id: xv::Port) -> Result<Cookie<'_, Conn, ListSurfaceTypesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -232,7 +232,7 @@ impl TryFrom<&[u8]> for ListSurfaceTypesReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
-pub fn create_context<Conn>(conn: &Conn, context_id: CONTEXT, port_id: xv::PORT, surface_id: SURFACE, width: u16, height: u16, flags: u32) -> Result<Cookie<'_, Conn, CreateContextReply>, ConnectionError>
+pub fn create_context<Conn>(conn: &Conn, context_id: Context, port_id: xv::Port, surface_id: Surface, width: u16, height: u16, flags: u32) -> Result<Cookie<'_, Conn, CreateContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -308,7 +308,7 @@ impl TryFrom<&[u8]> for CreateContextReply {
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 3;
-pub fn destroy_context<Conn>(conn: &Conn, context_id: CONTEXT) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_context<Conn>(conn: &Conn, context_id: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -333,7 +333,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateSurface request
 pub const CREATE_SURFACE_REQUEST: u8 = 4;
-pub fn create_surface<Conn>(conn: &Conn, surface_id: SURFACE, context_id: CONTEXT) -> Result<Cookie<'_, Conn, CreateSurfaceReply>, ConnectionError>
+pub fn create_surface<Conn>(conn: &Conn, surface_id: Surface, context_id: Context) -> Result<Cookie<'_, Conn, CreateSurfaceReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -387,7 +387,7 @@ impl TryFrom<&[u8]> for CreateSurfaceReply {
 
 /// Opcode for the DestroySurface request
 pub const DESTROY_SURFACE_REQUEST: u8 = 5;
-pub fn destroy_surface<Conn>(conn: &Conn, surface_id: SURFACE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_surface<Conn>(conn: &Conn, surface_id: Surface) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -412,7 +412,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateSubpicture request
 pub const CREATE_SUBPICTURE_REQUEST: u8 = 6;
-pub fn create_subpicture<Conn>(conn: &Conn, subpicture_id: SUBPICTURE, context: CONTEXT, xvimage_id: u32, width: u16, height: u16) -> Result<Cookie<'_, Conn, CreateSubpictureReply>, ConnectionError>
+pub fn create_subpicture<Conn>(conn: &Conn, subpicture_id: Subpicture, context: Context, xvimage_id: u32, width: u16, height: u16) -> Result<Cookie<'_, Conn, CreateSubpictureReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -496,7 +496,7 @@ impl TryFrom<&[u8]> for CreateSubpictureReply {
 
 /// Opcode for the DestroySubpicture request
 pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
-pub fn destroy_subpicture<Conn>(conn: &Conn, subpicture_id: SUBPICTURE) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_subpicture<Conn>(conn: &Conn, subpicture_id: Subpicture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -521,7 +521,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ListSubpictureTypes request
 pub const LIST_SUBPICTURE_TYPES_REQUEST: u8 = 8;
-pub fn list_subpicture_types<Conn>(conn: &Conn, port_id: xv::PORT, surface_id: SURFACE) -> Result<Cookie<'_, Conn, ListSubpictureTypesReply>, ConnectionError>
+pub fn list_subpicture_types<Conn>(conn: &Conn, port_id: xv::Port, surface_id: Surface) -> Result<Cookie<'_, Conn, ListSubpictureTypesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -582,42 +582,42 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self)
     }
 
-    fn xvmc_list_surface_types(&self, port_id: xv::PORT) -> Result<Cookie<'_, Self, ListSurfaceTypesReply>, ConnectionError>
+    fn xvmc_list_surface_types(&self, port_id: xv::Port) -> Result<Cookie<'_, Self, ListSurfaceTypesReply>, ConnectionError>
     {
         list_surface_types(self, port_id)
     }
 
-    fn xvmc_create_context(&self, context_id: CONTEXT, port_id: xv::PORT, surface_id: SURFACE, width: u16, height: u16, flags: u32) -> Result<Cookie<'_, Self, CreateContextReply>, ConnectionError>
+    fn xvmc_create_context(&self, context_id: Context, port_id: xv::Port, surface_id: Surface, width: u16, height: u16, flags: u32) -> Result<Cookie<'_, Self, CreateContextReply>, ConnectionError>
     {
         create_context(self, context_id, port_id, surface_id, width, height, flags)
     }
 
-    fn xvmc_destroy_context(&self, context_id: CONTEXT) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xvmc_destroy_context(&self, context_id: Context) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_context(self, context_id)
     }
 
-    fn xvmc_create_surface(&self, surface_id: SURFACE, context_id: CONTEXT) -> Result<Cookie<'_, Self, CreateSurfaceReply>, ConnectionError>
+    fn xvmc_create_surface(&self, surface_id: Surface, context_id: Context) -> Result<Cookie<'_, Self, CreateSurfaceReply>, ConnectionError>
     {
         create_surface(self, surface_id, context_id)
     }
 
-    fn xvmc_destroy_surface(&self, surface_id: SURFACE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xvmc_destroy_surface(&self, surface_id: Surface) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_surface(self, surface_id)
     }
 
-    fn xvmc_create_subpicture(&self, subpicture_id: SUBPICTURE, context: CONTEXT, xvimage_id: u32, width: u16, height: u16) -> Result<Cookie<'_, Self, CreateSubpictureReply>, ConnectionError>
+    fn xvmc_create_subpicture(&self, subpicture_id: Subpicture, context: Context, xvimage_id: u32, width: u16, height: u16) -> Result<Cookie<'_, Self, CreateSubpictureReply>, ConnectionError>
     {
         create_subpicture(self, subpicture_id, context, xvimage_id, width, height)
     }
 
-    fn xvmc_destroy_subpicture(&self, subpicture_id: SUBPICTURE) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xvmc_destroy_subpicture(&self, subpicture_id: Subpicture) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_subpicture(self, subpicture_id)
     }
 
-    fn xvmc_list_subpicture_types(&self, port_id: xv::PORT, surface_id: SURFACE) -> Result<Cookie<'_, Self, ListSubpictureTypesReply>, ConnectionError>
+    fn xvmc_list_subpicture_types(&self, port_id: xv::Port, surface_id: Surface) -> Result<Cookie<'_, Self, ListSubpictureTypesReply>, ConnectionError>
     {
         list_subpicture_types(self, port_id, surface_id)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ mod generated;
 use connection::Connection;
 use errors::ConnectError;
 pub use generated::*;
-use xproto::{KEYSYM, TIMESTAMP};
+use xproto::{Keysym, Timestamp};
 
 /// Establish a new connection to an X11 server.
 ///
@@ -155,7 +155,7 @@ pub const COPY_DEPTH_FROM_PARENT: u8 = 0;
 pub const COPY_CLASS_FROM_PARENT: u16 = 0;
 
 /// This constant can be used in most request that take a timestamp argument
-pub const CURRENT_TIME: TIMESTAMP = 0;
+pub const CURRENT_TIME: Timestamp = 0;
 
-/// This constant can be used to fill unused entries in `KEYSYM` tables
-pub const NO_SYMBOL: KEYSYM = 0;
+/// This constant can be used to fill unused entries in `Keysym` tables
+pub const NO_SYMBOL: Keysym = 0;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use super::cookie::VoidCookie;
 use super::errors::{ConnectionError, ReplyError};
 use super::x11_utils::TryParse;
-use super::xproto::{ConnectionExt as XProtoConnectionExt, Atom, Window};
+use super::xproto::{Atom, ConnectionExt as XProtoConnectionExt, Window};
 
 /// Iterator implementation used by `GetPropertyReply`.
 ///

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use super::cookie::VoidCookie;
 use super::errors::{ConnectionError, ReplyError};
 use super::x11_utils::TryParse;
-use super::xproto::{ConnectionExt as XProtoConnectionExt, ATOM, WINDOW};
+use super::xproto::{ConnectionExt as XProtoConnectionExt, Atom, Window};
 
 /// Iterator implementation used by `GetPropertyReply`.
 ///
@@ -54,15 +54,15 @@ pub trait ConnectionExt: XProtoConnectionExt {
     fn change_property8<A, B, C>(
         &self,
         mode: A,
-        window: WINDOW,
+        window: Window,
         property: B,
         type_: C,
         data: &[u8],
     ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
-        B: Into<ATOM>,
-        C: Into<ATOM>,
+        B: Into<Atom>,
+        C: Into<Atom>,
     {
         self.change_property(
             mode,
@@ -79,15 +79,15 @@ pub trait ConnectionExt: XProtoConnectionExt {
     fn change_property16<A, B, C>(
         &self,
         mode: A,
-        window: WINDOW,
+        window: Window,
         property: B,
         type_: C,
         data: &[u16],
     ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
-        B: Into<ATOM>,
-        C: Into<ATOM>,
+        B: Into<Atom>,
+        C: Into<Atom>,
     {
         let mut data_u8 = Vec::with_capacity(data.len() * 2);
         for item in data {
@@ -108,15 +108,15 @@ pub trait ConnectionExt: XProtoConnectionExt {
     fn change_property32<A, B, C>(
         &self,
         mode: A,
-        window: WINDOW,
+        window: Window,
         property: B,
         type_: C,
         data: &[u32],
     ) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<u8>,
-        B: Into<ATOM>,
-        C: Into<ATOM>,
+        B: Into<Atom>,
+        C: Into<Atom>,
     {
         let mut data_u8 = Vec::with_capacity(data.len() * 4);
         for item in data {

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -330,15 +330,15 @@ macro_rules! bitmask_binop {
 ///
 /// If we need to use multiple atoms, one would normally write code such as
 /// ```
-/// # use x11rb::xproto::{ATOM, ConnectionExt, InternAtomReply};
+/// # use x11rb::xproto::{Atom, ConnectionExt, InternAtomReply};
 /// # use x11rb::errors::{ConnectionError, ReplyError};
 /// # use x11rb::cookie::Cookie;
 /// #[allow(non_snake_case)]
 /// pub struct AtomCollection {
-///     pub _NET_WM_NAME: ATOM,
-///     pub _NET_WM_ICON: ATOM,
-///     pub ATOM_WITH_SPACES: ATOM,
-///     pub WHATEVER: ATOM,
+///     pub _NET_WM_NAME: Atom,
+///     pub _NET_WM_ICON: Atom,
+///     pub ATOM_WITH_SPACES: Atom,
+///     pub WHATEVER: Atom,
 /// }
 ///
 /// #[allow(non_snake_case)]
@@ -408,7 +408,7 @@ macro_rules! atom_manager {
         #[derive(Debug, Clone, Copy)]
         $vis struct $struct_name {
             $(
-                $vis $field_name: $crate::xproto::ATOM,
+                $vis $field_name: $crate::xproto::Atom,
             )*
         }
 


### PR DESCRIPTION
Up to now, xproto.rs contained this:

  pub type WINDOW = u32;

This type name does not follow the usual Rust naming convention. The
reason for this is that xproto also has an enum with name Window and the
two names collided (=were identical).

This commit changes the type alias to be called Window. The name
collision is handled by appending 'Enum' to the name of enums that
collide with type aliases.

There is the following uglyness in this commit:

  if field_type.is_simple and field_type.__class__.__name__ != "Enum":

Suggestions on how to do this differently / less ugly are welcome. It
seems like xcb-proto does not want one to easily tell apart enums and
"simple" types...

Fixes: https://github.com/psychon/x11rb/issues/13
Signed-off-by: Uli Schlachter <psychon@znc.in>