### PR TITLE
Add a mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: Automatic merge
+    conditions:
+      - label!=no-mergify
+      - "#approved-reviews-by>=1"
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=continuous-integration/appveyor/pr
+    actions:
+      merge:
+        method: merge
+      delete_head_branch: {}
+      dismiss_reviews: {}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
     "/Makefile",
     "/rs_code_generator.py",
     "/code_generator_helpers",
+    "/.mergify.yml",
 ]
 
 [dependencies]


### PR DESCRIPTION
This configuration makes mergify merge PRs that passed CI and that have
one approved review. PRs that are marked with the no-mergify label are
ignored.

When the conditions are fulfilled, mergify merges the PR and deletes the
branch that was merged (if it is in the same repo).

Oh and old reviews are automatically dismissed when new commits are
pushed.

Signed-off-by: Uli Schlachter <psychon@znc.in>