### PR TITLE
Remove impl From<TryFromIntError> for ParseError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,12 +18,6 @@ impl std::fmt::Display for ParseError {
     }
 }
 
-impl From<std::num::TryFromIntError> for ParseError {
-    fn from(_: std::num::TryFromIntError) -> Self {
-        ParseError::ParseError
-    }
-}
-
 /// An error that occurred while connecting to an X11 server
 #[derive(Debug)]
 pub enum ConnectError {
@@ -164,12 +158,6 @@ impl From<ParseError> for ConnectionError {
     }
 }
 
-impl From<std::num::TryFromIntError> for ConnectionError {
-    fn from(err: std::num::TryFromIntError) -> Self {
-        Self::from(ParseError::from(err))
-    }
-}
-
 impl From<std::io::Error> for ConnectionError {
     fn from(err: std::io::Error) -> Self {
         ConnectionError::IOError(err)
@@ -199,12 +187,6 @@ impl<B: AsRef<[u8]> + std::fmt::Debug> std::fmt::Display for ReplyError<B> {
 impl<B: AsRef<[u8]> + std::fmt::Debug> From<ParseError> for ReplyError<B> {
     fn from(err: ParseError) -> Self {
         Self::from(ConnectionError::from(err))
-    }
-}
-
-impl<B: AsRef<[u8]> + std::fmt::Debug> From<std::num::TryFromIntError> for ReplyError<B> {
-    fn from(err: std::num::TryFromIntError) -> Self {
-        Self::from(ParseError::from(err))
     }
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -69,7 +69,7 @@ pub trait ConnectionExt: XProtoConnectionExt {
             property,
             type_,
             8,
-            data.len().try_into()?,
+            data.len().try_into().expect("`data` has too many elements"),
             data,
         )
     }
@@ -97,7 +97,7 @@ pub trait ConnectionExt: XProtoConnectionExt {
             property,
             type_,
             16,
-            data.len().try_into()?,
+            data.len().try_into().expect("`data` has too many elements"),
             &data_u8,
         )
     }
@@ -125,7 +125,7 @@ pub trait ConnectionExt: XProtoConnectionExt {
             property,
             type_,
             32,
-            data.len().try_into()?,
+            data.len().try_into().expect("`data` has too many elements"),
             &data_u8,
         )
     }

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -98,7 +98,7 @@ impl<B: AsRef<[u8]>> GenericEvent<B> {
             value_slice[6],
             value_slice[7],
         ]);
-        let length_field: usize = length_field.try_into()?;
+        let length_field: usize = length_field.try_into().or(Err(ParseError::ParseError))?;
         let actual_length = value_slice.len();
         let event = GenericEvent(value);
         let expected_length = match event.response_type() {

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -318,7 +318,7 @@ impl XCBConnection {
         if (*event & 0x7f) == super::xproto::GE_GENERIC_EVENT {
             // Read the length field of the event to get its length
             let length_field = u32::from_ne_bytes([header[4], header[5], header[6], header[7]]);
-            let length_field: usize = length_field.try_into()?;
+            let length_field: usize = length_field.try_into().or(Err(ParseError::ParseError))?;
             length += length_field * 4;
             // Discard the `full_sequence` field inserted by xcb at
             // the 32-byte boundary.


### PR DESCRIPTION
The new code generator does not use this impl but instead panics (and failing to send a request with `ParseError` is weird anyway). Thus, it makes sense to just remove this completely.