### PR TITLE
Silence a rustdoc warning

### DIFF
--- a/code_generator_helpers/special_cases.py
+++ b/code_generator_helpers/special_cases.py
@@ -93,7 +93,7 @@ def extra_get_property_impl(out):
             out("/// };")
             out("/// assert!(reply.value%d().is_none());", width)
             out("/// ```")
-            out("#[allow(single_use_lifetimes)] // Work around a rustc bug")
+            out("#[allow(single_use_lifetimes, private_doc_tests)] // Work around a rustc bug and rustdoc bug")
             out("pub fn value%d<'a>(&'a self) -> Option<impl Iterator<Item=u%d> + 'a> {", width, width)
             with Indent(out):
                 out("if self.format == %d {", width)

--- a/src/generated/xproto.rs
+++ b/src/generated/xproto.rs
@@ -8740,7 +8740,7 @@ impl GetPropertyReply {
     /// };
     /// assert!(reply.value8().is_none());
     /// ```
-    #[allow(single_use_lifetimes)] // Work around a rustc bug
+    #[allow(single_use_lifetimes, private_doc_tests)] // Work around a rustc bug and rustdoc bug
     pub fn value8<'a>(&'a self) -> Option<impl Iterator<Item=u8> + 'a> {
         if self.format == 8 {
             Some(crate::wrapper::PropertyIterator::new(&self.value))
@@ -8794,7 +8794,7 @@ impl GetPropertyReply {
     /// };
     /// assert!(reply.value16().is_none());
     /// ```
-    #[allow(single_use_lifetimes)] // Work around a rustc bug
+    #[allow(single_use_lifetimes, private_doc_tests)] // Work around a rustc bug and rustdoc bug
     pub fn value16<'a>(&'a self) -> Option<impl Iterator<Item=u16> + 'a> {
         if self.format == 16 {
             Some(crate::wrapper::PropertyIterator::new(&self.value))
@@ -8847,7 +8847,7 @@ impl GetPropertyReply {
     /// };
     /// assert!(reply.value32().is_none());
     /// ```
-    #[allow(single_use_lifetimes)] // Work around a rustc bug
+    #[allow(single_use_lifetimes, private_doc_tests)] // Work around a rustc bug and rustdoc bug
     pub fn value32<'a>(&'a self) -> Option<impl Iterator<Item=u32> + 'a> {
         if self.format == 32 {
             Some(crate::wrapper::PropertyIterator::new(&self.value))


### PR DESCRIPTION
The 'generated' module is not public, but generated::* is publicly
re-exported. This constellation triggers the private_doc_tests lint.
Silence this with #[allow].

Fixes: https://github.com/psychon/x11rb/issues/310
Signed-off-by: Uli Schlachter <psychon@znc.in>