### PR TITLE
Return a simplified struct in `RequestConnection::extension_information`

### DIFF
--- a/code_generator_helpers/errors_events.py
+++ b/code_generator_helpers/errors_events.py
@@ -63,7 +63,7 @@ def _errors(out, modules):
         out("/// Parse a generic X11 error into a concrete error type.")
         out("pub fn parse(")
         out.indent("error: GenericError<B>,")
-        out.indent("iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,")
+        out.indent("iter: impl Iterator<Item=(&'static str, ExtensionInformation)>,")
         out(") -> Result<Self, ParseError> {")
         with Indent(out):
             out("let error_code = error.error_code();")
@@ -80,7 +80,7 @@ def _errors(out, modules):
 
             out("// Find the extension that this error could belong to")
             out("let ext_info = iter")
-            out.indent(".map(|(name, reply)| (name, reply.first_error))")
+            out.indent(".map(|(name, ext_info)| (name, ext_info.first_error))")
             out.indent(".filter(|&(_, first_error)| first_error <= error_code)")
             out.indent(".max_by_key(|&(_, first_error)| first_error);")
             out("match ext_info {")
@@ -121,7 +121,7 @@ def _events(out, modules):
         out("/// Parse a generic X11 event into a concrete event type.")
         out("pub fn parse(")
         out.indent("event: GenericEvent<B>,")
-        out.indent("iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,")
+        out.indent("iter: impl Iterator<Item=(&'static str, ExtensionInformation)>,")
         out(") -> Result<Self, ParseError> {")
         with Indent(out):
             out("let event_type = event.response_type();")
@@ -143,7 +143,7 @@ def _events(out, modules):
 
             out("// Find the extension that this event could belong to")
             out("let ext_info = iter")
-            out.indent(".map(|(name, reply)| (name, reply.first_event))")
+            out.indent(".map(|(name, ext_info)| (name, ext_info.first_event))")
             out.indent(".filter(|&(_, first_event)| first_event <= event_type)")
             out.indent(".max_by_key(|&(_, first_event)| first_event);")
             out("match ext_info {")
@@ -184,7 +184,7 @@ def _events(out, modules):
 
         out("fn from_generic_event(")
         out.indent("event: GenericEvent<B>,")
-        out.indent("iter: impl Iterator<Item=(&'static str, QueryExtensionReply)>,")
+        out.indent("iter: impl Iterator<Item=(&'static str, ExtensionInformation)>,")
         out(") -> Result<Self, ParseError> {")
         with Indent(out):
             out("let bytes = event.raw_bytes();")
@@ -192,7 +192,7 @@ def _events(out, modules):
             out("#[allow(unused_variables)]")
             out("let (extension, event_type) = (ge_event.extension, ge_event.event_type);")
             out("let ext_name = iter")
-            out.indent(".map(|(name, reply)| (name, reply.major_opcode))")
+            out.indent(".map(|(name, ext_info)| (name, ext_info.major_opcode))")
             out.indent(".find(|&(_, opcode)| extension == opcode)")
             out.indent(".map(|(name, _)| name);")
             out("match ext_name {")

--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -31,8 +31,7 @@ main_output_file = output_helper.Output()
 output_helper.generated_code_header(main_output_file)
 main_output_file("use std::convert::{TryFrom, TryInto};")
 main_output_file("use crate::errors::ParseError;")
-main_output_file("use crate::x11_utils::{Event as _, GenericError, GenericEvent};")
-main_output_file("use xproto::QueryExtensionReply;")
+main_output_file("use crate::x11_utils::{Event as _, ExtensionInformation, GenericError, GenericEvent};")
 
 
 # Now the real fun begins

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -46,8 +46,8 @@ use std::io::IoSlice;
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::utils::RawFdContainer;
-use crate::x11_utils::{GenericError, GenericEvent};
-use crate::xproto::{QueryExtensionReply, Setup};
+use crate::x11_utils::{ExtensionInformation, GenericError, GenericEvent};
+use crate::xproto::Setup;
 use crate::{Error, Event};
 
 /// Number type used for referring to things that were sent to the server in responses from the
@@ -176,15 +176,16 @@ pub trait RequestConnection {
 
     /// Get information about an extension.
     ///
-    /// To send a request for some extension, the `QueryExtensionReply` for the extension is
-    /// necessary. This function provides this information.
+    /// To send a request for some extension, information about the extension (major opcode,
+    /// first event code and first error code) is necessary. This function provides this
+    /// information.
     ///
     /// The returned object is guaranteed to have a non-zero `present` field. Extensions that are
     /// not present are instead returned as `None`.
     fn extension_information(
         &self,
         extension_name: &'static str,
-    ) -> Result<Option<QueryExtensionReply>, ConnectionError>;
+    ) -> Result<Option<ExtensionInformation>, ConnectionError>;
 
     /// Wait for the reply to a request.
     ///
@@ -349,6 +350,7 @@ pub enum DiscardMode {
 /// use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
 /// use x11rb::errors::{ParseError, ConnectionError};
 /// use x11rb::utils::RawFdContainer;
+/// use x11rb::x11_utils::ExtensionInformation;
 ///
 /// struct MyConnection();
 ///
@@ -368,7 +370,7 @@ pub enum DiscardMode {
 ///     #     unimplemented!()
 ///     # }
 ///     # fn extension_information(&self, ext: &'static str)
-///     # -> Result<Option<x11rb::xproto::QueryExtensionReply>, ConnectionError> {
+///     # -> Result<Option<ExtensionInformation>, ConnectionError> {
 ///     #    unimplemented!()
 ///     # }
 ///     # fn wait_for_reply_or_error(&self, sequence: SequenceNumber)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub mod x11_utils;
 pub mod connection;
 pub mod cookie;
 pub mod errors;
-pub mod extension_information;
+pub mod extension_manager;
 pub mod rust_connection;
 pub mod wrapper;
 

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -78,8 +78,7 @@ mod test {
     use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
     use crate::errors::{ConnectionError, ParseError, ReplyError};
     use crate::utils::RawFdContainer;
-    use crate::x11_utils::GenericError;
-    use crate::xproto::QueryExtensionReply;
+    use crate::x11_utils::{ExtensionInformation, GenericError};
 
     use super::IDAllocator;
 
@@ -185,12 +184,8 @@ mod test {
         fn extension_information(
             &self,
             _extension_name: &'static str,
-        ) -> Result<Option<QueryExtensionReply>, ConnectionError> {
-            Ok(self.0.as_ref().map(|_| QueryExtensionReply {
-                response_type: 1,
-                sequence: 0,
-                length: 0,
-                present: true,
+        ) -> Result<Option<ExtensionInformation>, ConnectionError> {
+            Ok(self.0.as_ref().map(|_| ExtensionInformation {
                 major_opcode: 127,
                 first_event: 0,
                 first_error: 0,

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -2,6 +2,17 @@ use std::convert::{TryFrom, TryInto};
 
 use crate::errors::ParseError;
 
+/// Information about a X11 extension.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ExtensionInformation {
+    /// Major opcode used in request
+    pub major_opcode: u8,
+    /// Lowest event number used by the extension.
+    pub first_event: u8,
+    /// Lowest error number used by the extension.
+    pub first_error: u8,
+}
+
 /// Common information on events and errors.
 ///
 /// This trait exists to share some code between `GenericEvent` and `GenericError`.

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -9,10 +9,9 @@ use x11rb::connection::{
 use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
 use x11rb::errors::{ConnectionError, ParseError, ReplyError};
 use x11rb::utils::RawFdContainer;
-use x11rb::x11_utils::{GenericError, Serialize, TryParse};
+use x11rb::x11_utils::{ExtensionInformation, GenericError, Serialize, TryParse};
 use x11rb::xproto::{
-    ClientMessageData, ConnectionExt, KeymapNotifyEvent, QueryExtensionReply, Segment,
-    SetupAuthenticate,
+    ClientMessageData, ConnectionExt, KeymapNotifyEvent, Segment, SetupAuthenticate,
 };
 
 #[derive(Debug)]
@@ -110,7 +109,7 @@ impl RequestConnection for FakeConnection {
     fn extension_information(
         &self,
         _extension_name: &'static str,
-    ) -> Result<Option<QueryExtensionReply>, ConnectionError> {
+    ) -> Result<Option<ExtensionInformation>, ConnectionError> {
         unimplemented!()
     }
 


### PR DESCRIPTION
`RequestConnection::extension_information` returned `QueryExtensionReply`,
which hass fields (`response_type`, `sequence`...) which we do not really
need to store. So, instead of returning `QueryExtensionReply`, a new struct
has been created, which only has the needed fields:
```rust
pub struct ExtensionInformation {
    pub major_opcode: u8,
    pub first_event: u8,
    pub first_error: u8,
}
```

There was already an `ExtensionInformation`-named type which contained the information
about all the feteched extensions, it has been renamed to `ExtensionsInformation`.