### PR TITLE
Use specific code to parse `u8` lists

### DIFF
--- a/src/generated/dri2.rs
+++ b/src/generated/dri2.rs
@@ -481,9 +481,12 @@ impl TryParse for ConnectReply {
         let (driver_name_length, remaining) = u32::try_parse(remaining)?;
         let (device_name_length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (driver_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, driver_name_length as usize)?;
-        let (alignment_pad, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((driver_name_length as usize) + 3) & (!3)) - (driver_name_length as usize))?;
-        let (device_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, device_name_length as usize)?;
+        let (driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, driver_name_length as usize)?;
+        let driver_name = driver_name.to_vec();
+        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (((driver_name_length as usize) + 3) & (!3)) - (driver_name_length as usize))?;
+        let alignment_pad = alignment_pad.to_vec();
+        let (device_name, remaining) = crate::x11_utils::parse_u8_list(remaining, device_name_length as usize)?;
+        let device_name = device_name.to_vec();
         let result = ConnectReply { response_type, sequence, length, driver_name, alignment_pad, device_name };
         Ok((result, remaining))
     }

--- a/src/generated/glx.rs
+++ b/src/generated/glx.rs
@@ -2505,57 +2505,10 @@ impl TryParse for VendorPrivateWithReplyReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let (retval, remaining) = u32::try_parse(remaining)?;
-        let (data1_0, remaining) = u8::try_parse(remaining)?;
-        let (data1_1, remaining) = u8::try_parse(remaining)?;
-        let (data1_2, remaining) = u8::try_parse(remaining)?;
-        let (data1_3, remaining) = u8::try_parse(remaining)?;
-        let (data1_4, remaining) = u8::try_parse(remaining)?;
-        let (data1_5, remaining) = u8::try_parse(remaining)?;
-        let (data1_6, remaining) = u8::try_parse(remaining)?;
-        let (data1_7, remaining) = u8::try_parse(remaining)?;
-        let (data1_8, remaining) = u8::try_parse(remaining)?;
-        let (data1_9, remaining) = u8::try_parse(remaining)?;
-        let (data1_10, remaining) = u8::try_parse(remaining)?;
-        let (data1_11, remaining) = u8::try_parse(remaining)?;
-        let (data1_12, remaining) = u8::try_parse(remaining)?;
-        let (data1_13, remaining) = u8::try_parse(remaining)?;
-        let (data1_14, remaining) = u8::try_parse(remaining)?;
-        let (data1_15, remaining) = u8::try_parse(remaining)?;
-        let (data1_16, remaining) = u8::try_parse(remaining)?;
-        let (data1_17, remaining) = u8::try_parse(remaining)?;
-        let (data1_18, remaining) = u8::try_parse(remaining)?;
-        let (data1_19, remaining) = u8::try_parse(remaining)?;
-        let (data1_20, remaining) = u8::try_parse(remaining)?;
-        let (data1_21, remaining) = u8::try_parse(remaining)?;
-        let (data1_22, remaining) = u8::try_parse(remaining)?;
-        let (data1_23, remaining) = u8::try_parse(remaining)?;
-        let data1 = [
-            data1_0,
-            data1_1,
-            data1_2,
-            data1_3,
-            data1_4,
-            data1_5,
-            data1_6,
-            data1_7,
-            data1_8,
-            data1_9,
-            data1_10,
-            data1_11,
-            data1_12,
-            data1_13,
-            data1_14,
-            data1_15,
-            data1_16,
-            data1_17,
-            data1_18,
-            data1_19,
-            data1_20,
-            data1_21,
-            data1_22,
-            data1_23,
-        ];
-        let (data2, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data1, remaining) = crate::x11_utils::parse_u8_list(remaining, 24)?;
+        let data1 = <[u8; 24]>::try_from(data1).unwrap();
+        let (data2, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data2 = data2.to_vec();
         let result = VendorPrivateWithReplyReply { response_type, sequence, retval, data1, data2 };
         Ok((result, remaining))
     }
@@ -2669,7 +2622,8 @@ impl TryParse for QueryServerStringReply {
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (str_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, str_len as usize)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, str_len as usize)?;
+        let string = string.to_vec();
         let result = QueryServerStringReply { response_type, sequence, length, string };
         Ok((result, remaining))
     }
@@ -3991,7 +3945,8 @@ impl TryParse for ReadPixelsReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = ReadPixelsReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -5060,7 +5015,8 @@ impl TryParse for GetPolygonStippleReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetPolygonStippleReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -5120,7 +5076,8 @@ impl TryParse for GetStringReply {
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n as usize)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, n as usize)?;
+        let string = string.to_vec();
         let result = GetStringReply { response_type, sequence, length, string };
         Ok((result, remaining))
     }
@@ -5539,7 +5496,8 @@ impl TryParse for GetTexImageReply {
         let (height, remaining) = i32::try_parse(remaining)?;
         let (depth, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetTexImageReply { response_type, sequence, width, height, depth, data };
         Ok((result, remaining))
     }
@@ -6248,7 +6206,8 @@ impl TryParse for GetColorTableReply {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let (width, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetColorTableReply { response_type, sequence, width, data };
         Ok((result, remaining))
     }
@@ -6459,7 +6418,8 @@ impl TryParse for GetConvolutionFilterReply {
         let (width, remaining) = i32::try_parse(remaining)?;
         let (height, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetConvolutionFilterReply { response_type, sequence, width, height, data };
         Ok((result, remaining))
     }
@@ -6670,7 +6630,8 @@ impl TryParse for GetSeparableFilterReply {
         let (row_w, remaining) = i32::try_parse(remaining)?;
         let (col_h, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (rows_and_cols, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (rows_and_cols, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let rows_and_cols = rows_and_cols.to_vec();
         let result = GetSeparableFilterReply { response_type, sequence, row_w, col_h, rows_and_cols };
         Ok((result, remaining))
     }
@@ -6746,7 +6707,8 @@ impl TryParse for GetHistogramReply {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let (width, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetHistogramReply { response_type, sequence, width, data };
         Ok((result, remaining))
     }
@@ -6953,7 +6915,8 @@ impl TryParse for GetMinmaxReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetMinmaxReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -7152,7 +7115,8 @@ impl TryParse for GetCompressedTexImageARBReply {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let (size, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetCompressedTexImageARBReply { response_type, sequence, size, data };
         Ok((result, remaining))
     }

--- a/src/generated/randr.rs
+++ b/src/generated/randr.rs
@@ -1278,7 +1278,8 @@ impl TryParse for GetScreenResourcesReply {
         let (crtcs, remaining) = crate::x11_utils::parse_list::<Crtc>(remaining, num_crtcs as usize)?;
         let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_outputs as usize)?;
         let (modes, remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
-        let (names, remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
+        let (names, remaining) = crate::x11_utils::parse_u8_list(remaining, names_len as usize)?;
+        let names = names.to_vec();
         let result = GetScreenResourcesReply { response_type, sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
         Ok((result, remaining))
     }
@@ -1425,7 +1426,8 @@ impl TryParse for GetOutputInfoReply {
         let (crtcs, remaining) = crate::x11_utils::parse_list::<Crtc>(remaining, num_crtcs as usize)?;
         let (modes, remaining) = crate::x11_utils::parse_list::<Mode>(remaining, num_modes as usize)?;
         let (clones, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_clones as usize)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         let status = status.try_into()?;
         let connection = connection.try_into()?;
         let subpixel_order = subpixel_order.try_into()?;
@@ -1759,7 +1761,8 @@ impl TryParse for GetOutputPropertyReply {
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (num_items as usize) * ((format as usize) / 8))?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (num_items as usize) * ((format as usize) / 8))?;
+        let data = data.to_vec();
         let result = GetOutputPropertyReply { response_type, format, sequence, length, type_, bytes_after, num_items, data };
         Ok((result, remaining))
     }
@@ -2327,7 +2330,8 @@ impl TryParse for GetScreenResourcesCurrentReply {
         let (crtcs, remaining) = crate::x11_utils::parse_list::<Crtc>(remaining, num_crtcs as usize)?;
         let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_outputs as usize)?;
         let (modes, remaining) = crate::x11_utils::parse_list::<ModeInfo>(remaining, num_modes as usize)?;
-        let (names, remaining) = crate::x11_utils::parse_list::<u8>(remaining, names_len as usize)?;
+        let (names, remaining) = crate::x11_utils::parse_u8_list(remaining, names_len as usize)?;
+        let names = names.to_vec();
         let result = GetScreenResourcesCurrentReply { response_type, sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
         Ok((result, remaining))
     }
@@ -2541,13 +2545,15 @@ impl TryParse for GetCrtcTransformReply {
         let (pending_nparams, remaining) = u16::try_parse(remaining)?;
         let (current_len, remaining) = u16::try_parse(remaining)?;
         let (current_nparams, remaining) = u16::try_parse(remaining)?;
-        let (pending_filter_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, pending_len as usize)?;
+        let (pending_filter_name, remaining) = crate::x11_utils::parse_u8_list(remaining, pending_len as usize)?;
+        let pending_filter_name = pending_filter_name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let (pending_params, remaining) = crate::x11_utils::parse_list::<render::Fixed>(remaining, pending_nparams as usize)?;
-        let (current_filter_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, current_len as usize)?;
+        let (current_filter_name, remaining) = crate::x11_utils::parse_u8_list(remaining, current_len as usize)?;
+        let current_filter_name = current_filter_name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -3010,7 +3016,8 @@ impl TryParse for GetProviderInfoReply {
         let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, num_outputs as usize)?;
         let (associated_providers, remaining) = crate::x11_utils::parse_list::<Provider>(remaining, num_associated_providers as usize)?;
         let (associated_capability, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_associated_providers as usize)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         let result = GetProviderInfoReply { response_type, status, sequence, length, timestamp, capabilities, num_associated_providers, crtcs, outputs, associated_providers, associated_capability, name };
         Ok((result, remaining))
     }
@@ -3413,7 +3420,8 @@ impl TryParse for GetProviderPropertyReply {
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (num_items as usize) * ((format as usize) / 8))?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (num_items as usize) * ((format as usize) / 8))?;
+        let data = data.to_vec();
         let result = GetProviderPropertyReply { response_type, format, sequence, length, type_, bytes_after, num_items, data };
         Ok((result, remaining))
     }

--- a/src/generated/record.rs
+++ b/src/generated/record.rs
@@ -795,7 +795,8 @@ impl TryParse for EnableContextReply {
         let (server_time, remaining) = u32::try_parse(remaining)?;
         let (rec_sequence_num, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = EnableContextReply { response_type, category, sequence, element_header, client_swapped, xid_base, server_time, rec_sequence_num, data };
         Ok((result, remaining))
     }

--- a/src/generated/sync.rs
+++ b/src/generated/sync.rs
@@ -375,7 +375,8 @@ impl TryParse for Systemcounter {
         let (counter, remaining) = Counter::try_parse(remaining)?;
         let (resolution, remaining) = Int64::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;

--- a/src/generated/xf86dri.rs
+++ b/src/generated/xf86dri.rs
@@ -235,7 +235,8 @@ impl TryParse for OpenConnectionReply {
         let (sarea_handle_high, remaining) = u32::try_parse(remaining)?;
         let (bus_id_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (bus_id, remaining) = crate::x11_utils::parse_list::<u8>(remaining, bus_id_len as usize)?;
+        let (bus_id, remaining) = crate::x11_utils::parse_u8_list(remaining, bus_id_len as usize)?;
+        let bus_id = bus_id.to_vec();
         let result = OpenConnectionReply { response_type, sequence, length, sarea_handle_low, sarea_handle_high, bus_id };
         Ok((result, remaining))
     }
@@ -322,7 +323,8 @@ impl TryParse for GetClientDriverNameReply {
         let (client_driver_patch_version, remaining) = u32::try_parse(remaining)?;
         let (client_driver_name_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (client_driver_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, client_driver_name_len as usize)?;
+        let (client_driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, client_driver_name_len as usize)?;
+        let client_driver_name = client_driver_name.to_vec();
         let result = GetClientDriverNameReply { response_type, sequence, length, client_driver_major_version, client_driver_minor_version, client_driver_patch_version, client_driver_name };
         Ok((result, remaining))
     }

--- a/src/generated/xf86vidmode.rs
+++ b/src/generated/xf86vidmode.rs
@@ -483,7 +483,8 @@ impl TryParse for GetModeLineReply {
         let (flags, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let (privsize, remaining) = u32::try_parse(remaining)?;
-        let (private, remaining) = crate::x11_utils::parse_list::<u8>(remaining, privsize as usize)?;
+        let (private, remaining) = crate::x11_utils::parse_u8_list(remaining, privsize as usize)?;
+        let private = private.to_vec();
         let result = GetModeLineReply { response_type, sequence, length, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private };
         Ok((result, remaining))
     }
@@ -658,9 +659,12 @@ impl TryParse for GetMonitorReply {
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let (hsync, remaining) = crate::x11_utils::parse_list::<Syncrange>(remaining, num_hsync as usize)?;
         let (vsync, remaining) = crate::x11_utils::parse_list::<Syncrange>(remaining, num_vsync as usize)?;
-        let (vendor, remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_length as usize)?;
-        let (alignment_pad, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((vendor_length as usize) + 3) & (!3)) - (vendor_length as usize))?;
-        let (model, remaining) = crate::x11_utils::parse_list::<u8>(remaining, model_length as usize)?;
+        let (vendor, remaining) = crate::x11_utils::parse_u8_list(remaining, vendor_length as usize)?;
+        let vendor = vendor.to_vec();
+        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (((vendor_length as usize) + 3) & (!3)) - (vendor_length as usize))?;
+        let alignment_pad = alignment_pad.to_vec();
+        let (model, remaining) = crate::x11_utils::parse_u8_list(remaining, model_length as usize)?;
+        let model = model.to_vec();
         let result = GetMonitorReply { response_type, sequence, length, hsync, vsync, vendor, alignment_pad, model };
         Ok((result, remaining))
     }

--- a/src/generated/xfixes.rs
+++ b/src/generated/xfixes.rs
@@ -1797,7 +1797,8 @@ impl TryParse for GetCursorNameReply {
         let (atom, remaining) = xproto::Atom::try_parse(remaining)?;
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, nbytes as usize)?;
+        let name = name.to_vec();
         let result = GetCursorNameReply { response_type, sequence, length, atom, name };
         Ok((result, remaining))
     }
@@ -1864,7 +1865,8 @@ impl TryParse for GetCursorImageAndNameReply {
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, nbytes as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, nbytes as usize)?;
+        let name = name.to_vec();
         let result = GetCursorImageAndNameReply { response_type, sequence, length, x, y, width, height, xhot, yhot, cursor_serial, cursor_atom, cursor_image, name };
         Ok((result, remaining))
     }

--- a/src/generated/xinput.rs
+++ b/src/generated/xinput.rs
@@ -856,7 +856,8 @@ pub struct DeviceName {
 impl TryParse for DeviceName {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (len, remaining) = u8::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, len as usize)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, len as usize)?;
+        let string = string.to_vec();
         let result = DeviceName { string };
         Ok((result, remaining))
     }
@@ -2289,72 +2290,8 @@ impl TryParse for KbdFeedbackState {
         let (click, remaining) = u8::try_parse(remaining)?;
         let (percent, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (auto_repeats_0, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_1, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_2, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_3, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_4, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_5, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_6, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_7, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_8, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_9, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_10, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_11, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_12, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_13, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_14, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_15, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_16, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_17, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_18, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_19, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_20, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_21, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_22, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_23, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_24, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_25, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_26, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_27, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_28, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_29, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_30, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_31, remaining) = u8::try_parse(remaining)?;
-        let auto_repeats = [
-            auto_repeats_0,
-            auto_repeats_1,
-            auto_repeats_2,
-            auto_repeats_3,
-            auto_repeats_4,
-            auto_repeats_5,
-            auto_repeats_6,
-            auto_repeats_7,
-            auto_repeats_8,
-            auto_repeats_9,
-            auto_repeats_10,
-            auto_repeats_11,
-            auto_repeats_12,
-            auto_repeats_13,
-            auto_repeats_14,
-            auto_repeats_15,
-            auto_repeats_16,
-            auto_repeats_17,
-            auto_repeats_18,
-            auto_repeats_19,
-            auto_repeats_20,
-            auto_repeats_21,
-            auto_repeats_22,
-            auto_repeats_23,
-            auto_repeats_24,
-            auto_repeats_25,
-            auto_repeats_26,
-            auto_repeats_27,
-            auto_repeats_28,
-            auto_repeats_29,
-            auto_repeats_30,
-            auto_repeats_31,
-        ];
+        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let auto_repeats = <[u8; 32]>::try_from(auto_repeats).unwrap();
         let class_id = class_id.try_into()?;
         let result = KbdFeedbackState { class_id, feedback_id, len, pitch, duration, led_mask, led_values, global_auto_repeat, click, percent, auto_repeats };
         Ok((result, remaining))
@@ -2774,72 +2711,8 @@ impl TryParse for FeedbackStateDataKeyboard {
         let (click, remaining) = u8::try_parse(remaining)?;
         let (percent, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (auto_repeats_0, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_1, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_2, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_3, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_4, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_5, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_6, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_7, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_8, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_9, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_10, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_11, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_12, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_13, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_14, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_15, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_16, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_17, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_18, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_19, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_20, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_21, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_22, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_23, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_24, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_25, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_26, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_27, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_28, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_29, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_30, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_31, remaining) = u8::try_parse(remaining)?;
-        let auto_repeats = [
-            auto_repeats_0,
-            auto_repeats_1,
-            auto_repeats_2,
-            auto_repeats_3,
-            auto_repeats_4,
-            auto_repeats_5,
-            auto_repeats_6,
-            auto_repeats_7,
-            auto_repeats_8,
-            auto_repeats_9,
-            auto_repeats_10,
-            auto_repeats_11,
-            auto_repeats_12,
-            auto_repeats_13,
-            auto_repeats_14,
-            auto_repeats_15,
-            auto_repeats_16,
-            auto_repeats_17,
-            auto_repeats_18,
-            auto_repeats_19,
-            auto_repeats_20,
-            auto_repeats_21,
-            auto_repeats_22,
-            auto_repeats_23,
-            auto_repeats_24,
-            auto_repeats_25,
-            auto_repeats_26,
-            auto_repeats_27,
-            auto_repeats_28,
-            auto_repeats_29,
-            auto_repeats_30,
-            auto_repeats_31,
-        ];
+        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let auto_repeats = <[u8; 32]>::try_from(auto_repeats).unwrap();
         let result = FeedbackStateDataKeyboard { pitch, duration, led_mask, led_values, global_auto_repeat, click, percent, auto_repeats };
         Ok((result, remaining))
     }
@@ -4413,7 +4286,8 @@ impl TryParse for GetDeviceModifierMappingReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (keycodes_per_modifier, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (keymaps, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (keycodes_per_modifier as usize) * 8)?;
+        let (keymaps, remaining) = crate::x11_utils::parse_u8_list(remaining, (keycodes_per_modifier as usize) * 8)?;
+        let keymaps = keymaps.to_vec();
         let result = GetDeviceModifierMappingReply { response_type, xi_reply_type, sequence, length, keymaps };
         Ok((result, remaining))
     }
@@ -4530,7 +4404,8 @@ impl TryParse for GetDeviceButtonMappingReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (map_size, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
-        let (map, remaining) = crate::x11_utils::parse_list::<u8>(remaining, map_size as usize)?;
+        let (map, remaining) = crate::x11_utils::parse_u8_list(remaining, map_size as usize)?;
+        let map = map.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -4619,72 +4494,8 @@ impl TryParse for KeyState {
         let (len, remaining) = u8::try_parse(remaining)?;
         let (num_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (keys_0, remaining) = u8::try_parse(remaining)?;
-        let (keys_1, remaining) = u8::try_parse(remaining)?;
-        let (keys_2, remaining) = u8::try_parse(remaining)?;
-        let (keys_3, remaining) = u8::try_parse(remaining)?;
-        let (keys_4, remaining) = u8::try_parse(remaining)?;
-        let (keys_5, remaining) = u8::try_parse(remaining)?;
-        let (keys_6, remaining) = u8::try_parse(remaining)?;
-        let (keys_7, remaining) = u8::try_parse(remaining)?;
-        let (keys_8, remaining) = u8::try_parse(remaining)?;
-        let (keys_9, remaining) = u8::try_parse(remaining)?;
-        let (keys_10, remaining) = u8::try_parse(remaining)?;
-        let (keys_11, remaining) = u8::try_parse(remaining)?;
-        let (keys_12, remaining) = u8::try_parse(remaining)?;
-        let (keys_13, remaining) = u8::try_parse(remaining)?;
-        let (keys_14, remaining) = u8::try_parse(remaining)?;
-        let (keys_15, remaining) = u8::try_parse(remaining)?;
-        let (keys_16, remaining) = u8::try_parse(remaining)?;
-        let (keys_17, remaining) = u8::try_parse(remaining)?;
-        let (keys_18, remaining) = u8::try_parse(remaining)?;
-        let (keys_19, remaining) = u8::try_parse(remaining)?;
-        let (keys_20, remaining) = u8::try_parse(remaining)?;
-        let (keys_21, remaining) = u8::try_parse(remaining)?;
-        let (keys_22, remaining) = u8::try_parse(remaining)?;
-        let (keys_23, remaining) = u8::try_parse(remaining)?;
-        let (keys_24, remaining) = u8::try_parse(remaining)?;
-        let (keys_25, remaining) = u8::try_parse(remaining)?;
-        let (keys_26, remaining) = u8::try_parse(remaining)?;
-        let (keys_27, remaining) = u8::try_parse(remaining)?;
-        let (keys_28, remaining) = u8::try_parse(remaining)?;
-        let (keys_29, remaining) = u8::try_parse(remaining)?;
-        let (keys_30, remaining) = u8::try_parse(remaining)?;
-        let (keys_31, remaining) = u8::try_parse(remaining)?;
-        let keys = [
-            keys_0,
-            keys_1,
-            keys_2,
-            keys_3,
-            keys_4,
-            keys_5,
-            keys_6,
-            keys_7,
-            keys_8,
-            keys_9,
-            keys_10,
-            keys_11,
-            keys_12,
-            keys_13,
-            keys_14,
-            keys_15,
-            keys_16,
-            keys_17,
-            keys_18,
-            keys_19,
-            keys_20,
-            keys_21,
-            keys_22,
-            keys_23,
-            keys_24,
-            keys_25,
-            keys_26,
-            keys_27,
-            keys_28,
-            keys_29,
-            keys_30,
-            keys_31,
-        ];
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let keys = <[u8; 32]>::try_from(keys).unwrap();
         let class_id = class_id.try_into()?;
         let result = KeyState { class_id, len, num_keys, keys };
         Ok((result, remaining))
@@ -4764,72 +4575,8 @@ impl TryParse for ButtonState {
         let (len, remaining) = u8::try_parse(remaining)?;
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (buttons_0, remaining) = u8::try_parse(remaining)?;
-        let (buttons_1, remaining) = u8::try_parse(remaining)?;
-        let (buttons_2, remaining) = u8::try_parse(remaining)?;
-        let (buttons_3, remaining) = u8::try_parse(remaining)?;
-        let (buttons_4, remaining) = u8::try_parse(remaining)?;
-        let (buttons_5, remaining) = u8::try_parse(remaining)?;
-        let (buttons_6, remaining) = u8::try_parse(remaining)?;
-        let (buttons_7, remaining) = u8::try_parse(remaining)?;
-        let (buttons_8, remaining) = u8::try_parse(remaining)?;
-        let (buttons_9, remaining) = u8::try_parse(remaining)?;
-        let (buttons_10, remaining) = u8::try_parse(remaining)?;
-        let (buttons_11, remaining) = u8::try_parse(remaining)?;
-        let (buttons_12, remaining) = u8::try_parse(remaining)?;
-        let (buttons_13, remaining) = u8::try_parse(remaining)?;
-        let (buttons_14, remaining) = u8::try_parse(remaining)?;
-        let (buttons_15, remaining) = u8::try_parse(remaining)?;
-        let (buttons_16, remaining) = u8::try_parse(remaining)?;
-        let (buttons_17, remaining) = u8::try_parse(remaining)?;
-        let (buttons_18, remaining) = u8::try_parse(remaining)?;
-        let (buttons_19, remaining) = u8::try_parse(remaining)?;
-        let (buttons_20, remaining) = u8::try_parse(remaining)?;
-        let (buttons_21, remaining) = u8::try_parse(remaining)?;
-        let (buttons_22, remaining) = u8::try_parse(remaining)?;
-        let (buttons_23, remaining) = u8::try_parse(remaining)?;
-        let (buttons_24, remaining) = u8::try_parse(remaining)?;
-        let (buttons_25, remaining) = u8::try_parse(remaining)?;
-        let (buttons_26, remaining) = u8::try_parse(remaining)?;
-        let (buttons_27, remaining) = u8::try_parse(remaining)?;
-        let (buttons_28, remaining) = u8::try_parse(remaining)?;
-        let (buttons_29, remaining) = u8::try_parse(remaining)?;
-        let (buttons_30, remaining) = u8::try_parse(remaining)?;
-        let (buttons_31, remaining) = u8::try_parse(remaining)?;
-        let buttons = [
-            buttons_0,
-            buttons_1,
-            buttons_2,
-            buttons_3,
-            buttons_4,
-            buttons_5,
-            buttons_6,
-            buttons_7,
-            buttons_8,
-            buttons_9,
-            buttons_10,
-            buttons_11,
-            buttons_12,
-            buttons_13,
-            buttons_14,
-            buttons_15,
-            buttons_16,
-            buttons_17,
-            buttons_18,
-            buttons_19,
-            buttons_20,
-            buttons_21,
-            buttons_22,
-            buttons_23,
-            buttons_24,
-            buttons_25,
-            buttons_26,
-            buttons_27,
-            buttons_28,
-            buttons_29,
-            buttons_30,
-            buttons_31,
-        ];
+        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let buttons = <[u8; 32]>::try_from(buttons).unwrap();
         let class_id = class_id.try_into()?;
         let result = ButtonState { class_id, len, num_buttons, buttons };
         Ok((result, remaining))
@@ -5011,72 +4758,8 @@ impl TryParse for InputStateDataKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (keys_0, remaining) = u8::try_parse(remaining)?;
-        let (keys_1, remaining) = u8::try_parse(remaining)?;
-        let (keys_2, remaining) = u8::try_parse(remaining)?;
-        let (keys_3, remaining) = u8::try_parse(remaining)?;
-        let (keys_4, remaining) = u8::try_parse(remaining)?;
-        let (keys_5, remaining) = u8::try_parse(remaining)?;
-        let (keys_6, remaining) = u8::try_parse(remaining)?;
-        let (keys_7, remaining) = u8::try_parse(remaining)?;
-        let (keys_8, remaining) = u8::try_parse(remaining)?;
-        let (keys_9, remaining) = u8::try_parse(remaining)?;
-        let (keys_10, remaining) = u8::try_parse(remaining)?;
-        let (keys_11, remaining) = u8::try_parse(remaining)?;
-        let (keys_12, remaining) = u8::try_parse(remaining)?;
-        let (keys_13, remaining) = u8::try_parse(remaining)?;
-        let (keys_14, remaining) = u8::try_parse(remaining)?;
-        let (keys_15, remaining) = u8::try_parse(remaining)?;
-        let (keys_16, remaining) = u8::try_parse(remaining)?;
-        let (keys_17, remaining) = u8::try_parse(remaining)?;
-        let (keys_18, remaining) = u8::try_parse(remaining)?;
-        let (keys_19, remaining) = u8::try_parse(remaining)?;
-        let (keys_20, remaining) = u8::try_parse(remaining)?;
-        let (keys_21, remaining) = u8::try_parse(remaining)?;
-        let (keys_22, remaining) = u8::try_parse(remaining)?;
-        let (keys_23, remaining) = u8::try_parse(remaining)?;
-        let (keys_24, remaining) = u8::try_parse(remaining)?;
-        let (keys_25, remaining) = u8::try_parse(remaining)?;
-        let (keys_26, remaining) = u8::try_parse(remaining)?;
-        let (keys_27, remaining) = u8::try_parse(remaining)?;
-        let (keys_28, remaining) = u8::try_parse(remaining)?;
-        let (keys_29, remaining) = u8::try_parse(remaining)?;
-        let (keys_30, remaining) = u8::try_parse(remaining)?;
-        let (keys_31, remaining) = u8::try_parse(remaining)?;
-        let keys = [
-            keys_0,
-            keys_1,
-            keys_2,
-            keys_3,
-            keys_4,
-            keys_5,
-            keys_6,
-            keys_7,
-            keys_8,
-            keys_9,
-            keys_10,
-            keys_11,
-            keys_12,
-            keys_13,
-            keys_14,
-            keys_15,
-            keys_16,
-            keys_17,
-            keys_18,
-            keys_19,
-            keys_20,
-            keys_21,
-            keys_22,
-            keys_23,
-            keys_24,
-            keys_25,
-            keys_26,
-            keys_27,
-            keys_28,
-            keys_29,
-            keys_30,
-            keys_31,
-        ];
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let keys = <[u8; 32]>::try_from(keys).unwrap();
         let result = InputStateDataKey { num_keys, keys };
         Ok((result, remaining))
     }
@@ -5144,72 +4827,8 @@ impl TryParse for InputStateDataButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (buttons_0, remaining) = u8::try_parse(remaining)?;
-        let (buttons_1, remaining) = u8::try_parse(remaining)?;
-        let (buttons_2, remaining) = u8::try_parse(remaining)?;
-        let (buttons_3, remaining) = u8::try_parse(remaining)?;
-        let (buttons_4, remaining) = u8::try_parse(remaining)?;
-        let (buttons_5, remaining) = u8::try_parse(remaining)?;
-        let (buttons_6, remaining) = u8::try_parse(remaining)?;
-        let (buttons_7, remaining) = u8::try_parse(remaining)?;
-        let (buttons_8, remaining) = u8::try_parse(remaining)?;
-        let (buttons_9, remaining) = u8::try_parse(remaining)?;
-        let (buttons_10, remaining) = u8::try_parse(remaining)?;
-        let (buttons_11, remaining) = u8::try_parse(remaining)?;
-        let (buttons_12, remaining) = u8::try_parse(remaining)?;
-        let (buttons_13, remaining) = u8::try_parse(remaining)?;
-        let (buttons_14, remaining) = u8::try_parse(remaining)?;
-        let (buttons_15, remaining) = u8::try_parse(remaining)?;
-        let (buttons_16, remaining) = u8::try_parse(remaining)?;
-        let (buttons_17, remaining) = u8::try_parse(remaining)?;
-        let (buttons_18, remaining) = u8::try_parse(remaining)?;
-        let (buttons_19, remaining) = u8::try_parse(remaining)?;
-        let (buttons_20, remaining) = u8::try_parse(remaining)?;
-        let (buttons_21, remaining) = u8::try_parse(remaining)?;
-        let (buttons_22, remaining) = u8::try_parse(remaining)?;
-        let (buttons_23, remaining) = u8::try_parse(remaining)?;
-        let (buttons_24, remaining) = u8::try_parse(remaining)?;
-        let (buttons_25, remaining) = u8::try_parse(remaining)?;
-        let (buttons_26, remaining) = u8::try_parse(remaining)?;
-        let (buttons_27, remaining) = u8::try_parse(remaining)?;
-        let (buttons_28, remaining) = u8::try_parse(remaining)?;
-        let (buttons_29, remaining) = u8::try_parse(remaining)?;
-        let (buttons_30, remaining) = u8::try_parse(remaining)?;
-        let (buttons_31, remaining) = u8::try_parse(remaining)?;
-        let buttons = [
-            buttons_0,
-            buttons_1,
-            buttons_2,
-            buttons_3,
-            buttons_4,
-            buttons_5,
-            buttons_6,
-            buttons_7,
-            buttons_8,
-            buttons_9,
-            buttons_10,
-            buttons_11,
-            buttons_12,
-            buttons_13,
-            buttons_14,
-            buttons_15,
-            buttons_16,
-            buttons_17,
-            buttons_18,
-            buttons_19,
-            buttons_20,
-            buttons_21,
-            buttons_22,
-            buttons_23,
-            buttons_24,
-            buttons_25,
-            buttons_26,
-            buttons_27,
-            buttons_28,
-            buttons_29,
-            buttons_30,
-            buttons_31,
-        ];
+        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let buttons = <[u8; 32]>::try_from(buttons).unwrap();
         let result = InputStateDataButton { num_buttons, buttons };
         Ok((result, remaining))
     }
@@ -7522,7 +7141,8 @@ impl GetDevicePropertyItems {
         if switch_expr == u8::from(PropertyFormat::M8Bits) {
             let remaining = outer_remaining;
             let value = remaining;
-            let (data8, remaining) = crate::x11_utils::parse_list::<u8>(remaining, num_items as usize)?;
+            let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items as usize)?;
+            let data8 = data8.to_vec();
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -8116,7 +7736,8 @@ impl TryParse for AddMaster {
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let (send_core, remaining) = bool::try_parse(remaining)?;
         let (enable, remaining) = bool::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -8330,7 +7951,8 @@ impl TryParse for HierarchyChangeDataAddMaster {
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let (send_core, remaining) = bool::try_parse(remaining)?;
         let (enable, remaining) = bool::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -10066,7 +9688,8 @@ impl TryParse for XIDeviceInfo {
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let (enabled, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -11201,7 +10824,8 @@ impl XIGetPropertyItems {
         if switch_expr == u8::from(PropertyFormat::M8Bits) {
             let remaining = outer_remaining;
             let value = remaining;
-            let (data8, remaining) = crate::x11_utils::parse_list::<u8>(remaining, num_items as usize)?;
+            let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items as usize)?;
+            let data8 = data8.to_vec();
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -12706,26 +12330,10 @@ impl TryParse for DeviceStateNotifyEvent {
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
         let (num_valuators, remaining) = u8::try_parse(remaining)?;
         let (classes_reported, remaining) = u8::try_parse(remaining)?;
-        let (buttons_0, remaining) = u8::try_parse(remaining)?;
-        let (buttons_1, remaining) = u8::try_parse(remaining)?;
-        let (buttons_2, remaining) = u8::try_parse(remaining)?;
-        let (buttons_3, remaining) = u8::try_parse(remaining)?;
-        let buttons = [
-            buttons_0,
-            buttons_1,
-            buttons_2,
-            buttons_3,
-        ];
-        let (keys_0, remaining) = u8::try_parse(remaining)?;
-        let (keys_1, remaining) = u8::try_parse(remaining)?;
-        let (keys_2, remaining) = u8::try_parse(remaining)?;
-        let (keys_3, remaining) = u8::try_parse(remaining)?;
-        let keys = [
-            keys_0,
-            keys_1,
-            keys_2,
-            keys_3,
-        ];
+        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let buttons = <[u8; 4]>::try_from(buttons).unwrap();
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let keys = <[u8; 4]>::try_from(keys).unwrap();
         let (valuators_0, remaining) = u32::try_parse(remaining)?;
         let (valuators_1, remaining) = u32::try_parse(remaining)?;
         let (valuators_2, remaining) = u32::try_parse(remaining)?;
@@ -13085,64 +12693,8 @@ impl TryParse for DeviceKeyStateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (keys_0, remaining) = u8::try_parse(remaining)?;
-        let (keys_1, remaining) = u8::try_parse(remaining)?;
-        let (keys_2, remaining) = u8::try_parse(remaining)?;
-        let (keys_3, remaining) = u8::try_parse(remaining)?;
-        let (keys_4, remaining) = u8::try_parse(remaining)?;
-        let (keys_5, remaining) = u8::try_parse(remaining)?;
-        let (keys_6, remaining) = u8::try_parse(remaining)?;
-        let (keys_7, remaining) = u8::try_parse(remaining)?;
-        let (keys_8, remaining) = u8::try_parse(remaining)?;
-        let (keys_9, remaining) = u8::try_parse(remaining)?;
-        let (keys_10, remaining) = u8::try_parse(remaining)?;
-        let (keys_11, remaining) = u8::try_parse(remaining)?;
-        let (keys_12, remaining) = u8::try_parse(remaining)?;
-        let (keys_13, remaining) = u8::try_parse(remaining)?;
-        let (keys_14, remaining) = u8::try_parse(remaining)?;
-        let (keys_15, remaining) = u8::try_parse(remaining)?;
-        let (keys_16, remaining) = u8::try_parse(remaining)?;
-        let (keys_17, remaining) = u8::try_parse(remaining)?;
-        let (keys_18, remaining) = u8::try_parse(remaining)?;
-        let (keys_19, remaining) = u8::try_parse(remaining)?;
-        let (keys_20, remaining) = u8::try_parse(remaining)?;
-        let (keys_21, remaining) = u8::try_parse(remaining)?;
-        let (keys_22, remaining) = u8::try_parse(remaining)?;
-        let (keys_23, remaining) = u8::try_parse(remaining)?;
-        let (keys_24, remaining) = u8::try_parse(remaining)?;
-        let (keys_25, remaining) = u8::try_parse(remaining)?;
-        let (keys_26, remaining) = u8::try_parse(remaining)?;
-        let (keys_27, remaining) = u8::try_parse(remaining)?;
-        let keys = [
-            keys_0,
-            keys_1,
-            keys_2,
-            keys_3,
-            keys_4,
-            keys_5,
-            keys_6,
-            keys_7,
-            keys_8,
-            keys_9,
-            keys_10,
-            keys_11,
-            keys_12,
-            keys_13,
-            keys_14,
-            keys_15,
-            keys_16,
-            keys_17,
-            keys_18,
-            keys_19,
-            keys_20,
-            keys_21,
-            keys_22,
-            keys_23,
-            keys_24,
-            keys_25,
-            keys_26,
-            keys_27,
-        ];
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
+        let keys = <[u8; 28]>::try_from(keys).unwrap();
         let result = DeviceKeyStateNotifyEvent { response_type, device_id, sequence, keys };
         Ok((result, remaining))
     }
@@ -13227,64 +12779,8 @@ impl TryParse for DeviceButtonStateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (buttons_0, remaining) = u8::try_parse(remaining)?;
-        let (buttons_1, remaining) = u8::try_parse(remaining)?;
-        let (buttons_2, remaining) = u8::try_parse(remaining)?;
-        let (buttons_3, remaining) = u8::try_parse(remaining)?;
-        let (buttons_4, remaining) = u8::try_parse(remaining)?;
-        let (buttons_5, remaining) = u8::try_parse(remaining)?;
-        let (buttons_6, remaining) = u8::try_parse(remaining)?;
-        let (buttons_7, remaining) = u8::try_parse(remaining)?;
-        let (buttons_8, remaining) = u8::try_parse(remaining)?;
-        let (buttons_9, remaining) = u8::try_parse(remaining)?;
-        let (buttons_10, remaining) = u8::try_parse(remaining)?;
-        let (buttons_11, remaining) = u8::try_parse(remaining)?;
-        let (buttons_12, remaining) = u8::try_parse(remaining)?;
-        let (buttons_13, remaining) = u8::try_parse(remaining)?;
-        let (buttons_14, remaining) = u8::try_parse(remaining)?;
-        let (buttons_15, remaining) = u8::try_parse(remaining)?;
-        let (buttons_16, remaining) = u8::try_parse(remaining)?;
-        let (buttons_17, remaining) = u8::try_parse(remaining)?;
-        let (buttons_18, remaining) = u8::try_parse(remaining)?;
-        let (buttons_19, remaining) = u8::try_parse(remaining)?;
-        let (buttons_20, remaining) = u8::try_parse(remaining)?;
-        let (buttons_21, remaining) = u8::try_parse(remaining)?;
-        let (buttons_22, remaining) = u8::try_parse(remaining)?;
-        let (buttons_23, remaining) = u8::try_parse(remaining)?;
-        let (buttons_24, remaining) = u8::try_parse(remaining)?;
-        let (buttons_25, remaining) = u8::try_parse(remaining)?;
-        let (buttons_26, remaining) = u8::try_parse(remaining)?;
-        let (buttons_27, remaining) = u8::try_parse(remaining)?;
-        let buttons = [
-            buttons_0,
-            buttons_1,
-            buttons_2,
-            buttons_3,
-            buttons_4,
-            buttons_5,
-            buttons_6,
-            buttons_7,
-            buttons_8,
-            buttons_9,
-            buttons_10,
-            buttons_11,
-            buttons_12,
-            buttons_13,
-            buttons_14,
-            buttons_15,
-            buttons_16,
-            buttons_17,
-            buttons_18,
-            buttons_19,
-            buttons_20,
-            buttons_21,
-            buttons_22,
-            buttons_23,
-            buttons_24,
-            buttons_25,
-            buttons_26,
-            buttons_27,
-        ];
+        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
+        let buttons = <[u8; 28]>::try_from(buttons).unwrap();
         let result = DeviceButtonStateNotifyEvent { response_type, device_id, sequence, buttons };
         Ok((result, remaining))
     }

--- a/src/generated/xkb.rs
+++ b/src/generated/xkb.rs
@@ -2534,16 +2534,8 @@ pub struct KeyName {
 }
 impl TryParse for KeyName {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name_0, remaining) = u8::try_parse(remaining)?;
-        let (name_1, remaining) = u8::try_parse(remaining)?;
-        let (name_2, remaining) = u8::try_parse(remaining)?;
-        let (name_3, remaining) = u8::try_parse(remaining)?;
-        let name = [
-            name_0,
-            name_1,
-            name_2,
-            name_3,
-        ];
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let name = <[u8; 4]>::try_from(name).unwrap();
         let result = KeyName { name };
         Ok((result, remaining))
     }
@@ -2577,26 +2569,10 @@ pub struct KeyAlias {
 }
 impl TryParse for KeyAlias {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (real_0, remaining) = u8::try_parse(remaining)?;
-        let (real_1, remaining) = u8::try_parse(remaining)?;
-        let (real_2, remaining) = u8::try_parse(remaining)?;
-        let (real_3, remaining) = u8::try_parse(remaining)?;
-        let real = [
-            real_0,
-            real_1,
-            real_2,
-            real_3,
-        ];
-        let (alias_0, remaining) = u8::try_parse(remaining)?;
-        let (alias_1, remaining) = u8::try_parse(remaining)?;
-        let (alias_2, remaining) = u8::try_parse(remaining)?;
-        let (alias_3, remaining) = u8::try_parse(remaining)?;
-        let alias = [
-            alias_0,
-            alias_1,
-            alias_2,
-            alias_3,
-        ];
+        let (real, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let real = <[u8; 4]>::try_from(real).unwrap();
+        let (alias, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let alias = <[u8; 4]>::try_from(alias).unwrap();
         let result = KeyAlias { real, alias };
         Ok((result, remaining))
     }
@@ -2636,8 +2612,10 @@ pub struct CountedString16 {
 impl TryParse for CountedString16 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_list::<u8>(remaining, length as usize)?;
-        let (alignment_pad, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (((length as usize) + 5) & (!3)) - ((length as usize) + 2))?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, length as usize)?;
+        let string = string.to_vec();
+        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (((length as usize) + 5) & (!3)) - ((length as usize) + 2))?;
+        let alignment_pad = alignment_pad.to_vec();
         let result = CountedString16 { string, alignment_pad };
         Ok((result, remaining))
     }
@@ -2781,16 +2759,8 @@ pub struct KeySymMap {
 }
 impl TryParse for KeySymMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (kt_index_0, remaining) = u8::try_parse(remaining)?;
-        let (kt_index_1, remaining) = u8::try_parse(remaining)?;
-        let (kt_index_2, remaining) = u8::try_parse(remaining)?;
-        let (kt_index_3, remaining) = u8::try_parse(remaining)?;
-        let kt_index = [
-            kt_index_0,
-            kt_index_1,
-            kt_index_2,
-            kt_index_3,
-        ];
+        let (kt_index, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let kt_index = <[u8; 4]>::try_from(kt_index).unwrap();
         let (group_info, remaining) = u8::try_parse(remaining)?;
         let (width, remaining) = u8::try_parse(remaining)?;
         let (n_syms, remaining) = u16::try_parse(remaining)?;
@@ -3542,16 +3512,8 @@ pub struct Key {
 }
 impl TryParse for Key {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name_0, remaining) = String8::try_parse(remaining)?;
-        let (name_1, remaining) = String8::try_parse(remaining)?;
-        let (name_2, remaining) = String8::try_parse(remaining)?;
-        let (name_3, remaining) = String8::try_parse(remaining)?;
-        let name = [
-            name_0,
-            name_1,
-            name_2,
-            name_3,
-        ];
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let name = <[u8; 4]>::try_from(name).unwrap();
         let (gap, remaining) = i16::try_parse(remaining)?;
         let (shape_ndx, remaining) = u8::try_parse(remaining)?;
         let (color_ndx, remaining) = u8::try_parse(remaining)?;
@@ -3598,26 +3560,10 @@ pub struct OverlayKey {
 }
 impl TryParse for OverlayKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (over_0, remaining) = String8::try_parse(remaining)?;
-        let (over_1, remaining) = String8::try_parse(remaining)?;
-        let (over_2, remaining) = String8::try_parse(remaining)?;
-        let (over_3, remaining) = String8::try_parse(remaining)?;
-        let over = [
-            over_0,
-            over_1,
-            over_2,
-            over_3,
-        ];
-        let (under_0, remaining) = String8::try_parse(remaining)?;
-        let (under_1, remaining) = String8::try_parse(remaining)?;
-        let (under_2, remaining) = String8::try_parse(remaining)?;
-        let (under_3, remaining) = String8::try_parse(remaining)?;
-        let under = [
-            under_0,
-            under_1,
-            under_2,
-            under_3,
-        ];
+        let (over, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let over = <[u8; 4]>::try_from(over).unwrap();
+        let (under, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let under = <[u8; 4]>::try_from(under).unwrap();
         let result = OverlayKey { over, under };
         Ok((result, remaining))
     }
@@ -3850,7 +3796,8 @@ impl TryParse for Listing {
         let value = remaining;
         let (flags, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_list::<String8>(remaining, length as usize)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, length as usize)?;
+        let string = string.to_vec();
         // Align offset to multiple of 2
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (2 - (offset % 2)) % 2;
@@ -5375,20 +5322,8 @@ impl TryParse for SAActionMessage {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
         let (flags, remaining) = u8::try_parse(remaining)?;
-        let (message_0, remaining) = u8::try_parse(remaining)?;
-        let (message_1, remaining) = u8::try_parse(remaining)?;
-        let (message_2, remaining) = u8::try_parse(remaining)?;
-        let (message_3, remaining) = u8::try_parse(remaining)?;
-        let (message_4, remaining) = u8::try_parse(remaining)?;
-        let (message_5, remaining) = u8::try_parse(remaining)?;
-        let message = [
-            message_0,
-            message_1,
-            message_2,
-            message_3,
-            message_4,
-            message_5,
-        ];
+        let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, 6)?;
+        let message = <[u8; 6]>::try_from(message).unwrap();
         let type_ = type_.try_into()?;
         let result = SAActionMessage { type_, flags, message };
         Ok((result, remaining))
@@ -5817,22 +5752,8 @@ pub struct SIAction {
 impl TryParse for SIAction {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (data_0, remaining) = u8::try_parse(remaining)?;
-        let (data_1, remaining) = u8::try_parse(remaining)?;
-        let (data_2, remaining) = u8::try_parse(remaining)?;
-        let (data_3, remaining) = u8::try_parse(remaining)?;
-        let (data_4, remaining) = u8::try_parse(remaining)?;
-        let (data_5, remaining) = u8::try_parse(remaining)?;
-        let (data_6, remaining) = u8::try_parse(remaining)?;
-        let data = [
-            data_0,
-            data_1,
-            data_2,
-            data_3,
-            data_4,
-            data_5,
-            data_6,
-        ];
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, 7)?;
+        let data = <[u8; 7]>::try_from(data).unwrap();
         let type_ = type_.try_into()?;
         let result = SIAction { type_, data };
         Ok((result, remaining))
@@ -7055,72 +6976,8 @@ impl TryParse for GetControlsReply {
         let (access_x_timeout_mask, remaining) = u32::try_parse(remaining)?;
         let (access_x_timeout_values, remaining) = u32::try_parse(remaining)?;
         let (enabled_controls, remaining) = u32::try_parse(remaining)?;
-        let (per_key_repeat_0, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_1, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_2, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_3, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_4, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_5, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_6, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_7, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_8, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_9, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_10, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_11, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_12, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_13, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_14, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_15, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_16, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_17, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_18, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_19, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_20, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_21, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_22, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_23, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_24, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_25, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_26, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_27, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_28, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_29, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_30, remaining) = u8::try_parse(remaining)?;
-        let (per_key_repeat_31, remaining) = u8::try_parse(remaining)?;
-        let per_key_repeat = [
-            per_key_repeat_0,
-            per_key_repeat_1,
-            per_key_repeat_2,
-            per_key_repeat_3,
-            per_key_repeat_4,
-            per_key_repeat_5,
-            per_key_repeat_6,
-            per_key_repeat_7,
-            per_key_repeat_8,
-            per_key_repeat_9,
-            per_key_repeat_10,
-            per_key_repeat_11,
-            per_key_repeat_12,
-            per_key_repeat_13,
-            per_key_repeat_14,
-            per_key_repeat_15,
-            per_key_repeat_16,
-            per_key_repeat_17,
-            per_key_repeat_18,
-            per_key_repeat_19,
-            per_key_repeat_20,
-            per_key_repeat_21,
-            per_key_repeat_22,
-            per_key_repeat_23,
-            per_key_repeat_24,
-            per_key_repeat_25,
-            per_key_repeat_26,
-            per_key_repeat_27,
-            per_key_repeat_28,
-            per_key_repeat_29,
-            per_key_repeat_30,
-            per_key_repeat_31,
-        ];
+        let (per_key_repeat, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let per_key_repeat = <[u8; 32]>::try_from(per_key_repeat).unwrap();
         let result = GetControlsReply { response_type, device_id, sequence, length, mouse_keys_dflt_btn, num_groups, groups_wrap, internal_mods_mask, ignore_lock_mods_mask, internal_mods_real_mods, ignore_lock_mods_real_mods, internal_mods_vmods, ignore_lock_mods_vmods, repeat_delay, repeat_interval, slow_keys_delay, debounce_delay, mouse_keys_delay, mouse_keys_interval, mouse_keys_time_to_max, mouse_keys_max_speed, mouse_keys_curve, access_x_option, access_x_timeout, access_x_timeout_options_mask, access_x_timeout_options_values, access_x_timeout_mask, access_x_timeout_values, enabled_controls, per_key_repeat };
         Ok((result, remaining))
     }
@@ -7358,7 +7215,8 @@ pub struct GetMapMapBitcase3 {
 impl GetMapMapBitcase3 {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_key_actions as usize)?;
+        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions as usize)?;
+        let acts_rtrn_count = acts_rtrn_count.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -7418,7 +7276,8 @@ impl GetMapMap {
         let vmods_rtrn = if switch_expr & u16::from(MapPart::VirtualMods) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (vmods_rtrn, remaining) = crate::x11_utils::parse_list::<u8>(remaining, usize::try_from(virtual_mods.count_ones()).unwrap())?;
+            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, usize::try_from(virtual_mods.count_ones()).unwrap())?;
+            let vmods_rtrn = vmods_rtrn.to_vec();
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -8271,7 +8130,8 @@ pub struct GetNamesValueListBitcase8 {
 impl GetNamesValueListBitcase8 {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (n_levels_per_type, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_types as usize)?;
+        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types as usize)?;
+        let n_levels_per_type = n_levels_per_type.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -8965,7 +8825,8 @@ pub struct GetKbdByNameRepliesTypesMapBitcase3 {
 impl GetKbdByNameRepliesTypesMapBitcase3 {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_key_actions as usize)?;
+        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions as usize)?;
+        let acts_rtrn_count = acts_rtrn_count.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -9025,7 +8886,8 @@ impl GetKbdByNameRepliesTypesMap {
         let vmods_rtrn = if switch_expr & u16::from(MapPart::VirtualMods) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (vmods_rtrn, remaining) = crate::x11_utils::parse_list::<u8>(remaining, usize::try_from(virtual_mods.count_ones()).unwrap())?;
+            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, usize::try_from(virtual_mods.count_ones()).unwrap())?;
+            let vmods_rtrn = vmods_rtrn.to_vec();
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -9225,7 +9087,8 @@ pub struct GetKbdByNameRepliesKeyNamesValueListBitcase8 {
 impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (n_levels_per_type, remaining) = crate::x11_utils::parse_list::<u8>(remaining, n_types as usize)?;
+        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types as usize)?;
+        let n_levels_per_type = n_levels_per_type.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -9651,7 +9514,8 @@ impl TryParse for GetDeviceInfoReply {
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (dev_type, remaining) = xproto::Atom::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<String8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -10888,24 +10752,8 @@ impl TryParse for ActionMessageEvent {
         let (key_event_follows, remaining) = bool::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let (group, remaining) = u8::try_parse(remaining)?;
-        let (message_0, remaining) = String8::try_parse(remaining)?;
-        let (message_1, remaining) = String8::try_parse(remaining)?;
-        let (message_2, remaining) = String8::try_parse(remaining)?;
-        let (message_3, remaining) = String8::try_parse(remaining)?;
-        let (message_4, remaining) = String8::try_parse(remaining)?;
-        let (message_5, remaining) = String8::try_parse(remaining)?;
-        let (message_6, remaining) = String8::try_parse(remaining)?;
-        let (message_7, remaining) = String8::try_parse(remaining)?;
-        let message = [
-            message_0,
-            message_1,
-            message_2,
-            message_3,
-            message_4,
-            message_5,
-            message_6,
-            message_7,
-        ];
+        let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, 8)?;
+        let message = <[u8; 8]>::try_from(message).unwrap();
         let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
         let group = group.try_into()?;
         let result = ActionMessageEvent { response_type, xkb_type, sequence, time, device_id, keycode, press, key_event_follows, mods, group, message };

--- a/src/generated/xprint.rs
+++ b/src/generated/xprint.rs
@@ -48,13 +48,15 @@ impl TryParse for Printer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
         let (name_len, remaining) = u32::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<String8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let (desc_len, remaining) = u32::try_parse(remaining)?;
-        let (description, remaining) = crate::x11_utils::parse_list::<String8>(remaining, desc_len as usize)?;
+        let (description, remaining) = crate::x11_utils::parse_u8_list(remaining, desc_len as usize)?;
+        let description = description.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -909,7 +911,8 @@ impl TryParse for PrintGetDocumentDataReply {
         let (finished_flag, remaining) = u32::try_parse(remaining)?;
         let (data_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, data_len as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len as usize)?;
+        let data = data.to_vec();
         let result = PrintGetDocumentDataReply { response_type, sequence, length, status_code, finished_flag, data };
         Ok((result, remaining))
     }
@@ -1108,7 +1111,8 @@ impl TryParse for PrintGetAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (string_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attributes, remaining) = crate::x11_utils::parse_list::<String8>(remaining, string_len as usize)?;
+        let (attributes, remaining) = crate::x11_utils::parse_u8_list(remaining, string_len as usize)?;
+        let attributes = attributes.to_vec();
         let result = PrintGetAttributesReply { response_type, sequence, length, attributes };
         Ok((result, remaining))
     }
@@ -1176,7 +1180,8 @@ impl TryParse for PrintGetOneAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (value, remaining) = crate::x11_utils::parse_list::<String8>(remaining, value_len as usize)?;
+        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len as usize)?;
+        let value = value.to_vec();
         let result = PrintGetOneAttributesReply { response_type, sequence, length, value };
         Ok((result, remaining))
     }

--- a/src/generated/xproto.rs
+++ b/src/generated/xproto.rs
@@ -752,12 +752,14 @@ impl TryParse for SetupRequest {
         let (authorization_protocol_name_len, remaining) = u16::try_parse(remaining)?;
         let (authorization_protocol_data_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (authorization_protocol_name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, authorization_protocol_name_len as usize)?;
+        let (authorization_protocol_name, remaining) = crate::x11_utils::parse_u8_list(remaining, authorization_protocol_name_len as usize)?;
+        let authorization_protocol_name = authorization_protocol_name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (authorization_protocol_data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, authorization_protocol_data_len as usize)?;
+        let (authorization_protocol_data, remaining) = crate::x11_utils::parse_u8_list(remaining, authorization_protocol_data_len as usize)?;
+        let authorization_protocol_data = authorization_protocol_data.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -812,7 +814,8 @@ impl TryParse for SetupFailed {
         let (protocol_major_version, remaining) = u16::try_parse(remaining)?;
         let (protocol_minor_version, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (reason, remaining) = crate::x11_utils::parse_list::<u8>(remaining, reason_len as usize)?;
+        let (reason, remaining) = crate::x11_utils::parse_u8_list(remaining, reason_len as usize)?;
+        let reason = reason.to_vec();
         let result = SetupFailed { status, protocol_major_version, protocol_minor_version, length, reason };
         Ok((result, remaining))
     }
@@ -852,7 +855,8 @@ impl TryParse for SetupAuthenticate {
         let (status, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(5..).ok_or(ParseError::ParseError)?;
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (reason, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (reason, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let reason = reason.to_vec();
         let result = SetupAuthenticate { status, reason };
         Ok((result, remaining))
     }
@@ -995,7 +999,8 @@ impl TryParse for Setup {
         let (min_keycode, remaining) = Keycode::try_parse(remaining)?;
         let (max_keycode, remaining) = Keycode::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (vendor, remaining) = crate::x11_utils::parse_list::<u8>(remaining, vendor_len as usize)?;
+        let (vendor, remaining) = crate::x11_utils::parse_u8_list(remaining, vendor_len as usize)?;
+        let vendor = vendor.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -2706,70 +2711,8 @@ pub struct KeymapNotifyEvent {
 impl TryParse for KeymapNotifyEvent {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (response_type, remaining) = u8::try_parse(remaining)?;
-        let (keys_0, remaining) = u8::try_parse(remaining)?;
-        let (keys_1, remaining) = u8::try_parse(remaining)?;
-        let (keys_2, remaining) = u8::try_parse(remaining)?;
-        let (keys_3, remaining) = u8::try_parse(remaining)?;
-        let (keys_4, remaining) = u8::try_parse(remaining)?;
-        let (keys_5, remaining) = u8::try_parse(remaining)?;
-        let (keys_6, remaining) = u8::try_parse(remaining)?;
-        let (keys_7, remaining) = u8::try_parse(remaining)?;
-        let (keys_8, remaining) = u8::try_parse(remaining)?;
-        let (keys_9, remaining) = u8::try_parse(remaining)?;
-        let (keys_10, remaining) = u8::try_parse(remaining)?;
-        let (keys_11, remaining) = u8::try_parse(remaining)?;
-        let (keys_12, remaining) = u8::try_parse(remaining)?;
-        let (keys_13, remaining) = u8::try_parse(remaining)?;
-        let (keys_14, remaining) = u8::try_parse(remaining)?;
-        let (keys_15, remaining) = u8::try_parse(remaining)?;
-        let (keys_16, remaining) = u8::try_parse(remaining)?;
-        let (keys_17, remaining) = u8::try_parse(remaining)?;
-        let (keys_18, remaining) = u8::try_parse(remaining)?;
-        let (keys_19, remaining) = u8::try_parse(remaining)?;
-        let (keys_20, remaining) = u8::try_parse(remaining)?;
-        let (keys_21, remaining) = u8::try_parse(remaining)?;
-        let (keys_22, remaining) = u8::try_parse(remaining)?;
-        let (keys_23, remaining) = u8::try_parse(remaining)?;
-        let (keys_24, remaining) = u8::try_parse(remaining)?;
-        let (keys_25, remaining) = u8::try_parse(remaining)?;
-        let (keys_26, remaining) = u8::try_parse(remaining)?;
-        let (keys_27, remaining) = u8::try_parse(remaining)?;
-        let (keys_28, remaining) = u8::try_parse(remaining)?;
-        let (keys_29, remaining) = u8::try_parse(remaining)?;
-        let (keys_30, remaining) = u8::try_parse(remaining)?;
-        let keys = [
-            keys_0,
-            keys_1,
-            keys_2,
-            keys_3,
-            keys_4,
-            keys_5,
-            keys_6,
-            keys_7,
-            keys_8,
-            keys_9,
-            keys_10,
-            keys_11,
-            keys_12,
-            keys_13,
-            keys_14,
-            keys_15,
-            keys_16,
-            keys_17,
-            keys_18,
-            keys_19,
-            keys_20,
-            keys_21,
-            keys_22,
-            keys_23,
-            keys_24,
-            keys_25,
-            keys_26,
-            keys_27,
-            keys_28,
-            keys_29,
-            keys_30,
-        ];
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 31)?;
+        let keys = <[u8; 31]>::try_from(keys).unwrap();
         let result = KeymapNotifyEvent { response_type, keys };
         Ok((result, remaining))
     }
@@ -5585,48 +5528,8 @@ pub struct ClientMessageData([u8; 20]);
 impl ClientMessageData {
     pub fn as_data8(&self) -> [u8; 20] {
         fn do_the_parse(remaining: &[u8]) -> Result<[u8; 20], ParseError> {
-            let (data8_0, remaining) = u8::try_parse(remaining)?;
-            let (data8_1, remaining) = u8::try_parse(remaining)?;
-            let (data8_2, remaining) = u8::try_parse(remaining)?;
-            let (data8_3, remaining) = u8::try_parse(remaining)?;
-            let (data8_4, remaining) = u8::try_parse(remaining)?;
-            let (data8_5, remaining) = u8::try_parse(remaining)?;
-            let (data8_6, remaining) = u8::try_parse(remaining)?;
-            let (data8_7, remaining) = u8::try_parse(remaining)?;
-            let (data8_8, remaining) = u8::try_parse(remaining)?;
-            let (data8_9, remaining) = u8::try_parse(remaining)?;
-            let (data8_10, remaining) = u8::try_parse(remaining)?;
-            let (data8_11, remaining) = u8::try_parse(remaining)?;
-            let (data8_12, remaining) = u8::try_parse(remaining)?;
-            let (data8_13, remaining) = u8::try_parse(remaining)?;
-            let (data8_14, remaining) = u8::try_parse(remaining)?;
-            let (data8_15, remaining) = u8::try_parse(remaining)?;
-            let (data8_16, remaining) = u8::try_parse(remaining)?;
-            let (data8_17, remaining) = u8::try_parse(remaining)?;
-            let (data8_18, remaining) = u8::try_parse(remaining)?;
-            let (data8_19, remaining) = u8::try_parse(remaining)?;
-            let data8 = [
-                data8_0,
-                data8_1,
-                data8_2,
-                data8_3,
-                data8_4,
-                data8_5,
-                data8_6,
-                data8_7,
-                data8_8,
-                data8_9,
-                data8_10,
-                data8_11,
-                data8_12,
-                data8_13,
-                data8_14,
-                data8_15,
-                data8_16,
-                data8_17,
-                data8_18,
-                data8_19,
-            ];
+            let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, 20)?;
+            let data8 = <[u8; 20]>::try_from(data8).unwrap();
             let _ = remaining;
             Ok(data8)
         }
@@ -9979,7 +9882,8 @@ impl TryParse for GetAtomNameReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         let result = GetAtomNameReply { response_type, sequence, length, name };
         Ok((result, remaining))
     }
@@ -10574,7 +10478,8 @@ impl TryParse for GetPropertyReply {
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (value, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (value_len as usize) * ((format as usize) / 8))?;
+        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, (value_len as usize) * ((format as usize) / 8))?;
+        let value = value.to_vec();
         let result = GetPropertyReply { response_type, format, sequence, length, type_, bytes_after, value_len, value };
         Ok((result, remaining))
     }
@@ -12878,72 +12783,8 @@ impl TryParse for QueryKeymapReply {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (keys_0, remaining) = u8::try_parse(remaining)?;
-        let (keys_1, remaining) = u8::try_parse(remaining)?;
-        let (keys_2, remaining) = u8::try_parse(remaining)?;
-        let (keys_3, remaining) = u8::try_parse(remaining)?;
-        let (keys_4, remaining) = u8::try_parse(remaining)?;
-        let (keys_5, remaining) = u8::try_parse(remaining)?;
-        let (keys_6, remaining) = u8::try_parse(remaining)?;
-        let (keys_7, remaining) = u8::try_parse(remaining)?;
-        let (keys_8, remaining) = u8::try_parse(remaining)?;
-        let (keys_9, remaining) = u8::try_parse(remaining)?;
-        let (keys_10, remaining) = u8::try_parse(remaining)?;
-        let (keys_11, remaining) = u8::try_parse(remaining)?;
-        let (keys_12, remaining) = u8::try_parse(remaining)?;
-        let (keys_13, remaining) = u8::try_parse(remaining)?;
-        let (keys_14, remaining) = u8::try_parse(remaining)?;
-        let (keys_15, remaining) = u8::try_parse(remaining)?;
-        let (keys_16, remaining) = u8::try_parse(remaining)?;
-        let (keys_17, remaining) = u8::try_parse(remaining)?;
-        let (keys_18, remaining) = u8::try_parse(remaining)?;
-        let (keys_19, remaining) = u8::try_parse(remaining)?;
-        let (keys_20, remaining) = u8::try_parse(remaining)?;
-        let (keys_21, remaining) = u8::try_parse(remaining)?;
-        let (keys_22, remaining) = u8::try_parse(remaining)?;
-        let (keys_23, remaining) = u8::try_parse(remaining)?;
-        let (keys_24, remaining) = u8::try_parse(remaining)?;
-        let (keys_25, remaining) = u8::try_parse(remaining)?;
-        let (keys_26, remaining) = u8::try_parse(remaining)?;
-        let (keys_27, remaining) = u8::try_parse(remaining)?;
-        let (keys_28, remaining) = u8::try_parse(remaining)?;
-        let (keys_29, remaining) = u8::try_parse(remaining)?;
-        let (keys_30, remaining) = u8::try_parse(remaining)?;
-        let (keys_31, remaining) = u8::try_parse(remaining)?;
-        let keys = [
-            keys_0,
-            keys_1,
-            keys_2,
-            keys_3,
-            keys_4,
-            keys_5,
-            keys_6,
-            keys_7,
-            keys_8,
-            keys_9,
-            keys_10,
-            keys_11,
-            keys_12,
-            keys_13,
-            keys_14,
-            keys_15,
-            keys_16,
-            keys_17,
-            keys_18,
-            keys_19,
-            keys_20,
-            keys_21,
-            keys_22,
-            keys_23,
-            keys_24,
-            keys_25,
-            keys_26,
-            keys_27,
-            keys_28,
-            keys_29,
-            keys_30,
-            keys_31,
-        ];
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let keys = <[u8; 32]>::try_from(keys).unwrap();
         let result = QueryKeymapReply { response_type, sequence, length, keys };
         Ok((result, remaining))
     }
@@ -13418,7 +13259,8 @@ pub struct Str {
 impl TryParse for Str {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name_len, remaining) = u8::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         let result = Str { name };
         Ok((result, remaining))
     }
@@ -13617,7 +13459,8 @@ impl TryParse for ListFontsWithInfoReply {
         let (font_descent, remaining) = i16::try_parse(remaining)?;
         let (replies_hint, remaining) = u32::try_parse(remaining)?;
         let (properties, remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len as usize)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let name = name.to_vec();
         let draw_direction = draw_direction.try_into()?;
         let result = ListFontsWithInfoReply { response_type, sequence, length, min_bounds, max_bounds, min_char_or_byte2, max_char_or_byte2, default_char, draw_direction, min_byte1, max_byte1, all_chars_exist, font_ascent, font_descent, replies_hint, properties, name };
         Ok((result, remaining))
@@ -16446,7 +16289,8 @@ impl TryParse for GetImageReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (visual, remaining) = Visualid::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let data = data.to_vec();
         let result = GetImageReply { response_type, depth, sequence, visual, data };
         Ok((result, remaining))
     }
@@ -18755,72 +18599,8 @@ impl TryParse for GetKeyboardControlReply {
         let (bell_pitch, remaining) = u16::try_parse(remaining)?;
         let (bell_duration, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (auto_repeats_0, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_1, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_2, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_3, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_4, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_5, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_6, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_7, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_8, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_9, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_10, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_11, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_12, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_13, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_14, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_15, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_16, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_17, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_18, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_19, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_20, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_21, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_22, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_23, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_24, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_25, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_26, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_27, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_28, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_29, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_30, remaining) = u8::try_parse(remaining)?;
-        let (auto_repeats_31, remaining) = u8::try_parse(remaining)?;
-        let auto_repeats = [
-            auto_repeats_0,
-            auto_repeats_1,
-            auto_repeats_2,
-            auto_repeats_3,
-            auto_repeats_4,
-            auto_repeats_5,
-            auto_repeats_6,
-            auto_repeats_7,
-            auto_repeats_8,
-            auto_repeats_9,
-            auto_repeats_10,
-            auto_repeats_11,
-            auto_repeats_12,
-            auto_repeats_13,
-            auto_repeats_14,
-            auto_repeats_15,
-            auto_repeats_16,
-            auto_repeats_17,
-            auto_repeats_18,
-            auto_repeats_19,
-            auto_repeats_20,
-            auto_repeats_21,
-            auto_repeats_22,
-            auto_repeats_23,
-            auto_repeats_24,
-            auto_repeats_25,
-            auto_repeats_26,
-            auto_repeats_27,
-            auto_repeats_28,
-            auto_repeats_29,
-            auto_repeats_30,
-            auto_repeats_31,
-        ];
+        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let auto_repeats = <[u8; 32]>::try_from(auto_repeats).unwrap();
         let global_auto_repeat = global_auto_repeat.try_into()?;
         let result = GetKeyboardControlReply { response_type, global_auto_repeat, sequence, length, led_mask, key_click_percent, bell_percent, bell_pitch, bell_duration, auto_repeats };
         Ok((result, remaining))
@@ -19336,7 +19116,8 @@ impl TryParse for Host {
         let (family, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (address_len, remaining) = u16::try_parse(remaining)?;
-        let (address, remaining) = crate::x11_utils::parse_list::<u8>(remaining, address_len as usize)?;
+        let (address, remaining) = crate::x11_utils::parse_u8_list(remaining, address_len as usize)?;
+        let address = address.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -19977,7 +19758,8 @@ impl TryParse for GetPointerMappingReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (map, remaining) = crate::x11_utils::parse_list::<u8>(remaining, map_len as usize)?;
+        let (map, remaining) = crate::x11_utils::parse_u8_list(remaining, map_len as usize)?;
+        let map = map.to_vec();
         let result = GetPointerMappingReply { response_type, sequence, length, map };
         Ok((result, remaining))
     }
@@ -20154,7 +19936,8 @@ impl TryParse for GetModifierMappingReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (keycodes, remaining) = crate::x11_utils::parse_list::<Keycode>(remaining, (keycodes_per_modifier as usize) * 8)?;
+        let (keycodes, remaining) = crate::x11_utils::parse_u8_list(remaining, (keycodes_per_modifier as usize) * 8)?;
+        let keycodes = keycodes.to_vec();
         let result = GetModifierMappingReply { response_type, sequence, length, keycodes };
         Ok((result, remaining))
     }

--- a/src/generated/xselinux.rs
+++ b/src/generated/xselinux.rs
@@ -160,7 +160,8 @@ impl TryParse for GetDeviceCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetDeviceCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -250,7 +251,8 @@ impl TryParse for GetDeviceContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetDeviceContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -330,7 +332,8 @@ impl TryParse for GetWindowCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetWindowCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -384,7 +387,8 @@ impl TryParse for GetWindowContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetWindowContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -408,12 +412,14 @@ impl TryParse for ListItem {
         let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (object_context_len, remaining) = u32::try_parse(remaining)?;
         let (data_context_len, remaining) = u32::try_parse(remaining)?;
-        let (object_context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, object_context_len as usize)?;
+        let (object_context, remaining) = crate::x11_utils::parse_u8_list(remaining, object_context_len as usize)?;
+        let object_context = object_context.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (data_context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, data_context_len as usize)?;
+        let (data_context, remaining) = crate::x11_utils::parse_u8_list(remaining, data_context_len as usize)?;
+        let data_context = data_context.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -517,7 +523,8 @@ impl TryParse for GetPropertyCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetPropertyCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -597,7 +604,8 @@ impl TryParse for GetPropertyUseContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetPropertyUseContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -656,7 +664,8 @@ impl TryParse for GetPropertyContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetPropertyContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -715,7 +724,8 @@ impl TryParse for GetPropertyDataContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetPropertyDataContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -849,7 +859,8 @@ impl TryParse for GetSelectionCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetSelectionCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -929,7 +940,8 @@ impl TryParse for GetSelectionUseContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetSelectionUseContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -983,7 +995,8 @@ impl TryParse for GetSelectionContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetSelectionContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -1037,7 +1050,8 @@ impl TryParse for GetSelectionDataContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetSelectionDataContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }
@@ -1140,7 +1154,8 @@ impl TryParse for GetClientContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_list::<u8>(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let context = context.to_vec();
         let result = GetClientContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
     }

--- a/src/generated/xv.rs
+++ b/src/generated/xv.rs
@@ -636,7 +636,8 @@ impl TryParse for AdaptorInfo {
         let (num_formats, remaining) = u16::try_parse(remaining)?;
         let (type_, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_size as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_size as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -692,7 +693,8 @@ impl TryParse for EncodingInfo {
         let (height, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (rate, remaining) = Rational::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, name_size as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_size as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -747,7 +749,8 @@ impl TryParse for Image {
         let (num_planes, remaining) = u32::try_parse(remaining)?;
         let (pitches, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes as usize)?;
         let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes as usize)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u8>(remaining, data_size as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_size as usize)?;
+        let data = data.to_vec();
         let result = Image { id, width, height, num_planes, pitches, offsets, data };
         Ok((result, remaining))
     }
@@ -793,7 +796,8 @@ impl TryParse for AttributeInfo {
         let (min, remaining) = i32::try_parse(remaining)?;
         let (max, remaining) = i32::try_parse(remaining)?;
         let (size, remaining) = u32::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_list::<u8>(remaining, size as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, size as usize)?;
+        let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
@@ -858,40 +862,8 @@ impl TryParse for ImageFormatInfo {
         let (type_, remaining) = u8::try_parse(remaining)?;
         let (byte_order, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (guid_0, remaining) = u8::try_parse(remaining)?;
-        let (guid_1, remaining) = u8::try_parse(remaining)?;
-        let (guid_2, remaining) = u8::try_parse(remaining)?;
-        let (guid_3, remaining) = u8::try_parse(remaining)?;
-        let (guid_4, remaining) = u8::try_parse(remaining)?;
-        let (guid_5, remaining) = u8::try_parse(remaining)?;
-        let (guid_6, remaining) = u8::try_parse(remaining)?;
-        let (guid_7, remaining) = u8::try_parse(remaining)?;
-        let (guid_8, remaining) = u8::try_parse(remaining)?;
-        let (guid_9, remaining) = u8::try_parse(remaining)?;
-        let (guid_10, remaining) = u8::try_parse(remaining)?;
-        let (guid_11, remaining) = u8::try_parse(remaining)?;
-        let (guid_12, remaining) = u8::try_parse(remaining)?;
-        let (guid_13, remaining) = u8::try_parse(remaining)?;
-        let (guid_14, remaining) = u8::try_parse(remaining)?;
-        let (guid_15, remaining) = u8::try_parse(remaining)?;
-        let guid = [
-            guid_0,
-            guid_1,
-            guid_2,
-            guid_3,
-            guid_4,
-            guid_5,
-            guid_6,
-            guid_7,
-            guid_8,
-            guid_9,
-            guid_10,
-            guid_11,
-            guid_12,
-            guid_13,
-            guid_14,
-            guid_15,
-        ];
+        let (guid, remaining) = crate::x11_utils::parse_u8_list(remaining, 16)?;
+        let guid = <[u8; 16]>::try_from(guid).unwrap();
         let (bpp, remaining) = u8::try_parse(remaining)?;
         let (num_planes, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
@@ -911,72 +883,8 @@ impl TryParse for ImageFormatInfo {
         let (vvert_y_period, remaining) = u32::try_parse(remaining)?;
         let (vvert_u_period, remaining) = u32::try_parse(remaining)?;
         let (vvert_v_period, remaining) = u32::try_parse(remaining)?;
-        let (vcomp_order_0, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_1, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_2, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_3, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_4, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_5, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_6, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_7, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_8, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_9, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_10, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_11, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_12, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_13, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_14, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_15, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_16, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_17, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_18, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_19, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_20, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_21, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_22, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_23, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_24, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_25, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_26, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_27, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_28, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_29, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_30, remaining) = u8::try_parse(remaining)?;
-        let (vcomp_order_31, remaining) = u8::try_parse(remaining)?;
-        let vcomp_order = [
-            vcomp_order_0,
-            vcomp_order_1,
-            vcomp_order_2,
-            vcomp_order_3,
-            vcomp_order_4,
-            vcomp_order_5,
-            vcomp_order_6,
-            vcomp_order_7,
-            vcomp_order_8,
-            vcomp_order_9,
-            vcomp_order_10,
-            vcomp_order_11,
-            vcomp_order_12,
-            vcomp_order_13,
-            vcomp_order_14,
-            vcomp_order_15,
-            vcomp_order_16,
-            vcomp_order_17,
-            vcomp_order_18,
-            vcomp_order_19,
-            vcomp_order_20,
-            vcomp_order_21,
-            vcomp_order_22,
-            vcomp_order_23,
-            vcomp_order_24,
-            vcomp_order_25,
-            vcomp_order_26,
-            vcomp_order_27,
-            vcomp_order_28,
-            vcomp_order_29,
-            vcomp_order_30,
-            vcomp_order_31,
-        ];
+        let (vcomp_order, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
+        let vcomp_order = <[u8; 32]>::try_from(vcomp_order).unwrap();
         let (vscanline_order, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let type_ = type_.try_into()?;

--- a/src/generated/xvmc.rs
+++ b/src/generated/xvmc.rs
@@ -486,16 +486,8 @@ impl TryParse for CreateSubpictureReply {
         let (height_actual, remaining) = u16::try_parse(remaining)?;
         let (num_palette_entries, remaining) = u16::try_parse(remaining)?;
         let (entry_bytes, remaining) = u16::try_parse(remaining)?;
-        let (component_order_0, remaining) = u8::try_parse(remaining)?;
-        let (component_order_1, remaining) = u8::try_parse(remaining)?;
-        let (component_order_2, remaining) = u8::try_parse(remaining)?;
-        let (component_order_3, remaining) = u8::try_parse(remaining)?;
-        let component_order = [
-            component_order_0,
-            component_order_1,
-            component_order_2,
-            component_order_3,
-        ];
+        let (component_order, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let component_order = <[u8; 4]>::try_from(component_order).unwrap();
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
         let result = CreateSubpictureReply { response_type, sequence, width_actual, height_actual, num_palette_entries, entry_bytes, component_order, priv_data };

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -387,6 +387,15 @@ where
     Ok((result, remaining))
 }
 
+/// Parse a list of `u8` from the given data.
+pub fn parse_u8_list(data: &[u8], list_length: usize) -> Result<(&[u8], &[u8]), ParseError> {
+    if data.len() < list_length {
+        Err(ParseError::ParseError)
+    } else {
+        Ok(data.split_at(list_length))
+    }
+}
+
 impl<T: Serialize> Serialize for [T] {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Self::Bytes {


### PR DESCRIPTION
In particular, this significantly simplifies the parsing of fixed length `u8` lists.