### PR TITLE
Code generator: Produce readable literals

### DIFF
--- a/src/generated/bigreq.rs
+++ b/src/generated/bigreq.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/composite.rs
+++ b/src/generated/composite.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/damage.rs
+++ b/src/generated/damage.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/dpms.rs
+++ b/src/generated/dpms.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/dri2.rs
+++ b/src/generated/dri2.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/dri3.rs
+++ b/src/generated/dri3.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/ge.rs
+++ b/src/generated/ge.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/glx.rs
+++ b/src/generated/glx.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
@@ -1647,12 +1646,12 @@ pub enum GC {
     GL_LIST_BIT = 1 << 17,
     GL_TEXTURE_BIT = 1 << 18,
     GL_SCISSOR_BIT = 1 << 19,
-    GL_ALL_ATTRIB_BITS = 16777215,
+    GL_ALL_ATTRIB_BITS = 16_777_215,
 }
 impl From<GC> for u32 {
     fn from(input: GC) -> Self {
         match input {
-            GC::GL_ALL_ATTRIB_BITS => 16777215,
+            GC::GL_ALL_ATTRIB_BITS => 16_777_215,
             GC::GL_CURRENT_BIT => 1 << 0,
             GC::GL_POINT_BIT => 1 << 1,
             GC::GL_LINE_BIT => 1 << 2,
@@ -1702,10 +1701,10 @@ impl TryFrom<u32> for GC {
             16384 => Ok(GC::GL_COLOR_BUFFER_BIT),
             32768 => Ok(GC::GL_HINT_BIT),
             65536 => Ok(GC::GL_EVAL_BIT),
-            131072 => Ok(GC::GL_LIST_BIT),
-            262144 => Ok(GC::GL_TEXTURE_BIT),
-            524288 => Ok(GC::GL_SCISSOR_BIT),
-            16777215 => Ok(GC::GL_ALL_ATTRIB_BITS),
+            131_072 => Ok(GC::GL_LIST_BIT),
+            262_144 => Ok(GC::GL_TEXTURE_BIT),
+            524_288 => Ok(GC::GL_SCISSOR_BIT),
+            16_777_215 => Ok(GC::GL_ALL_ATTRIB_BITS),
             _ => Err(ParseError::ParseError)
         }
     }

--- a/src/generated/present.rs
+++ b/src/generated/present.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/randr.rs
+++ b/src/generated/randr.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/record.rs
+++ b/src/generated/record.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/render.rs
+++ b/src/generated/render.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/res.rs
+++ b/src/generated/res.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/screensaver.rs
+++ b/src/generated/screensaver.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/shape.rs
+++ b/src/generated/shape.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/shm.rs
+++ b/src/generated/shm.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/sync.rs
+++ b/src/generated/sync.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xc_misc.rs
+++ b/src/generated/xc_misc.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xevie.rs
+++ b/src/generated/xevie.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xf86dri.rs
+++ b/src/generated/xf86dri.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xf86vidmode.rs
+++ b/src/generated/xf86vidmode.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xfixes.rs
+++ b/src/generated/xfixes.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xinerama.rs
+++ b/src/generated/xinerama.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xinput.rs
+++ b/src/generated/xinput.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
@@ -8448,16 +8447,16 @@ impl TryFrom<u32> for XIEventMask {
             16384 => Ok(XIEventMask::RawKeyRelease),
             32768 => Ok(XIEventMask::RawButtonPress),
             65536 => Ok(XIEventMask::RawButtonRelease),
-            131072 => Ok(XIEventMask::RawMotion),
-            262144 => Ok(XIEventMask::TouchBegin),
-            524288 => Ok(XIEventMask::TouchUpdate),
-            1048576 => Ok(XIEventMask::TouchEnd),
-            2097152 => Ok(XIEventMask::TouchOwnership),
-            4194304 => Ok(XIEventMask::RawTouchBegin),
-            8388608 => Ok(XIEventMask::RawTouchUpdate),
-            16777216 => Ok(XIEventMask::RawTouchEnd),
-            33554432 => Ok(XIEventMask::BarrierHit),
-            67108864 => Ok(XIEventMask::BarrierLeave),
+            131_072 => Ok(XIEventMask::RawMotion),
+            262_144 => Ok(XIEventMask::TouchBegin),
+            524_288 => Ok(XIEventMask::TouchUpdate),
+            1_048_576 => Ok(XIEventMask::TouchEnd),
+            2_097_152 => Ok(XIEventMask::TouchOwnership),
+            4_194_304 => Ok(XIEventMask::RawTouchBegin),
+            8_388_608 => Ok(XIEventMask::RawTouchUpdate),
+            16_777_216 => Ok(XIEventMask::RawTouchEnd),
+            33_554_432 => Ok(XIEventMask::BarrierHit),
+            67_108_864 => Ok(XIEventMask::BarrierLeave),
             _ => Err(ParseError::ParseError)
         }
     }
@@ -10305,7 +10304,7 @@ impl TryFrom<u32> for ModifierMask {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
-            2147483648 => Ok(ModifierMask::Any),
+            2_147_483_648 => Ok(ModifierMask::Any),
             _ => Err(ParseError::ParseError)
         }
     }
@@ -14252,7 +14251,7 @@ impl TryFrom<u32> for TouchEventFlags {
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             65536 => Ok(TouchEventFlags::TouchPendingEnd),
-            131072 => Ok(TouchEventFlags::TouchEmulatingPointer),
+            131_072 => Ok(TouchEventFlags::TouchEmulatingPointer),
             _ => Err(ParseError::ParseError)
         }
     }

--- a/src/generated/xkb.rs
+++ b/src/generated/xkb.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
@@ -659,11 +658,11 @@ impl TryFrom<u32> for Control {
     type Error = ParseError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
-            134217728 => Ok(Control::GroupsWrap),
-            268435456 => Ok(Control::InternalMods),
-            536870912 => Ok(Control::IgnoreLockMods),
-            1073741824 => Ok(Control::PerKeyRepeat),
-            2147483648 => Ok(Control::ControlsEnabled),
+            134_217_728 => Ok(Control::GroupsWrap),
+            268_435_456 => Ok(Control::InternalMods),
+            536_870_912 => Ok(Control::IgnoreLockMods),
+            1_073_741_824 => Ok(Control::PerKeyRepeat),
+            2_147_483_648 => Ok(Control::ControlsEnabled),
             _ => Err(ParseError::ParseError)
         }
     }

--- a/src/generated/xprint.rs
+++ b/src/generated/xprint.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xproto.rs
+++ b/src/generated/xproto.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
@@ -575,14 +574,14 @@ impl TryFrom<u32> for EventMask {
             16384 => Ok(EventMask::KeymapState),
             32768 => Ok(EventMask::Exposure),
             65536 => Ok(EventMask::VisibilityChange),
-            131072 => Ok(EventMask::StructureNotify),
-            262144 => Ok(EventMask::ResizeRedirect),
-            524288 => Ok(EventMask::SubstructureNotify),
-            1048576 => Ok(EventMask::SubstructureRedirect),
-            2097152 => Ok(EventMask::FocusChange),
-            4194304 => Ok(EventMask::PropertyChange),
-            8388608 => Ok(EventMask::ColorMapChange),
-            16777216 => Ok(EventMask::OwnerGrabButton),
+            131_072 => Ok(EventMask::StructureNotify),
+            262_144 => Ok(EventMask::ResizeRedirect),
+            524_288 => Ok(EventMask::SubstructureNotify),
+            1_048_576 => Ok(EventMask::SubstructureRedirect),
+            2_097_152 => Ok(EventMask::FocusChange),
+            4_194_304 => Ok(EventMask::PropertyChange),
+            8_388_608 => Ok(EventMask::ColorMapChange),
+            16_777_216 => Ok(EventMask::OwnerGrabButton),
             _ => Err(ParseError::ParseError)
         }
     }
@@ -12210,12 +12209,12 @@ impl TryFrom<u32> for GC {
             16384 => Ok(GC::Font),
             32768 => Ok(GC::SubwindowMode),
             65536 => Ok(GC::GraphicsExposures),
-            131072 => Ok(GC::ClipOriginX),
-            262144 => Ok(GC::ClipOriginY),
-            524288 => Ok(GC::ClipMask),
-            1048576 => Ok(GC::DashOffset),
-            2097152 => Ok(GC::DashList),
-            4194304 => Ok(GC::ArcMode),
+            131_072 => Ok(GC::ClipOriginX),
+            262_144 => Ok(GC::ClipOriginY),
+            524_288 => Ok(GC::ClipMask),
+            1_048_576 => Ok(GC::DashOffset),
+            2_097_152 => Ok(GC::DashList),
+            4_194_304 => Ok(GC::ArcMode),
             _ => Err(ParseError::ParseError)
         }
     }

--- a/src/generated/xselinux.rs
+++ b/src/generated/xselinux.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xtest.rs
+++ b/src/generated/xtest.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xv.rs
+++ b/src/generated/xv.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/generated/xvmc.rs
+++ b/src/generated/xvmc.rs
@@ -1,7 +1,6 @@
 // This file contains generated code. Do not edit directly.
 // To regenerate this, run 'make'.
 
-#![allow(clippy::unreadable_literal)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::identity_op)]
 #![allow(clippy::trivially_copy_pass_by_ref)]


### PR DESCRIPTION
Clippy knows that 123456 is totally unreadable and needs to be written
as 123_456 (but 1_2_3_4_5_6 would also be okay, and so is 12_34_56). So
far we just silenced this unreadable_literal lint. This commit makes the
code generator produce readable literals instead.

Signed-off-by: Uli Schlachter <psychon@znc.in>