### PR TITLE
Add an `ExtInfoProvider` trait that allows to get extension information from the major opcode, event code or error code.

### DIFF
--- a/rs_code_generator.py
+++ b/rs_code_generator.py
@@ -31,7 +31,7 @@ main_output_file = output_helper.Output()
 output_helper.generated_code_header(main_output_file)
 main_output_file("use std::convert::{TryFrom, TryInto};")
 main_output_file("use crate::errors::ParseError;")
-main_output_file("use crate::x11_utils::{Event as _, ExtensionInformation, GenericError, GenericEvent};")
+main_output_file("use crate::x11_utils::{Event as _, ExtInfoProvider, GenericError, GenericEvent};")
 
 
 # Now the real fun begins

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -3,7 +3,7 @@
 
 use std::convert::{TryFrom, TryInto};
 use crate::errors::ParseError;
-use crate::x11_utils::{Event as _, ExtensionInformation, GenericError, GenericEvent};
+use crate::x11_utils::{Event as _, ExtInfoProvider, GenericError, GenericEvent};
 pub mod bigreq;
 #[cfg(feature = "composite")]
 pub mod composite;
@@ -183,7 +183,7 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
     /// Parse a generic X11 error into a concrete error type.
     pub fn parse(
         error: GenericError<B>,
-        iter: impl Iterator<Item=(&'static str, ExtensionInformation)>,
+        ext_info_provider: &dyn ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         let error_code = error.error_code();
         // Check if this is a core protocol error
@@ -208,21 +208,18 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
             _ => {}
         }
         // Find the extension that this error could belong to
-        let ext_info = iter
-            .map(|(name, ext_info)| (name, ext_info.first_error))
-            .filter(|&(_, first_error)| first_error <= error_code)
-            .max_by_key(|&(_, first_error)| first_error);
+        let ext_info = ext_info_provider.get_from_error_code(error_code);
         match ext_info {
             #[cfg(feature = "damage")]
-            Some(("DAMAGE", first_error)) => {
-                match error_code - first_error {
+            Some(("DAMAGE", ext_info)) => {
+                match error_code - ext_info.first_error {
                     damage::BAD_DAMAGE_ERROR => Ok(Self::DamageBadDamage(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "glx")]
-            Some(("GLX", first_error)) => {
-                match error_code - first_error {
+            Some(("GLX", ext_info)) => {
+                match error_code - ext_info.first_error {
                     glx::BAD_CONTEXT_ERROR => Ok(Self::GlxBadContext(error.into())),
                     glx::BAD_CONTEXT_STATE_ERROR => Ok(Self::GlxBadContextState(error.into())),
                     glx::BAD_CONTEXT_TAG_ERROR => Ok(Self::GlxBadContextTag(error.into())),
@@ -241,8 +238,8 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
                 }
             }
             #[cfg(feature = "randr")]
-            Some(("RANDR", first_error)) => {
-                match error_code - first_error {
+            Some(("RANDR", ext_info)) => {
+                match error_code - ext_info.first_error {
                     randr::BAD_CRTC_ERROR => Ok(Self::RandrBadCrtc(error.into())),
                     randr::BAD_MODE_ERROR => Ok(Self::RandrBadMode(error.into())),
                     randr::BAD_OUTPUT_ERROR => Ok(Self::RandrBadOutput(error.into())),
@@ -251,15 +248,15 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
                 }
             }
             #[cfg(feature = "record")]
-            Some(("RECORD", first_error)) => {
-                match error_code - first_error {
+            Some(("RECORD", ext_info)) => {
+                match error_code - ext_info.first_error {
                     record::BAD_CONTEXT_ERROR => Ok(Self::RecordBadContext(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "render")]
-            Some(("RENDER", first_error)) => {
-                match error_code - first_error {
+            Some(("RENDER", ext_info)) => {
+                match error_code - ext_info.first_error {
                     render::GLYPH_ERROR => Ok(Self::RenderGlyph(error.into())),
                     render::GLYPH_SET_ERROR => Ok(Self::RenderGlyphSet(error.into())),
                     render::PICT_FORMAT_ERROR => Ok(Self::RenderPictFormat(error.into())),
@@ -269,23 +266,23 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
                 }
             }
             #[cfg(feature = "shm")]
-            Some(("MIT-SHM", first_error)) => {
-                match error_code - first_error {
+            Some(("MIT-SHM", ext_info)) => {
+                match error_code - ext_info.first_error {
                     shm::BAD_SEG_ERROR => Ok(Self::ShmBadSeg(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "sync")]
-            Some(("SYNC", first_error)) => {
-                match error_code - first_error {
+            Some(("SYNC", ext_info)) => {
+                match error_code - ext_info.first_error {
                     sync::ALARM_ERROR => Ok(Self::SyncAlarm(error.into())),
                     sync::COUNTER_ERROR => Ok(Self::SyncCounter(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xf86vidmode")]
-            Some(("XFree86-VidModeExtension", first_error)) => {
-                match error_code - first_error {
+            Some(("XFree86-VidModeExtension", ext_info)) => {
+                match error_code - ext_info.first_error {
                     xf86vidmode::BAD_CLOCK_ERROR => Ok(Self::Xf86vidmodeBadClock(error.into())),
                     xf86vidmode::BAD_H_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadHTimings(error.into())),
                     xf86vidmode::BAD_V_TIMINGS_ERROR => Ok(Self::Xf86vidmodeBadVTimings(error.into())),
@@ -297,15 +294,15 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
                 }
             }
             #[cfg(feature = "xfixes")]
-            Some(("XFIXES", first_error)) => {
-                match error_code - first_error {
+            Some(("XFIXES", ext_info)) => {
+                match error_code - ext_info.first_error {
                     xfixes::BAD_REGION_ERROR => Ok(Self::XfixesBadRegion(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xinput")]
-            Some(("XInputExtension", first_error)) => {
-                match error_code - first_error {
+            Some(("XInputExtension", ext_info)) => {
+                match error_code - ext_info.first_error {
                     xinput::CLASS_ERROR => Ok(Self::XinputClass(error.into())),
                     xinput::DEVICE_ERROR => Ok(Self::XinputDevice(error.into())),
                     xinput::DEVICE_BUSY_ERROR => Ok(Self::XinputDeviceBusy(error.into())),
@@ -315,23 +312,23 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Error<B> {
                 }
             }
             #[cfg(feature = "xkb")]
-            Some(("XKEYBOARD", first_error)) => {
-                match error_code - first_error {
+            Some(("XKEYBOARD", ext_info)) => {
+                match error_code - ext_info.first_error {
                     xkb::KEYBOARD_ERROR => Ok(Self::XkbKeyboard(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xprint")]
-            Some(("XpExtension", first_error)) => {
-                match error_code - first_error {
+            Some(("XpExtension", ext_info)) => {
+                match error_code - ext_info.first_error {
                     xprint::BAD_CONTEXT_ERROR => Ok(Self::XprintBadContext(error.into())),
                     xprint::BAD_SEQUENCE_ERROR => Ok(Self::XprintBadSequence(error.into())),
                     _ => Ok(Self::Unknown(error))
                 }
             }
             #[cfg(feature = "xv")]
-            Some(("XVideo", first_error)) => {
-                match error_code - first_error {
+            Some(("XVideo", ext_info)) => {
+                match error_code - ext_info.first_error {
                     xv::BAD_CONTROL_ERROR => Ok(Self::XvBadControl(error.into())),
                     xv::BAD_ENCODING_ERROR => Ok(Self::XvBadEncoding(error.into())),
                     xv::BAD_PORT_ERROR => Ok(Self::XvBadPort(error.into())),
@@ -542,12 +539,12 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
     /// Parse a generic X11 event into a concrete event type.
     pub fn parse(
         event: GenericEvent<B>,
-        iter: impl Iterator<Item=(&'static str, ExtensionInformation)>,
+        ext_info_provider: &dyn ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         let event_type = event.response_type();
         // Check if this is a core protocol error or from the generic event extension
         match event_type {
-            0 => return Ok(Self::Error(Error::parse(event.try_into()?, iter)?)),
+            0 => return Ok(Self::Error(Error::parse(event.try_into()?, ext_info_provider)?)),
             xproto::BUTTON_PRESS_EVENT => return Ok(Self::ButtonPress(event.into())),
             xproto::BUTTON_RELEASE_EVENT => return Ok(Self::ButtonRelease(event.into())),
             xproto::CIRCULATE_NOTIFY_EVENT => return Ok(Self::CirculateNotify(event.into())),
@@ -581,93 +578,90 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
             xproto::SELECTION_REQUEST_EVENT => return Ok(Self::SelectionRequest(event.into())),
             xproto::UNMAP_NOTIFY_EVENT => return Ok(Self::UnmapNotify(event.into())),
             xproto::VISIBILITY_NOTIFY_EVENT => return Ok(Self::VisibilityNotify(event.into())),
-            xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, iter),
+            xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, ext_info_provider),
             _ => {}
         }
         // Find the extension that this event could belong to
-        let ext_info = iter
-            .map(|(name, ext_info)| (name, ext_info.first_event))
-            .filter(|&(_, first_event)| first_event <= event_type)
-            .max_by_key(|&(_, first_event)| first_event);
+        let ext_info = ext_info_provider.get_from_event_code(event_type);
         match ext_info {
             #[cfg(feature = "damage")]
-            Some(("DAMAGE", first_event)) => {
-                match event_type - first_event {
+            Some(("DAMAGE", ext_info)) => {
+                match event_type - ext_info.first_event {
                     damage::NOTIFY_EVENT => Ok(Self::DamageNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "dri2")]
-            Some(("DRI2", first_event)) => {
-                match event_type - first_event {
+            Some(("DRI2", ext_info)) => {
+                match event_type - ext_info.first_event {
                     dri2::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::Dri2BufferSwapComplete(event.into())),
                     dri2::INVALIDATE_BUFFERS_EVENT => Ok(Self::Dri2InvalidateBuffers(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "glx")]
-            Some(("GLX", first_event)) => {
-                match event_type - first_event {
+            Some(("GLX", ext_info)) => {
+                match event_type - ext_info.first_event {
                     glx::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::GlxBufferSwapComplete(event.into())),
                     glx::PBUFFER_CLOBBER_EVENT => Ok(Self::GlxPbufferClobber(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "present")]
-            Some(("Present", first_event)) => {
-                match event_type - first_event {
+            Some(("Present", ext_info)) => {
+                match event_type - ext_info.first_event {
                     present::GENERIC_EVENT => Ok(Self::PresentGeneric(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "randr")]
-            Some(("RANDR", first_event)) => {
-                match event_type - first_event {
+            Some(("RANDR", ext_info)) => {
+                match event_type - ext_info.first_event {
                     randr::NOTIFY_EVENT => Ok(Self::RandrNotify(event.into())),
                     randr::SCREEN_CHANGE_NOTIFY_EVENT => Ok(Self::RandrScreenChangeNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "screensaver")]
-            Some(("MIT-SCREEN-SAVER", first_event)) => {
-                match event_type - first_event {
+            Some(("MIT-SCREEN-SAVER", ext_info)) => {
+                match event_type - ext_info.first_event {
                     screensaver::NOTIFY_EVENT => Ok(Self::ScreensaverNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "shape")]
-            Some(("SHAPE", first_event)) => {
-                match event_type - first_event {
+            Some(("SHAPE", ext_info)) => {
+                match event_type - ext_info.first_event {
                     shape::NOTIFY_EVENT => Ok(Self::ShapeNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "shm")]
-            Some(("MIT-SHM", first_event)) => {
-                match event_type - first_event {
+            Some(("MIT-SHM", ext_info)) => {
+                match event_type - ext_info.first_event {
                     shm::COMPLETION_EVENT => Ok(Self::ShmCompletion(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "sync")]
-            Some(("SYNC", first_event)) => {
-                match event_type - first_event {
+            Some(("SYNC", ext_info)) => {
+                match event_type - ext_info.first_event {
                     sync::ALARM_NOTIFY_EVENT => Ok(Self::SyncAlarmNotify(event.into())),
                     sync::COUNTER_NOTIFY_EVENT => Ok(Self::SyncCounterNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xfixes")]
-            Some(("XFIXES", first_event)) => {
-                match event_type - first_event {
+            Some(("XFIXES", ext_info)) => {
+                match event_type - ext_info.first_event {
                     xfixes::CURSOR_NOTIFY_EVENT => Ok(Self::XfixesCursorNotify(event.into())),
                     xfixes::SELECTION_NOTIFY_EVENT => Ok(Self::XfixesSelectionNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xinput")]
-            Some(("XInputExtension", first_event)) => {
-                match event_type - first_event {
+            Some(("XInputExtension", ext_info)) => {
+                match event_type - ext_info.first_event {
                     xinput::CHANGE_DEVICE_NOTIFY_EVENT => Ok(Self::XinputChangeDeviceNotify(event.into())),
                     xinput::DEVICE_BUTTON_PRESS_EVENT => Ok(Self::XinputDeviceButtonPress(event.into())),
                     xinput::DEVICE_BUTTON_RELEASE_EVENT => Ok(Self::XinputDeviceButtonRelease(event.into())),
@@ -689,8 +683,8 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
                 }
             }
             #[cfg(feature = "xkb")]
-            Some(("XKEYBOARD", first_event)) => {
-                if event_type != first_event {
+            Some(("XKEYBOARD", ext_info)) => {
+                if event_type != ext_info.first_event {
                     return Ok(Self::Unknown(event));
                 }
                 match event.raw_bytes()[1] {
@@ -710,16 +704,16 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
                 }
             }
             #[cfg(feature = "xprint")]
-            Some(("XpExtension", first_event)) => {
-                match event_type - first_event {
+            Some(("XpExtension", ext_info)) => {
+                match event_type - ext_info.first_event {
                     xprint::ATTRIBUT_NOTIFY_EVENT => Ok(Self::XprintAttributNotify(event.into())),
                     xprint::NOTIFY_EVENT => Ok(Self::XprintNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
                 }
             }
             #[cfg(feature = "xv")]
-            Some(("XVideo", first_event)) => {
-                match event_type - first_event {
+            Some(("XVideo", ext_info)) => {
+                match event_type - ext_info.first_event {
                     xv::PORT_NOTIFY_EVENT => Ok(Self::XvPortNotify(event.into())),
                     xv::VIDEO_NOTIFY_EVENT => Ok(Self::XvVideoNotify(event.into())),
                     _ => Ok(Self::Unknown(event))
@@ -731,20 +725,17 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
 
     fn from_generic_event(
         event: GenericEvent<B>,
-        iter: impl Iterator<Item=(&'static str, ExtensionInformation)>,
+        ext_info_provider: &dyn ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         let bytes = event.raw_bytes();
         let ge_event = xproto::GeGenericEvent::try_from(bytes)?;
-        #[allow(unused_variables)]
-        let (extension, event_type) = (ge_event.extension, ge_event.event_type);
-        let ext_name = iter
-            .map(|(name, ext_info)| (name, ext_info.major_opcode))
-            .find(|&(_, opcode)| extension == opcode)
+        let ext_name = ext_info_provider
+            .get_from_major_opcode(ge_event.extension)
             .map(|(name, _)| name);
         match ext_name {
             #[cfg(feature = "present")]
             Some("Present") => {
-                match event_type {
+                match ge_event.event_type {
                     present::COMPLETE_NOTIFY_EVENT => Ok(Self::PresentCompleteNotify(event.try_into()?)),
                     present::CONFIGURE_NOTIFY_EVENT => Ok(Self::PresentConfigureNotify(event.try_into()?)),
                     present::IDLE_NOTIFY_EVENT => Ok(Self::PresentIdleNotify(event.try_into()?)),
@@ -754,7 +745,7 @@ impl<B: std::fmt::Debug + AsRef<[u8]>> Event<B> {
             }
             #[cfg(feature = "xinput")]
             Some("XInputExtension") => {
-                match event_type {
+                match ge_event.event_type {
                     xinput::BARRIER_HIT_EVENT => Ok(Self::XinputBarrierHit(event.try_into()?)),
                     xinput::BARRIER_LEAVE_EVENT => Ok(Self::XinputBarrierLeave(event.try_into()?)),
                     xinput::BUTTON_PRESS_EVENT => Ok(Self::XinputButtonPress(event.try_into()?)),

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -415,13 +415,13 @@ impl<R: Read, W: Write> Connection for RustConnection<R, W> {
     }
 
     fn parse_error(&self, error: GenericError) -> Result<Error, ParseError> {
-        let ext_info = self.extension_manager.lock().unwrap();
-        Error::parse(error, ext_info.known_present())
+        let ext_mgr = self.extension_manager.lock().unwrap();
+        Error::parse(error, &*ext_mgr)
     }
 
     fn parse_event(&self, event: GenericEvent) -> Result<Event, ParseError> {
-        let ext_info = self.extension_manager.lock().unwrap();
-        Event::parse(event, ext_info.known_present())
+        let ext_mgr = self.extension_manager.lock().unwrap();
+        Event::parse(event, &*ext_mgr)
     }
 
     fn flush(&self) -> Result<(), ConnectionError> {

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -13,6 +13,21 @@ pub struct ExtensionInformation {
     pub first_error: u8,
 }
 
+/// Trait to provide information about extensions.
+pub trait ExtInfoProvider {
+    /// Returns the information of the extension that whose
+    /// opcode is `major_opcode`.
+    fn get_from_major_opcode(&self, major_opcode: u8) -> Option<(&str, ExtensionInformation)>;
+
+    /// Returns the information of the extension that whose
+    /// event number range includes `event_number`.
+    fn get_from_event_code(&self, event_code: u8) -> Option<(&str, ExtensionInformation)>;
+
+    /// Returns the information of the extension that whose
+    /// error number range includes `error_number`.
+    fn get_from_error_code(&self, error_code: u8) -> Option<(&str, ExtensionInformation)>;
+}
+
 /// Common information on events and errors.
 ///
 /// This trait exists to share some code between `GenericEvent` and `GenericError`.

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -503,12 +503,12 @@ impl Connection for XCBConnection {
 
     fn parse_error(&self, error: GenericError) -> Result<Error, ParseError> {
         let ext_mgr = self.ext_mgr.lock().unwrap();
-        Error::parse(error, ext_mgr.known_present())
+        Error::parse(error, &*ext_mgr)
     }
 
     fn parse_event(&self, event: GenericEvent) -> Result<Event, ParseError> {
         let ext_mgr = self.ext_mgr.lock().unwrap();
-        Event::parse(event, ext_mgr.known_present())
+        Event::parse(event, &*ext_mgr)
     }
 
     fn flush(&self) -> Result<(), ConnectionError> {


### PR DESCRIPTION
This trait is implemented by `ExtensionManager`.

`Event::parse()` and `Error::parse()` now uses this trait to get
extension information instead of an iterator.