### PR TITLE
Avoid shadowing types from xproto

### DIFF
--- a/code_generator_helpers/request.py
+++ b/code_generator_helpers/request.py
@@ -90,11 +90,6 @@ def collect_function_arguments(module, obj, name, aux_name):
                 where.append("%s: Into<%s>" % (letter, rust_type))
                 rust_type = letter
 
-            if name == ('xcb', 'Test', 'CompareCursor') and field.field_name == 'cursor':
-                # xtest contains a 'Cursor' enum that shadows the cursor type from xproto.
-                # Since this problem only occurs once, handle it explicitly/specially.
-                rust_type = "super::xproto::" + rust_type
-
             args.append("%s: %s" % (module._to_rust_variable(field.field_name), rust_type))
             arg_names.append(module._to_rust_variable(field.field_name))
             if field.isfd:

--- a/src/generated/composite.rs
+++ b/src/generated/composite.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 #[allow(unused_imports)]
 use super::render;
 #[allow(unused_imports)]
@@ -163,7 +163,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the RedirectWindow request
 pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
-pub fn redirect_window<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn redirect_window<Conn, A>(conn: &Conn, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -194,7 +194,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the RedirectSubwindows request
 pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
-pub fn redirect_subwindows<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn redirect_subwindows<Conn, A>(conn: &Conn, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -225,7 +225,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the UnredirectWindow request
 pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
-pub fn unredirect_window<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unredirect_window<Conn, A>(conn: &Conn, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -256,7 +256,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the UnredirectSubwindows request
 pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
-pub fn unredirect_subwindows<Conn, A>(conn: &Conn, window: Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unredirect_subwindows<Conn, A>(conn: &Conn, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -287,7 +287,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the CreateRegionFromBorderClip request
 pub const CREATE_REGION_FROM_BORDER_CLIP_REQUEST: u8 = 5;
-pub fn create_region_from_border_clip<Conn>(conn: &Conn, region: xfixes::Region, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_border_clip<Conn>(conn: &Conn, region: xfixes::Region, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -317,7 +317,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the NameWindowPixmap request
 pub const NAME_WINDOW_PIXMAP_REQUEST: u8 = 6;
-pub fn name_window_pixmap<Conn>(conn: &Conn, window: Window, pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn name_window_pixmap<Conn>(conn: &Conn, window: xproto::Window, pixmap: xproto::Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -347,7 +347,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetOverlayWindow request
 pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
-pub fn get_overlay_window<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetOverlayWindowReply>, ConnectionError>
+pub fn get_overlay_window<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetOverlayWindowReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -374,7 +374,7 @@ pub struct GetOverlayWindowReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub overlay_win: Window,
+    pub overlay_win: xproto::Window,
 }
 impl GetOverlayWindowReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -382,7 +382,7 @@ impl GetOverlayWindowReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (overlay_win, remaining) = Window::try_parse(remaining)?;
+        let (overlay_win, remaining) = xproto::Window::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = GetOverlayWindowReply { response_type, sequence, length, overlay_win };
         Ok((result, remaining))
@@ -397,7 +397,7 @@ impl TryFrom<&[u8]> for GetOverlayWindowReply {
 
 /// Opcode for the ReleaseOverlayWindow request
 pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
-pub fn release_overlay_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn release_overlay_window<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -427,46 +427,46 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn composite_redirect_window<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_redirect_window<A>(&self, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         redirect_window(self, window, update)
     }
 
-    fn composite_redirect_subwindows<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_redirect_subwindows<A>(&self, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         redirect_subwindows(self, window, update)
     }
 
-    fn composite_unredirect_window<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_unredirect_window<A>(&self, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         unredirect_window(self, window, update)
     }
 
-    fn composite_unredirect_subwindows<A>(&self, window: Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_unredirect_subwindows<A>(&self, window: xproto::Window, update: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         unredirect_subwindows(self, window, update)
     }
 
-    fn composite_create_region_from_border_clip(&self, region: xfixes::Region, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_create_region_from_border_clip(&self, region: xfixes::Region, window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_region_from_border_clip(self, region, window)
     }
 
-    fn composite_name_window_pixmap(&self, window: Window, pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_name_window_pixmap(&self, window: xproto::Window, pixmap: xproto::Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         name_window_pixmap(self, window, pixmap)
     }
 
-    fn composite_get_overlay_window(&self, window: Window) -> Result<Cookie<'_, Self, GetOverlayWindowReply>, ConnectionError>
+    fn composite_get_overlay_window(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetOverlayWindowReply>, ConnectionError>
     {
         get_overlay_window(self, window)
     }
 
-    fn composite_release_overlay_window(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn composite_release_overlay_window(&self, window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         release_overlay_window(self, window)
     }

--- a/src/generated/damage.rs
+++ b/src/generated/damage.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 #[allow(unused_imports)]
 use super::render;
 #[allow(unused_imports)]
@@ -223,7 +223,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Create request
 pub const CREATE_REQUEST: u8 = 1;
-pub fn create<Conn, A>(conn: &Conn, damage: Damage, drawable: Drawable, level: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create<Conn, A>(conn: &Conn, damage: Damage, drawable: xproto::Drawable, level: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -319,7 +319,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the Add request
 pub const ADD_REQUEST: u8 = 4;
-pub fn add<Conn>(conn: &Conn, drawable: Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn add<Conn>(conn: &Conn, drawable: xproto::Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -354,22 +354,22 @@ pub struct NotifyEvent {
     pub response_type: u8,
     pub level: ReportLevel,
     pub sequence: u16,
-    pub drawable: Drawable,
+    pub drawable: xproto::Drawable,
     pub damage: Damage,
-    pub timestamp: Timestamp,
-    pub area: Rectangle,
-    pub geometry: Rectangle,
+    pub timestamp: xproto::Timestamp,
+    pub area: xproto::Rectangle,
+    pub geometry: xproto::Rectangle,
 }
 impl NotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (level, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
         let (damage, remaining) = Damage::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (area, remaining) = Rectangle::try_parse(remaining)?;
-        let (geometry, remaining) = Rectangle::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (area, remaining) = xproto::Rectangle::try_parse(remaining)?;
+        let (geometry, remaining) = xproto::Rectangle::try_parse(remaining)?;
         let level = level.try_into()?;
         let result = NotifyEvent { response_type, level, sequence, drawable, damage, timestamp, area, geometry };
         Ok((result, remaining))
@@ -424,7 +424,7 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn damage_create<A>(&self, damage: Damage, drawable: Drawable, level: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn damage_create<A>(&self, damage: Damage, drawable: xproto::Drawable, level: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>
     {
         create(self, damage, drawable, level)
@@ -440,7 +440,7 @@ pub trait ConnectionExt: RequestConnection {
         subtract(self, damage, repair, parts)
     }
 
-    fn damage_add(&self, drawable: Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn damage_add(&self, drawable: xproto::Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         add(self, drawable, region)
     }

--- a/src/generated/dri2.rs
+++ b/src/generated/dri2.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "DRI2";
@@ -421,7 +421,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Connect request
 pub const CONNECT_REQUEST: u8 = 1;
-pub fn connect<Conn, A>(conn: &Conn, window: Window, driver_type: A) -> Result<Cookie<'_, Conn, ConnectReply>, ConnectionError>
+pub fn connect<Conn, A>(conn: &Conn, window: xproto::Window, driver_type: A) -> Result<Cookie<'_, Conn, ConnectReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u32>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -483,7 +483,7 @@ impl TryFrom<&[u8]> for ConnectReply {
 
 /// Opcode for the Authenticate request
 pub const AUTHENTICATE_REQUEST: u8 = 2;
-pub fn authenticate<Conn>(conn: &Conn, window: Window, magic: u32) -> Result<Cookie<'_, Conn, AuthenticateReply>, ConnectionError>
+pub fn authenticate<Conn>(conn: &Conn, window: xproto::Window, magic: u32) -> Result<Cookie<'_, Conn, AuthenticateReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -537,7 +537,7 @@ impl TryFrom<&[u8]> for AuthenticateReply {
 
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 3;
-pub fn create_drawable<Conn>(conn: &Conn, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_drawable<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -562,7 +562,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 4;
-pub fn destroy_drawable<Conn>(conn: &Conn, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn destroy_drawable<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -587,7 +587,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetBuffers request
 pub const GET_BUFFERS_REQUEST: u8 = 5;
-pub fn get_buffers<'c, Conn>(conn: &'c Conn, drawable: Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
+pub fn get_buffers<'c, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -651,7 +651,7 @@ impl TryFrom<&[u8]> for GetBuffersReply {
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 6;
-pub fn copy_region<Conn>(conn: &Conn, drawable: Drawable, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Conn, CopyRegionReply>, ConnectionError>
+pub fn copy_region<Conn>(conn: &Conn, drawable: xproto::Drawable, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Conn, CopyRegionReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -713,7 +713,7 @@ impl TryFrom<&[u8]> for CopyRegionReply {
 
 /// Opcode for the GetBuffersWithFormat request
 pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
-pub fn get_buffers_with_format<'c, Conn>(conn: &'c Conn, drawable: Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
+pub fn get_buffers_with_format<'c, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -777,7 +777,7 @@ impl TryFrom<&[u8]> for GetBuffersWithFormatReply {
 
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 8;
-pub fn swap_buffers<Conn>(conn: &Conn, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, SwapBuffersReply>, ConnectionError>
+pub fn swap_buffers<Conn>(conn: &Conn, drawable: xproto::Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, SwapBuffersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -858,7 +858,7 @@ impl TryFrom<&[u8]> for SwapBuffersReply {
 
 /// Opcode for the GetMSC request
 pub const GET_MSC_REQUEST: u8 = 9;
-pub fn get_msc<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, GetMSCReply>, ConnectionError>
+pub fn get_msc<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, GetMSCReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -917,7 +917,7 @@ impl TryFrom<&[u8]> for GetMSCReply {
 
 /// Opcode for the WaitMSC request
 pub const WAIT_MSC_REQUEST: u8 = 10;
-pub fn wait_msc<Conn>(conn: &Conn, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, WaitMSCReply>, ConnectionError>
+pub fn wait_msc<Conn>(conn: &Conn, drawable: xproto::Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, WaitMSCReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1006,7 +1006,7 @@ impl TryFrom<&[u8]> for WaitMSCReply {
 
 /// Opcode for the WaitSBC request
 pub const WAIT_SBC_REQUEST: u8 = 11;
-pub fn wait_sbc<Conn>(conn: &Conn, drawable: Drawable, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Conn, WaitSBCReply>, ConnectionError>
+pub fn wait_sbc<Conn>(conn: &Conn, drawable: xproto::Drawable, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Conn, WaitSBCReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1075,7 +1075,7 @@ impl TryFrom<&[u8]> for WaitSBCReply {
 
 /// Opcode for the SwapInterval request
 pub const SWAP_INTERVAL_REQUEST: u8 = 12;
-pub fn swap_interval<Conn>(conn: &Conn, drawable: Drawable, interval: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn swap_interval<Conn>(conn: &Conn, drawable: xproto::Drawable, interval: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1105,7 +1105,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetParam request
 pub const GET_PARAM_REQUEST: u8 = 13;
-pub fn get_param<Conn>(conn: &Conn, drawable: Drawable, param: u32) -> Result<Cookie<'_, Conn, GetParamReply>, ConnectionError>
+pub fn get_param<Conn>(conn: &Conn, drawable: xproto::Drawable, param: u32) -> Result<Cookie<'_, Conn, GetParamReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1167,7 +1167,7 @@ pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub event_type: EventType,
-    pub drawable: Drawable,
+    pub drawable: xproto::Drawable,
     pub ust_hi: u32,
     pub ust_lo: u32,
     pub msc_hi: u32,
@@ -1181,7 +1181,7 @@ impl BufferSwapCompleteEvent {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
         let (ust_hi, remaining) = u32::try_parse(remaining)?;
         let (ust_lo, remaining) = u32::try_parse(remaining)?;
         let (msc_hi, remaining) = u32::try_parse(remaining)?;
@@ -1241,14 +1241,14 @@ pub const INVALIDATE_BUFFERS_EVENT: u8 = 1;
 pub struct InvalidateBuffersEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub drawable: Drawable,
+    pub drawable: xproto::Drawable,
 }
 impl InvalidateBuffersEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
         let result = InvalidateBuffersEvent { response_type, sequence, drawable };
         Ok((result, remaining))
     }
@@ -1297,68 +1297,68 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn dri2_connect<A>(&self, window: Window, driver_type: A) -> Result<Cookie<'_, Self, ConnectReply>, ConnectionError>
+    fn dri2_connect<A>(&self, window: xproto::Window, driver_type: A) -> Result<Cookie<'_, Self, ConnectReply>, ConnectionError>
     where A: Into<u32>
     {
         connect(self, window, driver_type)
     }
 
-    fn dri2_authenticate(&self, window: Window, magic: u32) -> Result<Cookie<'_, Self, AuthenticateReply>, ConnectionError>
+    fn dri2_authenticate(&self, window: xproto::Window, magic: u32) -> Result<Cookie<'_, Self, AuthenticateReply>, ConnectionError>
     {
         authenticate(self, window, magic)
     }
 
-    fn dri2_create_drawable(&self, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri2_create_drawable(&self, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_drawable(self, drawable)
     }
 
-    fn dri2_destroy_drawable(&self, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri2_destroy_drawable(&self, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         destroy_drawable(self, drawable)
     }
 
-    fn dri2_get_buffers<'c>(&'c self, drawable: Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Self, GetBuffersReply>, ConnectionError>
+    fn dri2_get_buffers<'c>(&'c self, drawable: xproto::Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Self, GetBuffersReply>, ConnectionError>
     {
         get_buffers(self, drawable, count, attachments)
     }
 
-    fn dri2_copy_region(&self, drawable: Drawable, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Self, CopyRegionReply>, ConnectionError>
+    fn dri2_copy_region(&self, drawable: xproto::Drawable, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Self, CopyRegionReply>, ConnectionError>
     {
         copy_region(self, drawable, region, dest, src)
     }
 
-    fn dri2_get_buffers_with_format<'c>(&'c self, drawable: Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Self, GetBuffersWithFormatReply>, ConnectionError>
+    fn dri2_get_buffers_with_format<'c>(&'c self, drawable: xproto::Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Self, GetBuffersWithFormatReply>, ConnectionError>
     {
         get_buffers_with_format(self, drawable, count, attachments)
     }
 
-    fn dri2_swap_buffers(&self, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, SwapBuffersReply>, ConnectionError>
+    fn dri2_swap_buffers(&self, drawable: xproto::Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, SwapBuffersReply>, ConnectionError>
     {
         swap_buffers(self, drawable, target_msc_hi, target_msc_lo, divisor_hi, divisor_lo, remainder_hi, remainder_lo)
     }
 
-    fn dri2_get_msc(&self, drawable: Drawable) -> Result<Cookie<'_, Self, GetMSCReply>, ConnectionError>
+    fn dri2_get_msc(&self, drawable: xproto::Drawable) -> Result<Cookie<'_, Self, GetMSCReply>, ConnectionError>
     {
         get_msc(self, drawable)
     }
 
-    fn dri2_wait_msc(&self, drawable: Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, WaitMSCReply>, ConnectionError>
+    fn dri2_wait_msc(&self, drawable: xproto::Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Self, WaitMSCReply>, ConnectionError>
     {
         wait_msc(self, drawable, target_msc_hi, target_msc_lo, divisor_hi, divisor_lo, remainder_hi, remainder_lo)
     }
 
-    fn dri2_wait_sbc(&self, drawable: Drawable, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Self, WaitSBCReply>, ConnectionError>
+    fn dri2_wait_sbc(&self, drawable: xproto::Drawable, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Self, WaitSBCReply>, ConnectionError>
     {
         wait_sbc(self, drawable, target_sbc_hi, target_sbc_lo)
     }
 
-    fn dri2_swap_interval(&self, drawable: Drawable, interval: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri2_swap_interval(&self, drawable: xproto::Drawable, interval: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         swap_interval(self, drawable, interval)
     }
 
-    fn dri2_get_param(&self, drawable: Drawable, param: u32) -> Result<Cookie<'_, Self, GetParamReply>, ConnectionError>
+    fn dri2_get_param(&self, drawable: xproto::Drawable, param: u32) -> Result<Cookie<'_, Self, GetParamReply>, ConnectionError>
     {
         get_param(self, drawable, param)
     }

--- a/src/generated/dri3.rs
+++ b/src/generated/dri3.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "DRI3";
@@ -94,7 +94,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Open request
 pub const OPEN_REQUEST: u8 = 1;
-pub fn open<Conn>(conn: &Conn, drawable: Drawable, provider: u32) -> Result<CookieWithFds<'_, Conn, OpenReply>, ConnectionError>
+pub fn open<Conn>(conn: &Conn, drawable: xproto::Drawable, provider: u32) -> Result<CookieWithFds<'_, Conn, OpenReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -152,7 +152,7 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for OpenReply {
 
 /// Opcode for the PixmapFromBuffer request
 pub const PIXMAP_FROM_BUFFER_REQUEST: u8 = 2;
-pub fn pixmap_from_buffer<Conn, A>(conn: &Conn, pixmap: Pixmap, drawable: Drawable, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn pixmap_from_buffer<Conn, A>(conn: &Conn, pixmap: xproto::Pixmap, drawable: xproto::Drawable, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -201,7 +201,7 @@ where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 
 /// Opcode for the BufferFromPixmap request
 pub const BUFFER_FROM_PIXMAP_REQUEST: u8 = 3;
-pub fn buffer_from_pixmap<Conn>(conn: &Conn, pixmap: Pixmap) -> Result<CookieWithFds<'_, Conn, BufferFromPixmapReply>, ConnectionError>
+pub fn buffer_from_pixmap<Conn>(conn: &Conn, pixmap: xproto::Pixmap) -> Result<CookieWithFds<'_, Conn, BufferFromPixmapReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -266,7 +266,7 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for BufferFromPixmapReply {
 
 /// Opcode for the FenceFromFD request
 pub const FENCE_FROM_FD_REQUEST: u8 = 4;
-pub fn fence_from_fd<Conn, A>(conn: &Conn, drawable: Drawable, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn fence_from_fd<Conn, A>(conn: &Conn, drawable: xproto::Drawable, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -302,7 +302,7 @@ where Conn: RequestConnection + ?Sized, A: Into<RawFdContainer>
 
 /// Opcode for the FDFromFence request
 pub const FD_FROM_FENCE_REQUEST: u8 = 5;
-pub fn fd_from_fence<Conn>(conn: &Conn, drawable: Drawable, fence: u32) -> Result<CookieWithFds<'_, Conn, FDFromFenceReply>, ConnectionError>
+pub fn fd_from_fence<Conn>(conn: &Conn, drawable: xproto::Drawable, fence: u32) -> Result<CookieWithFds<'_, Conn, FDFromFenceReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -420,7 +420,7 @@ impl TryFrom<&[u8]> for GetSupportedModifiersReply {
 
 /// Opcode for the PixmapFromBuffers request
 pub const PIXMAP_FROM_BUFFERS_REQUEST: u8 = 7;
-pub fn pixmap_from_buffers<'c, Conn>(conn: &'c Conn, pixmap: Pixmap, window: Window, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn pixmap_from_buffers<'c, Conn>(conn: &'c Conn, pixmap: xproto::Pixmap, window: xproto::Window, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -517,7 +517,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the BuffersFromPixmap request
 pub const BUFFERS_FROM_PIXMAP_REQUEST: u8 = 8;
-pub fn buffers_from_pixmap<Conn>(conn: &Conn, pixmap: Pixmap) -> Result<CookieWithFds<'_, Conn, BuffersFromPixmapReply>, ConnectionError>
+pub fn buffers_from_pixmap<Conn>(conn: &Conn, pixmap: xproto::Pixmap) -> Result<CookieWithFds<'_, Conn, BuffersFromPixmapReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -592,29 +592,29 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn dri3_open(&self, drawable: Drawable, provider: u32) -> Result<CookieWithFds<'_, Self, OpenReply>, ConnectionError>
+    fn dri3_open(&self, drawable: xproto::Drawable, provider: u32) -> Result<CookieWithFds<'_, Self, OpenReply>, ConnectionError>
     {
         open(self, drawable, provider)
     }
 
-    fn dri3_pixmap_from_buffer<A>(&self, pixmap: Pixmap, drawable: Drawable, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri3_pixmap_from_buffer<A>(&self, pixmap: xproto::Pixmap, drawable: xproto::Drawable, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<RawFdContainer>
     {
         pixmap_from_buffer(self, pixmap, drawable, size, width, height, stride, depth, bpp, pixmap_fd)
     }
 
-    fn dri3_buffer_from_pixmap(&self, pixmap: Pixmap) -> Result<CookieWithFds<'_, Self, BufferFromPixmapReply>, ConnectionError>
+    fn dri3_buffer_from_pixmap(&self, pixmap: xproto::Pixmap) -> Result<CookieWithFds<'_, Self, BufferFromPixmapReply>, ConnectionError>
     {
         buffer_from_pixmap(self, pixmap)
     }
 
-    fn dri3_fence_from_fd<A>(&self, drawable: Drawable, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn dri3_fence_from_fd<A>(&self, drawable: xproto::Drawable, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<RawFdContainer>
     {
         fence_from_fd(self, drawable, fence, initially_triggered, fence_fd)
     }
 
-    fn dri3_fd_from_fence(&self, drawable: Drawable, fence: u32) -> Result<CookieWithFds<'_, Self, FDFromFenceReply>, ConnectionError>
+    fn dri3_fd_from_fence(&self, drawable: xproto::Drawable, fence: u32) -> Result<CookieWithFds<'_, Self, FDFromFenceReply>, ConnectionError>
     {
         fd_from_fence(self, drawable, fence)
     }
@@ -624,12 +624,12 @@ pub trait ConnectionExt: RequestConnection {
         get_supported_modifiers(self, window, depth, bpp)
     }
 
-    fn dri3_pixmap_from_buffers<'c>(&'c self, pixmap: Pixmap, window: Window, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn dri3_pixmap_from_buffers<'c>(&'c self, pixmap: xproto::Pixmap, window: xproto::Window, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         pixmap_from_buffers(self, pixmap, window, width, height, stride0, offset0, stride1, offset1, stride2, offset2, stride3, offset3, depth, bpp, modifier, buffers)
     }
 
-    fn dri3_buffers_from_pixmap(&self, pixmap: Pixmap) -> Result<CookieWithFds<'_, Self, BuffersFromPixmapReply>, ConnectionError>
+    fn dri3_buffers_from_pixmap(&self, pixmap: xproto::Pixmap) -> Result<CookieWithFds<'_, Self, BuffersFromPixmapReply>, ConnectionError>
     {
         buffers_from_pixmap(self, pixmap)
     }

--- a/src/generated/glx.rs
+++ b/src/generated/glx.rs
@@ -21,7 +21,7 @@ use crate::errors::{ParseError, ConnectionError};
 #[allow(unused_imports)]
 use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "GLX";
@@ -1301,7 +1301,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 3;
-pub fn create_context<Conn>(conn: &Conn, context: Context, visual: Visualid, screen: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_context<Conn>(conn: &Conn, context: Context, visual: xproto::Visualid, screen: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1746,7 +1746,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the UseXFont request
 pub const USE_X_FONT_REQUEST: u8 = 12;
-pub fn use_x_font<Conn>(conn: &Conn, context_tag: ContextTag, font: Font, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn use_x_font<Conn>(conn: &Conn, context_tag: ContextTag, font: xproto::Font, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1791,7 +1791,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateGLXPixmap request
 pub const CREATE_GLX_PIXMAP_REQUEST: u8 = 13;
-pub fn create_glx_pixmap<Conn>(conn: &Conn, screen: u32, visual: Visualid, pixmap: Pixmap, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_glx_pixmap<Conn>(conn: &Conn, screen: u32, visual: xproto::Visualid, pixmap: xproto::Pixmap, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2251,7 +2251,7 @@ impl TryFrom<&[u8]> for GetFBConfigsReply {
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 22;
-pub fn create_pixmap<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pixmap: Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pixmap<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pixmap: xproto::Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2651,7 +2651,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateWindow request
 pub const CREATE_WINDOW_REQUEST: u8 = 31;
-pub fn create_window<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, window: Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_window<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, window: xproto::Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -6780,7 +6780,7 @@ pub trait ConnectionExt: RequestConnection {
         render_large(self, context_tag, request_num, request_total, data)
     }
 
-    fn glx_create_context(&self, context: Context, visual: Visualid, screen: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_create_context(&self, context: Context, visual: xproto::Visualid, screen: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_context(self, context, visual, screen, share_list, is_direct)
     }
@@ -6825,12 +6825,12 @@ pub trait ConnectionExt: RequestConnection {
         swap_buffers(self, context_tag, drawable)
     }
 
-    fn glx_use_x_font(&self, context_tag: ContextTag, font: Font, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_use_x_font(&self, context_tag: ContextTag, font: xproto::Font, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         use_x_font(self, context_tag, font, first, count, list_base)
     }
 
-    fn glx_create_glx_pixmap(&self, screen: u32, visual: Visualid, pixmap: Pixmap, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn glx_create_glx_pixmap(&self, screen: u32, visual: xproto::Visualid, pixmap: xproto::Pixmap, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_glx_pixmap(self, screen, visual, pixmap, glx_pixmap)
     }
@@ -6875,7 +6875,7 @@ pub trait ConnectionExt: RequestConnection {
         get_fb_configs(self, screen)
     }
 
-    fn glx_create_pixmap<'c>(&'c self, screen: u32, fbconfig: Fbconfig, pixmap: Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_pixmap<'c>(&'c self, screen: u32, fbconfig: Fbconfig, pixmap: xproto::Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pixmap(self, screen, fbconfig, pixmap, glx_pixmap, attribs)
     }
@@ -6920,7 +6920,7 @@ pub trait ConnectionExt: RequestConnection {
         change_drawable_attributes(self, drawable, attribs)
     }
 
-    fn glx_create_window<'c>(&'c self, screen: u32, fbconfig: Fbconfig, window: Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_window<'c>(&'c self, screen: u32, fbconfig: Fbconfig, window: xproto::Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_window(self, screen, fbconfig, window, glx_window, attribs)
     }

--- a/src/generated/present.rs
+++ b/src/generated/present.rs
@@ -21,7 +21,7 @@ use crate::errors::{ParseError, ConnectionError};
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 #[allow(unused_imports)]
 use super::render;
 #[allow(unused_imports)]
@@ -459,12 +459,12 @@ impl TryFrom<u32> for CompleteMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Notify {
-    pub window: Window,
+    pub window: xproto::Window,
     pub serial: u32,
 }
 impl TryParse for Notify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
         let result = Notify { window, serial };
         Ok((result, remaining))
@@ -557,7 +557,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Pixmap request
 pub const PIXMAP_REQUEST: u8 = 1;
-pub fn pixmap<'c, Conn>(conn: &'c Conn, window: Window, pixmap: Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn pixmap<'c, Conn>(conn: &'c Conn, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -663,7 +663,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the NotifyMSC request
 pub const NOTIFY_MSC_REQUEST: u8 = 2;
-pub fn notify_msc<Conn>(conn: &Conn, window: Window, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn notify_msc<Conn>(conn: &Conn, window: xproto::Window, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -726,7 +726,7 @@ pub type Event = u32;
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 3;
-pub fn select_input<Conn>(conn: &Conn, eid: Event, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, eid: Event, window: xproto::Window, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -882,7 +882,7 @@ pub struct ConfigureNotifyEvent {
     pub length: u32,
     pub event_type: u16,
     pub event: Event,
-    pub window: Window,
+    pub window: xproto::Window,
     pub x: i16,
     pub y: i16,
     pub width: u16,
@@ -902,7 +902,7 @@ impl ConfigureNotifyEvent {
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (event, remaining) = Event::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -947,7 +947,7 @@ pub struct CompleteNotifyEvent {
     pub kind: CompleteKind,
     pub mode: CompleteMode,
     pub event: Event,
-    pub window: Window,
+    pub window: xproto::Window,
     pub serial: u32,
     pub ust: u64,
     pub msc: u64,
@@ -962,7 +962,7 @@ impl CompleteNotifyEvent {
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (event, remaining) = Event::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
         let (ust, remaining) = u64::try_parse(remaining)?;
         let (msc, remaining) = u64::try_parse(remaining)?;
@@ -1001,9 +1001,9 @@ pub struct IdleNotifyEvent {
     pub length: u32,
     pub event_type: u16,
     pub event: Event,
-    pub window: Window,
+    pub window: xproto::Window,
     pub serial: u32,
-    pub pixmap: Pixmap,
+    pub pixmap: xproto::Pixmap,
     pub idle_fence: sync::Fence,
 }
 impl IdleNotifyEvent {
@@ -1015,9 +1015,9 @@ impl IdleNotifyEvent {
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (event, remaining) = Event::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
-        let (pixmap, remaining) = Pixmap::try_parse(remaining)?;
+        let (pixmap, remaining) = xproto::Pixmap::try_parse(remaining)?;
         let (idle_fence, remaining) = sync::Fence::try_parse(remaining)?;
         let result = IdleNotifyEvent { response_type, extension, sequence, length, event_type, event, window, serial, pixmap, idle_fence };
         Ok((result, remaining))
@@ -1053,14 +1053,14 @@ pub struct RedirectNotifyEvent {
     pub event_type: u16,
     pub update_window: bool,
     pub event: Event,
-    pub event_window: Window,
-    pub window: Window,
-    pub pixmap: Pixmap,
+    pub event_window: xproto::Window,
+    pub window: xproto::Window,
+    pub pixmap: xproto::Pixmap,
     pub serial: u32,
     pub valid_region: xfixes::Region,
     pub update_region: xfixes::Region,
-    pub valid_rect: Rectangle,
-    pub update_rect: Rectangle,
+    pub valid_rect: xproto::Rectangle,
+    pub update_rect: xproto::Rectangle,
     pub x_off: i16,
     pub y_off: i16,
     pub target_crtc: randr::Crtc,
@@ -1082,14 +1082,14 @@ impl RedirectNotifyEvent {
         let (update_window, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (event, remaining) = Event::try_parse(remaining)?;
-        let (event_window, remaining) = Window::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
-        let (pixmap, remaining) = Pixmap::try_parse(remaining)?;
+        let (event_window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (pixmap, remaining) = xproto::Pixmap::try_parse(remaining)?;
         let (serial, remaining) = u32::try_parse(remaining)?;
         let (valid_region, remaining) = xfixes::Region::try_parse(remaining)?;
         let (update_region, remaining) = xfixes::Region::try_parse(remaining)?;
-        let (valid_rect, remaining) = Rectangle::try_parse(remaining)?;
-        let (update_rect, remaining) = Rectangle::try_parse(remaining)?;
+        let (valid_rect, remaining) = xproto::Rectangle::try_parse(remaining)?;
+        let (update_rect, remaining) = xproto::Rectangle::try_parse(remaining)?;
         let (x_off, remaining) = i16::try_parse(remaining)?;
         let (y_off, remaining) = i16::try_parse(remaining)?;
         let (target_crtc, remaining) = randr::Crtc::try_parse(remaining)?;
@@ -1138,17 +1138,17 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn present_pixmap<'c>(&'c self, window: Window, pixmap: Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn present_pixmap<'c>(&'c self, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         self::pixmap(self, window, pixmap, serial, valid, update, x_off, y_off, target_crtc, wait_fence, idle_fence, options, target_msc, divisor, remainder, notifies)
     }
 
-    fn present_notify_msc(&self, window: Window, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn present_notify_msc(&self, window: xproto::Window, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         notify_msc(self, window, serial, target_msc, divisor, remainder)
     }
 
-    fn present_select_input(&self, eid: Event, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn present_select_input(&self, eid: Event, window: xproto::Window, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, eid, window, event_mask)
     }

--- a/src/generated/randr.rs
+++ b/src/generated/randr.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 #[allow(unused_imports)]
 use super::render;
 
@@ -541,7 +541,7 @@ impl TryFrom<u32> for SetConfig {
 
 /// Opcode for the SetScreenConfig request
 pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
-pub fn set_screen_config<Conn>(conn: &Conn, window: Window, timestamp: Timestamp, config_timestamp: Timestamp, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
+pub fn set_screen_config<Conn>(conn: &Conn, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -590,9 +590,9 @@ pub struct SetScreenConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub new_timestamp: Timestamp,
-    pub config_timestamp: Timestamp,
-    pub root: Window,
+    pub new_timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
+    pub root: xproto::Window,
     pub subpixel_order: render::SubPixel,
 }
 impl SetScreenConfigReply {
@@ -601,9 +601,9 @@ impl SetScreenConfigReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (new_timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (root, remaining) = Window::try_parse(remaining)?;
+        let (new_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
         let (subpixel_order, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
         let status = status.try_into()?;
@@ -702,7 +702,7 @@ bitmask_binop!(NotifyMask, u8);
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
-pub fn select_input<Conn>(conn: &Conn, window: Window, enable: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, window: xproto::Window, enable: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -732,7 +732,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetScreenInfo request
 pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
-pub fn get_screen_info<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenInfoReply>, ConnectionError>
+pub fn get_screen_info<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -760,9 +760,9 @@ pub struct GetScreenInfoReply {
     pub rotations: u8,
     pub sequence: u16,
     pub length: u32,
-    pub root: Window,
-    pub timestamp: Timestamp,
-    pub config_timestamp: Timestamp,
+    pub root: xproto::Window,
+    pub timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
     pub size_id: u16,
     pub rotation: u16,
     pub rate: u16,
@@ -776,9 +776,9 @@ impl GetScreenInfoReply {
         let (rotations, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = Window::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (n_sizes, remaining) = u16::try_parse(remaining)?;
         let (size_id, remaining) = u16::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
@@ -800,7 +800,7 @@ impl TryFrom<&[u8]> for GetScreenInfoReply {
 
 /// Opcode for the GetScreenSizeRange request
 pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
-pub fn get_screen_size_range<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenSizeRangeReply>, ConnectionError>
+pub fn get_screen_size_range<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenSizeRangeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -856,7 +856,7 @@ impl TryFrom<&[u8]> for GetScreenSizeRangeReply {
 
 /// Opcode for the SetScreenSize request
 pub const SET_SCREEN_SIZE_REQUEST: u8 = 7;
-pub fn set_screen_size<Conn>(conn: &Conn, window: Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_screen_size<Conn>(conn: &Conn, window: xproto::Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1090,7 +1090,7 @@ impl Serialize for ModeInfo {
 
 /// Opcode for the GetScreenResources request
 pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
-pub fn get_screen_resources<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenResourcesReply>, ConnectionError>
+pub fn get_screen_resources<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenResourcesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1117,8 +1117,8 @@ pub struct GetScreenResourcesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
-    pub config_timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
     pub crtcs: Vec<Crtc>,
     pub outputs: Vec<Output>,
     pub modes: Vec<ModeInfo>,
@@ -1130,8 +1130,8 @@ impl GetScreenResourcesReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (num_crtcs, remaining) = u16::try_parse(remaining)?;
         let (num_outputs, remaining) = u16::try_parse(remaining)?;
         let (num_modes, remaining) = u16::try_parse(remaining)?;
@@ -1219,7 +1219,7 @@ impl TryFrom<u32> for Connection {
 
 /// Opcode for the GetOutputInfo request
 pub const GET_OUTPUT_INFO_REQUEST: u8 = 9;
-pub fn get_output_info<Conn>(conn: &Conn, output: Output, config_timestamp: Timestamp) -> Result<Cookie<'_, Conn, GetOutputInfoReply>, ConnectionError>
+pub fn get_output_info<Conn>(conn: &Conn, output: Output, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetOutputInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1252,7 +1252,7 @@ pub struct GetOutputInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub crtc: Crtc,
     pub mm_width: u32,
     pub mm_height: u32,
@@ -1270,7 +1270,7 @@ impl GetOutputInfoReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (crtc, remaining) = Crtc::try_parse(remaining)?;
         let (mm_width, remaining) = u32::try_parse(remaining)?;
         let (mm_height, remaining) = u32::try_parse(remaining)?;
@@ -1328,7 +1328,7 @@ pub struct ListOutputPropertiesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atoms: Vec<Atom>,
+    pub atoms: Vec<xproto::Atom>,
 }
 impl ListOutputPropertiesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1338,7 +1338,7 @@ impl ListOutputPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_atoms, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_atoms as usize)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, num_atoms as usize)?;
         let result = ListOutputPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -1352,7 +1352,7 @@ impl TryFrom<&[u8]> for ListOutputPropertiesReply {
 
 /// Opcode for the QueryOutputProperty request
 pub const QUERY_OUTPUT_PROPERTY_REQUEST: u8 = 11;
-pub fn query_output_property<Conn>(conn: &Conn, output: Output, property: Atom) -> Result<Cookie<'_, Conn, QueryOutputPropertyReply>, ConnectionError>
+pub fn query_output_property<Conn>(conn: &Conn, output: Output, property: xproto::Atom) -> Result<Cookie<'_, Conn, QueryOutputPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1412,7 +1412,7 @@ impl TryFrom<&[u8]> for QueryOutputPropertyReply {
 
 /// Opcode for the ConfigureOutputProperty request
 pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
-pub fn configure_output_property<'c, Conn>(conn: &'c Conn, output: Output, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_output_property<'c, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1452,7 +1452,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ChangeOutputProperty request
 pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
-pub fn change_output_property<'c, Conn, A>(conn: &'c Conn, output: Output, property: Atom, type_: Atom, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_output_property<'c, Conn, A>(conn: &'c Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1503,7 +1503,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the DeleteOutputProperty request
 pub const DELETE_OUTPUT_PROPERTY_REQUEST: u8 = 14;
-pub fn delete_output_property<Conn>(conn: &Conn, output: Output, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_output_property<Conn>(conn: &Conn, output: Output, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1533,7 +1533,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetOutputProperty request
 pub const GET_OUTPUT_PROPERTY_REQUEST: u8 = 15;
-pub fn get_output_property<Conn>(conn: &Conn, output: Output, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetOutputPropertyReply>, ConnectionError>
+pub fn get_output_property<Conn>(conn: &Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetOutputPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1587,7 +1587,7 @@ pub struct GetOutputPropertyReply {
     pub format: u8,
     pub sequence: u16,
     pub length: u32,
-    pub type_: Atom,
+    pub type_: xproto::Atom,
     pub bytes_after: u32,
     pub num_items: u32,
     pub data: Vec<u8>,
@@ -1598,7 +1598,7 @@ impl GetOutputPropertyReply {
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (type_, remaining) = Atom::try_parse(remaining)?;
+        let (type_, remaining) = xproto::Atom::try_parse(remaining)?;
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
@@ -1616,7 +1616,7 @@ impl TryFrom<&[u8]> for GetOutputPropertyReply {
 
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
-pub fn create_mode<'c, Conn>(conn: &'c Conn, window: Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
+pub fn create_mode<'c, Conn>(conn: &'c Conn, window: xproto::Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1787,7 +1787,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetCrtcInfo request
 pub const GET_CRTC_INFO_REQUEST: u8 = 20;
-pub fn get_crtc_info<Conn>(conn: &Conn, crtc: Crtc, config_timestamp: Timestamp) -> Result<Cookie<'_, Conn, GetCrtcInfoReply>, ConnectionError>
+pub fn get_crtc_info<Conn>(conn: &Conn, crtc: Crtc, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetCrtcInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1820,7 +1820,7 @@ pub struct GetCrtcInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub x: i16,
     pub y: i16,
     pub width: u16,
@@ -1837,7 +1837,7 @@ impl GetCrtcInfoReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -1863,7 +1863,7 @@ impl TryFrom<&[u8]> for GetCrtcInfoReply {
 
 /// Opcode for the SetCrtcConfig request
 pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
-pub fn set_crtc_config<'c, Conn>(conn: &'c Conn, crtc: Crtc, timestamp: Timestamp, config_timestamp: Timestamp, x: i16, y: i16, mode: Mode, rotation: u16, outputs: &[Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
+pub fn set_crtc_config<'c, Conn>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: u16, outputs: &[Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1921,7 +1921,7 @@ pub struct SetCrtcConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
 }
 impl SetCrtcConfigReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1929,7 +1929,7 @@ impl SetCrtcConfigReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let status = status.try_into()?;
         let result = SetCrtcConfigReply { response_type, status, sequence, length, timestamp };
@@ -2092,7 +2092,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetScreenResourcesCurrent request
 pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
-pub fn get_screen_resources_current<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenResourcesCurrentReply>, ConnectionError>
+pub fn get_screen_resources_current<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenResourcesCurrentReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2119,8 +2119,8 @@ pub struct GetScreenResourcesCurrentReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
-    pub config_timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
     pub crtcs: Vec<Crtc>,
     pub outputs: Vec<Output>,
     pub modes: Vec<ModeInfo>,
@@ -2132,8 +2132,8 @@ impl GetScreenResourcesCurrentReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (num_crtcs, remaining) = u16::try_parse(remaining)?;
         let (num_outputs, remaining) = u16::try_parse(remaining)?;
         let (num_modes, remaining) = u16::try_parse(remaining)?;
@@ -2404,7 +2404,7 @@ pub struct GetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub left: u16,
     pub top: u16,
     pub width: u16,
@@ -2424,7 +2424,7 @@ impl GetPanningReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (left, remaining) = u16::try_parse(remaining)?;
         let (top, remaining) = u16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -2451,7 +2451,7 @@ impl TryFrom<&[u8]> for GetPanningReply {
 
 /// Opcode for the SetPanning request
 pub const SET_PANNING_REQUEST: u8 = 29;
-pub fn set_panning<Conn>(conn: &Conn, crtc: Crtc, timestamp: Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Conn, SetPanningReply>, ConnectionError>
+pub fn set_panning<Conn>(conn: &Conn, crtc: Crtc, timestamp: xproto::Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Conn, SetPanningReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2520,7 +2520,7 @@ pub struct SetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
 }
 impl SetPanningReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2528,7 +2528,7 @@ impl SetPanningReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let status = status.try_into()?;
         let result = SetPanningReply { response_type, status, sequence, length, timestamp };
         Ok((result, remaining))
@@ -2543,7 +2543,7 @@ impl TryFrom<&[u8]> for SetPanningReply {
 
 /// Opcode for the SetOutputPrimary request
 pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
-pub fn set_output_primary<Conn>(conn: &Conn, window: Window, output: Output) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_output_primary<Conn>(conn: &Conn, window: xproto::Window, output: Output) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2573,7 +2573,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetOutputPrimary request
 pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
-pub fn get_output_primary<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetOutputPrimaryReply>, ConnectionError>
+pub fn get_output_primary<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetOutputPrimaryReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2622,7 +2622,7 @@ impl TryFrom<&[u8]> for GetOutputPrimaryReply {
 
 /// Opcode for the GetProviders request
 pub const GET_PROVIDERS_REQUEST: u8 = 32;
-pub fn get_providers<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetProvidersReply>, ConnectionError>
+pub fn get_providers<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetProvidersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2649,7 +2649,7 @@ pub struct GetProvidersReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub providers: Vec<Provider>,
 }
 impl GetProvidersReply {
@@ -2658,7 +2658,7 @@ impl GetProvidersReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (num_providers, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let (providers, remaining) = crate::x11_utils::parse_list::<Provider>(remaining, num_providers as usize)?;
@@ -2744,7 +2744,7 @@ bitmask_binop!(ProviderCapability, u8);
 
 /// Opcode for the GetProviderInfo request
 pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;
-pub fn get_provider_info<Conn>(conn: &Conn, provider: Provider, config_timestamp: Timestamp) -> Result<Cookie<'_, Conn, GetProviderInfoReply>, ConnectionError>
+pub fn get_provider_info<Conn>(conn: &Conn, provider: Provider, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetProviderInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2777,7 +2777,7 @@ pub struct GetProviderInfoReply {
     pub status: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub capabilities: u32,
     pub num_associated_providers: u16,
     pub crtcs: Vec<Crtc>,
@@ -2792,7 +2792,7 @@ impl GetProviderInfoReply {
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (capabilities, remaining) = u32::try_parse(remaining)?;
         let (num_crtcs, remaining) = u16::try_parse(remaining)?;
         let (num_outputs, remaining) = u16::try_parse(remaining)?;
@@ -2817,7 +2817,7 @@ impl TryFrom<&[u8]> for GetProviderInfoReply {
 
 /// Opcode for the SetProviderOffloadSink request
 pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
-pub fn set_provider_offload_sink<Conn>(conn: &Conn, provider: Provider, sink_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_provider_offload_sink<Conn>(conn: &Conn, provider: Provider, sink_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2852,7 +2852,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetProviderOutputSource request
 pub const SET_PROVIDER_OUTPUT_SOURCE_REQUEST: u8 = 35;
-pub fn set_provider_output_source<Conn>(conn: &Conn, provider: Provider, source_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_provider_output_source<Conn>(conn: &Conn, provider: Provider, source_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2914,7 +2914,7 @@ pub struct ListProviderPropertiesReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atoms: Vec<Atom>,
+    pub atoms: Vec<xproto::Atom>,
 }
 impl ListProviderPropertiesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2924,7 +2924,7 @@ impl ListProviderPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_atoms, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, num_atoms as usize)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, num_atoms as usize)?;
         let result = ListProviderPropertiesReply { response_type, sequence, length, atoms };
         Ok((result, remaining))
     }
@@ -2938,7 +2938,7 @@ impl TryFrom<&[u8]> for ListProviderPropertiesReply {
 
 /// Opcode for the QueryProviderProperty request
 pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
-pub fn query_provider_property<Conn>(conn: &Conn, provider: Provider, property: Atom) -> Result<Cookie<'_, Conn, QueryProviderPropertyReply>, ConnectionError>
+pub fn query_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom) -> Result<Cookie<'_, Conn, QueryProviderPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2998,7 +2998,7 @@ impl TryFrom<&[u8]> for QueryProviderPropertyReply {
 
 /// Opcode for the ConfigureProviderProperty request
 pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
-pub fn configure_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3038,7 +3038,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ChangeProviderProperty request
 pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
-pub fn change_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: Atom, type_: Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3088,7 +3088,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeleteProviderProperty request
 pub const DELETE_PROVIDER_PROPERTY_REQUEST: u8 = 40;
-pub fn delete_provider_property<Conn>(conn: &Conn, provider: Provider, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3118,7 +3118,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetProviderProperty request
 pub const GET_PROVIDER_PROPERTY_REQUEST: u8 = 41;
-pub fn get_provider_property<Conn>(conn: &Conn, provider: Provider, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetProviderPropertyReply>, ConnectionError>
+pub fn get_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetProviderPropertyReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3172,7 +3172,7 @@ pub struct GetProviderPropertyReply {
     pub format: u8,
     pub sequence: u16,
     pub length: u32,
-    pub type_: Atom,
+    pub type_: xproto::Atom,
     pub bytes_after: u32,
     pub num_items: u32,
     pub data: Vec<u8>,
@@ -3183,7 +3183,7 @@ impl GetProviderPropertyReply {
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (type_, remaining) = Atom::try_parse(remaining)?;
+        let (type_, remaining) = xproto::Atom::try_parse(remaining)?;
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
@@ -3206,10 +3206,10 @@ pub struct ScreenChangeNotifyEvent {
     pub response_type: u8,
     pub rotation: u8,
     pub sequence: u16,
-    pub timestamp: Timestamp,
-    pub config_timestamp: Timestamp,
-    pub root: Window,
-    pub request_window: Window,
+    pub timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
+    pub root: xproto::Window,
+    pub request_window: xproto::Window,
     pub size_id: u16,
     pub subpixel_order: render::SubPixel,
     pub width: u16,
@@ -3222,10 +3222,10 @@ impl ScreenChangeNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (rotation, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (root, remaining) = Window::try_parse(remaining)?;
-        let (request_window, remaining) = Window::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (request_window, remaining) = xproto::Window::try_parse(remaining)?;
         let (size_id, remaining) = u16::try_parse(remaining)?;
         let (subpixel_order, remaining) = u16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -3363,8 +3363,8 @@ impl TryFrom<u32> for Notify {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CrtcChange {
-    pub timestamp: Timestamp,
-    pub window: Window,
+    pub timestamp: xproto::Timestamp,
+    pub window: xproto::Window,
     pub crtc: Crtc,
     pub mode: Mode,
     pub rotation: u16,
@@ -3375,8 +3375,8 @@ pub struct CrtcChange {
 }
 impl TryParse for CrtcChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (crtc, remaining) = Crtc::try_parse(remaining)?;
         let (mode, remaining) = Mode::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
@@ -3455,9 +3455,9 @@ impl Serialize for CrtcChange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutputChange {
-    pub timestamp: Timestamp,
-    pub config_timestamp: Timestamp,
-    pub window: Window,
+    pub timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
+    pub window: xproto::Window,
     pub output: Output,
     pub crtc: Crtc,
     pub mode: Mode,
@@ -3467,9 +3467,9 @@ pub struct OutputChange {
 }
 impl TryParse for OutputChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (config_timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (output, remaining) = Output::try_parse(remaining)?;
         let (crtc, remaining) = Crtc::try_parse(remaining)?;
         let (mode, remaining) = Mode::try_parse(remaining)?;
@@ -3547,18 +3547,18 @@ impl Serialize for OutputChange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutputProperty {
-    pub window: Window,
+    pub window: xproto::Window,
     pub output: Output,
-    pub atom: Atom,
-    pub timestamp: Timestamp,
-    pub status: Property,
+    pub atom: xproto::Atom,
+    pub timestamp: xproto::Timestamp,
+    pub status: xproto::Property,
 }
 impl TryParse for OutputProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (output, remaining) = Output::try_parse(remaining)?;
-        let (atom, remaining) = Atom::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (atom, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let status = status.try_into()?;
@@ -3624,14 +3624,14 @@ impl Serialize for OutputProperty {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderChange {
-    pub timestamp: Timestamp,
-    pub window: Window,
+    pub timestamp: xproto::Timestamp,
+    pub window: xproto::Window,
     pub provider: Provider,
 }
 impl TryParse for ProviderChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (provider, remaining) = Provider::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = ProviderChange { timestamp, window, provider };
@@ -3692,18 +3692,18 @@ impl Serialize for ProviderChange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProviderProperty {
-    pub window: Window,
+    pub window: xproto::Window,
     pub provider: Provider,
-    pub atom: Atom,
-    pub timestamp: Timestamp,
+    pub atom: xproto::Atom,
+    pub timestamp: xproto::Timestamp,
     pub state: u8,
 }
 impl TryParse for ProviderProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (provider, remaining) = Provider::try_parse(remaining)?;
-        let (atom, remaining) = Atom::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (atom, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let result = ProviderProperty { window, provider, atom, timestamp, state };
@@ -3768,13 +3768,13 @@ impl Serialize for ProviderProperty {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResourceChange {
-    pub timestamp: Timestamp,
-    pub window: Window,
+    pub timestamp: xproto::Timestamp,
+    pub window: xproto::Window,
 }
 impl TryParse for ResourceChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let result = ResourceChange { timestamp, window };
         Ok((result, remaining))
@@ -3832,7 +3832,7 @@ impl Serialize for ResourceChange {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MonitorInfo {
-    pub name: Atom,
+    pub name: xproto::Atom,
     pub primary: bool,
     pub automatic: bool,
     pub x: i16,
@@ -3845,7 +3845,7 @@ pub struct MonitorInfo {
 }
 impl TryParse for MonitorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = Atom::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (primary, remaining) = bool::try_parse(remaining)?;
         let (automatic, remaining) = bool::try_parse(remaining)?;
         let (n_output, remaining) = u16::try_parse(remaining)?;
@@ -3892,7 +3892,7 @@ impl Serialize for MonitorInfo {
 
 /// Opcode for the GetMonitors request
 pub const GET_MONITORS_REQUEST: u8 = 42;
-pub fn get_monitors<Conn>(conn: &Conn, window: Window, get_active: bool) -> Result<Cookie<'_, Conn, GetMonitorsReply>, ConnectionError>
+pub fn get_monitors<Conn>(conn: &Conn, window: xproto::Window, get_active: bool) -> Result<Cookie<'_, Conn, GetMonitorsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3924,7 +3924,7 @@ pub struct GetMonitorsReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub n_outputs: u32,
     pub monitors: Vec<MonitorInfo>,
 }
@@ -3934,7 +3934,7 @@ impl GetMonitorsReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (n_monitors, remaining) = u32::try_parse(remaining)?;
         let (n_outputs, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
@@ -3952,7 +3952,7 @@ impl TryFrom<&[u8]> for GetMonitorsReply {
 
 /// Opcode for the SetMonitor request
 pub const SET_MONITOR_REQUEST: u8 = 43;
-pub fn set_monitor<Conn>(conn: &Conn, window: Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_monitor<Conn>(conn: &Conn, window: xproto::Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3981,7 +3981,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the DeleteMonitor request
 pub const DELETE_MONITOR_REQUEST: u8 = 44;
-pub fn delete_monitor<Conn>(conn: &Conn, window: Window, name: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn delete_monitor<Conn>(conn: &Conn, window: xproto::Window, name: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -4011,7 +4011,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateLease request
 pub const CREATE_LEASE_REQUEST: u8 = 45;
-pub fn create_lease<'c, Conn>(conn: &'c Conn, window: Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
+pub fn create_lease<'c, Conn>(conn: &'c Conn, window: xproto::Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -4113,15 +4113,15 @@ where Conn: RequestConnection + ?Sized
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LeaseNotify {
-    pub timestamp: Timestamp,
-    pub window: Window,
+    pub timestamp: xproto::Timestamp,
+    pub window: xproto::Window,
     pub lease: Lease,
     pub created: u8,
 }
 impl TryParse for LeaseNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (lease, remaining) = Lease::try_parse(remaining)?;
         let (created, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
@@ -4186,7 +4186,7 @@ impl Serialize for LeaseNotify {
 #[derive(Debug, Copy, Clone)]
 pub struct NotifyData([u8; 28]);
 impl NotifyData {
-    pub fn as_cc(&self) -> CrtcChange {
+    pub fn as_xproto_cc(&self) -> CrtcChange {
         fn do_the_parse(remaining: &[u8]) -> Result<CrtcChange, ParseError> {
             let (cc, remaining) = CrtcChange::try_parse(remaining)?;
             let _ = remaining;
@@ -4194,7 +4194,7 @@ impl NotifyData {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_oc(&self) -> OutputChange {
+    pub fn as_xproto_oc(&self) -> OutputChange {
         fn do_the_parse(remaining: &[u8]) -> Result<OutputChange, ParseError> {
             let (oc, remaining) = OutputChange::try_parse(remaining)?;
             let _ = remaining;
@@ -4202,7 +4202,7 @@ impl NotifyData {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_op(&self) -> OutputProperty {
+    pub fn as_xproto_op(&self) -> OutputProperty {
         fn do_the_parse(remaining: &[u8]) -> Result<OutputProperty, ParseError> {
             let (op, remaining) = OutputProperty::try_parse(remaining)?;
             let _ = remaining;
@@ -4210,7 +4210,7 @@ impl NotifyData {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_pc(&self) -> ProviderChange {
+    pub fn as_xproto_pc(&self) -> ProviderChange {
         fn do_the_parse(remaining: &[u8]) -> Result<ProviderChange, ParseError> {
             let (pc, remaining) = ProviderChange::try_parse(remaining)?;
             let _ = remaining;
@@ -4218,7 +4218,7 @@ impl NotifyData {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_pp(&self) -> ProviderProperty {
+    pub fn as_xproto_pp(&self) -> ProviderProperty {
         fn do_the_parse(remaining: &[u8]) -> Result<ProviderProperty, ParseError> {
             let (pp, remaining) = ProviderProperty::try_parse(remaining)?;
             let _ = remaining;
@@ -4226,7 +4226,7 @@ impl NotifyData {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_rc(&self) -> ResourceChange {
+    pub fn as_xproto_rc(&self) -> ResourceChange {
         fn do_the_parse(remaining: &[u8]) -> Result<ResourceChange, ParseError> {
             let (rc, remaining) = ResourceChange::try_parse(remaining)?;
             let _ = remaining;
@@ -4234,7 +4234,7 @@ impl NotifyData {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_lc(&self) -> LeaseNotify {
+    pub fn as_xproto_lc(&self) -> LeaseNotify {
         fn do_the_parse(remaining: &[u8]) -> Result<LeaseNotify, ParseError> {
             let (lc, remaining) = LeaseNotify::try_parse(remaining)?;
             let _ = remaining;
@@ -4363,37 +4363,37 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major_version, minor_version)
     }
 
-    fn randr_set_screen_config(&self, window: Window, timestamp: Timestamp, config_timestamp: Timestamp, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Self, SetScreenConfigReply>, ConnectionError>
+    fn randr_set_screen_config(&self, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: u16, rate: u16) -> Result<Cookie<'_, Self, SetScreenConfigReply>, ConnectionError>
     {
         set_screen_config(self, window, timestamp, config_timestamp, size_id, rotation, rate)
     }
 
-    fn randr_select_input(&self, window: Window, enable: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_select_input(&self, window: xproto::Window, enable: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, window, enable)
     }
 
-    fn randr_get_screen_info(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenInfoReply>, ConnectionError>
+    fn randr_get_screen_info(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetScreenInfoReply>, ConnectionError>
     {
         get_screen_info(self, window)
     }
 
-    fn randr_get_screen_size_range(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenSizeRangeReply>, ConnectionError>
+    fn randr_get_screen_size_range(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetScreenSizeRangeReply>, ConnectionError>
     {
         get_screen_size_range(self, window)
     }
 
-    fn randr_set_screen_size(&self, window: Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_screen_size(&self, window: xproto::Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_screen_size(self, window, width, height, mm_width, mm_height)
     }
 
-    fn randr_get_screen_resources(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenResourcesReply>, ConnectionError>
+    fn randr_get_screen_resources(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetScreenResourcesReply>, ConnectionError>
     {
         get_screen_resources(self, window)
     }
 
-    fn randr_get_output_info(&self, output: Output, config_timestamp: Timestamp) -> Result<Cookie<'_, Self, GetOutputInfoReply>, ConnectionError>
+    fn randr_get_output_info(&self, output: Output, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Self, GetOutputInfoReply>, ConnectionError>
     {
         get_output_info(self, output, config_timestamp)
     }
@@ -4403,33 +4403,33 @@ pub trait ConnectionExt: RequestConnection {
         list_output_properties(self, output)
     }
 
-    fn randr_query_output_property(&self, output: Output, property: Atom) -> Result<Cookie<'_, Self, QueryOutputPropertyReply>, ConnectionError>
+    fn randr_query_output_property(&self, output: Output, property: xproto::Atom) -> Result<Cookie<'_, Self, QueryOutputPropertyReply>, ConnectionError>
     {
         query_output_property(self, output, property)
     }
 
-    fn randr_configure_output_property<'c>(&'c self, output: Output, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_configure_output_property<'c>(&'c self, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_output_property(self, output, property, pending, range, values)
     }
 
-    fn randr_change_output_property<'c, A>(&'c self, output: Output, property: Atom, type_: Atom, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_change_output_property<'c, A>(&'c self, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: A, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         change_output_property(self, output, property, type_, format, mode, num_units, data)
     }
 
-    fn randr_delete_output_property(&self, output: Output, property: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_delete_output_property(&self, output: Output, property: xproto::Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_output_property(self, output, property)
     }
 
-    fn randr_get_output_property(&self, output: Output, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetOutputPropertyReply>, ConnectionError>
+    fn randr_get_output_property(&self, output: Output, property: xproto::Atom, type_: xproto::Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetOutputPropertyReply>, ConnectionError>
     {
         get_output_property(self, output, property, type_, long_offset, long_length, delete, pending)
     }
 
-    fn randr_create_mode<'c>(&'c self, window: Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Self, CreateModeReply>, ConnectionError>
+    fn randr_create_mode<'c>(&'c self, window: xproto::Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Self, CreateModeReply>, ConnectionError>
     {
         create_mode(self, window, mode_info, name)
     }
@@ -4449,12 +4449,12 @@ pub trait ConnectionExt: RequestConnection {
         delete_output_mode(self, output, mode)
     }
 
-    fn randr_get_crtc_info(&self, crtc: Crtc, config_timestamp: Timestamp) -> Result<Cookie<'_, Self, GetCrtcInfoReply>, ConnectionError>
+    fn randr_get_crtc_info(&self, crtc: Crtc, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Self, GetCrtcInfoReply>, ConnectionError>
     {
         get_crtc_info(self, crtc, config_timestamp)
     }
 
-    fn randr_set_crtc_config<'c>(&'c self, crtc: Crtc, timestamp: Timestamp, config_timestamp: Timestamp, x: i16, y: i16, mode: Mode, rotation: u16, outputs: &[Output]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
+    fn randr_set_crtc_config<'c>(&'c self, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: u16, outputs: &[Output]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
     {
         set_crtc_config(self, crtc, timestamp, config_timestamp, x, y, mode, rotation, outputs)
     }
@@ -4474,7 +4474,7 @@ pub trait ConnectionExt: RequestConnection {
         set_crtc_gamma(self, crtc, size, red, green, blue)
     }
 
-    fn randr_get_screen_resources_current(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenResourcesCurrentReply>, ConnectionError>
+    fn randr_get_screen_resources_current(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetScreenResourcesCurrentReply>, ConnectionError>
     {
         get_screen_resources_current(self, window)
     }
@@ -4494,37 +4494,37 @@ pub trait ConnectionExt: RequestConnection {
         get_panning(self, crtc)
     }
 
-    fn randr_set_panning(&self, crtc: Crtc, timestamp: Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Self, SetPanningReply>, ConnectionError>
+    fn randr_set_panning(&self, crtc: Crtc, timestamp: xproto::Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Self, SetPanningReply>, ConnectionError>
     {
         set_panning(self, crtc, timestamp, left, top, width, height, track_left, track_top, track_width, track_height, border_left, border_top, border_right, border_bottom)
     }
 
-    fn randr_set_output_primary(&self, window: Window, output: Output) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_output_primary(&self, window: xproto::Window, output: Output) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_output_primary(self, window, output)
     }
 
-    fn randr_get_output_primary(&self, window: Window) -> Result<Cookie<'_, Self, GetOutputPrimaryReply>, ConnectionError>
+    fn randr_get_output_primary(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetOutputPrimaryReply>, ConnectionError>
     {
         get_output_primary(self, window)
     }
 
-    fn randr_get_providers(&self, window: Window) -> Result<Cookie<'_, Self, GetProvidersReply>, ConnectionError>
+    fn randr_get_providers(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetProvidersReply>, ConnectionError>
     {
         get_providers(self, window)
     }
 
-    fn randr_get_provider_info(&self, provider: Provider, config_timestamp: Timestamp) -> Result<Cookie<'_, Self, GetProviderInfoReply>, ConnectionError>
+    fn randr_get_provider_info(&self, provider: Provider, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Self, GetProviderInfoReply>, ConnectionError>
     {
         get_provider_info(self, provider, config_timestamp)
     }
 
-    fn randr_set_provider_offload_sink(&self, provider: Provider, sink_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_provider_offload_sink(&self, provider: Provider, sink_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_provider_offload_sink(self, provider, sink_provider, config_timestamp)
     }
 
-    fn randr_set_provider_output_source(&self, provider: Provider, source_provider: Provider, config_timestamp: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_provider_output_source(&self, provider: Provider, source_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_provider_output_source(self, provider, source_provider, config_timestamp)
     }
@@ -4534,47 +4534,47 @@ pub trait ConnectionExt: RequestConnection {
         list_provider_properties(self, provider)
     }
 
-    fn randr_query_provider_property(&self, provider: Provider, property: Atom) -> Result<Cookie<'_, Self, QueryProviderPropertyReply>, ConnectionError>
+    fn randr_query_provider_property(&self, provider: Provider, property: xproto::Atom) -> Result<Cookie<'_, Self, QueryProviderPropertyReply>, ConnectionError>
     {
         query_provider_property(self, provider, property)
     }
 
-    fn randr_configure_provider_property<'c>(&'c self, provider: Provider, property: Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_configure_provider_property<'c>(&'c self, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_provider_property(self, provider, property, pending, range, values)
     }
 
-    fn randr_change_provider_property<'c>(&'c self, provider: Provider, property: Atom, type_: Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_change_provider_property<'c>(&'c self, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_provider_property(self, provider, property, type_, format, mode, num_items, data)
     }
 
-    fn randr_delete_provider_property(&self, provider: Provider, property: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_delete_provider_property(&self, provider: Provider, property: xproto::Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_provider_property(self, provider, property)
     }
 
-    fn randr_get_provider_property(&self, provider: Provider, property: Atom, type_: Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetProviderPropertyReply>, ConnectionError>
+    fn randr_get_provider_property(&self, provider: Provider, property: xproto::Atom, type_: xproto::Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Self, GetProviderPropertyReply>, ConnectionError>
     {
         get_provider_property(self, provider, property, type_, long_offset, long_length, delete, pending)
     }
 
-    fn randr_get_monitors(&self, window: Window, get_active: bool) -> Result<Cookie<'_, Self, GetMonitorsReply>, ConnectionError>
+    fn randr_get_monitors(&self, window: xproto::Window, get_active: bool) -> Result<Cookie<'_, Self, GetMonitorsReply>, ConnectionError>
     {
         get_monitors(self, window, get_active)
     }
 
-    fn randr_set_monitor(&self, window: Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_set_monitor(&self, window: xproto::Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_monitor(self, window, monitorinfo)
     }
 
-    fn randr_delete_monitor(&self, window: Window, name: Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn randr_delete_monitor(&self, window: xproto::Window, name: xproto::Atom) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         delete_monitor(self, window, name)
     }
 
-    fn randr_create_lease<'c>(&'c self, window: Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Self, CreateLeaseReply>, ConnectionError>
+    fn randr_create_lease<'c>(&'c self, window: xproto::Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Self, CreateLeaseReply>, ConnectionError>
     {
         create_lease(self, window, lid, crtcs, outputs)
     }

--- a/src/generated/render.rs
+++ b/src/generated/render.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "RENDER";
@@ -1068,7 +1068,7 @@ pub struct Pictforminfo {
     pub type_: PictType,
     pub depth: u8,
     pub direct: Directformat,
-    pub colormap: Colormap,
+    pub colormap: xproto::Colormap,
 }
 impl TryParse for Pictforminfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1077,7 +1077,7 @@ impl TryParse for Pictforminfo {
         let (depth, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (direct, remaining) = Directformat::try_parse(remaining)?;
-        let (colormap, remaining) = Colormap::try_parse(remaining)?;
+        let (colormap, remaining) = xproto::Colormap::try_parse(remaining)?;
         let type_ = type_.try_into()?;
         let result = Pictforminfo { id, type_, depth, direct, colormap };
         Ok((result, remaining))
@@ -1141,12 +1141,12 @@ impl Serialize for Pictforminfo {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pictvisual {
-    pub visual: Visualid,
+    pub visual: xproto::Visualid,
     pub format: Pictformat,
 }
 impl TryParse for Pictvisual {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (visual, remaining) = Visualid::try_parse(remaining)?;
+        let (visual, remaining) = xproto::Visualid::try_parse(remaining)?;
         let (format, remaining) = Pictformat::try_parse(remaining)?;
         let result = Pictvisual { visual, format };
         Ok((result, remaining))
@@ -1838,12 +1838,12 @@ pub struct CreatePictureAux {
     pub alphayorigin: Option<i32>,
     pub clipxorigin: Option<i32>,
     pub clipyorigin: Option<i32>,
-    pub clipmask: Option<Pixmap>,
+    pub clipmask: Option<xproto::Pixmap>,
     pub graphicsexposure: Option<u32>,
     pub subwindowmode: Option<u32>,
     pub polyedge: Option<u32>,
     pub polymode: Option<u32>,
-    pub dither: Option<Atom>,
+    pub dither: Option<xproto::Atom>,
     pub componentalpha: Option<u32>,
 }
 impl CreatePictureAux {
@@ -1925,7 +1925,7 @@ impl CreatePictureAux {
         self
     }
     /// Set the clipmask field of this structure.
-    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
+    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Pixmap>> {
         self.clipmask = value.into();
         self
     }
@@ -1950,7 +1950,7 @@ impl CreatePictureAux {
         self
     }
     /// Set the dither field of this structure.
-    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.dither = value.into();
         self
     }
@@ -2009,7 +2009,7 @@ impl Serialize for CreatePictureAux {
         }
     }
 }
-pub fn create_picture<'c, Conn>(conn: &'c Conn, pid: Picture, drawable: Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_picture<'c, Conn>(conn: &'c Conn, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2063,12 +2063,12 @@ pub struct ChangePictureAux {
     pub alphayorigin: Option<i32>,
     pub clipxorigin: Option<i32>,
     pub clipyorigin: Option<i32>,
-    pub clipmask: Option<Pixmap>,
+    pub clipmask: Option<xproto::Pixmap>,
     pub graphicsexposure: Option<u32>,
     pub subwindowmode: Option<u32>,
     pub polyedge: Option<u32>,
     pub polymode: Option<u32>,
-    pub dither: Option<Atom>,
+    pub dither: Option<xproto::Atom>,
     pub componentalpha: Option<u32>,
 }
 impl ChangePictureAux {
@@ -2150,7 +2150,7 @@ impl ChangePictureAux {
         self
     }
     /// Set the clipmask field of this structure.
-    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
+    pub fn clipmask<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Pixmap>> {
         self.clipmask = value.into();
         self
     }
@@ -2175,7 +2175,7 @@ impl ChangePictureAux {
         self
     }
     /// Set the dither field of this structure.
-    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn dither<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.dither = value.into();
         self
     }
@@ -2269,7 +2269,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetPictureClipRectangles request
 pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
-pub fn set_picture_clip_rectangles<'c, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_picture_clip_rectangles<'c, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2916,7 +2916,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the FillRectangles request
 pub const FILL_RECTANGLES_REQUEST: u8 = 26;
-pub fn fill_rectangles<'c, Conn, A>(conn: &'c Conn, op: A, dst: Picture, color: Color, rects: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn fill_rectangles<'c, Conn, A>(conn: &'c Conn, op: A, dst: Picture, color: Color, rects: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2960,7 +2960,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 27;
-pub fn create_cursor<Conn>(conn: &Conn, cid: Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_cursor<Conn>(conn: &Conn, cid: xproto::Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3156,7 +3156,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the QueryFilters request
 pub const QUERY_FILTERS_REQUEST: u8 = 29;
-pub fn query_filters<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, QueryFiltersReply>, ConnectionError>
+pub fn query_filters<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, QueryFiltersReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3184,7 +3184,7 @@ pub struct QueryFiltersReply {
     pub sequence: u16,
     pub length: u32,
     pub aliases: Vec<u16>,
-    pub filters: Vec<Str>,
+    pub filters: Vec<xproto::Str>,
 }
 impl QueryFiltersReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3196,7 +3196,7 @@ impl QueryFiltersReply {
         let (num_filters, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let (aliases, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_aliases as usize)?;
-        let (filters, remaining) = crate::x11_utils::parse_list::<Str>(remaining, num_filters as usize)?;
+        let (filters, remaining) = crate::x11_utils::parse_list::<xproto::Str>(remaining, num_filters as usize)?;
         let result = QueryFiltersReply { response_type, sequence, length, aliases, filters };
         Ok((result, remaining))
     }
@@ -3248,12 +3248,12 @@ where Conn: RequestConnection + ?Sized
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Animcursorelt {
-    pub cursor: Cursor,
+    pub cursor: xproto::Cursor,
     pub delay: u32,
 }
 impl TryParse for Animcursorelt {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (cursor, remaining) = Cursor::try_parse(remaining)?;
+        let (cursor, remaining) = xproto::Cursor::try_parse(remaining)?;
         let (delay, remaining) = u32::try_parse(remaining)?;
         let result = Animcursorelt { cursor, delay };
         Ok((result, remaining))
@@ -3290,7 +3290,7 @@ impl Serialize for Animcursorelt {
 
 /// Opcode for the CreateAnimCursor request
 pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
-pub fn create_anim_cursor<'c, Conn>(conn: &'c Conn, cid: Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_anim_cursor<'c, Conn>(conn: &'c Conn, cid: xproto::Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -3685,7 +3685,7 @@ pub trait ConnectionExt: RequestConnection {
         query_pict_index_values(self, format)
     }
 
-    fn render_create_picture<'c>(&'c self, pid: Picture, drawable: Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_picture<'c>(&'c self, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_picture(self, pid, drawable, format, value_list)
     }
@@ -3695,7 +3695,7 @@ pub trait ConnectionExt: RequestConnection {
         change_picture(self, picture, value_list)
     }
 
-    fn render_set_picture_clip_rectangles<'c>(&'c self, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_set_picture_clip_rectangles<'c>(&'c self, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_picture_clip_rectangles(self, picture, clip_x_origin, clip_y_origin, rectangles)
     }
@@ -3778,13 +3778,13 @@ pub trait ConnectionExt: RequestConnection {
         composite_glyphs32(self, op, src, dst, mask_format, glyphset, src_x, src_y, glyphcmds)
     }
 
-    fn render_fill_rectangles<'c, A>(&'c self, op: A, dst: Picture, color: Color, rects: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_fill_rectangles<'c, A>(&'c self, op: A, dst: Picture, color: Color, rects: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         fill_rectangles(self, op, dst, color, rects)
     }
 
-    fn render_create_cursor(&self, cid: Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn render_create_cursor(&self, cid: xproto::Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_cursor(self, cid, source, x, y)
     }
@@ -3794,7 +3794,7 @@ pub trait ConnectionExt: RequestConnection {
         set_picture_transform(self, picture, transform)
     }
 
-    fn render_query_filters(&self, drawable: Drawable) -> Result<Cookie<'_, Self, QueryFiltersReply>, ConnectionError>
+    fn render_query_filters(&self, drawable: xproto::Drawable) -> Result<Cookie<'_, Self, QueryFiltersReply>, ConnectionError>
     {
         query_filters(self, drawable)
     }
@@ -3804,7 +3804,7 @@ pub trait ConnectionExt: RequestConnection {
         set_picture_filter(self, picture, filter, values)
     }
 
-    fn render_create_anim_cursor<'c>(&'c self, cid: Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_anim_cursor<'c>(&'c self, cid: xproto::Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_anim_cursor(self, cid, cursors)
     }

--- a/src/generated/res.rs
+++ b/src/generated/res.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "X-Resource";
@@ -80,12 +80,12 @@ impl Serialize for Client {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Type {
-    pub resource_type: Atom,
+    pub resource_type: xproto::Atom,
     pub count: u32,
 }
 impl TryParse for Type {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (resource_type, remaining) = Atom::try_parse(remaining)?;
+        let (resource_type, remaining) = xproto::Atom::try_parse(remaining)?;
         let (count, remaining) = u32::try_parse(remaining)?;
         let result = Type { resource_type, count };
         Ok((result, remaining))

--- a/src/generated/screensaver.rs
+++ b/src/generated/screensaver.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "MIT-SCREEN-SAVER";
@@ -287,7 +287,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the QueryInfo request
 pub const QUERY_INFO_REQUEST: u8 = 1;
-pub fn query_info<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, QueryInfoReply>, ConnectionError>
+pub fn query_info<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, QueryInfoReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -315,7 +315,7 @@ pub struct QueryInfoReply {
     pub state: u8,
     pub sequence: u16,
     pub length: u32,
-    pub saver_window: Window,
+    pub saver_window: xproto::Window,
     pub ms_until_server: u32,
     pub ms_since_user_input: u32,
     pub event_mask: u32,
@@ -327,7 +327,7 @@ impl QueryInfoReply {
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (saver_window, remaining) = Window::try_parse(remaining)?;
+        let (saver_window, remaining) = xproto::Window::try_parse(remaining)?;
         let (ms_until_server, remaining) = u32::try_parse(remaining)?;
         let (ms_since_user_input, remaining) = u32::try_parse(remaining)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
@@ -347,7 +347,7 @@ impl TryFrom<&[u8]> for QueryInfoReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 2;
-pub fn select_input<Conn>(conn: &Conn, drawable: Drawable, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, drawable: xproto::Drawable, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -380,21 +380,21 @@ pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
 /// Auxiliary and optional information for the set_attributes function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SetAttributesAux {
-    pub background_pixmap: Option<Pixmap>,
+    pub background_pixmap: Option<xproto::Pixmap>,
     pub background_pixel: Option<u32>,
-    pub border_pixmap: Option<Pixmap>,
+    pub border_pixmap: Option<xproto::Pixmap>,
     pub border_pixel: Option<u32>,
     pub bit_gravity: Option<u32>,
     pub win_gravity: Option<u32>,
     pub backing_store: Option<u32>,
     pub backing_planes: Option<u32>,
     pub backing_pixel: Option<u32>,
-    pub override_redirect: Option<Bool32>,
-    pub save_under: Option<Bool32>,
+    pub override_redirect: Option<xproto::Bool32>,
+    pub save_under: Option<xproto::Bool32>,
     pub event_mask: Option<u32>,
     pub do_not_propogate_mask: Option<u32>,
-    pub colormap: Option<Colormap>,
-    pub cursor: Option<Cursor>,
+    pub colormap: Option<xproto::Colormap>,
+    pub cursor: Option<xproto::Cursor>,
 }
 impl SetAttributesAux {
     /// Create a new instance with all fields unset / not present.
@@ -404,54 +404,54 @@ impl SetAttributesAux {
     fn value_mask(&self) -> u32 {
         let mut mask = 0;
         if self.background_pixmap.is_some() {
-            mask |= Into::<u32>::into(CW::BackPixmap);
+            mask |= Into::<u32>::into(xproto::CW::BackPixmap);
         }
         if self.background_pixel.is_some() {
-            mask |= Into::<u32>::into(CW::BackPixel);
+            mask |= Into::<u32>::into(xproto::CW::BackPixel);
         }
         if self.border_pixmap.is_some() {
-            mask |= Into::<u32>::into(CW::BorderPixmap);
+            mask |= Into::<u32>::into(xproto::CW::BorderPixmap);
         }
         if self.border_pixel.is_some() {
-            mask |= Into::<u32>::into(CW::BorderPixel);
+            mask |= Into::<u32>::into(xproto::CW::BorderPixel);
         }
         if self.bit_gravity.is_some() {
-            mask |= Into::<u32>::into(CW::BitGravity);
+            mask |= Into::<u32>::into(xproto::CW::BitGravity);
         }
         if self.win_gravity.is_some() {
-            mask |= Into::<u32>::into(CW::WinGravity);
+            mask |= Into::<u32>::into(xproto::CW::WinGravity);
         }
         if self.backing_store.is_some() {
-            mask |= Into::<u32>::into(CW::BackingStore);
+            mask |= Into::<u32>::into(xproto::CW::BackingStore);
         }
         if self.backing_planes.is_some() {
-            mask |= Into::<u32>::into(CW::BackingPlanes);
+            mask |= Into::<u32>::into(xproto::CW::BackingPlanes);
         }
         if self.backing_pixel.is_some() {
-            mask |= Into::<u32>::into(CW::BackingPixel);
+            mask |= Into::<u32>::into(xproto::CW::BackingPixel);
         }
         if self.override_redirect.is_some() {
-            mask |= Into::<u32>::into(CW::OverrideRedirect);
+            mask |= Into::<u32>::into(xproto::CW::OverrideRedirect);
         }
         if self.save_under.is_some() {
-            mask |= Into::<u32>::into(CW::SaveUnder);
+            mask |= Into::<u32>::into(xproto::CW::SaveUnder);
         }
         if self.event_mask.is_some() {
-            mask |= Into::<u32>::into(CW::EventMask);
+            mask |= Into::<u32>::into(xproto::CW::EventMask);
         }
         if self.do_not_propogate_mask.is_some() {
-            mask |= Into::<u32>::into(CW::DontPropagate);
+            mask |= Into::<u32>::into(xproto::CW::DontPropagate);
         }
         if self.colormap.is_some() {
-            mask |= Into::<u32>::into(CW::Colormap);
+            mask |= Into::<u32>::into(xproto::CW::Colormap);
         }
         if self.cursor.is_some() {
-            mask |= Into::<u32>::into(CW::Cursor);
+            mask |= Into::<u32>::into(xproto::CW::Cursor);
         }
         mask
     }
     /// Set the background_pixmap field of this structure.
-    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
+    pub fn background_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Pixmap>> {
         self.background_pixmap = value.into();
         self
     }
@@ -461,7 +461,7 @@ impl SetAttributesAux {
         self
     }
     /// Set the border_pixmap field of this structure.
-    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<Pixmap>> {
+    pub fn border_pixmap<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Pixmap>> {
         self.border_pixmap = value.into();
         self
     }
@@ -496,12 +496,12 @@ impl SetAttributesAux {
         self
     }
     /// Set the override_redirect field of this structure.
-    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
+    pub fn override_redirect<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Bool32>> {
         self.override_redirect = value.into();
         self
     }
     /// Set the save_under field of this structure.
-    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<Bool32>> {
+    pub fn save_under<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Bool32>> {
         self.save_under = value.into();
         self
     }
@@ -516,12 +516,12 @@ impl SetAttributesAux {
         self
     }
     /// Set the colormap field of this structure.
-    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<Colormap>> {
+    pub fn colormap<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Colormap>> {
         self.colormap = value.into();
         self
     }
     /// Set the cursor field of this structure.
-    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<Cursor>> {
+    pub fn cursor<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Cursor>> {
         self.cursor = value.into();
         self
     }
@@ -581,7 +581,7 @@ impl Serialize for SetAttributesAux {
         }
     }
 }
-pub fn set_attributes<'c, Conn, A>(conn: &'c Conn, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_attributes<'c, Conn, A>(conn: &'c Conn, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: xproto::Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -641,7 +641,7 @@ where Conn: RequestConnection + ?Sized, A: Into<u8>
 
 /// Opcode for the UnsetAttributes request
 pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
-pub fn unset_attributes<Conn>(conn: &Conn, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn unset_attributes<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -696,9 +696,9 @@ pub struct NotifyEvent {
     pub response_type: u8,
     pub state: State,
     pub sequence: u16,
-    pub time: Timestamp,
-    pub root: Window,
-    pub window: Window,
+    pub time: xproto::Timestamp,
+    pub root: xproto::Window,
+    pub window: xproto::Window,
     pub kind: Kind,
     pub forced: bool,
 }
@@ -707,9 +707,9 @@ impl NotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
-        let (root, remaining) = Window::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (forced, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
@@ -768,23 +768,23 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn screensaver_query_info(&self, drawable: Drawable) -> Result<Cookie<'_, Self, QueryInfoReply>, ConnectionError>
+    fn screensaver_query_info(&self, drawable: xproto::Drawable) -> Result<Cookie<'_, Self, QueryInfoReply>, ConnectionError>
     {
         query_info(self, drawable)
     }
 
-    fn screensaver_select_input(&self, drawable: Drawable, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn screensaver_select_input(&self, drawable: xproto::Drawable, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, drawable, event_mask)
     }
 
-    fn screensaver_set_attributes<'c, A>(&'c self, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn screensaver_set_attributes<'c, A>(&'c self, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: A, depth: u8, visual: xproto::Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<u8>
     {
         set_attributes(self, drawable, x, y, width, height, border_width, class, depth, visual, value_list)
     }
 
-    fn screensaver_unset_attributes(&self, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn screensaver_unset_attributes(&self, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         unset_attributes(self, drawable)
     }

--- a/src/generated/shape.rs
+++ b/src/generated/shape.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "SHAPE";
@@ -183,12 +183,12 @@ pub struct NotifyEvent {
     pub response_type: u8,
     pub shape_kind: SK,
     pub sequence: u16,
-    pub affected_window: Window,
+    pub affected_window: xproto::Window,
     pub extents_x: i16,
     pub extents_y: i16,
     pub extents_width: u16,
     pub extents_height: u16,
-    pub server_time: Timestamp,
+    pub server_time: xproto::Timestamp,
     pub shaped: bool,
 }
 impl NotifyEvent {
@@ -196,12 +196,12 @@ impl NotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (shape_kind, remaining) = Kind::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (affected_window, remaining) = Window::try_parse(remaining)?;
+        let (affected_window, remaining) = xproto::Window::try_parse(remaining)?;
         let (extents_x, remaining) = i16::try_parse(remaining)?;
         let (extents_y, remaining) = i16::try_parse(remaining)?;
         let (extents_width, remaining) = u16::try_parse(remaining)?;
         let (extents_height, remaining) = u16::try_parse(remaining)?;
-        let (server_time, remaining) = Timestamp::try_parse(remaining)?;
+        let (server_time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (shaped, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let shape_kind = shape_kind.try_into()?;
@@ -301,7 +301,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Rectangles request
 pub const RECTANGLES_REQUEST: u8 = 1;
-pub fn rectangles<'c, Conn, A, B, C>(conn: &'c Conn, operation: A, destination_kind: B, ordering: C, destination_window: Window, x_offset: i16, y_offset: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn rectangles<'c, Conn, A, B, C>(conn: &'c Conn, operation: A, destination_kind: B, ordering: C, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>, C: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -346,7 +346,7 @@ where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>, C: Into<u8>
 
 /// Opcode for the Mask request
 pub const MASK_REQUEST: u8 = 2;
-pub fn mask<Conn, A, B>(conn: &Conn, operation: A, destination_kind: B, destination_window: Window, x_offset: i16, y_offset: i16, source_bitmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn mask<Conn, A, B>(conn: &Conn, operation: A, destination_kind: B, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_bitmap: xproto::Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -390,7 +390,7 @@ where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>
 
 /// Opcode for the Combine request
 pub const COMBINE_REQUEST: u8 = 3;
-pub fn combine<Conn, A, B, C>(conn: &Conn, operation: A, destination_kind: B, source_kind: C, destination_window: Window, x_offset: i16, y_offset: i16, source_window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn combine<Conn, A, B, C>(conn: &Conn, operation: A, destination_kind: B, source_kind: C, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>, C: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -436,7 +436,7 @@ where Conn: RequestConnection + ?Sized, A: Into<Op>, B: Into<Kind>, C: Into<Kind
 
 /// Opcode for the Offset request
 pub const OFFSET_REQUEST: u8 = 4;
-pub fn offset<Conn, A>(conn: &Conn, destination_kind: A, destination_window: Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn offset<Conn, A>(conn: &Conn, destination_kind: A, destination_window: xproto::Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -473,7 +473,7 @@ where Conn: RequestConnection + ?Sized, A: Into<Kind>
 
 /// Opcode for the QueryExtents request
 pub const QUERY_EXTENTS_REQUEST: u8 = 5;
-pub fn query_extents<Conn>(conn: &Conn, destination_window: Window) -> Result<Cookie<'_, Conn, QueryExtentsReply>, ConnectionError>
+pub fn query_extents<Conn>(conn: &Conn, destination_window: xproto::Window) -> Result<Cookie<'_, Conn, QueryExtentsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -541,7 +541,7 @@ impl TryFrom<&[u8]> for QueryExtentsReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 6;
-pub fn select_input<Conn>(conn: &Conn, destination_window: Window, enable: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, destination_window: xproto::Window, enable: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -571,7 +571,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the InputSelected request
 pub const INPUT_SELECTED_REQUEST: u8 = 7;
-pub fn input_selected<Conn>(conn: &Conn, destination_window: Window) -> Result<Cookie<'_, Conn, InputSelectedReply>, ConnectionError>
+pub fn input_selected<Conn>(conn: &Conn, destination_window: xproto::Window) -> Result<Cookie<'_, Conn, InputSelectedReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -619,7 +619,7 @@ impl TryFrom<&[u8]> for InputSelectedReply {
 
 /// Opcode for the GetRectangles request
 pub const GET_RECTANGLES_REQUEST: u8 = 8;
-pub fn get_rectangles<Conn, A>(conn: &Conn, window: Window, source_kind: A) -> Result<Cookie<'_, Conn, GetRectanglesReply>, ConnectionError>
+pub fn get_rectangles<Conn, A>(conn: &Conn, window: xproto::Window, source_kind: A) -> Result<Cookie<'_, Conn, GetRectanglesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -650,10 +650,10 @@ where Conn: RequestConnection + ?Sized, A: Into<Kind>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetRectanglesReply {
     pub response_type: u8,
-    pub ordering: ClipOrdering,
+    pub ordering: xproto::ClipOrdering,
     pub sequence: u16,
     pub length: u32,
-    pub rectangles: Vec<Rectangle>,
+    pub rectangles: Vec<xproto::Rectangle>,
 }
 impl GetRectanglesReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -663,7 +663,7 @@ impl GetRectanglesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (rectangles_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (rectangles, remaining) = crate::x11_utils::parse_list::<Rectangle>(remaining, rectangles_len as usize)?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, rectangles_len as usize)?;
         let ordering = ordering.try_into()?;
         let result = GetRectanglesReply { response_type, ordering, sequence, length, rectangles };
         Ok((result, remaining))
@@ -683,46 +683,46 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self)
     }
 
-    fn shape_rectangles<'c, A, B, C>(&'c self, operation: A, destination_kind: B, ordering: C, destination_window: Window, x_offset: i16, y_offset: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn shape_rectangles<'c, A, B, C>(&'c self, operation: A, destination_kind: B, ordering: C, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where A: Into<Op>, B: Into<Kind>, C: Into<u8>
     {
         self::rectangles(self, operation, destination_kind, ordering, destination_window, x_offset, y_offset, rectangles)
     }
 
-    fn shape_mask<A, B>(&self, operation: A, destination_kind: B, destination_window: Window, x_offset: i16, y_offset: i16, source_bitmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shape_mask<A, B>(&self, operation: A, destination_kind: B, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_bitmap: xproto::Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<Op>, B: Into<Kind>
     {
         mask(self, operation, destination_kind, destination_window, x_offset, y_offset, source_bitmap)
     }
 
-    fn shape_combine<A, B, C>(&self, operation: A, destination_kind: B, source_kind: C, destination_window: Window, x_offset: i16, y_offset: i16, source_window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shape_combine<A, B, C>(&self, operation: A, destination_kind: B, source_kind: C, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<Op>, B: Into<Kind>, C: Into<Kind>
     {
         combine(self, operation, destination_kind, source_kind, destination_window, x_offset, y_offset, source_window)
     }
 
-    fn shape_offset<A>(&self, destination_kind: A, destination_window: Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shape_offset<A>(&self, destination_kind: A, destination_window: xproto::Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<Kind>
     {
         offset(self, destination_kind, destination_window, x_offset, y_offset)
     }
 
-    fn shape_query_extents(&self, destination_window: Window) -> Result<Cookie<'_, Self, QueryExtentsReply>, ConnectionError>
+    fn shape_query_extents(&self, destination_window: xproto::Window) -> Result<Cookie<'_, Self, QueryExtentsReply>, ConnectionError>
     {
         query_extents(self, destination_window)
     }
 
-    fn shape_select_input(&self, destination_window: Window, enable: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn shape_select_input(&self, destination_window: xproto::Window, enable: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, destination_window, enable)
     }
 
-    fn shape_input_selected(&self, destination_window: Window) -> Result<Cookie<'_, Self, InputSelectedReply>, ConnectionError>
+    fn shape_input_selected(&self, destination_window: xproto::Window) -> Result<Cookie<'_, Self, InputSelectedReply>, ConnectionError>
     {
         input_selected(self, destination_window)
     }
 
-    fn shape_get_rectangles<A>(&self, window: Window, source_kind: A) -> Result<Cookie<'_, Self, GetRectanglesReply>, ConnectionError>
+    fn shape_get_rectangles<A>(&self, window: xproto::Window, source_kind: A) -> Result<Cookie<'_, Self, GetRectanglesReply>, ConnectionError>
     where A: Into<Kind>
     {
         get_rectangles(self, window, source_kind)

--- a/src/generated/sync.rs
+++ b/src/generated/sync.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "SYNC";
@@ -1371,7 +1371,7 @@ impl TryFrom<&[u8]> for GetPriorityReply {
 
 /// Opcode for the CreateFence request
 pub const CREATE_FENCE_REQUEST: u8 = 14;
-pub fn create_fence<Conn>(conn: &Conn, drawable: Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_fence<Conn>(conn: &Conn, drawable: xproto::Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1563,7 +1563,7 @@ pub struct CounterNotifyEvent {
     pub counter: Counter,
     pub wait_value: Int64,
     pub counter_value: Int64,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub count: u16,
     pub destroyed: bool,
 }
@@ -1575,7 +1575,7 @@ impl CounterNotifyEvent {
         let (counter, remaining) = Counter::try_parse(remaining)?;
         let (wait_value, remaining) = Int64::try_parse(remaining)?;
         let (counter_value, remaining) = Int64::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (count, remaining) = u16::try_parse(remaining)?;
         let (destroyed, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
@@ -1636,7 +1636,7 @@ pub struct AlarmNotifyEvent {
     pub alarm: Alarm,
     pub counter_value: Int64,
     pub alarm_value: Int64,
-    pub timestamp: Timestamp,
+    pub timestamp: xproto::Timestamp,
     pub state: ALARMSTATE,
 }
 impl AlarmNotifyEvent {
@@ -1647,7 +1647,7 @@ impl AlarmNotifyEvent {
         let (alarm, remaining) = Alarm::try_parse(remaining)?;
         let (counter_value, remaining) = Int64::try_parse(remaining)?;
         let (alarm_value, remaining) = Int64::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
@@ -1769,7 +1769,7 @@ pub trait ConnectionExt: RequestConnection {
         get_priority(self, id)
     }
 
-    fn sync_create_fence(&self, drawable: Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn sync_create_fence(&self, drawable: xproto::Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_fence(self, drawable, fence, initially_triggered)
     }

--- a/src/generated/xfixes.rs
+++ b/src/generated/xfixes.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 #[allow(unused_imports)]
 use super::render;
 #[allow(unused_imports)]
@@ -285,7 +285,7 @@ impl TryFrom<u32> for SaveSetMapping {
 
 /// Opcode for the ChangeSaveSet request
 pub const CHANGE_SAVE_SET_REQUEST: u8 = 1;
-pub fn change_save_set<Conn, A, B, C>(conn: &Conn, mode: A, target: B, map: C, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_save_set<Conn, A, B, C>(conn: &Conn, mode: A, target: B, map: C, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<u8>, B: Into<u8>, C: Into<u8>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -456,22 +456,22 @@ pub struct SelectionNotifyEvent {
     pub response_type: u8,
     pub subtype: SelectionEvent,
     pub sequence: u16,
-    pub window: Window,
-    pub owner: Window,
-    pub selection: Atom,
-    pub timestamp: Timestamp,
-    pub selection_timestamp: Timestamp,
+    pub window: xproto::Window,
+    pub owner: xproto::Window,
+    pub selection: xproto::Atom,
+    pub timestamp: xproto::Timestamp,
+    pub selection_timestamp: xproto::Timestamp,
 }
 impl SelectionNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (subtype, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
-        let (owner, remaining) = Window::try_parse(remaining)?;
-        let (selection, remaining) = Atom::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (selection_timestamp, remaining) = Timestamp::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (owner, remaining) = xproto::Window::try_parse(remaining)?;
+        let (selection, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (selection_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let subtype = subtype.try_into()?;
         let result = SelectionNotifyEvent { response_type, subtype, sequence, window, owner, selection, timestamp, selection_timestamp };
@@ -522,7 +522,7 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectSelectionInput request
 pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
-pub fn select_selection_input<Conn>(conn: &Conn, window: Window, selection: Atom, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_selection_input<Conn>(conn: &Conn, window: xproto::Window, selection: xproto::Atom, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -681,20 +681,20 @@ pub struct CursorNotifyEvent {
     pub response_type: u8,
     pub subtype: CursorNotify,
     pub sequence: u16,
-    pub window: Window,
+    pub window: xproto::Window,
     pub cursor_serial: u32,
-    pub timestamp: Timestamp,
-    pub name: Atom,
+    pub timestamp: xproto::Timestamp,
+    pub name: xproto::Atom,
 }
 impl CursorNotifyEvent {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (subtype, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (cursor_serial, remaining) = u32::try_parse(remaining)?;
-        let (timestamp, remaining) = Timestamp::try_parse(remaining)?;
-        let (name, remaining) = Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let subtype = subtype.try_into()?;
         let result = CursorNotifyEvent { response_type, subtype, sequence, window, cursor_serial, timestamp, name };
@@ -744,7 +744,7 @@ impl From<CursorNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectCursorInput request
 pub const SELECT_CURSOR_INPUT_REQUEST: u8 = 3;
-pub fn select_cursor_input<Conn>(conn: &Conn, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_cursor_input<Conn>(conn: &Conn, window: xproto::Window, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -946,7 +946,7 @@ impl TryFrom<u32> for RegionEnum {
 
 /// Opcode for the CreateRegion request
 pub const CREATE_REGION_REQUEST: u8 = 5;
-pub fn create_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -975,7 +975,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateRegionFromBitmap request
 pub const CREATE_REGION_FROM_BITMAP_REQUEST: u8 = 6;
-pub fn create_region_from_bitmap<Conn>(conn: &Conn, region: Region, bitmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_bitmap<Conn>(conn: &Conn, region: Region, bitmap: xproto::Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1005,7 +1005,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the CreateRegionFromWindow request
 pub const CREATE_REGION_FROM_WINDOW_REQUEST: u8 = 7;
-pub fn create_region_from_window<Conn, A>(conn: &Conn, region: Region, window: Window, kind: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_window<Conn, A>(conn: &Conn, region: Region, window: xproto::Window, kind: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<shape::Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1041,7 +1041,7 @@ where Conn: RequestConnection + ?Sized, A: Into<shape::Kind>
 
 /// Opcode for the CreateRegionFromGC request
 pub const CREATE_REGION_FROM_GC_REQUEST: u8 = 8;
-pub fn create_region_from_gc<Conn>(conn: &Conn, region: Region, gc: Gcontext) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn create_region_from_gc<Conn>(conn: &Conn, region: Region, gc: xproto::Gcontext) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1126,7 +1126,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetRegion request
 pub const SET_REGION_REQUEST: u8 = 11;
-pub fn set_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1290,7 +1290,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the InvertRegion request
 pub const INVERT_REGION_REQUEST: u8 = 16;
-pub fn invert_region<Conn>(conn: &Conn, source: Region, bounds: Rectangle, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn invert_region<Conn>(conn: &Conn, source: Region, bounds: xproto::Rectangle, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1416,8 +1416,8 @@ where Conn: RequestConnection + ?Sized
 pub struct FetchRegionReply {
     pub response_type: u8,
     pub sequence: u16,
-    pub extents: Rectangle,
-    pub rectangles: Vec<Rectangle>,
+    pub extents: xproto::Rectangle,
+    pub rectangles: Vec<xproto::Rectangle>,
 }
 impl FetchRegionReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1425,9 +1425,9 @@ impl FetchRegionReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (extents, remaining) = Rectangle::try_parse(remaining)?;
+        let (extents, remaining) = xproto::Rectangle::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (rectangles, remaining) = crate::x11_utils::parse_list::<Rectangle>(remaining, (length as usize) / (2))?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, (length as usize) / (2))?;
         let result = FetchRegionReply { response_type, sequence, extents, rectangles };
         Ok((result, remaining))
     }
@@ -1441,7 +1441,7 @@ impl TryFrom<&[u8]> for FetchRegionReply {
 
 /// Opcode for the SetGCClipRegion request
 pub const SET_GC_CLIP_REGION_REQUEST: u8 = 20;
-pub fn set_gc_clip_region<Conn>(conn: &Conn, gc: Gcontext, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_gc_clip_region<Conn>(conn: &Conn, gc: xproto::Gcontext, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1477,7 +1477,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetWindowShapeRegion request
 pub const SET_WINDOW_SHAPE_REGION_REQUEST: u8 = 21;
-pub fn set_window_shape_region<Conn, A>(conn: &Conn, dest: Window, dest_kind: A, x_offset: i16, y_offset: i16, region: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_window_shape_region<Conn, A>(conn: &Conn, dest: xproto::Window, dest_kind: A, x_offset: i16, y_offset: i16, region: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<shape::Kind>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1555,7 +1555,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SetCursorName request
 pub const SET_CURSOR_NAME_REQUEST: u8 = 23;
-pub fn set_cursor_name<'c, Conn>(conn: &'c Conn, cursor: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_cursor_name<'c, Conn>(conn: &'c Conn, cursor: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1589,7 +1589,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetCursorName request
 pub const GET_CURSOR_NAME_REQUEST: u8 = 24;
-pub fn get_cursor_name<Conn>(conn: &Conn, cursor: Cursor) -> Result<Cookie<'_, Conn, GetCursorNameReply>, ConnectionError>
+pub fn get_cursor_name<Conn>(conn: &Conn, cursor: xproto::Cursor) -> Result<Cookie<'_, Conn, GetCursorNameReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1616,7 +1616,7 @@ pub struct GetCursorNameReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub atom: Atom,
+    pub atom: xproto::Atom,
     pub name: Vec<u8>,
 }
 impl GetCursorNameReply {
@@ -1625,7 +1625,7 @@ impl GetCursorNameReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (atom, remaining) = Atom::try_parse(remaining)?;
+        let (atom, remaining) = xproto::Atom::try_parse(remaining)?;
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
         let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
@@ -1671,7 +1671,7 @@ pub struct GetCursorImageAndNameReply {
     pub xhot: u16,
     pub yhot: u16,
     pub cursor_serial: u32,
-    pub cursor_atom: Atom,
+    pub cursor_atom: xproto::Atom,
     pub cursor_image: Vec<u32>,
     pub name: Vec<u8>,
 }
@@ -1688,7 +1688,7 @@ impl GetCursorImageAndNameReply {
         let (xhot, remaining) = u16::try_parse(remaining)?;
         let (yhot, remaining) = u16::try_parse(remaining)?;
         let (cursor_serial, remaining) = u32::try_parse(remaining)?;
-        let (cursor_atom, remaining) = Atom::try_parse(remaining)?;
+        let (cursor_atom, remaining) = xproto::Atom::try_parse(remaining)?;
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
@@ -1706,7 +1706,7 @@ impl TryFrom<&[u8]> for GetCursorImageAndNameReply {
 
 /// Opcode for the ChangeCursor request
 pub const CHANGE_CURSOR_REQUEST: u8 = 26;
-pub fn change_cursor<Conn>(conn: &Conn, source: Cursor, destination: Cursor) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_cursor<Conn>(conn: &Conn, source: xproto::Cursor, destination: xproto::Cursor) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1736,7 +1736,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ChangeCursorByName request
 pub const CHANGE_CURSOR_BY_NAME_REQUEST: u8 = 27;
-pub fn change_cursor_by_name<'c, Conn>(conn: &'c Conn, src: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_cursor_by_name<'c, Conn>(conn: &'c Conn, src: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1812,7 +1812,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the HideCursor request
 pub const HIDE_CURSOR_REQUEST: u8 = 29;
-pub fn hide_cursor<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn hide_cursor<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1837,7 +1837,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ShowCursor request
 pub const SHOW_CURSOR_REQUEST: u8 = 30;
-pub fn show_cursor<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn show_cursor<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1933,7 +1933,7 @@ bitmask_binop!(BarrierDirections, u8);
 
 /// Opcode for the CreatePointerBarrier request
 pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;
-pub fn create_pointer_barrier<'c, Conn>(conn: &'c Conn, barrier: Barrier, window: Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pointer_barrier<'c, Conn>(conn: &'c Conn, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2020,18 +2020,18 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, client_major_version, client_minor_version)
     }
 
-    fn xfixes_change_save_set<A, B, C>(&self, mode: A, target: B, map: C, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_change_save_set<A, B, C>(&self, mode: A, target: B, map: C, window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<u8>, B: Into<u8>, C: Into<u8>
     {
         change_save_set(self, mode, target, map, window)
     }
 
-    fn xfixes_select_selection_input(&self, window: Window, selection: Atom, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_select_selection_input(&self, window: xproto::Window, selection: xproto::Atom, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_selection_input(self, window, selection, event_mask)
     }
 
-    fn xfixes_select_cursor_input(&self, window: Window, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_select_cursor_input(&self, window: xproto::Window, event_mask: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_cursor_input(self, window, event_mask)
     }
@@ -2041,23 +2041,23 @@ pub trait ConnectionExt: RequestConnection {
         get_cursor_image(self)
     }
 
-    fn xfixes_create_region<'c>(&'c self, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_create_region<'c>(&'c self, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_region(self, region, rectangles)
     }
 
-    fn xfixes_create_region_from_bitmap(&self, region: Region, bitmap: Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_create_region_from_bitmap(&self, region: Region, bitmap: xproto::Pixmap) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_region_from_bitmap(self, region, bitmap)
     }
 
-    fn xfixes_create_region_from_window<A>(&self, region: Region, window: Window, kind: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_create_region_from_window<A>(&self, region: Region, window: xproto::Window, kind: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<shape::Kind>
     {
         create_region_from_window(self, region, window, kind)
     }
 
-    fn xfixes_create_region_from_gc(&self, region: Region, gc: Gcontext) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_create_region_from_gc(&self, region: Region, gc: xproto::Gcontext) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         create_region_from_gc(self, region, gc)
     }
@@ -2072,7 +2072,7 @@ pub trait ConnectionExt: RequestConnection {
         destroy_region(self, region)
     }
 
-    fn xfixes_set_region<'c>(&'c self, region: Region, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_set_region<'c>(&'c self, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_region(self, region, rectangles)
     }
@@ -2097,7 +2097,7 @@ pub trait ConnectionExt: RequestConnection {
         subtract_region(self, source1, source2, destination)
     }
 
-    fn xfixes_invert_region(&self, source: Region, bounds: Rectangle, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_invert_region(&self, source: Region, bounds: xproto::Rectangle, destination: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         invert_region(self, source, bounds, destination)
     }
@@ -2117,12 +2117,12 @@ pub trait ConnectionExt: RequestConnection {
         fetch_region(self, region)
     }
 
-    fn xfixes_set_gc_clip_region(&self, gc: Gcontext, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_set_gc_clip_region(&self, gc: xproto::Gcontext, region: Region, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_gc_clip_region(self, gc, region, x_origin, y_origin)
     }
 
-    fn xfixes_set_window_shape_region<A>(&self, dest: Window, dest_kind: A, x_offset: i16, y_offset: i16, region: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_set_window_shape_region<A>(&self, dest: xproto::Window, dest_kind: A, x_offset: i16, y_offset: i16, region: Region) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<shape::Kind>
     {
         set_window_shape_region(self, dest, dest_kind, x_offset, y_offset, region)
@@ -2133,12 +2133,12 @@ pub trait ConnectionExt: RequestConnection {
         set_picture_clip_region(self, picture, region, x_origin, y_origin)
     }
 
-    fn xfixes_set_cursor_name<'c>(&'c self, cursor: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_set_cursor_name<'c>(&'c self, cursor: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_cursor_name(self, cursor, name)
     }
 
-    fn xfixes_get_cursor_name(&self, cursor: Cursor) -> Result<Cookie<'_, Self, GetCursorNameReply>, ConnectionError>
+    fn xfixes_get_cursor_name(&self, cursor: xproto::Cursor) -> Result<Cookie<'_, Self, GetCursorNameReply>, ConnectionError>
     {
         get_cursor_name(self, cursor)
     }
@@ -2148,12 +2148,12 @@ pub trait ConnectionExt: RequestConnection {
         get_cursor_image_and_name(self)
     }
 
-    fn xfixes_change_cursor(&self, source: Cursor, destination: Cursor) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_change_cursor(&self, source: xproto::Cursor, destination: xproto::Cursor) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         change_cursor(self, source, destination)
     }
 
-    fn xfixes_change_cursor_by_name<'c>(&'c self, src: Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_change_cursor_by_name<'c>(&'c self, src: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_cursor_by_name(self, src, name)
     }
@@ -2163,17 +2163,17 @@ pub trait ConnectionExt: RequestConnection {
         expand_region(self, source, destination, left, right, top, bottom)
     }
 
-    fn xfixes_hide_cursor(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_hide_cursor(&self, window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         hide_cursor(self, window)
     }
 
-    fn xfixes_show_cursor(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xfixes_show_cursor(&self, window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         show_cursor(self, window)
     }
 
-    fn xfixes_create_pointer_barrier<'c>(&'c self, barrier: Barrier, window: Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_create_pointer_barrier<'c>(&'c self, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: u32, devices: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pointer_barrier(self, barrier, window, x1, y1, x2, y2, directions, devices)
     }

--- a/src/generated/xinerama.rs
+++ b/src/generated/xinerama.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "XINERAMA";
@@ -140,7 +140,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 1;
-pub fn get_state<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
+pub fn get_state<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -168,7 +168,7 @@ pub struct GetStateReply {
     pub state: u8,
     pub sequence: u16,
     pub length: u32,
-    pub window: Window,
+    pub window: xproto::Window,
 }
 impl GetStateReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -176,7 +176,7 @@ impl GetStateReply {
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let result = GetStateReply { response_type, state, sequence, length, window };
         Ok((result, remaining))
     }
@@ -190,7 +190,7 @@ impl TryFrom<&[u8]> for GetStateReply {
 
 /// Opcode for the GetScreenCount request
 pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
-pub fn get_screen_count<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetScreenCountReply>, ConnectionError>
+pub fn get_screen_count<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenCountReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -218,7 +218,7 @@ pub struct GetScreenCountReply {
     pub screen_count: u8,
     pub sequence: u16,
     pub length: u32,
-    pub window: Window,
+    pub window: xproto::Window,
 }
 impl GetScreenCountReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -226,7 +226,7 @@ impl GetScreenCountReply {
         let (screen_count, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let result = GetScreenCountReply { response_type, screen_count, sequence, length, window };
         Ok((result, remaining))
     }
@@ -240,7 +240,7 @@ impl TryFrom<&[u8]> for GetScreenCountReply {
 
 /// Opcode for the GetScreenSize request
 pub const GET_SCREEN_SIZE_REQUEST: u8 = 3;
-pub fn get_screen_size<Conn>(conn: &Conn, window: Window, screen: u32) -> Result<Cookie<'_, Conn, GetScreenSizeReply>, ConnectionError>
+pub fn get_screen_size<Conn>(conn: &Conn, window: xproto::Window, screen: u32) -> Result<Cookie<'_, Conn, GetScreenSizeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -274,7 +274,7 @@ pub struct GetScreenSizeReply {
     pub length: u32,
     pub width: u32,
     pub height: u32,
-    pub window: Window,
+    pub window: xproto::Window,
     pub screen: u32,
 }
 impl GetScreenSizeReply {
@@ -285,7 +285,7 @@ impl GetScreenSizeReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (width, remaining) = u32::try_parse(remaining)?;
         let (height, remaining) = u32::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (screen, remaining) = u32::try_parse(remaining)?;
         let result = GetScreenSizeReply { response_type, sequence, length, width, height, window, screen };
         Ok((result, remaining))
@@ -395,17 +395,17 @@ pub trait ConnectionExt: RequestConnection {
         query_version(self, major, minor)
     }
 
-    fn xinerama_get_state(&self, window: Window) -> Result<Cookie<'_, Self, GetStateReply>, ConnectionError>
+    fn xinerama_get_state(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetStateReply>, ConnectionError>
     {
         get_state(self, window)
     }
 
-    fn xinerama_get_screen_count(&self, window: Window) -> Result<Cookie<'_, Self, GetScreenCountReply>, ConnectionError>
+    fn xinerama_get_screen_count(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetScreenCountReply>, ConnectionError>
     {
         get_screen_count(self, window)
     }
 
-    fn xinerama_get_screen_size(&self, window: Window, screen: u32) -> Result<Cookie<'_, Self, GetScreenSizeReply>, ConnectionError>
+    fn xinerama_get_screen_size(&self, window: xproto::Window, screen: u32) -> Result<Cookie<'_, Self, GetScreenSizeReply>, ConnectionError>
     {
         get_screen_size(self, window, screen)
     }

--- a/src/generated/xkb.rs
+++ b/src/generated/xkb.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "XKEYBOARD";
@@ -2777,7 +2777,7 @@ pub struct KeySymMap {
     pub kt_index: [u8; 4],
     pub group_info: u8,
     pub width: u8,
-    pub syms: Vec<Keysym>,
+    pub syms: Vec<xproto::Keysym>,
 }
 impl TryParse for KeySymMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2794,7 +2794,7 @@ impl TryParse for KeySymMap {
         let (group_info, remaining) = u8::try_parse(remaining)?;
         let (width, remaining) = u8::try_parse(remaining)?;
         let (n_syms, remaining) = u16::try_parse(remaining)?;
-        let (syms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, n_syms as usize)?;
+        let (syms, remaining) = crate::x11_utils::parse_list::<xproto::Keysym>(remaining, n_syms as usize)?;
         let result = KeySymMap { kt_index, group_info, width, syms };
         Ok((result, remaining))
     }
@@ -2966,12 +2966,12 @@ impl Serialize for RadioGroupBehavior {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OverlayBehavior {
     pub type_: u8,
-    pub key: Keycode,
+    pub key: xproto::Keycode,
 }
 impl TryParse for OverlayBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (key, remaining) = Keycode::try_parse(remaining)?;
+        let (key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let result = OverlayBehavior { type_, key };
         Ok((result, remaining))
     }
@@ -3072,12 +3072,12 @@ impl Serialize for PermamentRadioGroupBehavior {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PermamentOverlayBehavior {
     pub type_: u8,
-    pub key: Keycode,
+    pub key: xproto::Keycode,
 }
 impl TryParse for PermamentOverlayBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (key, remaining) = Keycode::try_parse(remaining)?;
+        let (key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let result = PermamentOverlayBehavior { type_, key };
         Ok((result, remaining))
     }
@@ -3108,7 +3108,7 @@ impl Serialize for PermamentOverlayBehavior {
 #[derive(Debug, Copy, Clone)]
 pub struct Behavior([u8; 2]);
 impl Behavior {
-    pub fn as_common(&self) -> CommonBehavior {
+    pub fn as_xproto_common(&self) -> CommonBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<CommonBehavior, ParseError> {
             let (common, remaining) = CommonBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3116,7 +3116,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_default(&self) -> DefaultBehavior {
+    pub fn as_xproto_default(&self) -> DefaultBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<DefaultBehavior, ParseError> {
             let (default, remaining) = DefaultBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3124,7 +3124,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_lock(&self) -> LockBehavior {
+    pub fn as_xproto_lock(&self) -> LockBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<LockBehavior, ParseError> {
             let (lock, remaining) = LockBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3132,7 +3132,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_radio_group(&self) -> RadioGroupBehavior {
+    pub fn as_xproto_radio_group(&self) -> RadioGroupBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<RadioGroupBehavior, ParseError> {
             let (radio_group, remaining) = RadioGroupBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3140,7 +3140,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_overlay1(&self) -> OverlayBehavior {
+    pub fn as_xproto_overlay1(&self) -> OverlayBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<OverlayBehavior, ParseError> {
             let (overlay1, remaining) = OverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3148,7 +3148,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_overlay2(&self) -> OverlayBehavior {
+    pub fn as_xproto_overlay2(&self) -> OverlayBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<OverlayBehavior, ParseError> {
             let (overlay2, remaining) = OverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3156,7 +3156,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_permament_lock(&self) -> PermamentLockBehavior {
+    pub fn as_xproto_permament_lock(&self) -> PermamentLockBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<PermamentLockBehavior, ParseError> {
             let (permament_lock, remaining) = PermamentLockBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3164,7 +3164,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_permament_radio_group(&self) -> PermamentRadioGroupBehavior {
+    pub fn as_xproto_permament_radio_group(&self) -> PermamentRadioGroupBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<PermamentRadioGroupBehavior, ParseError> {
             let (permament_radio_group, remaining) = PermamentRadioGroupBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3172,7 +3172,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_permament_overlay1(&self) -> PermamentOverlayBehavior {
+    pub fn as_xproto_permament_overlay1(&self) -> PermamentOverlayBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<PermamentOverlayBehavior, ParseError> {
             let (permament_overlay1, remaining) = PermamentOverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3180,7 +3180,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_permament_overlay2(&self) -> PermamentOverlayBehavior {
+    pub fn as_xproto_permament_overlay2(&self) -> PermamentOverlayBehavior {
         fn do_the_parse(remaining: &[u8]) -> Result<PermamentOverlayBehavior, ParseError> {
             let (permament_overlay2, remaining) = PermamentOverlayBehavior::try_parse(remaining)?;
             let _ = remaining;
@@ -3188,7 +3188,7 @@ impl Behavior {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_type(&self) -> u8 {
+    pub fn as_xproto_type(&self) -> u8 {
         fn do_the_parse(remaining: &[u8]) -> Result<u8, ParseError> {
             let (type_, remaining) = u8::try_parse(remaining)?;
             let _ = remaining;
@@ -3331,12 +3331,12 @@ impl TryFrom<u32> for BehaviorType {
 
 #[derive(Debug, Clone, Copy)]
 pub struct SetBehavior {
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub behavior: Behavior,
 }
 impl TryParse for SetBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (behavior, remaining) = Behavior::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = SetBehavior { keycode, behavior };
@@ -3371,12 +3371,12 @@ impl Serialize for SetBehavior {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetExplicit {
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub explicit: u8,
 }
 impl TryParse for SetExplicit {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (explicit, remaining) = u8::try_parse(remaining)?;
         let result = SetExplicit { keycode, explicit };
         Ok((result, remaining))
@@ -3407,12 +3407,12 @@ impl Serialize for SetExplicit {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyModMap {
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub mods: u8,
 }
 impl TryParse for KeyModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let result = KeyModMap { keycode, mods };
         Ok((result, remaining))
@@ -3443,12 +3443,12 @@ impl Serialize for KeyModMap {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyVModMap {
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub vmods: u16,
 }
 impl TryParse for KeyVModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (vmods, remaining) = u16::try_parse(remaining)?;
         let result = KeyVModMap { keycode, vmods };
@@ -3581,14 +3581,14 @@ pub type String8 = u8;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Outline {
     pub corner_radius: u8,
-    pub points: Vec<Point>,
+    pub points: Vec<xproto::Point>,
 }
 impl TryParse for Outline {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (n_points, remaining) = u8::try_parse(remaining)?;
         let (corner_radius, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (points, remaining) = crate::x11_utils::parse_list::<Point>(remaining, n_points as usize)?;
+        let (points, remaining) = crate::x11_utils::parse_list::<xproto::Point>(remaining, n_points as usize)?;
         let result = Outline { corner_radius, points };
         Ok((result, remaining))
     }
@@ -3618,14 +3618,14 @@ impl Serialize for Outline {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Shape {
-    pub name: Atom,
+    pub name: xproto::Atom,
     pub primary_ndx: u8,
     pub approx_ndx: u8,
     pub outlines: Vec<Outline>,
 }
 impl TryParse for Shape {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = Atom::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (n_outlines, remaining) = u8::try_parse(remaining)?;
         let (primary_ndx, remaining) = u8::try_parse(remaining)?;
         let (approx_ndx, remaining) = u8::try_parse(remaining)?;
@@ -3816,12 +3816,12 @@ impl Serialize for OverlayRow {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Overlay {
-    pub name: Atom,
+    pub name: xproto::Atom,
     pub rows: Vec<OverlayRow>,
 }
 impl TryParse for Overlay {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = Atom::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (n_rows, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let (rows, remaining) = crate::x11_utils::parse_list::<OverlayRow>(remaining, n_rows as usize)?;
@@ -4017,7 +4017,7 @@ pub struct DeviceLedInfo {
     pub maps_present: u32,
     pub phys_indicators: u32,
     pub state: u32,
-    pub names: Vec<Atom>,
+    pub names: Vec<xproto::Atom>,
     pub maps: Vec<IndicatorMap>,
 }
 impl TryParse for DeviceLedInfo {
@@ -4028,7 +4028,7 @@ impl TryParse for DeviceLedInfo {
         let (maps_present, remaining) = u32::try_parse(remaining)?;
         let (phys_indicators, remaining) = u32::try_parse(remaining)?;
         let (state, remaining) = u32::try_parse(remaining)?;
-        let (names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(names_present.count_ones()).unwrap())?;
+        let (names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, TryInto::<usize>::try_into(names_present.count_ones()).unwrap())?;
         let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, TryInto::<usize>::try_into(maps_present.count_ones()).unwrap())?;
         let led_class = led_class.try_into()?;
         let result = DeviceLedInfo { led_class, led_id, names_present, maps_present, phys_indicators, state, names, maps };
@@ -5787,7 +5787,7 @@ impl Serialize for SAActionMessage {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SARedirectKey {
     pub type_: SAType,
-    pub newkey: Keycode,
+    pub newkey: xproto::Keycode,
     pub mask: u8,
     pub real_modifiers: u8,
     pub vmods_mask_high: u8,
@@ -5798,7 +5798,7 @@ pub struct SARedirectKey {
 impl TryParse for SARedirectKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (newkey, remaining) = Keycode::try_parse(remaining)?;
+        let (newkey, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (mask, remaining) = u8::try_parse(remaining)?;
         let (real_modifiers, remaining) = u8::try_parse(remaining)?;
         let (vmods_mask_high, remaining) = u8::try_parse(remaining)?;
@@ -6228,7 +6228,7 @@ impl Serialize for SIAction {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SymInterpret {
-    pub sym: Keysym,
+    pub sym: xproto::Keysym,
     pub mods: u8,
     pub match_: u8,
     pub virtual_mod: u8,
@@ -6237,7 +6237,7 @@ pub struct SymInterpret {
 }
 impl TryParse for SymInterpret {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (sym, remaining) = Keysym::try_parse(remaining)?;
+        let (sym, remaining) = xproto::Keysym::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let (match_, remaining) = u8::try_parse(remaining)?;
         let (virtual_mod, remaining) = u8::try_parse(remaining)?;
@@ -6295,7 +6295,7 @@ impl Serialize for SymInterpret {
 #[derive(Debug, Copy, Clone)]
 pub struct Action([u8; 8]);
 impl Action {
-    pub fn as_noaction(&self) -> SANoAction {
+    pub fn as_xproto_noaction(&self) -> SANoAction {
         fn do_the_parse(remaining: &[u8]) -> Result<SANoAction, ParseError> {
             let (noaction, remaining) = SANoAction::try_parse(remaining)?;
             let _ = remaining;
@@ -6303,7 +6303,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_setmods(&self) -> SASetMods {
+    pub fn as_xproto_setmods(&self) -> SASetMods {
         fn do_the_parse(remaining: &[u8]) -> Result<SASetMods, ParseError> {
             let (setmods, remaining) = SASetMods::try_parse(remaining)?;
             let _ = remaining;
@@ -6311,7 +6311,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_latchmods(&self) -> SALatchMods {
+    pub fn as_xproto_latchmods(&self) -> SALatchMods {
         fn do_the_parse(remaining: &[u8]) -> Result<SALatchMods, ParseError> {
             let (latchmods, remaining) = SALatchMods::try_parse(remaining)?;
             let _ = remaining;
@@ -6319,7 +6319,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_lockmods(&self) -> SALockMods {
+    pub fn as_xproto_lockmods(&self) -> SALockMods {
         fn do_the_parse(remaining: &[u8]) -> Result<SALockMods, ParseError> {
             let (lockmods, remaining) = SALockMods::try_parse(remaining)?;
             let _ = remaining;
@@ -6327,7 +6327,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_setgroup(&self) -> SASetGroup {
+    pub fn as_xproto_setgroup(&self) -> SASetGroup {
         fn do_the_parse(remaining: &[u8]) -> Result<SASetGroup, ParseError> {
             let (setgroup, remaining) = SASetGroup::try_parse(remaining)?;
             let _ = remaining;
@@ -6335,7 +6335,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_latchgroup(&self) -> SALatchGroup {
+    pub fn as_xproto_latchgroup(&self) -> SALatchGroup {
         fn do_the_parse(remaining: &[u8]) -> Result<SALatchGroup, ParseError> {
             let (latchgroup, remaining) = SALatchGroup::try_parse(remaining)?;
             let _ = remaining;
@@ -6343,7 +6343,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_lockgroup(&self) -> SALockGroup {
+    pub fn as_xproto_lockgroup(&self) -> SALockGroup {
         fn do_the_parse(remaining: &[u8]) -> Result<SALockGroup, ParseError> {
             let (lockgroup, remaining) = SALockGroup::try_parse(remaining)?;
             let _ = remaining;
@@ -6351,7 +6351,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_moveptr(&self) -> SAMovePtr {
+    pub fn as_xproto_moveptr(&self) -> SAMovePtr {
         fn do_the_parse(remaining: &[u8]) -> Result<SAMovePtr, ParseError> {
             let (moveptr, remaining) = SAMovePtr::try_parse(remaining)?;
             let _ = remaining;
@@ -6359,7 +6359,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_ptrbtn(&self) -> SAPtrBtn {
+    pub fn as_xproto_ptrbtn(&self) -> SAPtrBtn {
         fn do_the_parse(remaining: &[u8]) -> Result<SAPtrBtn, ParseError> {
             let (ptrbtn, remaining) = SAPtrBtn::try_parse(remaining)?;
             let _ = remaining;
@@ -6367,7 +6367,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_lockptrbtn(&self) -> SALockPtrBtn {
+    pub fn as_xproto_lockptrbtn(&self) -> SALockPtrBtn {
         fn do_the_parse(remaining: &[u8]) -> Result<SALockPtrBtn, ParseError> {
             let (lockptrbtn, remaining) = SALockPtrBtn::try_parse(remaining)?;
             let _ = remaining;
@@ -6375,7 +6375,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_setptrdflt(&self) -> SASetPtrDflt {
+    pub fn as_xproto_setptrdflt(&self) -> SASetPtrDflt {
         fn do_the_parse(remaining: &[u8]) -> Result<SASetPtrDflt, ParseError> {
             let (setptrdflt, remaining) = SASetPtrDflt::try_parse(remaining)?;
             let _ = remaining;
@@ -6383,7 +6383,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_isolock(&self) -> SAIsoLock {
+    pub fn as_xproto_isolock(&self) -> SAIsoLock {
         fn do_the_parse(remaining: &[u8]) -> Result<SAIsoLock, ParseError> {
             let (isolock, remaining) = SAIsoLock::try_parse(remaining)?;
             let _ = remaining;
@@ -6391,7 +6391,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_terminate(&self) -> SATerminate {
+    pub fn as_xproto_terminate(&self) -> SATerminate {
         fn do_the_parse(remaining: &[u8]) -> Result<SATerminate, ParseError> {
             let (terminate, remaining) = SATerminate::try_parse(remaining)?;
             let _ = remaining;
@@ -6399,7 +6399,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_switchscreen(&self) -> SASwitchScreen {
+    pub fn as_xproto_switchscreen(&self) -> SASwitchScreen {
         fn do_the_parse(remaining: &[u8]) -> Result<SASwitchScreen, ParseError> {
             let (switchscreen, remaining) = SASwitchScreen::try_parse(remaining)?;
             let _ = remaining;
@@ -6407,7 +6407,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_setcontrols(&self) -> SASetControls {
+    pub fn as_xproto_setcontrols(&self) -> SASetControls {
         fn do_the_parse(remaining: &[u8]) -> Result<SASetControls, ParseError> {
             let (setcontrols, remaining) = SASetControls::try_parse(remaining)?;
             let _ = remaining;
@@ -6415,7 +6415,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_lockcontrols(&self) -> SALockControls {
+    pub fn as_xproto_lockcontrols(&self) -> SALockControls {
         fn do_the_parse(remaining: &[u8]) -> Result<SALockControls, ParseError> {
             let (lockcontrols, remaining) = SALockControls::try_parse(remaining)?;
             let _ = remaining;
@@ -6423,7 +6423,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_message(&self) -> SAActionMessage {
+    pub fn as_xproto_message(&self) -> SAActionMessage {
         fn do_the_parse(remaining: &[u8]) -> Result<SAActionMessage, ParseError> {
             let (message, remaining) = SAActionMessage::try_parse(remaining)?;
             let _ = remaining;
@@ -6431,7 +6431,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_redirect(&self) -> SARedirectKey {
+    pub fn as_xproto_redirect(&self) -> SARedirectKey {
         fn do_the_parse(remaining: &[u8]) -> Result<SARedirectKey, ParseError> {
             let (redirect, remaining) = SARedirectKey::try_parse(remaining)?;
             let _ = remaining;
@@ -6439,7 +6439,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_devbtn(&self) -> SADeviceBtn {
+    pub fn as_xproto_devbtn(&self) -> SADeviceBtn {
         fn do_the_parse(remaining: &[u8]) -> Result<SADeviceBtn, ParseError> {
             let (devbtn, remaining) = SADeviceBtn::try_parse(remaining)?;
             let _ = remaining;
@@ -6447,7 +6447,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_lockdevbtn(&self) -> SALockDeviceBtn {
+    pub fn as_xproto_lockdevbtn(&self) -> SALockDeviceBtn {
         fn do_the_parse(remaining: &[u8]) -> Result<SALockDeviceBtn, ParseError> {
             let (lockdevbtn, remaining) = SALockDeviceBtn::try_parse(remaining)?;
             let _ = remaining;
@@ -6455,7 +6455,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_devval(&self) -> SADeviceValuator {
+    pub fn as_xproto_devval(&self) -> SADeviceValuator {
         fn do_the_parse(remaining: &[u8]) -> Result<SADeviceValuator, ParseError> {
             let (devval, remaining) = SADeviceValuator::try_parse(remaining)?;
             let _ = remaining;
@@ -6463,7 +6463,7 @@ impl Action {
         }
         do_the_parse(&self.0).unwrap()
     }
-    pub fn as_type(&self) -> u8 {
+    pub fn as_xproto_type(&self) -> u8 {
         fn do_the_parse(remaining: &[u8]) -> Result<u8, ParseError> {
             let (type_, remaining) = u8::try_parse(remaining)?;
             let _ = remaining;
@@ -7096,7 +7096,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 3;
-pub fn bell<Conn>(conn: &Conn, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: Atom, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn bell<Conn>(conn: &Conn, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: xproto::Atom, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7552,7 +7552,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetMap request
 pub const GET_MAP_REQUEST: u8 = 8;
-pub fn get_map<Conn>(conn: &Conn, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, first_key_action: Keycode, n_key_actions: u8, first_key_behavior: Keycode, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: Keycode, n_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
+pub fn get_map<Conn>(conn: &Conn, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -7746,28 +7746,28 @@ pub struct GetMapReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub min_key_code: Keycode,
-    pub max_key_code: Keycode,
+    pub min_key_code: xproto::Keycode,
+    pub max_key_code: xproto::Keycode,
     pub present: u16,
     pub first_type: u8,
     pub n_types: u8,
     pub total_types: u8,
-    pub first_key_sym: Keycode,
+    pub first_key_sym: xproto::Keycode,
     pub total_syms: u16,
     pub n_key_syms: u8,
-    pub first_key_action: Keycode,
+    pub first_key_action: xproto::Keycode,
     pub total_actions: u16,
     pub n_key_actions: u8,
-    pub first_key_behavior: Keycode,
+    pub first_key_behavior: xproto::Keycode,
     pub n_key_behaviors: u8,
     pub total_key_behaviors: u8,
-    pub first_key_explicit: Keycode,
+    pub first_key_explicit: xproto::Keycode,
     pub n_key_explicit: u8,
     pub total_key_explicit: u8,
-    pub first_mod_map_key: Keycode,
+    pub first_mod_map_key: xproto::Keycode,
     pub n_mod_map_keys: u8,
     pub total_mod_map_keys: u8,
-    pub first_v_mod_map_key: Keycode,
+    pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
     pub total_v_mod_map_keys: u8,
     pub virtual_mods: u16,
@@ -7780,28 +7780,28 @@ impl GetMapReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
-        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (present, remaining) = u16::try_parse(remaining)?;
         let (first_type, remaining) = u8::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
         let (total_types, remaining) = u8::try_parse(remaining)?;
-        let (first_key_sym, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_sym, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (total_syms, remaining) = u16::try_parse(remaining)?;
         let (n_key_syms, remaining) = u8::try_parse(remaining)?;
-        let (first_key_action, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_action, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (total_actions, remaining) = u16::try_parse(remaining)?;
         let (n_key_actions, remaining) = u8::try_parse(remaining)?;
-        let (first_key_behavior, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_behavior, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_behaviors, remaining) = u8::try_parse(remaining)?;
         let (total_key_behaviors, remaining) = u8::try_parse(remaining)?;
-        let (first_key_explicit, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_explicit, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
         let (total_key_explicit, remaining) = u8::try_parse(remaining)?;
-        let (first_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
+        let (first_mod_map_key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (total_mod_map_keys, remaining) = u8::try_parse(remaining)?;
-        let (first_v_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
+        let (first_v_mod_map_key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (total_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
@@ -7959,7 +7959,7 @@ impl Serialize for SetMapAux {
         }
     }
 }
-pub fn set_map<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, flags: u16, min_key_code: Keycode, max_key_code: Keycode, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, total_syms: u16, first_key_action: Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_map<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, flags: u16, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8305,7 +8305,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetNamedIndicator request
 pub const GET_NAMED_INDICATOR_REQUEST: u8 = 15;
-pub fn get_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom) -> Result<Cookie<'_, Conn, GetNamedIndicatorReply>, ConnectionError>
+pub fn get_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: xproto::Atom) -> Result<Cookie<'_, Conn, GetNamedIndicatorReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<LedClassSpec>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8345,7 +8345,7 @@ pub struct GetNamedIndicatorReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub indicator: Atom,
+    pub indicator: xproto::Atom,
     pub found: bool,
     pub on: bool,
     pub real_indicator: bool,
@@ -8366,7 +8366,7 @@ impl GetNamedIndicatorReply {
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (indicator, remaining) = Atom::try_parse(remaining)?;
+        let (indicator, remaining) = xproto::Atom::try_parse(remaining)?;
         let (found, remaining) = bool::try_parse(remaining)?;
         let (on, remaining) = bool::try_parse(remaining)?;
         let (real_indicator, remaining) = bool::try_parse(remaining)?;
@@ -8394,7 +8394,7 @@ impl TryFrom<&[u8]> for GetNamedIndicatorReply {
 
 /// Opcode for the SetNamedIndicator request
 pub const SET_NAMED_INDICATOR_REQUEST: u8 = 16;
-pub fn set_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized, A: Into<LedClassSpec>
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -8488,7 +8488,7 @@ where Conn: RequestConnection + ?Sized
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetNamesValueListBitcase8 {
     pub n_levels_per_type: Vec<u8>,
-    pub kt_level_names: Vec<Atom>,
+    pub kt_level_names: Vec<xproto::Atom>,
 }
 impl GetNamesValueListBitcase8 {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -8498,7 +8498,7 @@ impl GetNamesValueListBitcase8 {
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, n_levels_per_type.iter().map(|x| TryInto::<usize>::try_into(*x).unwrap()).sum())?;
+        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().map(|x| TryInto::<usize>::try_into(*x).unwrap()).sum())?;
         let result = GetNamesValueListBitcase8 { n_levels_per_type, kt_level_names };
         Ok((result, remaining))
     }
@@ -8520,27 +8520,27 @@ impl Serialize for GetNamesValueListBitcase8 {
 }
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GetNamesValueList {
-    pub keycodes_name: Option<Atom>,
-    pub geometry_name: Option<Atom>,
-    pub symbols_name: Option<Atom>,
-    pub phys_symbols_name: Option<Atom>,
-    pub types_name: Option<Atom>,
-    pub compat_name: Option<Atom>,
-    pub type_names: Option<Vec<Atom>>,
+    pub keycodes_name: Option<xproto::Atom>,
+    pub geometry_name: Option<xproto::Atom>,
+    pub symbols_name: Option<xproto::Atom>,
+    pub phys_symbols_name: Option<xproto::Atom>,
+    pub types_name: Option<xproto::Atom>,
+    pub compat_name: Option<xproto::Atom>,
+    pub type_names: Option<Vec<xproto::Atom>>,
     pub bitcase8: Option<GetNamesValueListBitcase8>,
-    pub indicator_names: Option<Vec<Atom>>,
-    pub virtual_mod_names: Option<Vec<Atom>>,
-    pub groups: Option<Vec<Atom>>,
+    pub indicator_names: Option<Vec<xproto::Atom>>,
+    pub virtual_mod_names: Option<Vec<xproto::Atom>>,
+    pub groups: Option<Vec<xproto::Atom>>,
     pub key_names: Option<Vec<KeyName>>,
     pub key_aliases: Option<Vec<KeyAlias>>,
-    pub radio_group_names: Option<Vec<Atom>>,
+    pub radio_group_names: Option<Vec<xproto::Atom>>,
 }
 impl GetNamesValueList {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
         let mut outer_remaining = value;
         let keycodes_name = if which & Into::<u32>::into(NameDetail::Keycodes) != 0 {
             let remaining = outer_remaining;
-            let (keycodes_name, remaining) = Atom::try_parse(remaining)?;
+            let (keycodes_name, remaining) = xproto::Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(keycodes_name)
         } else {
@@ -8548,7 +8548,7 @@ impl GetNamesValueList {
         };
         let geometry_name = if which & Into::<u32>::into(NameDetail::Geometry) != 0 {
             let remaining = outer_remaining;
-            let (geometry_name, remaining) = Atom::try_parse(remaining)?;
+            let (geometry_name, remaining) = xproto::Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(geometry_name)
         } else {
@@ -8556,7 +8556,7 @@ impl GetNamesValueList {
         };
         let symbols_name = if which & Into::<u32>::into(NameDetail::Symbols) != 0 {
             let remaining = outer_remaining;
-            let (symbols_name, remaining) = Atom::try_parse(remaining)?;
+            let (symbols_name, remaining) = xproto::Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(symbols_name)
         } else {
@@ -8564,7 +8564,7 @@ impl GetNamesValueList {
         };
         let phys_symbols_name = if which & Into::<u32>::into(NameDetail::PhysSymbols) != 0 {
             let remaining = outer_remaining;
-            let (phys_symbols_name, remaining) = Atom::try_parse(remaining)?;
+            let (phys_symbols_name, remaining) = xproto::Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(phys_symbols_name)
         } else {
@@ -8572,7 +8572,7 @@ impl GetNamesValueList {
         };
         let types_name = if which & Into::<u32>::into(NameDetail::Types) != 0 {
             let remaining = outer_remaining;
-            let (types_name, remaining) = Atom::try_parse(remaining)?;
+            let (types_name, remaining) = xproto::Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(types_name)
         } else {
@@ -8580,7 +8580,7 @@ impl GetNamesValueList {
         };
         let compat_name = if which & Into::<u32>::into(NameDetail::Compat) != 0 {
             let remaining = outer_remaining;
-            let (compat_name, remaining) = Atom::try_parse(remaining)?;
+            let (compat_name, remaining) = xproto::Atom::try_parse(remaining)?;
             outer_remaining = remaining;
             Some(compat_name)
         } else {
@@ -8588,7 +8588,7 @@ impl GetNamesValueList {
         };
         let type_names = if which & Into::<u32>::into(NameDetail::KeyTypeNames) != 0 {
             let remaining = outer_remaining;
-            let (type_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, n_types as usize)?;
+            let (type_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_types as usize)?;
             outer_remaining = remaining;
             Some(type_names)
         } else {
@@ -8603,7 +8603,7 @@ impl GetNamesValueList {
         };
         let indicator_names = if which & Into::<u32>::into(NameDetail::IndicatorNames) != 0 {
             let remaining = outer_remaining;
-            let (indicator_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(indicators.count_ones()).unwrap())?;
+            let (indicator_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, TryInto::<usize>::try_into(indicators.count_ones()).unwrap())?;
             outer_remaining = remaining;
             Some(indicator_names)
         } else {
@@ -8611,7 +8611,7 @@ impl GetNamesValueList {
         };
         let virtual_mod_names = if which & Into::<u32>::into(NameDetail::VirtualModNames) != 0 {
             let remaining = outer_remaining;
-            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
+            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, TryInto::<usize>::try_into(virtual_mods.count_ones()).unwrap())?;
             outer_remaining = remaining;
             Some(virtual_mod_names)
         } else {
@@ -8619,7 +8619,7 @@ impl GetNamesValueList {
         };
         let groups = if which & Into::<u32>::into(NameDetail::GroupNames) != 0 {
             let remaining = outer_remaining;
-            let (groups, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, TryInto::<usize>::try_into(group_names.count_ones()).unwrap())?;
+            let (groups, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, TryInto::<usize>::try_into(group_names.count_ones()).unwrap())?;
             outer_remaining = remaining;
             Some(groups)
         } else {
@@ -8643,7 +8643,7 @@ impl GetNamesValueList {
         };
         let radio_group_names = if which & Into::<u32>::into(NameDetail::RGNames) != 0 {
             let remaining = outer_remaining;
-            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, n_radio_groups as usize)?;
+            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_radio_groups as usize)?;
             outer_remaining = remaining;
             Some(radio_group_names)
         } else {
@@ -8660,12 +8660,12 @@ pub struct GetNamesReply {
     pub sequence: u16,
     pub length: u32,
     pub which: u32,
-    pub min_key_code: Keycode,
-    pub max_key_code: Keycode,
+    pub min_key_code: xproto::Keycode,
+    pub max_key_code: xproto::Keycode,
     pub n_types: u8,
     pub group_names: u8,
     pub virtual_mods: u16,
-    pub first_key: Keycode,
+    pub first_key: xproto::Keycode,
     pub n_keys: u8,
     pub indicators: u32,
     pub n_radio_groups: u8,
@@ -8680,12 +8680,12 @@ impl GetNamesReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let (which, remaining) = u32::try_parse(remaining)?;
-        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
-        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
         let (group_names, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
-        let (first_key, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_keys, remaining) = u8::try_parse(remaining)?;
         let (indicators, remaining) = u32::try_parse(remaining)?;
         let (n_radio_groups, remaining) = u8::try_parse(remaining)?;
@@ -8709,7 +8709,7 @@ pub const SET_NAMES_REQUEST: u8 = 18;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetNamesAuxBitcase8 {
     pub n_levels_per_type: Vec<u8>,
-    pub kt_level_names: Vec<Atom>,
+    pub kt_level_names: Vec<xproto::Atom>,
 }
 impl Serialize for SetNamesAuxBitcase8 {
     type Bytes = Vec<u8>;
@@ -8728,20 +8728,20 @@ impl Serialize for SetNamesAuxBitcase8 {
 /// Auxiliary and optional information for the set_names function.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SetNamesAux {
-    pub keycodes_name: Option<Atom>,
-    pub geometry_name: Option<Atom>,
-    pub symbols_name: Option<Atom>,
-    pub phys_symbols_name: Option<Atom>,
-    pub types_name: Option<Atom>,
-    pub compat_name: Option<Atom>,
-    pub type_names: Option<Vec<Atom>>,
+    pub keycodes_name: Option<xproto::Atom>,
+    pub geometry_name: Option<xproto::Atom>,
+    pub symbols_name: Option<xproto::Atom>,
+    pub phys_symbols_name: Option<xproto::Atom>,
+    pub types_name: Option<xproto::Atom>,
+    pub compat_name: Option<xproto::Atom>,
+    pub type_names: Option<Vec<xproto::Atom>>,
     pub bitcase8: Option<SetNamesAuxBitcase8>,
-    pub indicator_names: Option<Vec<Atom>>,
-    pub virtual_mod_names: Option<Vec<Atom>>,
-    pub groups: Option<Vec<Atom>>,
+    pub indicator_names: Option<Vec<xproto::Atom>>,
+    pub virtual_mod_names: Option<Vec<xproto::Atom>>,
+    pub groups: Option<Vec<xproto::Atom>>,
     pub key_names: Option<Vec<KeyName>>,
     pub key_aliases: Option<Vec<KeyAlias>>,
-    pub radio_group_names: Option<Vec<Atom>>,
+    pub radio_group_names: Option<Vec<xproto::Atom>>,
 }
 impl SetNamesAux {
     /// Create a new instance with all fields unset / not present.
@@ -8795,37 +8795,37 @@ impl SetNamesAux {
         mask
     }
     /// Set the keycodesName field of this structure.
-    pub fn keycodes_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn keycodes_name<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.keycodes_name = value.into();
         self
     }
     /// Set the geometryName field of this structure.
-    pub fn geometry_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn geometry_name<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.geometry_name = value.into();
         self
     }
     /// Set the symbolsName field of this structure.
-    pub fn symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.symbols_name = value.into();
         self
     }
     /// Set the physSymbolsName field of this structure.
-    pub fn phys_symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn phys_symbols_name<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.phys_symbols_name = value.into();
         self
     }
     /// Set the typesName field of this structure.
-    pub fn types_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn types_name<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.types_name = value.into();
         self
     }
     /// Set the compatName field of this structure.
-    pub fn compat_name<I>(mut self, value: I) -> Self where I: Into<Option<Atom>> {
+    pub fn compat_name<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Atom>> {
         self.compat_name = value.into();
         self
     }
     /// Set the typeNames field of this structure.
-    pub fn type_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
+    pub fn type_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<xproto::Atom>>> {
         self.type_names = value.into();
         self
     }
@@ -8835,17 +8835,17 @@ impl SetNamesAux {
         self
     }
     /// Set the indicatorNames field of this structure.
-    pub fn indicator_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
+    pub fn indicator_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<xproto::Atom>>> {
         self.indicator_names = value.into();
         self
     }
     /// Set the virtualModNames field of this structure.
-    pub fn virtual_mod_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
+    pub fn virtual_mod_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<xproto::Atom>>> {
         self.virtual_mod_names = value.into();
         self
     }
     /// Set the groups field of this structure.
-    pub fn groups<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
+    pub fn groups<I>(mut self, value: I) -> Self where I: Into<Option<Vec<xproto::Atom>>> {
         self.groups = value.into();
         self
     }
@@ -8860,7 +8860,7 @@ impl SetNamesAux {
         self
     }
     /// Set the radioGroupNames field of this structure.
-    pub fn radio_group_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<Atom>>> {
+    pub fn radio_group_names<I>(mut self, value: I) -> Self where I: Into<Option<Vec<xproto::Atom>>> {
         self.radio_group_names = value.into();
         self
     }
@@ -8917,7 +8917,7 @@ impl Serialize for SetNamesAux {
         }
     }
 }
-pub fn set_names<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_names<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -9189,7 +9189,7 @@ pub struct GetDeviceInfoReply {
     pub has_own_state: bool,
     pub dflt_kbd_fb: u16,
     pub dflt_led_fb: u16,
-    pub dev_type: Atom,
+    pub dev_type: xproto::Atom,
     pub name: Vec<String8>,
     pub btn_actions: Vec<Action>,
     pub leds: Vec<DeviceLedInfo>,
@@ -9214,7 +9214,7 @@ impl GetDeviceInfoReply {
         let (dflt_kbd_fb, remaining) = u16::try_parse(remaining)?;
         let (dflt_led_fb, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (dev_type, remaining) = Atom::try_parse(remaining)?;
+        let (dev_type, remaining) = xproto::Atom::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let (name, remaining) = crate::x11_utils::parse_list::<String8>(remaining, name_len as usize)?;
         // Align offset to multiple of 4
@@ -9362,13 +9362,13 @@ pub struct NewKeyboardNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub old_device_id: u8,
-    pub min_key_code: Keycode,
-    pub max_key_code: Keycode,
-    pub old_min_key_code: Keycode,
-    pub old_max_key_code: Keycode,
+    pub min_key_code: xproto::Keycode,
+    pub max_key_code: xproto::Keycode,
+    pub old_min_key_code: xproto::Keycode,
+    pub old_max_key_code: xproto::Keycode,
     pub request_major: u8,
     pub request_minor: u8,
     pub changed: u16,
@@ -9378,13 +9378,13 @@ impl NewKeyboardNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (old_device_id, remaining) = u8::try_parse(remaining)?;
-        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
-        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
-        let (old_min_key_code, remaining) = Keycode::try_parse(remaining)?;
-        let (old_max_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (old_min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (old_max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
@@ -9447,25 +9447,25 @@ pub struct MapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub ptr_btn_actions: u8,
     pub changed: u16,
-    pub min_key_code: Keycode,
-    pub max_key_code: Keycode,
+    pub min_key_code: xproto::Keycode,
+    pub max_key_code: xproto::Keycode,
     pub first_type: u8,
     pub n_types: u8,
-    pub first_key_sym: Keycode,
+    pub first_key_sym: xproto::Keycode,
     pub n_key_syms: u8,
-    pub first_key_act: Keycode,
+    pub first_key_act: xproto::Keycode,
     pub n_key_acts: u8,
-    pub first_key_behavior: Keycode,
+    pub first_key_behavior: xproto::Keycode,
     pub n_key_behavior: u8,
-    pub first_key_explicit: Keycode,
+    pub first_key_explicit: xproto::Keycode,
     pub n_key_explicit: u8,
-    pub first_mod_map_key: Keycode,
+    pub first_mod_map_key: xproto::Keycode,
     pub n_mod_map_keys: u8,
-    pub first_v_mod_map_key: Keycode,
+    pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
     pub virtual_mods: u16,
 }
@@ -9474,25 +9474,25 @@ impl MapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (ptr_btn_actions, remaining) = u8::try_parse(remaining)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
-        let (min_key_code, remaining) = Keycode::try_parse(remaining)?;
-        let (max_key_code, remaining) = Keycode::try_parse(remaining)?;
+        let (min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (first_type, remaining) = u8::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
-        let (first_key_sym, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_sym, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_syms, remaining) = u8::try_parse(remaining)?;
-        let (first_key_act, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_act, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_acts, remaining) = u8::try_parse(remaining)?;
-        let (first_key_behavior, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_behavior, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_behavior, remaining) = u8::try_parse(remaining)?;
-        let (first_key_explicit, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key_explicit, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
-        let (first_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
+        let (first_mod_map_key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_mod_map_keys, remaining) = u8::try_parse(remaining)?;
-        let (first_v_mod_map_key, remaining) = Keycode::try_parse(remaining)?;
+        let (first_v_mod_map_key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
@@ -9565,7 +9565,7 @@ pub struct StateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub mods: u8,
     pub base_mods: u8,
@@ -9582,7 +9582,7 @@ pub struct StateNotifyEvent {
     pub compat_loockup_mods: u8,
     pub ptr_btn_state: u16,
     pub changed: u16,
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub event_type: u8,
     pub request_major: u8,
     pub request_minor: u8,
@@ -9592,7 +9592,7 @@ impl StateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let (base_mods, remaining) = u8::try_parse(remaining)?;
@@ -9609,7 +9609,7 @@ impl StateNotifyEvent {
         let (compat_loockup_mods, remaining) = u8::try_parse(remaining)?;
         let (ptr_btn_state, remaining) = u16::try_parse(remaining)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (event_type, remaining) = u8::try_parse(remaining)?;
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
@@ -9684,13 +9684,13 @@ pub struct ControlsNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub num_groups: u8,
     pub changed_controls: u32,
     pub enabled_controls: u32,
     pub enabled_control_changes: u32,
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub event_type: u8,
     pub request_major: u8,
     pub request_minor: u8,
@@ -9700,14 +9700,14 @@ impl ControlsNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (num_groups, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (changed_controls, remaining) = u32::try_parse(remaining)?;
         let (enabled_controls, remaining) = u32::try_parse(remaining)?;
         let (enabled_control_changes, remaining) = u32::try_parse(remaining)?;
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (event_type, remaining) = u8::try_parse(remaining)?;
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
@@ -9770,7 +9770,7 @@ pub struct IndicatorStateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub state: u32,
     pub state_changed: u32,
@@ -9780,7 +9780,7 @@ impl IndicatorStateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let (state, remaining) = u32::try_parse(remaining)?;
@@ -9838,7 +9838,7 @@ pub struct IndicatorMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub state: u32,
     pub map_changed: u32,
@@ -9848,7 +9848,7 @@ impl IndicatorMapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let (state, remaining) = u32::try_parse(remaining)?;
@@ -9906,7 +9906,7 @@ pub struct NamesNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub changed: u16,
     pub first_type: u8,
@@ -9917,7 +9917,7 @@ pub struct NamesNotifyEvent {
     pub n_key_aliases: u8,
     pub changed_group_names: u8,
     pub changed_virtual_mods: u16,
-    pub first_key: Keycode,
+    pub first_key: xproto::Keycode,
     pub n_keys: u8,
     pub changed_indicators: u32,
 }
@@ -9926,7 +9926,7 @@ impl NamesNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
@@ -9939,7 +9939,7 @@ impl NamesNotifyEvent {
         let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
         let (changed_group_names, remaining) = u8::try_parse(remaining)?;
         let (changed_virtual_mods, remaining) = u16::try_parse(remaining)?;
-        let (first_key, remaining) = Keycode::try_parse(remaining)?;
+        let (first_key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_keys, remaining) = u8::try_parse(remaining)?;
         let (changed_indicators, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
@@ -10005,7 +10005,7 @@ pub struct CompatMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub changed_groups: u8,
     pub first_si: u16,
@@ -10017,7 +10017,7 @@ impl CompatMapNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (changed_groups, remaining) = u8::try_parse(remaining)?;
         let (first_si, remaining) = u16::try_parse(remaining)?;
@@ -10078,15 +10078,15 @@ pub struct BellNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub bell_class: BellClassResult,
     pub bell_id: u8,
     pub percent: u8,
     pub pitch: u16,
     pub duration: u16,
-    pub name: Atom,
-    pub window: Window,
+    pub name: xproto::Atom,
+    pub window: xproto::Window,
     pub event_only: bool,
 }
 impl BellNotifyEvent {
@@ -10094,15 +10094,15 @@ impl BellNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (bell_class, remaining) = u8::try_parse(remaining)?;
         let (bell_id, remaining) = u8::try_parse(remaining)?;
         let (percent, remaining) = u8::try_parse(remaining)?;
         let (pitch, remaining) = u16::try_parse(remaining)?;
         let (duration, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = Atom::try_parse(remaining)?;
-        let (window, remaining) = Window::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (event_only, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
         let bell_class = bell_class.try_into()?;
@@ -10164,9 +10164,9 @@ pub struct ActionMessageEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub press: bool,
     pub key_event_follows: bool,
     pub mods: u8,
@@ -10178,9 +10178,9 @@ impl ActionMessageEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (press, remaining) = bool::try_parse(remaining)?;
         let (key_event_follows, remaining) = bool::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
@@ -10260,9 +10260,9 @@ pub struct AccessXNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
-    pub keycode: Keycode,
+    pub keycode: xproto::Keycode,
     pub detailt: u16,
     pub slow_keys_delay: u16,
     pub debounce_delay: u16,
@@ -10272,9 +10272,9 @@ impl AccessXNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
-        let (keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (detailt, remaining) = u16::try_parse(remaining)?;
         let (slow_keys_delay, remaining) = u16::try_parse(remaining)?;
         let (debounce_delay, remaining) = u16::try_parse(remaining)?;
@@ -10333,7 +10333,7 @@ pub struct ExtensionDeviceNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub device_id: u8,
     pub reason: u16,
     pub led_class: LedClassResult,
@@ -10350,7 +10350,7 @@ impl ExtensionDeviceNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (reason, remaining) = u16::try_parse(remaining)?;
@@ -10428,7 +10428,7 @@ pub trait ConnectionExt: RequestConnection {
         select_events(self, device_spec, affect_which, clear, select_all, affect_map, map, details)
     }
 
-    fn xkb_bell(&self, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: Atom, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xkb_bell(&self, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: xproto::Atom, window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         bell(self, device_spec, bell_class, bell_id, percent, force_sound, event_only, pitch, duration, name, window)
     }
@@ -10454,12 +10454,12 @@ pub trait ConnectionExt: RequestConnection {
         set_controls(self, device_spec, affect_internal_real_mods, internal_real_mods, affect_ignore_lock_real_mods, ignore_lock_real_mods, affect_internal_virtual_mods, internal_virtual_mods, affect_ignore_lock_virtual_mods, ignore_lock_virtual_mods, mouse_keys_dflt_btn, groups_wrap, access_x_options, affect_enabled_controls, enabled_controls, change_controls, repeat_delay, repeat_interval, slow_keys_delay, debounce_delay, mouse_keys_delay, mouse_keys_interval, mouse_keys_time_to_max, mouse_keys_max_speed, mouse_keys_curve, access_x_timeout, access_x_timeout_mask, access_x_timeout_values, access_x_timeout_options_mask, access_x_timeout_options_values, per_key_repeat)
     }
 
-    fn xkb_get_map(&self, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, first_key_action: Keycode, n_key_actions: u8, first_key_behavior: Keycode, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: Keycode, n_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Self, GetMapReply>, ConnectionError>
+    fn xkb_get_map(&self, device_spec: DeviceSpec, full: u16, partial: u16, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: u16, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Self, GetMapReply>, ConnectionError>
     {
         get_map(self, device_spec, full, partial, first_type, n_types, first_key_sym, n_key_syms, first_key_action, n_key_actions, first_key_behavior, n_key_behaviors, virtual_mods, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys)
     }
 
-    fn xkb_set_map<'c>(&'c self, device_spec: DeviceSpec, flags: u16, min_key_code: Keycode, max_key_code: Keycode, first_type: u8, n_types: u8, first_key_sym: Keycode, n_key_syms: u8, total_syms: u16, first_key_action: Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_map<'c>(&'c self, device_spec: DeviceSpec, flags: u16, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: u16, values: &SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_map(self, device_spec, flags, min_key_code, max_key_code, first_type, n_types, first_key_sym, n_key_syms, total_syms, first_key_action, n_key_actions, total_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, values)
     }
@@ -10489,13 +10489,13 @@ pub trait ConnectionExt: RequestConnection {
         set_indicator_map(self, device_spec, which, maps)
     }
 
-    fn xkb_get_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom) -> Result<Cookie<'_, Self, GetNamedIndicatorReply>, ConnectionError>
+    fn xkb_get_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: xproto::Atom) -> Result<Cookie<'_, Self, GetNamedIndicatorReply>, ConnectionError>
     where A: Into<LedClassSpec>
     {
         get_named_indicator(self, device_spec, led_class, led_id, indicator)
     }
 
-    fn xkb_set_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xkb_set_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: A, led_id: IDSpec, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: u8, map_which_groups: u8, map_groups: u8, map_which_mods: u8, map_real_mods: u8, map_vmods: u16, map_ctrls: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where A: Into<LedClassSpec>
     {
         set_named_indicator(self, device_spec, led_class, led_id, indicator, set_state, on, set_map, create_map, map_flags, map_which_groups, map_groups, map_which_mods, map_real_mods, map_vmods, map_ctrls)
@@ -10506,7 +10506,7 @@ pub trait ConnectionExt: RequestConnection {
         get_names(self, device_spec, which)
     }
 
-    fn xkb_set_names<'c>(&'c self, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_names<'c>(&'c self, device_spec: DeviceSpec, virtual_mods: u16, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: u8, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_names(self, device_spec, virtual_mods, first_type, n_types, first_kt_levelt, n_kt_levels, indicators, group_names, n_radio_groups, first_key, n_keys, n_key_aliases, total_kt_level_names, values)
     }

--- a/src/generated/xprint.rs
+++ b/src/generated/xprint.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "XpExtension";
@@ -656,7 +656,7 @@ pub struct PrintGetScreenOfContextReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub root: Window,
+    pub root: xproto::Window,
 }
 impl PrintGetScreenOfContextReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -664,7 +664,7 @@ impl PrintGetScreenOfContextReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (root, remaining) = Window::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
         let result = PrintGetScreenOfContextReply { response_type, sequence, length, root };
         Ok((result, remaining))
     }
@@ -778,7 +778,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PrintPutDocumentData request
 pub const PRINT_PUT_DOCUMENT_DATA_REQUEST: u8 = 11;
-pub fn print_put_document_data<'c, Conn>(conn: &'c Conn, drawable: Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn print_put_document_data<'c, Conn>(conn: &'c Conn, drawable: xproto::Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -882,7 +882,7 @@ impl TryFrom<&[u8]> for PrintGetDocumentDataReply {
 
 /// Opcode for the PrintStartPage request
 pub const PRINT_START_PAGE_REQUEST: u8 = 13;
-pub fn print_start_page<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn print_start_page<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1254,7 +1254,7 @@ pub struct PrintQueryScreensReply {
     pub response_type: u8,
     pub sequence: u16,
     pub length: u32,
-    pub roots: Vec<Window>,
+    pub roots: Vec<xproto::Window>,
 }
 impl PrintQueryScreensReply {
     pub(crate) fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1264,7 +1264,7 @@ impl PrintQueryScreensReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (list_count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (roots, remaining) = crate::x11_utils::parse_list::<Window>(remaining, list_count as usize)?;
+        let (roots, remaining) = crate::x11_utils::parse_list::<xproto::Window>(remaining, list_count as usize)?;
         let result = PrintQueryScreensReply { response_type, sequence, length, roots };
         Ok((result, remaining))
     }
@@ -1663,7 +1663,7 @@ pub trait ConnectionExt: RequestConnection {
         print_end_doc(self, cancel)
     }
 
-    fn xprint_print_put_document_data<'c>(&'c self, drawable: Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xprint_print_put_document_data<'c>(&'c self, drawable: xproto::Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         print_put_document_data(self, drawable, data, doc_format, options)
     }
@@ -1673,7 +1673,7 @@ pub trait ConnectionExt: RequestConnection {
         print_get_document_data(self, context, max_bytes)
     }
 
-    fn xprint_print_start_page(&self, window: Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xprint_print_start_page(&self, window: xproto::Window) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         print_start_page(self, window)
     }

--- a/src/generated/xselinux.rs
+++ b/src/generated/xselinux.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "SELinux";
@@ -325,7 +325,7 @@ impl TryFrom<&[u8]> for GetWindowCreateContextReply {
 
 /// Opcode for the GetWindowContext request
 pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
-pub fn get_window_context<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, GetWindowContextReply>, ConnectionError>
+pub fn get_window_context<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetWindowContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -376,14 +376,14 @@ impl TryFrom<&[u8]> for GetWindowContextReply {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListItem {
-    pub name: Atom,
+    pub name: xproto::Atom,
     pub object_context: Vec<u8>,
     pub data_context: Vec<u8>,
 }
 impl TryParse for ListItem {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (name, remaining) = Atom::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (object_context_len, remaining) = u32::try_parse(remaining)?;
         let (data_context_len, remaining) = u32::try_parse(remaining)?;
         let (object_context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, object_context_len as usize)?;
@@ -579,7 +579,7 @@ impl TryFrom<&[u8]> for GetPropertyUseContextReply {
 
 /// Opcode for the GetPropertyContext request
 pub const GET_PROPERTY_CONTEXT_REQUEST: u8 = 12;
-pub fn get_property_context<Conn>(conn: &Conn, window: Window, property: Atom) -> Result<Cookie<'_, Conn, GetPropertyContextReply>, ConnectionError>
+pub fn get_property_context<Conn>(conn: &Conn, window: xproto::Window, property: xproto::Atom) -> Result<Cookie<'_, Conn, GetPropertyContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -635,7 +635,7 @@ impl TryFrom<&[u8]> for GetPropertyContextReply {
 
 /// Opcode for the GetPropertyDataContext request
 pub const GET_PROPERTY_DATA_CONTEXT_REQUEST: u8 = 13;
-pub fn get_property_data_context<Conn>(conn: &Conn, window: Window, property: Atom) -> Result<Cookie<'_, Conn, GetPropertyDataContextReply>, ConnectionError>
+pub fn get_property_data_context<Conn>(conn: &Conn, window: xproto::Window, property: xproto::Atom) -> Result<Cookie<'_, Conn, GetPropertyDataContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -691,7 +691,7 @@ impl TryFrom<&[u8]> for GetPropertyDataContextReply {
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 14;
-pub fn list_properties<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
+pub fn list_properties<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -892,7 +892,7 @@ impl TryFrom<&[u8]> for GetSelectionUseContextReply {
 
 /// Opcode for the GetSelectionContext request
 pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
-pub fn get_selection_context<Conn>(conn: &Conn, selection: Atom) -> Result<Cookie<'_, Conn, GetSelectionContextReply>, ConnectionError>
+pub fn get_selection_context<Conn>(conn: &Conn, selection: xproto::Atom) -> Result<Cookie<'_, Conn, GetSelectionContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -943,7 +943,7 @@ impl TryFrom<&[u8]> for GetSelectionContextReply {
 
 /// Opcode for the GetSelectionDataContext request
 pub const GET_SELECTION_DATA_CONTEXT_REQUEST: u8 = 20;
-pub fn get_selection_data_context<Conn>(conn: &Conn, selection: Atom) -> Result<Cookie<'_, Conn, GetSelectionDataContextReply>, ConnectionError>
+pub fn get_selection_data_context<Conn>(conn: &Conn, selection: xproto::Atom) -> Result<Cookie<'_, Conn, GetSelectionDataContextReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1126,7 +1126,7 @@ pub trait ConnectionExt: RequestConnection {
         get_window_create_context(self)
     }
 
-    fn xselinux_get_window_context(&self, window: Window) -> Result<Cookie<'_, Self, GetWindowContextReply>, ConnectionError>
+    fn xselinux_get_window_context(&self, window: xproto::Window) -> Result<Cookie<'_, Self, GetWindowContextReply>, ConnectionError>
     {
         get_window_context(self, window)
     }
@@ -1151,17 +1151,17 @@ pub trait ConnectionExt: RequestConnection {
         get_property_use_context(self)
     }
 
-    fn xselinux_get_property_context(&self, window: Window, property: Atom) -> Result<Cookie<'_, Self, GetPropertyContextReply>, ConnectionError>
+    fn xselinux_get_property_context(&self, window: xproto::Window, property: xproto::Atom) -> Result<Cookie<'_, Self, GetPropertyContextReply>, ConnectionError>
     {
         get_property_context(self, window, property)
     }
 
-    fn xselinux_get_property_data_context(&self, window: Window, property: Atom) -> Result<Cookie<'_, Self, GetPropertyDataContextReply>, ConnectionError>
+    fn xselinux_get_property_data_context(&self, window: xproto::Window, property: xproto::Atom) -> Result<Cookie<'_, Self, GetPropertyDataContextReply>, ConnectionError>
     {
         get_property_data_context(self, window, property)
     }
 
-    fn xselinux_list_properties(&self, window: Window) -> Result<Cookie<'_, Self, ListPropertiesReply>, ConnectionError>
+    fn xselinux_list_properties(&self, window: xproto::Window) -> Result<Cookie<'_, Self, ListPropertiesReply>, ConnectionError>
     {
         list_properties(self, window)
     }
@@ -1186,12 +1186,12 @@ pub trait ConnectionExt: RequestConnection {
         get_selection_use_context(self)
     }
 
-    fn xselinux_get_selection_context(&self, selection: Atom) -> Result<Cookie<'_, Self, GetSelectionContextReply>, ConnectionError>
+    fn xselinux_get_selection_context(&self, selection: xproto::Atom) -> Result<Cookie<'_, Self, GetSelectionContextReply>, ConnectionError>
     {
         get_selection_context(self, selection)
     }
 
-    fn xselinux_get_selection_data_context(&self, selection: Atom) -> Result<Cookie<'_, Self, GetSelectionDataContextReply>, ConnectionError>
+    fn xselinux_get_selection_data_context(&self, selection: xproto::Atom) -> Result<Cookie<'_, Self, GetSelectionDataContextReply>, ConnectionError>
     {
         get_selection_data_context(self, selection)
     }

--- a/src/generated/xtest.rs
+++ b/src/generated/xtest.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 
 /// The X11 name of the extension for QueryExtension
 pub const X11_EXTENSION_NAME: &str = "XTEST";
@@ -151,7 +151,7 @@ impl TryFrom<u32> for Cursor {
 
 /// Opcode for the CompareCursor request
 pub const COMPARE_CURSOR_REQUEST: u8 = 1;
-pub fn compare_cursor<Conn>(conn: &Conn, window: Window, cursor: super::xproto::Cursor) -> Result<Cookie<'_, Conn, CompareCursorReply>, ConnectionError>
+pub fn compare_cursor<Conn>(conn: &Conn, window: xproto::Window, cursor: xproto::Cursor) -> Result<Cookie<'_, Conn, CompareCursorReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -204,7 +204,7 @@ impl TryFrom<&[u8]> for CompareCursorReply {
 
 /// Opcode for the FakeInput request
 pub const FAKE_INPUT_REQUEST: u8 = 2;
-pub fn fake_input<Conn>(conn: &Conn, type_: u8, detail: u8, time: u32, root: Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn fake_input<Conn>(conn: &Conn, type_: u8, detail: u8, time: u32, root: xproto::Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -293,12 +293,12 @@ pub trait ConnectionExt: RequestConnection {
         get_version(self, major_version, minor_version)
     }
 
-    fn xtest_compare_cursor(&self, window: Window, cursor: super::xproto::Cursor) -> Result<Cookie<'_, Self, CompareCursorReply>, ConnectionError>
+    fn xtest_compare_cursor(&self, window: xproto::Window, cursor: xproto::Cursor) -> Result<Cookie<'_, Self, CompareCursorReply>, ConnectionError>
     {
         compare_cursor(self, window, cursor)
     }
 
-    fn xtest_fake_input(&self, type_: u8, detail: u8, time: u32, root: Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xtest_fake_input(&self, type_: u8, detail: u8, time: u32, root: xproto::Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         fake_input(self, type_, detail, time, root, root_x, root_y, deviceid)
     }

--- a/src/generated/xv.rs
+++ b/src/generated/xv.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 #[allow(unused_imports)]
 use super::shm;
 
@@ -553,12 +553,12 @@ impl Serialize for Rational {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Format {
-    pub visual: Visualid,
+    pub visual: xproto::Visualid,
     pub depth: u8,
 }
 impl TryParse for Format {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (visual, remaining) = Visualid::try_parse(remaining)?;
+        let (visual, remaining) = xproto::Visualid::try_parse(remaining)?;
         let (depth, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = Format { visual, depth };
@@ -807,7 +807,7 @@ impl Serialize for AttributeInfo {
 pub struct ImageFormatInfo {
     pub id: u32,
     pub type_: ImageFormatInfoType,
-    pub byte_order: ImageOrder,
+    pub byte_order: xproto::ImageOrder,
     pub guid: [u8; 16],
     pub bpp: u8,
     pub num_planes: u8,
@@ -1318,8 +1318,8 @@ pub struct VideoNotifyEvent {
     pub response_type: u8,
     pub reason: VideoNotifyReason,
     pub sequence: u16,
-    pub time: Timestamp,
-    pub drawable: Drawable,
+    pub time: xproto::Timestamp,
+    pub drawable: xproto::Drawable,
     pub port: Port,
 }
 impl VideoNotifyEvent {
@@ -1327,8 +1327,8 @@ impl VideoNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (reason, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
-        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
         let (port, remaining) = Port::try_parse(remaining)?;
         let reason = reason.try_into()?;
         let result = VideoNotifyEvent { response_type, reason, sequence, time, drawable, port };
@@ -1381,9 +1381,9 @@ pub const PORT_NOTIFY_EVENT: u8 = 1;
 pub struct PortNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
-    pub time: Timestamp,
+    pub time: xproto::Timestamp,
     pub port: Port,
-    pub attribute: Atom,
+    pub attribute: xproto::Atom,
     pub value: i32,
 }
 impl PortNotifyEvent {
@@ -1391,9 +1391,9 @@ impl PortNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (port, remaining) = Port::try_parse(remaining)?;
-        let (attribute, remaining) = Atom::try_parse(remaining)?;
+        let (attribute, remaining) = xproto::Atom::try_parse(remaining)?;
         let (value, remaining) = i32::try_parse(remaining)?;
         let result = PortNotifyEvent { response_type, sequence, time, port, attribute, value };
         Ok((result, remaining))
@@ -1487,7 +1487,7 @@ impl TryFrom<&[u8]> for QueryExtensionReply {
 
 /// Opcode for the QueryAdaptors request
 pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
-pub fn query_adaptors<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, QueryAdaptorsReply>, ConnectionError>
+pub fn query_adaptors<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, QueryAdaptorsReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1589,7 +1589,7 @@ impl TryFrom<&[u8]> for QueryEncodingsReply {
 
 /// Opcode for the GrabPort request
 pub const GRAB_PORT_REQUEST: u8 = 3;
-pub fn grab_port<Conn>(conn: &Conn, port: Port, time: Timestamp) -> Result<Cookie<'_, Conn, GrabPortReply>, ConnectionError>
+pub fn grab_port<Conn>(conn: &Conn, port: Port, time: xproto::Timestamp) -> Result<Cookie<'_, Conn, GrabPortReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1643,7 +1643,7 @@ impl TryFrom<&[u8]> for GrabPortReply {
 
 /// Opcode for the UngrabPort request
 pub const UNGRAB_PORT_REQUEST: u8 = 4;
-pub fn ungrab_port<Conn>(conn: &Conn, port: Port, time: Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_port<Conn>(conn: &Conn, port: Port, time: xproto::Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1673,7 +1673,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PutVideo request
 pub const PUT_VIDEO_REQUEST: u8 = 5;
-pub fn put_video<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn put_video<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1732,7 +1732,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the PutStill request
 pub const PUT_STILL_REQUEST: u8 = 6;
-pub fn put_still<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn put_still<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1791,7 +1791,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetVideo request
 pub const GET_VIDEO_REQUEST: u8 = 7;
-pub fn get_video<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn get_video<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1850,7 +1850,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetStill request
 pub const GET_STILL_REQUEST: u8 = 8;
-pub fn get_still<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn get_still<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1909,7 +1909,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the StopVideo request
 pub const STOP_VIDEO_REQUEST: u8 = 9;
-pub fn stop_video<Conn>(conn: &Conn, port: Port, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn stop_video<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -1939,7 +1939,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the SelectVideoNotify request
 pub const SELECT_VIDEO_NOTIFY_REQUEST: u8 = 10;
-pub fn select_video_notify<Conn>(conn: &Conn, drawable: Drawable, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_video_notify<Conn>(conn: &Conn, drawable: xproto::Drawable, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2067,7 +2067,7 @@ impl TryFrom<&[u8]> for QueryBestSizeReply {
 
 /// Opcode for the SetPortAttribute request
 pub const SET_PORT_ATTRIBUTE_REQUEST: u8 = 13;
-pub fn set_port_attribute<Conn>(conn: &Conn, port: Port, attribute: Atom, value: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_port_attribute<Conn>(conn: &Conn, port: Port, attribute: xproto::Atom, value: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2102,7 +2102,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the GetPortAttribute request
 pub const GET_PORT_ATTRIBUTE_REQUEST: u8 = 14;
-pub fn get_port_attribute<Conn>(conn: &Conn, port: Port, attribute: Atom) -> Result<Cookie<'_, Conn, GetPortAttributeReply>, ConnectionError>
+pub fn get_port_attribute<Conn>(conn: &Conn, port: Port, attribute: xproto::Atom) -> Result<Cookie<'_, Conn, GetPortAttributeReply>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2331,7 +2331,7 @@ impl TryFrom<&[u8]> for QueryImageAttributesReply {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 18;
-pub fn put_image<'c, Conn>(conn: &'c Conn, port: Port, drawable: Drawable, gc: Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn put_image<'c, Conn>(conn: &'c Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2404,7 +2404,7 @@ where Conn: RequestConnection + ?Sized
 
 /// Opcode for the ShmPutImage request
 pub const SHM_PUT_IMAGE_REQUEST: u8 = 19;
-pub fn shm_put_image<Conn>(conn: &Conn, port: Port, drawable: Drawable, gc: Gcontext, shmseg: shm::Seg, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn shm_put_image<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, shmseg: shm::Seg, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where Conn: RequestConnection + ?Sized
 {
     let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
@@ -2494,7 +2494,7 @@ pub trait ConnectionExt: RequestConnection {
         query_extension(self)
     }
 
-    fn xv_query_adaptors(&self, window: Window) -> Result<Cookie<'_, Self, QueryAdaptorsReply>, ConnectionError>
+    fn xv_query_adaptors(&self, window: xproto::Window) -> Result<Cookie<'_, Self, QueryAdaptorsReply>, ConnectionError>
     {
         query_adaptors(self, window)
     }
@@ -2504,42 +2504,42 @@ pub trait ConnectionExt: RequestConnection {
         query_encodings(self, port)
     }
 
-    fn xv_grab_port(&self, port: Port, time: Timestamp) -> Result<Cookie<'_, Self, GrabPortReply>, ConnectionError>
+    fn xv_grab_port(&self, port: Port, time: xproto::Timestamp) -> Result<Cookie<'_, Self, GrabPortReply>, ConnectionError>
     {
         grab_port(self, port, time)
     }
 
-    fn xv_ungrab_port(&self, port: Port, time: Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_ungrab_port(&self, port: Port, time: xproto::Timestamp) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_port(self, port, time)
     }
 
-    fn xv_put_video(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_put_video(&self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         put_video(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_put_still(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_put_still(&self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         put_still(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_get_video(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_get_video(&self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         get_video(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_get_still(&self, port: Port, drawable: Drawable, gc: Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_get_still(&self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         get_still(self, port, drawable, gc, vid_x, vid_y, vid_w, vid_h, drw_x, drw_y, drw_w, drw_h)
     }
 
-    fn xv_stop_video(&self, port: Port, drawable: Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_stop_video(&self, port: Port, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         stop_video(self, port, drawable)
     }
 
-    fn xv_select_video_notify(&self, drawable: Drawable, onoff: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_select_video_notify(&self, drawable: xproto::Drawable, onoff: bool) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_video_notify(self, drawable, onoff)
     }
@@ -2554,12 +2554,12 @@ pub trait ConnectionExt: RequestConnection {
         query_best_size(self, port, vid_w, vid_h, drw_w, drw_h, motion)
     }
 
-    fn xv_set_port_attribute(&self, port: Port, attribute: Atom, value: i32) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_set_port_attribute(&self, port: Port, attribute: xproto::Atom, value: i32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         set_port_attribute(self, port, attribute, value)
     }
 
-    fn xv_get_port_attribute(&self, port: Port, attribute: Atom) -> Result<Cookie<'_, Self, GetPortAttributeReply>, ConnectionError>
+    fn xv_get_port_attribute(&self, port: Port, attribute: xproto::Atom) -> Result<Cookie<'_, Self, GetPortAttributeReply>, ConnectionError>
     {
         get_port_attribute(self, port, attribute)
     }
@@ -2579,12 +2579,12 @@ pub trait ConnectionExt: RequestConnection {
         query_image_attributes(self, port, id, width, height)
     }
 
-    fn xv_put_image<'c>(&'c self, port: Port, drawable: Drawable, gc: Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xv_put_image<'c>(&'c self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         put_image(self, port, drawable, gc, id, src_x, src_y, src_w, src_h, drw_x, drw_y, drw_w, drw_h, width, height, data)
     }
 
-    fn xv_shm_put_image(&self, port: Port, drawable: Drawable, gc: Gcontext, shmseg: shm::Seg, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xv_shm_put_image(&self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, shmseg: shm::Seg, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         shm_put_image(self, port, drawable, gc, shmseg, id, offset, src_x, src_y, src_w, src_h, drw_x, drw_y, drw_w, drw_h, width, height, send_event)
     }

--- a/src/generated/xvmc.rs
+++ b/src/generated/xvmc.rs
@@ -23,7 +23,7 @@ use crate::x11_utils::GenericEvent;
 #[allow(unused_imports)]
 use crate::x11_utils::GenericError;
 #[allow(unused_imports)]
-use super::xproto::*;
+use super::xproto;
 #[allow(unused_imports)]
 use super::shm;
 #[allow(unused_imports)]


### PR DESCRIPTION
For example, in glx.xml there is:

```xml
<request name="CreateGLXPixmap" opcode="13">
    <field type="CARD32" name="screen" />
    <field type="VISUALID" name="visual" />
    <field type="xproto:PIXMAP" name="pixmap" />
    <field type="glx:PIXMAP" name="glx_pixmap" />
</request>
```

But the function was generated as:

```rust
glx_create_glx_pixmap(&self, screen: u32, visual: xproto::Visualid, pixmap: Pixmap, glx_pixmap: Pixmap)
```

`xproto:PIXMAP` and `glx:PIXMAP` were both being resolved as `Pixmap`.

With this commit, the generated is is:

```rust
glx_create_glx_pixmap(&self, screen: u32, visual: xproto::Visualid, pixmap: xproto::Pixmap, glx_pixmap: Pixmap)
```