### PR TITLE
Add some ICCCM utility functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub mod connection;
 pub mod cookie;
 pub mod errors;
 pub mod extension_manager;
+pub mod properties;
 pub mod rust_connection;
 pub mod wrapper;
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,9 +1,12 @@
 //! Utility functions for working with X11 properties
 
+use std::convert::TryInto;
+
 use crate::connection::RequestConnection;
-use crate::cookie::Cookie;
+use crate::cookie::{Cookie, VoidCookie};
 use crate::errors::{ConnectionError, ParseError, ReplyError};
-use crate::xproto::{AtomEnum, GetPropertyReply, Window, get_property};
+use crate::xproto::{Atom, AtomEnum, GetPropertyReply, Window, get_property, self};
+use crate::x11_utils::{TryParse, Serialize};
 
 /// A cookie for getting a window's `WM_CLASS` property.
 #[derive(Debug)]
@@ -14,7 +17,7 @@ where Conn: RequestConnection + ?Sized
 {
     /// Send a `GetProperty` request for the `WM_CLASS` property of the given window
     pub fn new(conn: &'a Conn, window: Window) -> Result<Self, ConnectionError> {
-        Ok(WmClassCookie(get_property(
+        Ok(Self(get_property(
             conn,
             false,
             window,
@@ -27,13 +30,13 @@ where Conn: RequestConnection + ?Sized
 
     /// Get the reply that the server sent.
     pub fn reply(self) -> Result<WmClass, ReplyError<Conn::Buf>> {
-        Ok(WmClass::new(self.0.reply()?)?)
+        Ok(WmClass::from_reply(self.0.reply()?)?)
     }
 
     /// Get the reply that the server sent, but have errors handled as events.
     pub fn reply_unchecked(self) -> Result<Option<WmClass>, ConnectionError> {
         self.0.reply_unchecked()?
-            .map(|r| WmClass::new(r))
+            .map(|r| WmClass::from_reply(r))
             .transpose()
             .map_err(Into::into)
     }
@@ -53,7 +56,7 @@ impl WmClass {
     ///
     /// The original `GetProperty` request must have been for a `WM_CLASS` property for this
     /// function to return sensible results.
-    pub fn new(reply: GetPropertyReply) -> Result<Self, ParseError> {
+    pub fn from_reply(reply: GetPropertyReply) -> Result<Self, ParseError> {
         if reply.type_ != AtomEnum::STRING.into() || reply.format != 8 {
             return Err(ParseError::ParseError);
         }
@@ -82,6 +85,304 @@ impl WmClass {
             self.0.value.len()
         };
         &self.0.value[start..end]
+    }
+}
+
+/// Representation of whether some part of `WM_SIZE_HINTS` was user/program specified.
+#[derive(Debug, Copy, Clone)]
+pub enum WmSizeHintsSpecification {
+    UserSpecified,
+    ProgramSpecified,
+}
+
+/// A cookie for getting a window's `WM_SIZE_HINTS` property.
+#[derive(Debug)]
+pub struct WmSizeHintsCookie<'a, Conn: RequestConnection + ?Sized>(Cookie<'a, Conn, GetPropertyReply>);
+
+const NUM_WM_SIZE_HINTS_ELEMENTS: u32 = 18;
+
+impl<'a, Conn> WmSizeHintsCookie<'a, Conn>
+where Conn: RequestConnection + ?Sized
+{
+    /// Send a `GetProperty` request for the `WM_SIZE_HINTS` property of the given window.
+    pub fn new(conn: &'a Conn, window: Window, property: Atom) -> Result<Self, ConnectionError> {
+        Ok(Self(get_property(
+            conn,
+            false,
+            window,
+            property,
+            AtomEnum::WM_SIZE_HINTS.into(),
+            0,
+            NUM_WM_SIZE_HINTS_ELEMENTS,
+        )?))
+    }
+
+    /// Get the reply that the server sent.
+    pub fn reply(self) -> Result<WmSizeHints, ReplyError<Conn::Buf>> {
+        Ok(WmSizeHints::from_reply(self.0.reply()?)?)
+    }
+
+    /// Get the reply that the server sent, but have errors handled as events.
+    pub fn reply_unchecked(self) -> Result<Option<WmSizeHints>, ConnectionError> {
+        self.0.reply_unchecked()?
+            .map(|r| WmSizeHints::from_reply(r))
+            .transpose()
+            .map_err(Into::into)
+    }
+}
+
+// Possible flags for `WM_SIZE_HINTS`.
+const U_S_POSITION: u32 = 1 << 0;
+const U_S_SIZE: u32 = 1 << 1;
+const P_S_POSITION: u32 = 1 << 2;
+const P_S_SIZE: u32 = 1 << 3;
+const P_MIN_SIZE: u32 = 1 << 4;
+const P_MAX_SIZE: u32 = 1 << 5;
+const P_RESIZE_INCREMENT: u32 = 1 << 6;
+const P_ASPECT: u32 = 1 << 7;
+const P_BASE_SIZE: u32 = 1 << 8;
+const P_WIN_GRAVITY: u32 = 1 << 9;
+
+/// An aspect ratio
+#[derive(Debug, Copy, Clone)]
+pub struct AspectRatio {
+    pub numerator: i32,
+    pub denominator: i32,
+}
+
+impl AspectRatio {
+    pub fn new(numerator: i32, denominator: i32) -> Self {
+        Self {
+            numerator,
+            denominator
+        }
+    }
+}
+
+/// A structure representing a `WM_SIZE_HINTS` property.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct WmSizeHints {
+    pub position: Option<(WmSizeHintsSpecification, i32, i32)>,
+    pub size: Option<(WmSizeHintsSpecification, i32, i32)>,
+    pub min_size: Option<(i32, i32)>,
+    pub max_size: Option<(i32, i32)>,
+    pub size_increment: Option<(i32, i32)>,
+    /// The minimum and maximum aspect ratio
+    pub aspect: Option<(AspectRatio, AspectRatio)>,
+    pub base_size: Option<(i32, i32)>,
+    pub win_gravity: Option<xproto::Gravity>,
+}
+
+impl WmSizeHints {
+    /// Get a new, empty `WmSizeHints` structure.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Send a `GetProperty` request for the `WM_SIZE_HINTS` property of the given window
+    pub fn get<C: RequestConnection>(conn: &C, window: Window, property: Atom) -> Result<WmSizeHintsCookie<'_, C>, ConnectionError> {
+        WmSizeHintsCookie::new(conn, window, property)
+    }
+
+    /// Construct a new `WmSizeHints` instance from a `GetPropertyReply`.
+    ///
+    /// The original `WmSizeHints` request must have been for a `WM_SIZE_HINTS` property for this
+    /// function to return sensible results.
+    pub fn from_reply(reply: GetPropertyReply) -> Result<Self, ParseError> {
+        // Implemented based on what xcb_icccm does. At least a bit. This stuff makes no sense...
+
+        if reply.type_ != AtomEnum::WM_SIZE_HINTS.into() || reply.format != 32 {
+            return Err(ParseError::ParseError);
+        }
+
+        let remaining = &reply.value;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (x, remaining) = i32::try_parse(remaining)?;
+        let (y, remaining) = i32::try_parse(remaining)?;
+        let (width, remaining) = i32::try_parse(remaining)?;
+        let (height, remaining) = i32::try_parse(remaining)?;
+        let (min_width, remaining) = i32::try_parse(remaining)?;
+        let (min_height, remaining) = i32::try_parse(remaining)?;
+        let (max_width, remaining) = i32::try_parse(remaining)?;
+        let (max_height, remaining) = i32::try_parse(remaining)?;
+        let (width_increment, remaining) = i32::try_parse(remaining)?;
+        let (height_increment, remaining) = i32::try_parse(remaining)?;
+        let (min_aspect_num, remaining) = i32::try_parse(remaining)?;
+        let (min_aspect_den, remaining) = i32::try_parse(remaining)?;
+        let (max_aspect_num, remaining) = i32::try_parse(remaining)?;
+        let (max_aspect_den, remaining) = i32::try_parse(remaining)?;
+        // Apparently, some older version of ICCCM didn't have these...?
+        let (base_width, base_height, wire_win_gravity) = if remaining.is_empty() {
+            (min_width, min_height, 1)
+        } else {
+            let (base_width, remaining) = i32::try_parse(remaining)?;
+            let (base_height, remaining) = i32::try_parse(remaining)?;
+            let (wire_win_gravity, _remaining) = u32::try_parse(remaining)?;
+            (base_width, base_height, wire_win_gravity)
+        };
+
+        // FIXME: Move this into the code generator
+        let win_gravity = match wire_win_gravity {
+            1 => xproto::Gravity::NorthWest,
+            2 => xproto::Gravity::North,
+            3 => xproto::Gravity::NorthEast,
+            4 => xproto::Gravity::West,
+            5 => xproto::Gravity::Center,
+            6 => xproto::Gravity::East,
+            7 => xproto::Gravity::SouthWest,
+            8 => xproto::Gravity::South,
+            9 => xproto::Gravity::SouthEast,
+            10 => xproto::Gravity::Static,
+            // BitForget and WinUnmap are not allowed here
+            _ => return Err(ParseError::ParseError),
+        };
+        assert_eq!(wire_win_gravity, win_gravity.into());
+
+        let position = if flags & U_S_POSITION != 0 {
+            Some((WmSizeHintsSpecification::UserSpecified, x, y))
+        } else if flags & P_S_POSITION != 0 {
+            Some((WmSizeHintsSpecification::ProgramSpecified, x, y))
+        } else {
+            None
+        };
+        let size = if flags & U_S_SIZE != 0 {
+            Some((WmSizeHintsSpecification::UserSpecified, width, height))
+        } else if flags & P_S_SIZE != 0 {
+            Some((WmSizeHintsSpecification::ProgramSpecified, width, height))
+        } else {
+            None
+        };
+        let min_size = if flags & P_MIN_SIZE != 0 {
+            Some((min_width, min_height))
+        } else {
+            None
+        };
+        let max_size = if flags & P_MAX_SIZE != 0 {
+            Some((max_width, max_height))
+        } else {
+            None
+        };
+        let size_increment = if flags & P_RESIZE_INCREMENT != 0 {
+            Some((width_increment, height_increment))
+        } else {
+            None
+        };
+        let aspect = if flags & P_ASPECT != 0 {
+            let min_aspect = AspectRatio::new(min_aspect_num, min_aspect_den);
+            let max_aspect = AspectRatio::new(max_aspect_num, max_aspect_den);
+            Some((min_aspect, max_aspect))
+        } else {
+            None
+        };
+        let base_size = if flags & P_BASE_SIZE != 0 {
+            Some((base_width, base_height))
+        } else {
+            None
+        };
+        let win_gravity = if flags & P_WIN_GRAVITY != 0 {
+            Some(win_gravity)
+        } else {
+            None
+        };
+
+        Ok(WmSizeHints {
+            position,
+            size,
+            min_size,
+            max_size,
+            size_increment,
+            aspect,
+            base_size,
+            win_gravity,
+        })
+    }
+
+    /// Set these `WM_SIZE_HINTS` on some window.
+    pub fn set<'a, C: RequestConnection + ?Sized>(&self, conn: &'a C, window: Window, property: Atom) -> Result<VoidCookie<'a, C>, ConnectionError> {
+        // 18*4 surely fits into an usize, so this unwrap() cannot trigger
+        let mut data = Vec::with_capacity((NUM_WM_SIZE_HINTS_ELEMENTS * 4).try_into().unwrap());
+
+        let mut flags = 0;
+        match self.position {
+            Some((WmSizeHintsSpecification::UserSpecified, _, _)) => flags |= U_S_POSITION,
+            Some((WmSizeHintsSpecification::ProgramSpecified, _, _)) => flags |= P_S_POSITION,
+            None => {},
+        }
+        match self.size {
+            Some((WmSizeHintsSpecification::UserSpecified, _, _)) => flags |= U_S_SIZE,
+            Some((WmSizeHintsSpecification::ProgramSpecified, _, _)) => flags |= P_S_SIZE,
+            None => {},
+        }
+        if self.min_size.is_some() {
+            flags |= P_MIN_SIZE;
+        }
+        if self.max_size.is_some() {
+            flags |= P_MAX_SIZE;
+        }
+        if self.size_increment.is_some() {
+            flags |= P_RESIZE_INCREMENT;
+        }
+        if self.aspect.is_some() {
+            flags |= P_ASPECT;
+        }
+        if self.base_size.is_some() {
+            flags |= P_BASE_SIZE;
+        }
+        if self.win_gravity.is_some() {
+            flags |= P_WIN_GRAVITY;
+        }
+
+        flags.serialize_into(&mut data);
+
+        let (x, y) = match self.position {
+            Some((_, x, y)) => (x, y),
+            None => (0, 0),
+        };
+        x.serialize_into(&mut data);
+        y.serialize_into(&mut data);
+
+        let (width, height) = match self.size {
+            Some((_, width, height)) => (width, height),
+            None => (0, 0),
+        };
+        width.serialize_into(&mut data);
+        height.serialize_into(&mut data);
+
+        let (min_width, min_height) = self.min_size.unwrap_or((0, 0));
+        min_width.serialize_into(&mut data);
+        min_height.serialize_into(&mut data);
+
+        let (max_width, max_height) = self.max_size.unwrap_or((0, 0));
+        max_width.serialize_into(&mut data);
+        max_height.serialize_into(&mut data);
+
+        let (width_inc, height_inc) = self.size_increment.unwrap_or((0, 0));
+        width_inc.serialize_into(&mut data);
+        height_inc.serialize_into(&mut data);
+
+        let (min_aspect, max_aspect) = self.aspect.unwrap_or((AspectRatio::new(0, 0), AspectRatio::new(0, 0)));
+        min_aspect.numerator.serialize_into(&mut data);
+        min_aspect.denominator.serialize_into(&mut data);
+        max_aspect.numerator.serialize_into(&mut data);
+        max_aspect.denominator.serialize_into(&mut data);
+
+        let (base_width, base_height) = self.base_size.unwrap_or((0, 0));
+        base_width.serialize_into(&mut data);
+        base_height.serialize_into(&mut data);
+
+        let gravity = self.win_gravity.map_or(0, u32::from);
+        gravity.serialize_into(&mut data);
+
+        xproto::change_property(
+            conn,
+            xproto::PropMode::Replace,
+            window,
+            property,
+            AtomEnum::WM_SIZE_HINTS,
+            32,
+            NUM_WM_SIZE_HINTS_ELEMENTS,
+            &data,
+        )
     }
 }
 
@@ -118,7 +419,7 @@ mod test {
             (b"Hello\0World", b"Hello", b"World"),
             (b"Hello\0World\0Good\0Day", b"Hello", b"World\0Good\0Day"),
         ] {
-            let wm_class = WmClass::new(get_property_reply(input)).unwrap();
+            let wm_class = WmClass::from_reply(get_property_reply(input)).unwrap();
             assert_eq!((wm_class.instance(), wm_class.class()), (*instance, *class));
         }
     }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,0 +1,125 @@
+//! Utility functions for working with X11 properties
+
+use crate::connection::RequestConnection;
+use crate::cookie::Cookie;
+use crate::errors::{ConnectionError, ParseError, ReplyError};
+use crate::xproto::{AtomEnum, GetPropertyReply, Window, get_property};
+
+/// A cookie for getting a window's `WM_CLASS` property.
+#[derive(Debug)]
+pub struct WmClassCookie<'a, Conn: RequestConnection + ?Sized>(Cookie<'a, Conn, GetPropertyReply>);
+
+impl<'a, Conn> WmClassCookie<'a, Conn>
+where Conn: RequestConnection + ?Sized
+{
+    /// Send a `GetProperty` request for the `WM_CLASS` property of the given window
+    pub fn new(conn: &'a Conn, window: Window) -> Result<Self, ConnectionError> {
+        Ok(WmClassCookie(get_property(
+            conn,
+            false,
+            window,
+            AtomEnum::WM_CLASS.into(),
+            AtomEnum::STRING.into(),
+            0,
+            2048,
+        )?))
+    }
+
+    /// Get the reply that the server sent.
+    pub fn reply(self) -> Result<WmClass, ReplyError<Conn::Buf>> {
+        Ok(WmClass::new(self.0.reply()?)?)
+    }
+
+    /// Get the reply that the server sent, but have errors handled as events.
+    pub fn reply_unchecked(self) -> Result<Option<WmClass>, ConnectionError> {
+        self.0.reply_unchecked()?
+            .map(|r| WmClass::new(r))
+            .transpose()
+            .map_err(Into::into)
+    }
+}
+
+/// The value of a window's `WM_CLASS` property.
+#[derive(Debug)]
+pub struct WmClass(GetPropertyReply, usize);
+
+impl WmClass {
+    /// Send a `GetProperty` request for the `WM_CLASS` property of the given window
+    pub fn get<C: RequestConnection>(conn: &C, window: Window) -> Result<WmClassCookie<'_, C>, ConnectionError> {
+        WmClassCookie::new(conn, window)
+    }
+
+    /// Construct a new `WmClass` instance from a `GetPropertyReply`.
+    ///
+    /// The original `GetProperty` request must have been for a `WM_CLASS` property for this
+    /// function to return sensible results.
+    pub fn new(reply: GetPropertyReply) -> Result<Self, ParseError> {
+        if reply.type_ != AtomEnum::STRING.into() || reply.format != 8 {
+            return Err(ParseError::ParseError);
+        }
+        // Find the first zero byte in the value
+        let offset = reply.value
+            .iter()
+            .position(|&v| v == 0)
+            .unwrap_or_else(|| reply.value.len());
+        Ok(WmClass(reply, offset))
+    }
+
+    /// Get the instance contained in this `WM_CLASS` property
+    pub fn instance(&self) -> &[u8] {
+        &self.0.value[0..self.1]
+    }
+
+    /// Get the class contained in this `WM_CLASS` property
+    pub fn class(&self) -> &[u8] {
+        let start = self.1 + 1;
+        if start >= self.0.value.len() {
+            return &[];
+        };
+        let end = if self.0.value.last() == Some(&0) {
+            self.0.value.len() - 1
+        } else {
+            self.0.value.len()
+        };
+        &self.0.value[start..end]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryInto;
+
+    use crate::xproto::{AtomEnum, GetPropertyReply};
+    use super::WmClass;
+
+    fn get_property_reply(value: &[u8]) -> GetPropertyReply {
+        GetPropertyReply {
+            response_type: 1,
+            format: 8,
+            sequence: 0,
+            length: 0,
+            type_: AtomEnum::STRING.into(),
+            bytes_after: 0,
+            value_len: value.len().try_into().unwrap(),
+            value: value.to_vec(),
+        }
+    }
+
+    #[test]
+    fn test_wm_class() {
+        for (input, instance, class) in &[
+            (&b""[..], &b""[..], &b""[..]),
+            (b"\0", b"", b""),
+            (b"\0\0", b"", b""),
+            (b"\0\0\0", b"", b"\0"),
+            (b"Hello World", b"Hello World", b""),
+            (b"Hello World\0", b"Hello World", b""),
+            (b"Hello\0World\0", b"Hello", b"World"),
+            (b"Hello\0World", b"Hello", b"World"),
+            (b"Hello\0World\0Good\0Day", b"Hello", b"World\0Good\0Day"),
+        ] {
+            let wm_class = WmClass::new(get_property_reply(input)).unwrap();
+            assert_eq!((wm_class.instance(), wm_class.class()), (*instance, *class));
+        }
+    }
+}

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -40,7 +40,7 @@ where Conn: RequestConnection + ?Sized
     /// Get the reply that the server sent, but have errors handled as events.
     pub fn reply_unchecked(self) -> Result<Option<WmClass>, ConnectionError> {
         self.0.reply_unchecked()?
-            .map(|r| WmClass::from_reply(r))
+            .map(WmClass::from_reply)
             .transpose()
             .map_err(Into::into)
     }
@@ -156,14 +156,14 @@ where Conn: RequestConnection + ?Sized
     /// Get the reply that the server sent, but have errors handled as events.
     pub fn reply_unchecked(self) -> Result<Option<WmSizeHints>, ConnectionError> {
         self.0.reply_unchecked()?
-            .map(|r| WmSizeHints::from_reply(r))
+            .map(WmSizeHints::from_reply)
             .transpose()
             .map_err(Into::into)
     }
 }
 
 // Possible flags for `WM_SIZE_HINTS`.
-const U_S_POSITION: u32 = 1 << 0;
+const U_S_POSITION: u32 = 1;
 const U_S_SIZE: u32 = 1 << 1;
 const P_S_POSITION: u32 = 1 << 2;
 const P_S_SIZE: u32 = 1 << 3;
@@ -198,6 +198,7 @@ impl TryParse for AspectRatio {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 impl Serialize for AspectRatio {
     type Bytes = [u8; 8];
     fn serialize(&self) -> Self::Bytes {
@@ -422,7 +423,7 @@ where Conn: RequestConnection + ?Sized
     /// Get the reply that the server sent, but have errors handled as events.
     pub fn reply_unchecked(self) -> Result<Option<WmHints>, ConnectionError> {
         self.0.reply_unchecked()?
-            .map(|r| WmHints::from_reply(r))
+            .map(WmHints::from_reply)
             .transpose()
             .map_err(Into::into)
     }
@@ -436,7 +437,7 @@ pub enum WmHintsState {
 }
 
 // Possible flags for `WM_HINTS`.
-const HINT_INPUT: u32 = 1 << 0;
+const HINT_INPUT: u32 = 1;
 const HINT_STATE: u32 = 1 << 1;
 const HINT_ICON_PIXMAP: u32 = 1 << 2;
 const HINT_ICON_WINDOW: u32 = 1 << 3;
@@ -631,9 +632,9 @@ mod test {
         // This is the value of some random xterm window.
         // It was acquired via 'xtrace xprop WM_NORMAL_HINTS'.
         let input = [
-            0x00000350, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000015, 0x00000017,
-            0x00000000, 0x00000000, 0x0000000a, 0x00000013, 0x00000000, 0x00000000, 0x00000000,
-            0x00000000, 0x0000000b, 0x00000004, 0x00000001,
+            0x0000_0350, 0x0000_0000, 0x0000_0000, 0x0000_0000, 0x0000_0000, 0x0000_0015, 0x0000_0017,
+            0x0000_0000, 0x0000_0000, 0x0000_000a, 0x0000_0013, 0x0000_0000, 0x0000_0000, 0x0000_0000,
+            0x0000_0000, 0x0000_000b, 0x0000_0004, 0x0000_0001,
         ];
         let input = input
             .iter()
@@ -658,8 +659,8 @@ mod test {
         // This is the value of some random xterm window.
         // It was acquired via 'xtrace xprop WM_HINTS'.
         let input = [
-            0x00000043, 0x00000001, 0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
-            0x00000000, 0x00600009,
+            0x0000_0043, 0x0000_0001, 0x0000_0001, 0x0000_0000, 0x0000_0000, 0x000_00000, 0x000_00000,
+            0x0000_0000, 0x0060_0009,
         ];
         let input = input
             .iter()
@@ -676,7 +677,7 @@ mod test {
         assert_eq!(wm_hints.icon_window, None);
         assert_eq!(wm_hints.icon_position, None);
         assert_eq!(wm_hints.icon_mask, None);
-        assert_eq!(wm_hints.window_group, Some(0x600009));
+        assert_eq!(wm_hints.window_group, Some(0x0060_0009));
         assert_eq!(wm_hints.urgent, false);
 
         assert_eq!(input, wm_hints.serialize());

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -532,7 +532,7 @@ impl Serialize for WmHints {
         }
 
         flags.serialize_into(bytes);
-        self.input.unwrap_or(false).serialize_into(bytes);
+        Into::<u32>::into(self.input.unwrap_or(false)).serialize_into(bytes);
         match self.initial_state {
             Some(WmHintsState::Normal) => 1,
             Some(WmHintsState::Iconic) => 3,
@@ -619,6 +619,8 @@ mod test {
         assert!(wm_size_hints.aspect.is_none(), "{:?}", wm_size_hints.aspect);
         assert_eq!(wm_size_hints.base_size, Some((11, 4)));
         assert_eq!(wm_size_hints.win_gravity, Some(Gravity::NorthWest));
+
+        assert_eq!(input, wm_size_hints.serialize());
     }
 
     #[test]
@@ -646,5 +648,7 @@ mod test {
         assert_eq!(wm_hints.icon_mask, None);
         assert_eq!(wm_hints.window_group, Some(0x600009));
         assert_eq!(wm_hints.urgent, false);
+
+        assert_eq!(input, wm_hints.serialize());
     }
 }

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -339,8 +339,7 @@ impl Serialize for () {
     fn serialize(&self) -> Self::Bytes {
         []
     }
-    fn serialize_into(&self, _bytes: &mut Vec<u8>) {
-    }
+    fn serialize_into(&self, _bytes: &mut Vec<u8>) {}
 }
 
 impl<T: Serialize> Serialize for (T,) {

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -504,6 +504,7 @@ macro_rules! atom_manager {
         #[allow(non_snake_case)]
         #[derive(Debug)]
         $vis struct $cookie_name<'a, C: $crate::xproto::ConnectionExt> {
+            phantom: std::marker::PhantomData<&'a C>,
             $(
                 $field_name: $crate::cookie::Cookie<'a, C, $crate::xproto::InternAtomReply>,
             )*
@@ -520,11 +521,12 @@ macro_rules! atom_manager {
 
         impl $struct_name {
             $vis fn new<C: $crate::xproto::ConnectionExt>(
-                conn: &C,
+                _conn: &C,
             ) -> ::std::result::Result<$cookie_name<'_, C>, $crate::errors::ConnectionError> {
                 Ok($cookie_name {
+                    phantom: std::marker::PhantomData,
                     $(
-                        $field_name: conn.intern_atom(
+                        $field_name: _conn.intern_atom(
                             false,
                             $crate::__atom_manager_atom_value!($field_name$(: $atom_value)?),
                         )?,

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -292,6 +292,84 @@ impl Serialize for bool {
     }
 }
 
+// Tuple handling
+
+macro_rules! tuple_try_parse {
+    ($($name:ident)*) => {
+        impl<$($name,)*> TryParse for ($($name,)*)
+        where $($name: TryParse,)*
+        {
+            #[allow(non_snake_case)]
+            fn try_parse(remaining: &[u8]) -> Result<(($($name,)*), &[u8]), ParseError> {
+                $(let ($name, remaining) = $name::try_parse(remaining)?;)*
+                Ok((($($name,)*), remaining))
+            }
+        }
+    }
+}
+
+macro_rules! tuple_serialize {
+    ($($name:ident:$idx:tt)*) => {
+        impl<$($name,)*> Serialize for ($($name,)*)
+        where $($name: Serialize,)*
+        {
+            type Bytes = Vec<u8>;
+            fn serialize(&self) -> Self::Bytes {
+                let mut result = Vec::new();
+                self.serialize_into(&mut result);
+                result
+            }
+            fn serialize_into(&self, bytes: &mut Vec<u8>) {
+                $(self.$idx.serialize_into(bytes);)*
+            }
+        }
+    }
+}
+
+macro_rules! tuple_impls {
+    ($($name:ident:$idx:tt)*) => {
+        tuple_try_parse!($($name)*);
+        tuple_serialize!($($name:$idx)*);
+    }
+}
+
+// We can optimise serialisation of empty tuples or one-element-tuples with different Bytes type
+impl Serialize for () {
+    type Bytes = [u8; 0];
+    fn serialize(&self) -> Self::Bytes {
+        []
+    }
+    fn serialize_into(&self, _bytes: &mut Vec<u8>) {
+    }
+}
+
+impl<T: Serialize> Serialize for (T,) {
+    type Bytes = T::Bytes;
+    fn serialize(&self) -> Self::Bytes {
+        self.0.serialize()
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        self.0.serialize_into(bytes)
+    }
+}
+
+tuple_try_parse!();
+tuple_try_parse!(A);
+tuple_impls!(A:0 B:1);
+tuple_impls!(A:0 B:1 C:2);
+tuple_impls!(A:0 B:1 C:2 D:3);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8 J:9);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8 J:9 K:10);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8 J:9 K:10 L:11);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8 J:9 K:10 L:11 M:12);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8 J:9 K:10 L:11 M:12 N:13);
+tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8 J:9 K:10 L:11 M:12 N:13 O:14);
+
 /// Parse a list of objects from the given data.
 ///
 /// This function parses a list of objects where the length of the list was specified externally.


### PR DESCRIPTION
I took a look at #164 and found some non-trivial stuff in libxcb-icccm that is about "actual parsing" instead of just some slight convenience. This PR is the result.

Things like "make it slightly easier to query the desktop names" is left as future work. I'll mark #164 as "help wanted".