### PR TITLE
Allow clippy::option_as_ref_deref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,11 @@ script:
   - make
   - if ! git diff --exit-code; then exit 1; fi
 
-  - rustup component add clippy
-  - cargo clippy --all-targets --all-features -- -D warnings
+  - |
+    if [ "x$TRAVIS_RUST_VERSION" != "x1.37.0" ]; then
+        rustup component add clippy
+        cargo clippy --all-targets --all-features -- -D warnings
+    fi
 
   - |
     if [ "x$TRAVIS_RUST_VERSION" != "x1.37.0" ]; then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,9 @@
 //! * `allow-unsafe-code`: Enable features that require `unsafe`. Without this flag,
 //!   `x11rb::xcb_ffi::XCBConnection` and some support code for it are unavailable.
 
+// This lint suggests a function that was added in Rust 1.40.0. Since our minimum supported version
+// is Rust 1.37.0, just disable the lint.
+#![allow(clippy::option_as_ref_deref)]
 #![deny(
     missing_copy_implementations,
     missing_debug_implementations,


### PR DESCRIPTION
This is a new lint that was added two months ago. It triggers on our
code and makes the Rust nightly build fail. However, the lint is not
useful to us, because it suggests a method that was only added in Rust
1.40, while our minimum supported version is Rust 1.37. Thus, this
commit #[!allow]s the lint.

Signed-off-by: Uli Schlachter <psychon@znc.in>