### PR TITLE
Return already parsed errors/events in the Connection trait

### DIFF
--- a/examples/check_unchecked_requests.rs
+++ b/examples/check_unchecked_requests.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Now check if the things above really caused errors. This is the part that is supposed to
     // turn this example into a (bad) integration test.
     for &seq in &[seq1, seq2, seq3] {
-        let event = conn.wait_for_event()?;
+        let event = conn.wait_for_raw_event()?;
         assert_eq!(0, event.response_type());
         assert_eq!(Some(seq as _), event.raw_sequence_number());
     }

--- a/examples/check_unchecked_requests.rs
+++ b/examples/check_unchecked_requests.rs
@@ -9,8 +9,8 @@ extern crate x11rb;
 
 use x11rb::connection::Connection;
 use x11rb::wrapper::ConnectionExt as _;
-use x11rb::x11_utils::Event;
 use x11rb::xproto::ConnectionExt as _;
+use x11rb::Event;
 
 const INVALID_WINDOW: u32 = 0;
 
@@ -65,9 +65,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Now check if the things above really caused errors. This is the part that is supposed to
     // turn this example into a (bad) integration test.
     for &seq in &[seq1, seq2, seq3] {
-        let event = conn.wait_for_raw_event()?;
-        assert_eq!(0, event.response_type());
-        assert_eq!(Some(seq as _), event.raw_sequence_number());
+        let (seq2, event) = conn.wait_for_event_with_sequence()?;
+        match event {
+            Event::Error(_) => {},
+            event => panic!("Unexpectedly got {:?} instead of an X11 error", event)
+        }
+        assert_eq!(seq, seq2);
     }
     assert!(conn.poll_for_event()?.is_none());
 

--- a/examples/check_unchecked_requests.rs
+++ b/examples/check_unchecked_requests.rs
@@ -67,8 +67,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for &seq in &[seq1, seq2, seq3] {
         let (seq2, event) = conn.wait_for_event_with_sequence()?;
         match event {
-            Event::Error(_) => {},
-            event => panic!("Unexpectedly got {:?} instead of an X11 error", event)
+            Event::Error(_) => {}
+            event => panic!("Unexpectedly got {:?} instead of an X11 error", event),
         }
         assert_eq!(seq, seq2);
     }

--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -54,7 +54,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let event = conn.wait_for_event()?;
 
     // Now check that the event really is what we wanted to get
-    let event = conn.parse_event(event)?;
     let event = match event {
         Event::PresentConfigureNotify(event) => event,
         other => panic!("Unexpected event {:?}", other),

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -190,7 +190,6 @@ where
 
     loop {
         let event = conn.wait_for_event()?;
-        let event = conn.parse_event(event)?;
         match event {
             Event::Expose(event) => {
                 if let Some(state) = find_window_by_id(&windows, event.window) {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -1,6 +1,6 @@
 extern crate x11rb;
 
-use x11rb::connection::Connection;
+use x11rb::connection::{Connection, RequestConnection};
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xproto::*;
 use x11rb::Event;

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -1,6 +1,6 @@
 extern crate x11rb;
 
-use x11rb::connection::{Connection, RequestConnection};
+use x11rb::connection::Connection;
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xproto::*;
 use x11rb::Event;

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -86,7 +86,6 @@ fn main() {
 
     loop {
         let event = conn.wait_for_event().unwrap();
-        let event = conn.parse_event(event).unwrap();
         println!("{:?})", event);
         match event {
             Event::Expose(event) => {

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -334,10 +334,8 @@ fn become_wm<C: Connection>(conn: &C, screen: &Screen) -> Result<(), ReplyError<
             Error::Access(_) => {
                 eprintln!("Another WM is already running.");
                 exit(1);
-            },
-            // FIXME
-            //err => Err(error.into())
-            err => panic!("Unexpected error: {:?}", err)
+            }
+            error => Err(ReplyError::X11Error(error))
         }
     } else {
         Ok(())

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -359,7 +359,7 @@ fn main() {
         wm_state.refresh().unwrap();
         conn.flush().unwrap();
 
-        let event = conn.wait_for_event().unwrap();
+        let event = conn.wait_for_raw_event().unwrap();
         let mut event_option = Some(event);
         while let Some(event) = event_option {
             if event.response_type() == CLIENT_MESSAGE_EVENT {
@@ -369,7 +369,7 @@ fn main() {
 
             let event = conn.parse_event(event).unwrap();
             wm_state.handle_event(event).unwrap();
-            event_option = conn.poll_for_event().unwrap();
+            event_option = conn.poll_for_raw_event().unwrap();
         }
     }
 }

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -335,7 +335,7 @@ fn become_wm<C: Connection>(conn: &C, screen: &Screen) -> Result<(), ReplyError<
                 eprintln!("Another WM is already running.");
                 exit(1);
             }
-            error => Err(ReplyError::X11Error(error))
+            error => Err(ReplyError::X11Error(error)),
         }
     } else {
         Ok(())

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -10,7 +10,7 @@ use x11rb::connection::{Connection, RequestConnection};
 use x11rb::errors::{ReplyError, ReplyOrIdError};
 use x11rb::x11_utils::Event as _;
 use x11rb::xproto::*;
-use x11rb::{Event, COPY_DEPTH_FROM_PARENT};
+use x11rb::{Error, Event, COPY_DEPTH_FROM_PARENT};
 
 const TITLEBAR_HEIGHT: u16 = 20;
 
@@ -330,13 +330,18 @@ fn become_wm<C: Connection>(conn: &C, screen: &Screen) -> Result<(), ReplyError<
         .change_window_attributes(screen.root, &change)?
         .check()?;
     if let Some(error) = error {
-        if error.error_code() == ACCESS_ERROR {
-            eprintln!("Another WM is already running.");
-            exit(1);
+        match error {
+            Error::Access(_) => {
+                eprintln!("Another WM is already running.");
+                exit(1);
+            },
+            // FIXME
+            //err => Err(error.into())
+            err => panic!("Unexpected error: {:?}", err)
         }
-        return Err(error.into());
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 fn main() {

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -6,7 +6,7 @@ extern crate x11rb;
 use std::collections::HashSet;
 use std::process::exit;
 
-use x11rb::connection::Connection;
+use x11rb::connection::{Connection, RequestConnection};
 use x11rb::errors::{ReplyError, ReplyOrIdError};
 use x11rb::x11_utils::Event as _;
 use x11rb::xproto::*;

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -21,7 +21,7 @@ extern crate x11rb;
 
 use std::error::Error;
 
-use x11rb::connection::{Connection, SequenceNumber};
+use x11rb::connection::{Connection, SequenceNumber, RequestConnection};
 use x11rb::errors::{ConnectionError, ReplyError, ReplyOrIdError};
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xproto::*;

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -783,7 +783,7 @@ fn example6() -> Result<(), Box<dyn Error>> {
     conn.flush()?;
 
     loop {
-        let event = conn.parse_event(conn.wait_for_event()?)?;
+        let event = conn.wait_for_event()?;
         if let Event::Expose(_) = event {
             // We draw the points
             conn.poly_point(CoordMode::Origin, win, foreground, &points)?;
@@ -956,7 +956,7 @@ fn example_change_event_mask<C: Connection>(conn: &C, win: Window) -> Result<(),
 #[allow(unused)]
 fn example_wait_for_event<C: Connection>(conn: &C) -> Result<(), Box<dyn Error>> {
     loop {
-        let event = conn.parse_event(conn.wait_for_event()?)?;
+        let event = conn.wait_for_event()?;
         match event {
             Event::Expose(_event) => {
                 // ....
@@ -1300,7 +1300,7 @@ fn example7() -> Result<(), Box<dyn Error>> {
     conn.flush()?;
 
     loop {
-        let event = conn.parse_event(conn.wait_for_event()?)?;
+        let event = conn.wait_for_event()?;
         match event {
             Event::Expose(event) => {
                 println!(
@@ -1529,7 +1529,7 @@ fn example8() -> Result<(), Box<dyn Error>> {
     conn.flush()?;
 
     loop {
-        let event = conn.parse_event(conn.wait_for_event()?)?;
+        let event = conn.wait_for_event()?;
         match event {
             Event::Expose(_) => {
                 let text = "Press ESC key to exit...";
@@ -2404,7 +2404,7 @@ fn example10() -> Result<(), Box<dyn Error>> {
     let mut is_hand = false;
 
     loop {
-        let event = conn.parse_event(conn.wait_for_event()?)?;
+        let event = conn.wait_for_event()?;
         match event {
             Event::Expose(_) => {
                 let text = "click here to change cursor";

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -21,7 +21,7 @@ extern crate x11rb;
 
 use std::error::Error;
 
-use x11rb::connection::{Connection, SequenceNumber, RequestConnection};
+use x11rb::connection::{Connection, SequenceNumber};
 use x11rb::errors::{ConnectionError, ReplyError, ReplyOrIdError};
 use x11rb::wrapper::ConnectionExt as _;
 use x11rb::xproto::*;

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -307,7 +307,7 @@ fn main() {
         let event = conn.wait_for_event().unwrap();
         let mut event_option = Some(event);
         while let Some(event) = event_option {
-            match conn.parse_event(event).unwrap() {
+            match event {
                 Event::Expose(event) => {
                     if event.count == 0 {
                         need_repaint = true;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -259,6 +259,12 @@ pub trait RequestConnection {
 
     /// The maximum number of bytes that the X11 server accepts in a request.
     fn maximum_request_bytes(&self) -> usize;
+
+    /// Parse a generic error.
+    fn parse_error(&self, error: GenericError<Self::Buf>) -> Result<Error<Self::Buf>, ParseError>;
+
+    /// Parse a generic event.
+    fn parse_event(&self, event: GenericEvent<Self::Buf>) -> Result<Event<Self::Buf>, ParseError>;
 }
 
 /// A connection to an X11 server.
@@ -281,12 +287,6 @@ pub trait Connection: RequestConnection {
     fn poll_for_event_with_sequence(
         &self,
     ) -> Result<Option<EventAndSeqNumber<Self::Buf>>, ConnectionError>;
-
-    /// Parse a generic error.
-    fn parse_error(&self, error: GenericError<Self::Buf>) -> Result<Error<Self::Buf>, ParseError>;
-
-    /// Parse a generic event.
-    fn parse_event(&self, event: GenericEvent<Self::Buf>) -> Result<Event<Self::Buf>, ParseError>;
 
     /// Send all pending requests to the server.
     ///
@@ -350,7 +350,7 @@ pub enum DiscardMode {
 /// use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
 /// use x11rb::errors::{ParseError, ConnectionError};
 /// use x11rb::utils::RawFdContainer;
-/// use x11rb::x11_utils::ExtensionInformation;
+/// use x11rb::x11_utils::{ExtensionInformation, GenericError, GenericEvent};
 ///
 /// struct MyConnection();
 ///
@@ -394,6 +394,12 @@ pub enum DiscardMode {
 ///     # }
 ///     # fn prefetch_maximum_request_bytes(&self) {
 ///     #    unimplemented!()
+///     # }
+///     # fn parse_error(&self, _error: GenericError<Self::Buf>) -> Result<x11rb::Error<Self::Buf>, ParseError> {
+///     #     unimplemented!()
+///     # }
+///     # fn parse_event(&self, _event: GenericEvent<Self::Buf>) -> Result<x11rb::Event<Self::Buf>, ParseError> {
+///     #     unimplemented!()
 ///     # }
 ///
 ///     fn send_request_with_reply<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -66,11 +66,13 @@ pub type RawEventAndSeqNumber<B> = (SequenceNumber, GenericEvent<B>);
 
 /// Either a raw reply or a raw error response to an X11 request.
 #[derive(Debug)]
-pub enum ReplyOrError<R, E=R>
-where R: std::fmt::Debug,
-      E: AsRef<[u8]> + std::fmt::Debug {
+pub enum ReplyOrError<R, E = R>
+where
+    R: std::fmt::Debug,
+    E: AsRef<[u8]> + std::fmt::Debug,
+{
     Reply(R),
-    Error(GenericError<E>)
+    Error(GenericError<E>),
 }
 
 /// A connection to an X11 server for sending requests.
@@ -209,7 +211,7 @@ pub trait RequestConnection {
     ) -> Result<Self::Buf, ReplyError<Self::Buf>> {
         match self.wait_for_reply_or_raw_error(sequence)? {
             ReplyOrError::Reply(reply) => Ok(reply),
-            ReplyOrError::Error(error) => Err(ReplyError::X11Error(self.parse_error(error)?))
+            ReplyOrError::Error(error) => Err(ReplyError::X11Error(self.parse_error(error)?)),
         }
     }
 
@@ -335,16 +337,18 @@ pub trait Connection: RequestConnection {
     }
 
     /// Wait for a new event from the X11 server.
-    fn wait_for_event_with_sequence(&self)
-        -> Result<EventAndSeqNumber<Self::Buf>, ConnectionError> {
+    fn wait_for_event_with_sequence(
+        &self,
+    ) -> Result<EventAndSeqNumber<Self::Buf>, ConnectionError> {
         let (seq, event) = self.wait_for_raw_event_with_sequence()?;
         let event = self.parse_event(event)?;
         Ok((seq, event))
     }
 
     /// Wait for a new raw/unparsed event from the X11 server.
-    fn wait_for_raw_event_with_sequence(&self)
-        -> Result<RawEventAndSeqNumber<Self::Buf>, ConnectionError>;
+    fn wait_for_raw_event_with_sequence(
+        &self,
+    ) -> Result<RawEventAndSeqNumber<Self::Buf>, ConnectionError>;
 
     /// Poll for a new event from the X11 server.
     fn poll_for_event(&self) -> Result<Option<Event<Self::Buf>>, ConnectionError> {
@@ -362,7 +366,7 @@ pub trait Connection: RequestConnection {
     ) -> Result<Option<EventAndSeqNumber<Self::Buf>>, ConnectionError> {
         Ok(match self.poll_for_raw_event_with_sequence()? {
             Some((seq, event)) => Some((seq, self.parse_event(event)?)),
-            None => None
+            None => None,
         })
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -229,6 +229,20 @@ pub trait RequestConnection {
     fn check_for_error(
         &self,
         sequence: SequenceNumber,
+    ) -> Result<Option<Error<Self::Buf>>, ConnectionError> {
+        let res = self.check_for_raw_error(sequence)?;
+        let res = res.map(|e| self.parse_error(e)).transpose()?;
+        Ok(res)
+    }
+
+    /// Check whether a request that does not have a reply caused an X11 error.
+    ///
+    /// The given sequence number identifies the request for which the check should be performed.
+    ///
+    /// Users of this library will most likely not want to use this function directly.
+    fn check_for_raw_error(
+        &self,
+        sequence: SequenceNumber,
     ) -> Result<Option<GenericError<Self::Buf>>, ConnectionError>;
 
     /// Prefetches the maximum request length.
@@ -414,7 +428,7 @@ pub enum DiscardMode {
 ///     # -> Result<BufWithFds<Vec<u8>>, x11rb::errors::ReplyError<Vec<u8>>> {
 ///     #    unimplemented!()
 ///     # }
-///     # fn check_for_error(&self, sequence: SequenceNumber)
+///     # fn check_for_raw_error(&self, sequence: SequenceNumber)
 ///     # ->Result<Option<x11rb::x11_utils::GenericError<Vec<u8>>>, ConnectionError> {
 ///     #    unimplemented!()
 ///     # }

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use crate::connection::{BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber};
 use crate::errors::{ConnectionError, ParseError, ReplyError};
 use crate::utils::RawFdContainer;
-use crate::x11_utils::GenericError;
 use crate::xproto::ListFontsWithInfoReply;
+use crate::Error;
 
 /// A handle to a possible error from the X11 server.
 ///
@@ -49,7 +49,7 @@ where
     }
 
     /// Check if the original request caused an X11 error.
-    pub fn check(self) -> Result<Option<GenericError<C::Buf>>, ConnectionError> {
+    pub fn check(self) -> Result<Option<Error<C::Buf>>, ConnectionError> {
         let (connection, sequence) = self.consume();
         connection.check_for_error(sequence)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 
-use crate::x11_utils::{Event as _, GenericError};
+use crate::x11_utils::GenericError;
 use crate::xproto::{SetupAuthenticate, SetupFailed};
 
 /// An error occurred while parsing some data
@@ -193,7 +193,7 @@ impl<B: AsRef<[u8]> + std::fmt::Debug> std::fmt::Display for ReplyError<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReplyError::ConnectionError(e) => write!(f, "{}", e),
-            ReplyError::X11Error(e) => write!(f, "X11 error {:?}", e.raw_bytes()),
+            ReplyError::X11Error(e) => write!(f, "X11 error {:?}", e),
         }
     }
 }
@@ -244,7 +244,7 @@ impl<B: AsRef<[u8]> + std::fmt::Debug> std::fmt::Display for ReplyOrIdError<B> {
         match self {
             ReplyOrIdError::IdsExhausted => f.write_str("X11 IDs have been exhausted"),
             ReplyOrIdError::ConnectionError(e) => write!(f, "{}", e),
-            ReplyOrIdError::X11Error(e) => write!(f, "X11 error {:?}", e.raw_bytes()),
+            ReplyOrIdError::X11Error(e) => write!(f, "X11 error {:?}", e),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,5 @@
 //! This module contains the current mess that is error handling.
 
-use crate::x11_utils::GenericError;
 use crate::xproto::{SetupAuthenticate, SetupFailed};
 use crate::Error;
 
@@ -223,56 +222,6 @@ impl<B: AsRef<[u8]> + std::fmt::Debug> From<ConnectionError> for ReplyError<B> {
 
 impl<B: AsRef<[u8]> + std::fmt::Debug> From<Error<B>> for ReplyError<B> {
     fn from(err: Error<B>) -> Self {
-        Self::X11Error(err)
-    }
-}
-
-/// An error that occurred with some request.
-#[derive(Debug)]
-pub enum RawReplyError<B: AsRef<[u8]> + std::fmt::Debug> {
-    /// Some error occurred on the X11 connection.
-    ConnectionError(ConnectionError),
-    /// The X11 server sent an error in response to the request.
-    X11Error(GenericError<B>),
-}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> std::error::Error for RawReplyError<B> {}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> std::fmt::Display for RawReplyError<B> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RawReplyError::ConnectionError(e) => write!(f, "{}", e),
-            RawReplyError::X11Error(e) => write!(f, "X11 error {:?}", e),
-        }
-    }
-}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> From<ParseError> for RawReplyError<B> {
-    fn from(err: ParseError) -> Self {
-        Self::from(ConnectionError::from(err))
-    }
-}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> From<std::num::TryFromIntError> for RawReplyError<B> {
-    fn from(err: std::num::TryFromIntError) -> Self {
-        Self::from(ParseError::from(err))
-    }
-}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> From<std::io::Error> for RawReplyError<B> {
-    fn from(err: std::io::Error) -> Self {
-        ConnectionError::from(err).into()
-    }
-}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> From<ConnectionError> for RawReplyError<B> {
-    fn from(err: ConnectionError) -> Self {
-        Self::ConnectionError(err)
-    }
-}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> From<GenericError<B>> for RawReplyError<B> {
-    fn from(err: GenericError<B>) -> Self {
         Self::X11Error(err)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -180,7 +180,7 @@ impl From<std::io::Error> for ConnectionError {
 
 /// An error that occurred with some request.
 #[derive(Debug)]
-pub enum ReplyError<B: AsRef<[u8]>> {
+pub enum ReplyError<B: AsRef<[u8]> + std::fmt::Debug> {
     /// Some error occurred on the X11 connection.
     ConnectionError(ConnectionError),
     /// The X11 server sent an error in response to the request.
@@ -189,7 +189,7 @@ pub enum ReplyError<B: AsRef<[u8]>> {
 
 impl<B: AsRef<[u8]> + std::fmt::Debug> Error for ReplyError<B> {}
 
-impl<B: AsRef<[u8]>> std::fmt::Display for ReplyError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> std::fmt::Display for ReplyError<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReplyError::ConnectionError(e) => write!(f, "{}", e),
@@ -198,31 +198,31 @@ impl<B: AsRef<[u8]>> std::fmt::Display for ReplyError<B> {
     }
 }
 
-impl<B: AsRef<[u8]>> From<ParseError> for ReplyError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<ParseError> for ReplyError<B> {
     fn from(err: ParseError) -> Self {
         Self::from(ConnectionError::from(err))
     }
 }
 
-impl<B: AsRef<[u8]>> From<std::num::TryFromIntError> for ReplyError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<std::num::TryFromIntError> for ReplyError<B> {
     fn from(err: std::num::TryFromIntError) -> Self {
         Self::from(ParseError::from(err))
     }
 }
 
-impl<B: AsRef<[u8]>> From<std::io::Error> for ReplyError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<std::io::Error> for ReplyError<B> {
     fn from(err: std::io::Error) -> Self {
         ConnectionError::from(err).into()
     }
 }
 
-impl<B: AsRef<[u8]>> From<ConnectionError> for ReplyError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<ConnectionError> for ReplyError<B> {
     fn from(err: ConnectionError) -> Self {
         Self::ConnectionError(err)
     }
 }
 
-impl<B: AsRef<[u8]>> From<GenericError<B>> for ReplyError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<GenericError<B>> for ReplyError<B> {
     fn from(err: GenericError<B>) -> Self {
         Self::X11Error(err)
     }
@@ -230,7 +230,7 @@ impl<B: AsRef<[u8]>> From<GenericError<B>> for ReplyError<B> {
 
 /// An error caused by some request or by the exhaustion of IDs.
 #[derive(Debug)]
-pub enum ReplyOrIdError<B: AsRef<[u8]>> {
+pub enum ReplyOrIdError<B: AsRef<[u8]> + std::fmt::Debug> {
     /// All available IDs have been exhausted.
     IdsExhausted,
     /// Some error occurred on the X11 connection.
@@ -239,7 +239,7 @@ pub enum ReplyOrIdError<B: AsRef<[u8]>> {
     X11Error(GenericError<B>),
 }
 
-impl<B: AsRef<[u8]>> std::fmt::Display for ReplyOrIdError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> std::fmt::Display for ReplyOrIdError<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReplyOrIdError::IdsExhausted => f.write_str("X11 IDs have been exhausted"),
@@ -251,19 +251,19 @@ impl<B: AsRef<[u8]>> std::fmt::Display for ReplyOrIdError<B> {
 
 impl<B: AsRef<[u8]> + std::fmt::Debug> Error for ReplyOrIdError<B> {}
 
-impl<B: AsRef<[u8]>> From<ConnectionError> for ReplyOrIdError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<ConnectionError> for ReplyOrIdError<B> {
     fn from(err: ConnectionError) -> Self {
         ReplyOrIdError::ConnectionError(err)
     }
 }
 
-impl<B: AsRef<[u8]>> From<GenericError<B>> for ReplyOrIdError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<GenericError<B>> for ReplyOrIdError<B> {
     fn from(err: GenericError<B>) -> Self {
         ReplyOrIdError::X11Error(err)
     }
 }
 
-impl<B: AsRef<[u8]>> From<ReplyError<B>> for ReplyOrIdError<B> {
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<ReplyError<B>> for ReplyOrIdError<B> {
     fn from(err: ReplyError<B>) -> Self {
         match err {
             ReplyError::ConnectionError(err) => ReplyOrIdError::ConnectionError(err),

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -156,7 +156,7 @@ mod test {
         BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber,
     };
     use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-    use crate::errors::{ConnectionError, ParseError, ReplyError};
+    use crate::errors::{ConnectionError, ParseError, RawReplyError};
     use crate::utils::RawFdContainer;
     use crate::x11_utils::{ExtInfoProvider, ExtensionInformation, GenericError};
 
@@ -215,10 +215,10 @@ mod test {
             unimplemented!()
         }
 
-        fn wait_for_reply_or_error(
+        fn wait_for_reply_or_raw_error(
             &self,
             sequence: SequenceNumber,
-        ) -> Result<Vec<u8>, ReplyError<Vec<u8>>> {
+        ) -> Result<Vec<u8>, RawReplyError<Vec<u8>>> {
             // Code should only ask once for the reply to a request. Check that this is the case
             // (by requiring monotonically increasing sequence numbers here).
             let mut last = self.0.borrow_mut();
@@ -230,7 +230,7 @@ mod test {
             );
             *last = sequence;
             // Then return an error, because that's what the #[test] below needs.
-            Err(ReplyError::ConnectionError(ConnectionError::UnknownError))
+            Err(RawReplyError::ConnectionError(ConnectionError::UnknownError))
         }
 
         fn wait_for_reply(
@@ -240,10 +240,10 @@ mod test {
             unimplemented!()
         }
 
-        fn wait_for_reply_with_fds(
+        fn wait_for_reply_with_fds_raw(
             &self,
             _sequence: SequenceNumber,
-        ) -> Result<BufWithFds<Vec<u8>>, ReplyError<Vec<u8>>> {
+        ) -> Result<BufWithFds<Vec<u8>>, RawReplyError<Vec<u8>>> {
             unimplemented!()
         }
 

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -262,11 +262,17 @@ mod test {
             unimplemented!()
         }
 
-        fn parse_error(&self, _error: GenericError<Self::Buf>) -> Result<crate::Error<Self::Buf>, ParseError> {
+        fn parse_error(
+            &self,
+            _error: GenericError<Self::Buf>,
+        ) -> Result<crate::Error<Self::Buf>, ParseError> {
             unimplemented!()
         }
 
-        fn parse_event(&self, _event: crate::x11_utils::GenericEvent<Self::Buf>) -> Result<crate::Event<Self::Buf>, ParseError> {
+        fn parse_event(
+            &self,
+            _event: crate::x11_utils::GenericEvent<Self::Buf>,
+        ) -> Result<crate::Event<Self::Buf>, ParseError> {
             unimplemented!()
         }
     }

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -247,7 +247,7 @@ mod test {
             unimplemented!()
         }
 
-        fn check_for_error(
+        fn check_for_raw_error(
             &self,
             _sequence: SequenceNumber,
         ) -> Result<Option<GenericError<Vec<u8>>>, ConnectionError> {

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -153,10 +153,10 @@ mod test {
     use std::io::IoSlice;
 
     use crate::connection::{
-        BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber,
+        BufWithFds, DiscardMode, ReplyOrError, RequestConnection, RequestKind, SequenceNumber,
     };
     use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-    use crate::errors::{ConnectionError, ParseError, RawReplyError};
+    use crate::errors::{ConnectionError, ParseError};
     use crate::utils::RawFdContainer;
     use crate::x11_utils::{ExtInfoProvider, ExtensionInformation, GenericError};
 
@@ -218,7 +218,7 @@ mod test {
         fn wait_for_reply_or_raw_error(
             &self,
             sequence: SequenceNumber,
-        ) -> Result<Vec<u8>, RawReplyError<Vec<u8>>> {
+        ) -> Result<ReplyOrError<Vec<u8>>, ConnectionError> {
             // Code should only ask once for the reply to a request. Check that this is the case
             // (by requiring monotonically increasing sequence numbers here).
             let mut last = self.0.borrow_mut();
@@ -230,7 +230,7 @@ mod test {
             );
             *last = sequence;
             // Then return an error, because that's what the #[test] below needs.
-            Err(RawReplyError::ConnectionError(ConnectionError::UnknownError))
+            Err(ConnectionError::UnknownError)
         }
 
         fn wait_for_reply(
@@ -243,7 +243,7 @@ mod test {
         fn wait_for_reply_with_fds_raw(
             &self,
             _sequence: SequenceNumber,
-        ) -> Result<BufWithFds<Vec<u8>>, RawReplyError<Vec<u8>>> {
+        ) -> Result<ReplyOrError<BufWithFds<Vec<u8>>, Vec<u8>>, ConnectionError> {
             unimplemented!()
         }
 

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -261,6 +261,14 @@ mod test {
         fn prefetch_maximum_request_bytes(&self) {
             unimplemented!()
         }
+
+        fn parse_error(&self, _error: GenericError<Self::Buf>) -> Result<crate::Error<Self::Buf>, ParseError> {
+            unimplemented!()
+        }
+
+        fn parse_event(&self, _event: crate::x11_utils::GenericEvent<Self::Buf>) -> Result<crate::Event<Self::Buf>, ParseError> {
+            unimplemented!()
+        }
     }
 
     #[test]

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -228,11 +228,17 @@ mod test {
             unimplemented!()
         }
 
-        fn parse_error(&self, _error: GenericError<Self::Buf>) -> Result<crate::Error<Self::Buf>, ParseError> {
+        fn parse_error(
+            &self,
+            _error: GenericError<Self::Buf>,
+        ) -> Result<crate::Error<Self::Buf>, ParseError> {
             unimplemented!()
         }
 
-        fn parse_event(&self, _event: crate::x11_utils::GenericEvent<Self::Buf>) -> Result<crate::Event<Self::Buf>, ParseError> {
+        fn parse_event(
+            &self,
+            _event: crate::x11_utils::GenericEvent<Self::Buf>,
+        ) -> Result<crate::Event<Self::Buf>, ParseError> {
             unimplemented!()
         }
     }

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -213,7 +213,7 @@ mod test {
             unimplemented!()
         }
 
-        fn check_for_error(
+        fn check_for_raw_error(
             &self,
             _sequence: SequenceNumber,
         ) -> Result<Option<GenericError<Vec<u8>>>, ConnectionError> {

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -227,5 +227,13 @@ mod test {
         fn prefetch_maximum_request_bytes(&self) {
             unimplemented!()
         }
+
+        fn parse_error(&self, _error: GenericError<Self::Buf>) -> Result<crate::Error<Self::Buf>, ParseError> {
+            unimplemented!()
+        }
+
+        fn parse_event(&self, _event: crate::x11_utils::GenericEvent<Self::Buf>) -> Result<crate::Event<Self::Buf>, ParseError> {
+            unimplemented!()
+        }
     }
 }

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -76,7 +76,7 @@ mod test {
         BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber,
     };
     use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-    use crate::errors::{ConnectionError, ParseError, ReplyError};
+    use crate::errors::{ConnectionError, ParseError, RawReplyError};
     use crate::utils::RawFdContainer;
     use crate::x11_utils::{ExtensionInformation, GenericError};
 
@@ -192,10 +192,10 @@ mod test {
             }))
         }
 
-        fn wait_for_reply_or_error(
+        fn wait_for_reply_or_raw_error(
             &self,
             _sequence: SequenceNumber,
-        ) -> Result<Vec<u8>, ReplyError<Vec<u8>>> {
+        ) -> Result<Vec<u8>, RawReplyError<Vec<u8>>> {
             Ok(self.0.as_ref().unwrap().clone())
         }
 
@@ -206,10 +206,10 @@ mod test {
             unimplemented!()
         }
 
-        fn wait_for_reply_with_fds(
+        fn wait_for_reply_with_fds_raw(
             &self,
             _sequence: SequenceNumber,
-        ) -> Result<BufWithFds<Vec<u8>>, ReplyError<Vec<u8>>> {
+        ) -> Result<BufWithFds<Vec<u8>>, RawReplyError<Vec<u8>>> {
             unimplemented!()
         }
 

--- a/src/rust_connection/id_allocator.rs
+++ b/src/rust_connection/id_allocator.rs
@@ -73,10 +73,10 @@ mod test {
     use std::io::IoSlice;
 
     use crate::connection::{
-        BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber,
+        BufWithFds, DiscardMode, ReplyOrError, RequestConnection, RequestKind, SequenceNumber,
     };
     use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
-    use crate::errors::{ConnectionError, ParseError, RawReplyError};
+    use crate::errors::{ConnectionError, ParseError};
     use crate::utils::RawFdContainer;
     use crate::x11_utils::{ExtensionInformation, GenericError};
 
@@ -195,8 +195,8 @@ mod test {
         fn wait_for_reply_or_raw_error(
             &self,
             _sequence: SequenceNumber,
-        ) -> Result<Vec<u8>, RawReplyError<Vec<u8>>> {
-            Ok(self.0.as_ref().unwrap().clone())
+        ) -> Result<ReplyOrError<Vec<u8>>, ConnectionError> {
+            Ok(ReplyOrError::Reply(self.0.as_ref().unwrap().clone()))
         }
 
         fn wait_for_reply(
@@ -209,7 +209,7 @@ mod test {
         fn wait_for_reply_with_fds_raw(
             &self,
             _sequence: SequenceNumber,
-        ) -> Result<BufWithFds<Vec<u8>>, RawReplyError<Vec<u8>>> {
+        ) -> Result<ReplyOrError<BufWithFds<Vec<u8>>, Vec<u8>>, ConnectionError> {
             unimplemented!()
         }
 

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -397,6 +397,16 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
         let mut max_bytes = self.maximum_request_bytes.lock().unwrap();
         self.prefetch_maximum_request_bytes_impl(&mut max_bytes);
     }
+
+    fn parse_error(&self, error: GenericError) -> Result<Error, ParseError> {
+        let ext_mgr = self.extension_manager.lock().unwrap();
+        Error::parse(error, &*ext_mgr)
+    }
+
+    fn parse_event(&self, event: GenericEvent) -> Result<Event, ParseError> {
+        let ext_mgr = self.extension_manager.lock().unwrap();
+        Event::parse(event, &*ext_mgr)
+    }
 }
 
 impl<R: Read, W: Write> Connection for RustConnection<R, W> {
@@ -412,16 +422,6 @@ impl<R: Read, W: Write> Connection for RustConnection<R, W> {
 
     fn poll_for_event_with_sequence(&self) -> Result<Option<EventAndSeqNumber>, ConnectionError> {
         Ok(self.inner.lock().unwrap().poll_for_event_with_sequence())
-    }
-
-    fn parse_error(&self, error: GenericError) -> Result<Error, ParseError> {
-        let ext_mgr = self.extension_manager.lock().unwrap();
-        Error::parse(error, &*ext_mgr)
-    }
-
-    fn parse_event(&self, event: GenericEvent) -> Result<Event, ParseError> {
-        let ext_mgr = self.extension_manager.lock().unwrap();
-        Event::parse(event, &*ext_mgr)
     }
 
     fn flush(&self) -> Result<(), ConnectionError> {

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -29,6 +29,7 @@ pub type ReplyError = crate::errors::ReplyError<Buffer>;
 pub type GenericError = crate::x11_utils::GenericError<Buffer>;
 pub type GenericEvent = crate::x11_utils::GenericEvent<Buffer>;
 pub type EventAndSeqNumber = crate::connection::EventAndSeqNumber<Buffer>;
+pub type RawEventAndSeqNumber = crate::connection::RawEventAndSeqNumber<Buffer>;
 pub type BufWithFds = crate::connection::BufWithFds<Buffer>;
 pub type Error = crate::Error<Buffer>;
 pub type Event = crate::Event<Buffer>;
@@ -410,7 +411,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
 }
 
 impl<R: Read, W: Write> Connection for RustConnection<R, W> {
-    fn wait_for_event_with_sequence(&self) -> Result<EventAndSeqNumber, ConnectionError> {
+    fn wait_for_raw_event_with_sequence(&self) -> Result<RawEventAndSeqNumber, ConnectionError> {
         let mut inner = self.inner.lock().unwrap();
         loop {
             if let Some(event) = inner.poll_for_event_with_sequence() {
@@ -420,7 +421,7 @@ impl<R: Read, W: Write> Connection for RustConnection<R, W> {
         }
     }
 
-    fn poll_for_event_with_sequence(&self) -> Result<Option<EventAndSeqNumber>, ConnectionError> {
+    fn poll_for_raw_event_with_sequence(&self) -> Result<Option<RawEventAndSeqNumber>, ConnectionError> {
         Ok(self.inner.lock().unwrap().poll_for_event_with_sequence())
     }
 

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -6,7 +6,8 @@ use std::sync::{Condvar, Mutex, MutexGuard, TryLockError};
 
 use crate::bigreq::{ConnectionExt as _, EnableReply};
 use crate::connection::{
-    compute_length_field, Connection, DiscardMode, ReplyOrError, RequestConnection, RequestKind, SequenceNumber,
+    compute_length_field, Connection, DiscardMode, ReplyOrError, RequestConnection, RequestKind,
+    SequenceNumber,
 };
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 pub use crate::errors::{ConnectError, ConnectionError, ParseError};
@@ -312,7 +313,10 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
             .extension_information(self, extension_name)
     }
 
-    fn wait_for_reply_or_raw_error(&self, sequence: SequenceNumber) -> Result<ReplyOrError<Vec<u8>>, ConnectionError> {
+    fn wait_for_reply_or_raw_error(
+        &self,
+        sequence: SequenceNumber,
+    ) -> Result<ReplyOrError<Vec<u8>>, ConnectionError> {
         let mut inner = self.inner.lock().unwrap();
         inner.flush()?; // Ensure the request is sent
         loop {
@@ -358,7 +362,10 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
         }
     }
 
-    fn wait_for_reply_with_fds_raw(&self, _sequence: SequenceNumber) -> Result<ReplyOrError<BufWithFds, Buffer>, ConnectionError> {
+    fn wait_for_reply_with_fds_raw(
+        &self,
+        _sequence: SequenceNumber,
+    ) -> Result<ReplyOrError<BufWithFds, Buffer>, ConnectionError> {
         unreachable!(
             "To wait for a reply containing FDs, a successful call to \
         send_request_with_reply_with_fds() is necessary. However, this function never succeeds."
@@ -421,7 +428,9 @@ impl<R: Read, W: Write> Connection for RustConnection<R, W> {
         }
     }
 
-    fn poll_for_raw_event_with_sequence(&self) -> Result<Option<RawEventAndSeqNumber>, ConnectionError> {
+    fn poll_for_raw_event_with_sequence(
+        &self,
+    ) -> Result<Option<RawEventAndSeqNumber>, ConnectionError> {
         Ok(self.inner.lock().unwrap().poll_for_event_with_sequence())
     }
 

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -26,6 +26,7 @@ use inner::PollReply;
 type Buffer = <RustConnection as RequestConnection>::Buf;
 pub type ReplyOrIdError = crate::errors::ReplyOrIdError<Buffer>;
 pub type ReplyError = crate::errors::ReplyError<Buffer>;
+pub type RawReplyError = crate::errors::RawReplyError<Buffer>;
 pub type GenericError = crate::x11_utils::GenericError<Buffer>;
 pub type GenericEvent = crate::x11_utils::GenericEvent<Buffer>;
 pub type EventAndSeqNumber = crate::connection::EventAndSeqNumber<Buffer>;
@@ -312,7 +313,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
             .extension_information(self, extension_name)
     }
 
-    fn wait_for_reply_or_error(&self, sequence: SequenceNumber) -> Result<Vec<u8>, ReplyError> {
+    fn wait_for_reply_or_raw_error(&self, sequence: SequenceNumber) -> Result<Vec<u8>, RawReplyError> {
         let mut inner = self.inner.lock().unwrap();
         inner.flush()?; // Ensure the request is sent
         loop {
@@ -358,7 +359,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
         }
     }
 
-    fn wait_for_reply_with_fds(&self, _sequence: SequenceNumber) -> Result<BufWithFds, ReplyError> {
+    fn wait_for_reply_with_fds_raw(&self, _sequence: SequenceNumber) -> Result<BufWithFds, RawReplyError> {
         unreachable!(
             "To wait for a reply containing FDs, a successful call to \
         send_request_with_reply_with_fds() is necessary. However, this function never succeeds."

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -341,7 +341,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
         }
     }
 
-    fn check_for_error(
+    fn check_for_raw_error(
         &self,
         sequence: SequenceNumber,
     ) -> Result<Option<GenericError>, ConnectionError> {

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -31,6 +31,7 @@ pub type ReplyError = crate::errors::ReplyError<Buffer>;
 pub type GenericError = crate::x11_utils::GenericError<Buffer>;
 pub type GenericEvent = crate::x11_utils::GenericEvent<Buffer>;
 pub type EventAndSeqNumber = crate::connection::EventAndSeqNumber<Buffer>;
+pub type RawEventAndSeqNumber = crate::connection::RawEventAndSeqNumber<Buffer>;
 pub type BufWithFds = crate::connection::BufWithFds<Buffer>;
 pub type Error = crate::Error<Buffer>;
 pub type Event = crate::Event<Buffer>;
@@ -476,7 +477,7 @@ impl RequestConnection for XCBConnection {
 }
 
 impl Connection for XCBConnection {
-    fn wait_for_event_with_sequence(&self) -> Result<EventAndSeqNumber, ConnectionError> {
+    fn wait_for_raw_event_with_sequence(&self) -> Result<RawEventAndSeqNumber, ConnectionError> {
         if let Some(error) = self.errors.get(self) {
             return Ok((error.0, error.1.into()));
         }
@@ -489,7 +490,7 @@ impl Connection for XCBConnection {
         }
     }
 
-    fn poll_for_event_with_sequence(&self) -> Result<Option<EventAndSeqNumber>, ConnectionError> {
+    fn poll_for_raw_event_with_sequence(&self) -> Result<Option<RawEventAndSeqNumber>, ConnectionError> {
         if let Some(error) = self.errors.get(self) {
             return Ok(Some((error.0, error.1.into())));
         }

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -442,7 +442,7 @@ impl RequestConnection for XCBConnection {
         unimplemented!("FD passing is currently only implemented on Unix-like systems")
     }
 
-    fn check_for_error(
+    fn check_for_raw_error(
         &self,
         sequence: SequenceNumber,
     ) -> Result<Option<GenericError>, ConnectionError> {

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -463,6 +463,16 @@ impl RequestConnection for XCBConnection {
     fn prefetch_maximum_request_bytes(&self) {
         unsafe { raw_ffi::xcb_prefetch_maximum_request_length(self.conn.as_ptr()) };
     }
+
+    fn parse_error(&self, error: GenericError) -> Result<Error, ParseError> {
+        let ext_mgr = self.ext_mgr.lock().unwrap();
+        Error::parse(error, &*ext_mgr)
+    }
+
+    fn parse_event(&self, event: GenericEvent) -> Result<Event, ParseError> {
+        let ext_mgr = self.ext_mgr.lock().unwrap();
+        Event::parse(event, &*ext_mgr)
+    }
 }
 
 impl Connection for XCBConnection {
@@ -495,16 +505,6 @@ impl Connection for XCBConnection {
             }
             Ok(Some(Self::wrap_event(event as _)?))
         }
-    }
-
-    fn parse_error(&self, error: GenericError) -> Result<Error, ParseError> {
-        let ext_mgr = self.ext_mgr.lock().unwrap();
-        Error::parse(error, &*ext_mgr)
-    }
-
-    fn parse_event(&self, event: GenericEvent) -> Result<Event, ParseError> {
-        let ext_mgr = self.ext_mgr.lock().unwrap();
-        Event::parse(event, &*ext_mgr)
     }
 
     fn flush(&self) -> Result<(), ConnectionError> {

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -394,7 +394,7 @@ impl RequestConnection for XCBConnection {
             let reply = raw_ffi::xcb_wait_for_reply64(self.conn.as_ptr(), sequence, &mut error);
             match (reply.is_null(), error.is_null()) {
                 (true, true) => {
-                    Err(Self::connection_error_from_connection(self.conn.as_ptr()).into())
+                    Err(Self::connection_error_from_connection(self.conn.as_ptr()))
                 }
                 (false, true) => Ok(ReplyOrError::Reply(Self::wrap_reply(reply as _))),
                 (true, false) => Ok(ReplyOrError::Error(GenericError::new(Self::wrap_error(error as _))?)),

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -14,7 +14,7 @@ use libc::c_void;
 
 use super::xproto::Setup;
 use crate::connection::{
-    compute_length_field, Connection, DiscardMode, RequestConnection, RequestKind, SequenceNumber,
+    compute_length_field, Connection, DiscardMode, ReplyOrError, RequestConnection, RequestKind, SequenceNumber,
 };
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 pub use crate::errors::{ConnectError, ConnectionError, ParseError};
@@ -28,7 +28,6 @@ mod raw_ffi;
 type Buffer = <XCBConnection as RequestConnection>::Buf;
 pub type ReplyOrIdError = crate::errors::ReplyOrIdError<Buffer>;
 pub type ReplyError = crate::errors::ReplyError<Buffer>;
-pub type RawReplyError = crate::errors::RawReplyError<Buffer>;
 pub type GenericError = crate::x11_utils::GenericError<Buffer>;
 pub type GenericEvent = crate::x11_utils::GenericEvent<Buffer>;
 pub type EventAndSeqNumber = crate::connection::EventAndSeqNumber<Buffer>;
@@ -389,7 +388,7 @@ impl RequestConnection for XCBConnection {
             .extension_information(self, extension_name)
     }
 
-    fn wait_for_reply_or_raw_error(&self, sequence: SequenceNumber) -> Result<CSlice, RawReplyError> {
+    fn wait_for_reply_or_raw_error(&self, sequence: SequenceNumber) -> Result<ReplyOrError<CSlice>, ConnectionError> {
         unsafe {
             let mut error = null_mut();
             let reply = raw_ffi::xcb_wait_for_reply64(self.conn.as_ptr(), sequence, &mut error);
@@ -397,10 +396,8 @@ impl RequestConnection for XCBConnection {
                 (true, true) => {
                     Err(Self::connection_error_from_connection(self.conn.as_ptr()).into())
                 }
-                (false, true) => Ok(Self::wrap_reply(reply as _)),
-                (true, false) => Err(GenericError::new(Self::wrap_error(error as _))
-                    .unwrap()
-                    .into()),
+                (false, true) => Ok(ReplyOrError::Reply(Self::wrap_reply(reply as _))),
+                (true, false) => Ok(ReplyOrError::Error(GenericError::new(Self::wrap_error(error as _))?)),
                 // At least one of these pointers must be NULL.
                 (false, false) => unreachable!(),
             }
@@ -408,21 +405,21 @@ impl RequestConnection for XCBConnection {
     }
 
     fn wait_for_reply(&self, sequence: SequenceNumber) -> Result<Option<CSlice>, ConnectionError> {
-        match self.wait_for_reply_or_raw_error(sequence) {
-            Ok(buffer) => Ok(Some(buffer)),
-            Err(err) => match err {
-                RawReplyError::ConnectionError(err) => Err(err),
-                RawReplyError::X11Error(err) => {
-                    self.errors.append_error((sequence, err));
-                    Ok(None)
-                }
+        match self.wait_for_reply_or_raw_error(sequence)? {
+            ReplyOrError::Reply(reply) => Ok(Some(reply)),
+            ReplyOrError::Error(error) => {
+                self.errors.append_error((sequence, error));
+                Ok(None)
             },
         }
     }
 
     #[cfg(unix)]
-    fn wait_for_reply_with_fds_raw(&self, sequence: SequenceNumber) -> Result<BufWithFds, RawReplyError> {
-        let buffer = self.wait_for_reply_or_raw_error(sequence)?;
+    fn wait_for_reply_with_fds_raw(&self, sequence: SequenceNumber) -> Result<ReplyOrError<BufWithFds, Buffer>, ConnectionError> {
+        let buffer = match self.wait_for_reply_or_raw_error(sequence)? {
+            ReplyOrError::Reply(reply) => reply,
+            ReplyOrError::Error(error) => return Ok(ReplyOrError::Error(error))
+        };
 
         // Get a pointer to the array of integers where libxcb saved the FD numbers.
         // libxcb saves the list of FDs after the data of the reply. Since the reply's
@@ -435,11 +432,11 @@ impl RequestConnection for XCBConnection {
         let vector = unsafe { std::slice::from_raw_parts(fd_ptr, usize::from(buffer[1])) };
         let vector = vector.iter().map(|&fd| RawFdContainer::new(fd)).collect();
 
-        Ok((buffer, vector))
+        Ok(ReplyOrError::Reply((buffer, vector)))
     }
 
     #[cfg(not(unix))]
-    fn wait_for_reply_with_fds(&self, _sequence: SequenceNumber) -> Result<BufWithFds, ReplyError> {
+    fn wait_for_reply_with_fds_raw(&self, sequence: SequenceNumber) -> Result<ReplyOrError<BufWithFds, Buffer>, ConnectionError> {
         unimplemented!("FD passing is currently only implemented on Unix-like systems")
     }
 

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -46,7 +46,7 @@ fn multithread_test() {
 
     // Main thread: wait for events until finished
     loop {
-        let event = conn.wait_for_event().unwrap();
+        let event = conn.wait_for_raw_event().unwrap();
         if event.response_type() == CLIENT_MESSAGE_EVENT {
             break;
         }

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -4,10 +4,10 @@ use std::io::IoSlice;
 use std::ops::Deref;
 
 use x11rb::connection::{
-    compute_length_field, BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber,
+    compute_length_field, BufWithFds, DiscardMode, ReplyOrError, RequestConnection, RequestKind, SequenceNumber,
 };
 use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
-use x11rb::errors::{ConnectionError, ParseError, RawReplyError, ReplyError};
+use x11rb::errors::{ConnectionError, ParseError, ReplyError};
 use x11rb::utils::RawFdContainer;
 use x11rb::x11_utils::{ExtensionInformation, GenericError, Serialize, TryParse};
 use x11rb::xproto::{
@@ -116,7 +116,7 @@ impl RequestConnection for FakeConnection {
     fn wait_for_reply_or_raw_error(
         &self,
         _sequence: SequenceNumber,
-    ) -> Result<Vec<u8>, RawReplyError<Vec<u8>>> {
+    ) -> Result<ReplyOrError<Vec<u8>>, ConnectionError> {
         unimplemented!()
     }
 
@@ -130,7 +130,7 @@ impl RequestConnection for FakeConnection {
     fn wait_for_reply_with_fds_raw(
         &self,
         _sequence: SequenceNumber,
-    ) -> Result<BufWithFds<Vec<u8>>, RawReplyError<Vec<u8>>> {
+    ) -> Result<ReplyOrError<BufWithFds<Vec<u8>>, Vec<u8>>, ConnectionError> {
         unimplemented!()
     }
 

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -134,7 +134,7 @@ impl RequestConnection for FakeConnection {
         unimplemented!()
     }
 
-    fn check_for_error(
+    fn check_for_raw_error(
         &self,
         _sequence: SequenceNumber,
     ) -> Result<Option<GenericError<Vec<u8>>>, ConnectionError> {

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -4,7 +4,8 @@ use std::io::IoSlice;
 use std::ops::Deref;
 
 use x11rb::connection::{
-    compute_length_field, BufWithFds, DiscardMode, ReplyOrError, RequestConnection, RequestKind, SequenceNumber,
+    compute_length_field, BufWithFds, DiscardMode, ReplyOrError, RequestConnection, RequestKind,
+    SequenceNumber,
 };
 use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
 use x11rb::errors::{ConnectionError, ParseError, ReplyError};
@@ -150,11 +151,17 @@ impl RequestConnection for FakeConnection {
         unimplemented!()
     }
 
-    fn parse_error(&self, _error: GenericError<Self::Buf>) -> Result<x11rb::Error<Self::Buf>, ParseError> {
+    fn parse_error(
+        &self,
+        _error: GenericError<Self::Buf>,
+    ) -> Result<x11rb::Error<Self::Buf>, ParseError> {
         unimplemented!()
     }
 
-    fn parse_event(&self, _event: x11rb::x11_utils::GenericEvent<Self::Buf>) -> Result<x11rb::Event<Self::Buf>, ParseError> {
+    fn parse_event(
+        &self,
+        _event: x11rb::x11_utils::GenericEvent<Self::Buf>,
+    ) -> Result<x11rb::Event<Self::Buf>, ParseError> {
         unimplemented!()
     }
 }

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -149,6 +149,14 @@ impl RequestConnection for FakeConnection {
     fn prefetch_maximum_request_bytes(&self) {
         unimplemented!()
     }
+
+    fn parse_error(&self, _error: GenericError<Self::Buf>) -> Result<x11rb::Error<Self::Buf>, ParseError> {
+        unimplemented!()
+    }
+
+    fn parse_event(&self, _event: x11rb::x11_utils::GenericEvent<Self::Buf>) -> Result<x11rb::Event<Self::Buf>, ParseError> {
+        unimplemented!()
+    }
 }
 
 #[test]

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -7,7 +7,7 @@ use x11rb::connection::{
     compute_length_field, BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber,
 };
 use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
-use x11rb::errors::{ConnectionError, ParseError, ReplyError};
+use x11rb::errors::{ConnectionError, ParseError, RawReplyError, ReplyError};
 use x11rb::utils::RawFdContainer;
 use x11rb::x11_utils::{ExtensionInformation, GenericError, Serialize, TryParse};
 use x11rb::xproto::{
@@ -113,10 +113,10 @@ impl RequestConnection for FakeConnection {
         unimplemented!()
     }
 
-    fn wait_for_reply_or_error(
+    fn wait_for_reply_or_raw_error(
         &self,
         _sequence: SequenceNumber,
-    ) -> Result<Vec<u8>, ReplyError<Vec<u8>>> {
+    ) -> Result<Vec<u8>, RawReplyError<Vec<u8>>> {
         unimplemented!()
     }
 
@@ -127,10 +127,10 @@ impl RequestConnection for FakeConnection {
         unimplemented!()
     }
 
-    fn wait_for_reply_with_fds(
+    fn wait_for_reply_with_fds_raw(
         &self,
         _sequence: SequenceNumber,
-    ) -> Result<BufWithFds<Vec<u8>>, ReplyError<Vec<u8>>> {
+    ) -> Result<BufWithFds<Vec<u8>>, RawReplyError<Vec<u8>>> {
         unimplemented!()
     }
 


### PR DESCRIPTION
This is a step towards #312. All the APIs on `Connection` can now either return "just a bunch of bytes" or an already parsed error/event. I am not really sure if this is the right approach (the traits are growing way to big), but removing some of these "raw" APIs is left as future work (part of #312).

For now, this PR should be a move in the right direction.

@eduardosm Do you think this is good to go?