### PR TITLE
Move actual writing out of 'ConnectionInner'

### DIFF
--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -333,11 +333,6 @@ where
             .pop_front()
             .map(|(seqno, event)| (GenericEvent::new(event).unwrap(), seqno))
     }
-
-    /// Send all pending events by flushing the output buffer.
-    pub(crate) fn flush(&mut self) -> Result<(), std::io::Error> {
-        self.write.flush()
-    }
 }
 
 /// Read a `Setup` from the X11 server.

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -23,8 +23,7 @@ struct SentRequest {
 }
 
 #[derive(Debug)]
-pub(crate) struct ConnectionInner
-{
+pub(crate) struct ConnectionInner {
     // The sequence number of the last request that was written
     last_sequence_written: SequenceNumber,
     // Sorted(!) list with information on requests that were written, but no answer received yet.
@@ -41,8 +40,7 @@ pub(crate) struct ConnectionInner
     pending_replies: VecDeque<(SequenceNumber, Vec<u8>)>,
 }
 
-impl ConnectionInner
-{
+impl ConnectionInner {
     /// Crate a new `ConnectionInner`.
     ///
     /// It is assumed that the connection was just established. This means that the next request
@@ -62,12 +60,10 @@ impl ConnectionInner
     ///
     /// When this returns `None`, a sync with the server is necessary. Afterwards, the caller
     /// should try again.
-    pub(crate) fn send_request(
-        &mut self,
-        kind: RequestKind,
-    ) -> Option<SequenceNumber> {
+    pub(crate) fn send_request(&mut self, kind: RequestKind) -> Option<SequenceNumber> {
         if self.next_reply_expected + SequenceNumber::from(u16::max_value())
-            <= self.last_sequence_written && kind != RequestKind::HasResponse
+            <= self.last_sequence_written
+            && kind != RequestKind::HasResponse
         {
             // The caller need to call send_sync(). Otherwise, we might not be able to reconstruct
             // full sequence numbers for received packets.
@@ -215,10 +211,7 @@ impl ConnectionInner
     /// higher sequence number will be received. Since the X11 server handles requests in-order,
     /// if the reply to a later request is received, this means that the earlier request did not
     /// fail.
-    pub(crate) fn prepare_check_for_reply_or_error(
-        &mut self,
-        sequence: SequenceNumber,
-    ) -> bool {
+    pub(crate) fn prepare_check_for_reply_or_error(&mut self, sequence: SequenceNumber) -> bool {
         if self.next_reply_expected < sequence {
             true
         } else {

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -2,7 +2,7 @@
 
 use std::collections::VecDeque;
 use std::convert::TryInto;
-use std::io::{ErrorKind, IoSlice, Read, Write};
+use std::io::{Read, Write};
 
 use super::RawEventAndSeqNumber;
 use crate::connection::{DiscardMode, RequestKind, SequenceNumber};
@@ -33,7 +33,7 @@ where
 {
     // The underlying byte stream used for writing to the X11 server. Reading is done outside of
     // this struct (for synchronisation reasons).
-    write: W,
+    pub(crate) write: W,
 
     // The sequence number of the last request that was written
     last_sequence_written: SequenceNumber,
@@ -127,7 +127,6 @@ where
     /// should try again.
     pub(crate) fn send_request(
         &mut self,
-        bufs: &[IoSlice<'_>],
         kind: RequestKind,
     ) -> Result<Option<SequenceNumber>, std::io::Error> {
         if self.next_reply_expected + SequenceNumber::from(u16::max_value())
@@ -150,34 +149,6 @@ where
             discard_mode: None,
         };
         self.sent_requests.push_back(sent_request);
-
-        // Now actually send the buffers
-        // FIXME: We must always be able to read when we write
-        let mut bufs = bufs;
-        while !bufs.is_empty() {
-            let mut count = self.write.write_vectored(bufs)?;
-            if count == 0 {
-                return Err(std::io::Error::new(
-                    ErrorKind::WriteZero,
-                    "failed to write anything",
-                ));
-            }
-            while count > 0 {
-                if count >= bufs[0].len() {
-                    count -= bufs[0].len();
-                } else {
-                    let remaining = &bufs[0][count..];
-                    self.write.write_all(remaining)?;
-                    count = 0;
-                }
-                bufs = &bufs[1..];
-
-                // Skip empty slices
-                while bufs.first().map(|s| s.len()) == Some(0) {
-                    bufs = &bufs[1..];
-                }
-            }
-        }
 
         Ok(Some(seqno))
     }
@@ -396,8 +367,6 @@ fn read_setup(read: &mut impl Read) -> Result<Setup, ConnectError> {
 
 #[cfg(test)]
 mod test {
-    use std::io::IoSlice;
-
     use super::{read_setup, ConnectionInner};
     use crate::connection::RequestKind;
     use crate::errors::ConnectError;
@@ -470,39 +439,25 @@ mod test {
         // The connection must send a sync (GetInputFocus) request every 2^16 requests (that do not
         // have a reply). Thus, this test sends more than that and tests for the sync to appear.
 
-        let length = 1u16.to_ne_bytes();
-        let no_operation = [127, 0, length[0], length[1]];
-        let get_input_focus = [43, 0, length[0], length[1]];
-
         // Set up a connection that writes to this array
         let mut written = [0; 0x10000 * 4 + 4];
         let mut output = &mut written[..];
         let mut connection = ConnectionInner::new(&mut output);
 
         for num in 1..0x10000 {
-            let seqno =
-                connection.send_request(&[IoSlice::new(&no_operation)], RequestKind::IsVoid)?;
+            let seqno = connection.send_request(RequestKind::IsVoid)?;
             assert_eq!(Some(num), seqno);
         }
         // request 0x10000 should be a sync, hence the next one is 0x10001
-        let seqno = connection.send_request(&[IoSlice::new(&no_operation)], RequestKind::IsVoid)?;
+        let seqno = connection.send_request(RequestKind::IsVoid)?;
         assert_eq!(None, seqno);
 
-        let seqno = connection.send_request(&[IoSlice::new(&get_input_focus)], RequestKind::HasResponse)?;
+        let seqno = connection.send_request(RequestKind::HasResponse)?;
         assert_eq!(Some(0x10000), seqno);
 
-        let seqno = connection.send_request(&[IoSlice::new(&no_operation)], RequestKind::IsVoid)?;
+        let seqno = connection.send_request(RequestKind::IsVoid)?;
         assert_eq!(Some(0x10001), seqno);
 
-        let mut expected: Vec<_> = std::iter::repeat(&no_operation)
-            .take(0xffff)
-            .flatten()
-            .copied()
-            .collect();
-        expected.extend_from_slice(&get_input_focus);
-        expected.extend_from_slice(&no_operation);
-
-        assert_eq!(&written[..], &expected[..]);
         Ok(())
     }
 
@@ -511,26 +466,16 @@ mod test {
         // Compared to the previous test, this uses RequestKind::HasResponse, so no sync needs to
         // be inserted.
 
-        let length = 1u16.to_ne_bytes();
-        let get_input_focus = [43, 0, length[0], length[1]];
-
         // Set up a connection that writes to this array
         let mut written = [0; 0x10001 * 4];
         let mut output = &mut written[..];
         let mut connection = ConnectionInner::new(&mut output);
 
         for num in 1..=0x10001 {
-            let seqno = connection
-                .send_request(&[IoSlice::new(&get_input_focus)], RequestKind::HasResponse)?;
+            let seqno = connection.send_request(RequestKind::HasResponse)?;
             assert_eq!(Some(num), seqno);
         }
 
-        let expected: Vec<_> = std::iter::repeat(&get_input_focus)
-            .take(0x10001)
-            .flatten()
-            .copied()
-            .collect();
-        assert_eq!(&written[..], &expected[..]);
         Ok(())
     }
 
@@ -540,66 +485,19 @@ mod test {
         // the next request. Then it sends a RequestKind::HasResponse request so that no sync is
         // necessary. This is a regression test: Once upon a time, an unnecessary sync was done.
 
-        let length = 1u16.to_ne_bytes();
-        let no_operation = [127, 0, length[0], length[1]];
-        let get_input_focus = [43, 0, length[0], length[1]];
-
         // Set up a connection that writes to this array
         let mut written = [0; 0x10000 * 4];
         let mut output = &mut written[..];
         let mut connection = ConnectionInner::new(&mut output);
 
         for num in 1..0x10000 {
-            let seqno = connection
-                .send_request(&[IoSlice::new(&no_operation)], RequestKind::IsVoid)?;
+            let seqno = connection.send_request(RequestKind::IsVoid)?;
             assert_eq!(Some(num), seqno);
         }
 
-        let seqno = connection
-            .send_request(&[IoSlice::new(&get_input_focus)], RequestKind::HasResponse)?;
+        let seqno = connection.send_request(RequestKind::HasResponse)?;
         assert_eq!(Some(0x10000), seqno);
 
-        let mut expected: Vec<_> = std::iter::repeat(&no_operation)
-            .take(0xffff)
-            .flatten()
-            .copied()
-            .collect();
-        expected.extend_from_slice(&get_input_focus);
-
-        assert_eq!(&written[..], &expected[..]);
         Ok(())
-    }
-
-    fn partial_write_test(request: &[u8], expected_err: &str) {
-        let mut written = [0x21; 2];
-        let mut output = &mut written[..];
-        let mut connection = ConnectionInner::new(&mut output);
-        let request = [IoSlice::new(&request), IoSlice::new(&request)];
-        let error = connection
-            .send_request(&request, RequestKind::IsVoid)
-            .unwrap_err();
-        assert_eq!(expected_err, error.to_string());
-    }
-
-    #[test]
-    fn partial_write_larger_slice() {
-        partial_write_test(&[0; 4], "failed to write whole buffer");
-    }
-
-    #[test]
-    fn partial_write_slice_border() {
-        partial_write_test(&[0; 2], "failed to write anything");
-    }
-
-    #[test]
-    fn full_write_trailing_empty() {
-        let mut written = [0; 4];
-        let mut output = &mut written[..];
-        let mut connection = ConnectionInner::new(&mut output);
-        let (request1, request2) = ([0; 4], [0; 0]);
-        let request = [IoSlice::new(&request1), IoSlice::new(&request2)];
-        let _ = connection
-            .send_request(&request, RequestKind::IsVoid)
-            .unwrap();
     }
 }

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -212,12 +212,7 @@ impl ConnectionInner {
     /// if the reply to a later request is received, this means that the earlier request did not
     /// fail.
     pub(crate) fn prepare_check_for_reply_or_error(&mut self, sequence: SequenceNumber) -> bool {
-        if self.next_reply_expected < sequence {
-            true
-        } else {
-            assert!(self.next_reply_expected >= sequence);
-            false
-        }
+        self.next_reply_expected < sequence
     }
 
     /// Check if the request with the given sequence number was already handled by the server.

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -288,7 +288,7 @@ mod test {
     use crate::connection::RequestKind;
 
     #[test]
-    fn insert_sync_no_reply() -> Result<(), std::io::Error> {
+    fn insert_sync_no_reply() {
         // The connection must send a sync (GetInputFocus) request every 2^16 requests (that do not
         // have a reply). Thus, this test sends more than that and tests for the sync to appear.
 
@@ -310,12 +310,10 @@ mod test {
 
         let seqno = connection.send_request(RequestKind::IsVoid);
         assert_eq!(Some(0x10001), seqno);
-
-        Ok(())
     }
 
     #[test]
-    fn insert_no_sync_with_reply() -> Result<(), std::io::Error> {
+    fn insert_no_sync_with_reply() {
         // Compared to the previous test, this uses RequestKind::HasResponse, so no sync needs to
         // be inserted.
 
@@ -328,12 +326,10 @@ mod test {
             let seqno = connection.send_request(RequestKind::HasResponse);
             assert_eq!(Some(num), seqno);
         }
-
-        Ok(())
     }
 
     #[test]
-    fn insert_no_sync_when_already_syncing() -> Result<(), std::io::Error> {
+    fn insert_no_sync_when_already_syncing() {
         // This test sends enough RequestKind::IsVoid requests that a sync becomes necessary on
         // the next request. Then it sends a RequestKind::HasResponse request so that no sync is
         // necessary. This is a regression test: Once upon a time, an unnecessary sync was done.
@@ -350,7 +346,5 @@ mod test {
 
         let seqno = connection.send_request(RequestKind::HasResponse);
         assert_eq!(Some(0x10000), seqno);
-
-        Ok(())
     }
 }

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -154,7 +154,7 @@ where
         kind: RequestKind,
     ) -> Result<Option<SequenceNumber>, std::io::Error> {
         if self.next_reply_expected + SequenceNumber::from(u16::max_value())
-            <= self.last_sequence_written
+            <= self.last_sequence_written && kind != RequestKind::HasResponse
         {
             // The caller need to call send_sync(). Otherwise, we might not be able to reconstruct
             // full sequence numbers for received packets.

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -179,7 +179,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
                     // Now actually send the buffers
                     // FIXME: We must always be able to read when we write
                     write_all_vectored(&mut *write, bufs)?;
-                    return Ok(seqno)
+                    return Ok(seqno);
                 }
                 None => self.send_sync(&mut *inner, &mut *write)?,
             }
@@ -191,7 +191,11 @@ impl<R: Read, W: Write> RustConnection<R, W> {
     /// This function sends a `GetInputFocus` request to the X11 server and arranges for its reply
     /// to be ignored. This ensures that a reply is expected (`ConnectionInner.next_reply_expected`
     /// increases).
-    fn send_sync(&self, inner: &mut inner::ConnectionInner, write: &mut W) -> Result<(), std::io::Error> {
+    fn send_sync(
+        &self,
+        inner: &mut inner::ConnectionInner,
+        write: &mut W,
+    ) -> Result<(), std::io::Error> {
         let length = 1u16.to_ne_bytes();
         let request = [
             GET_INPUT_FOCUS_REQUEST,
@@ -200,7 +204,8 @@ impl<R: Read, W: Write> RustConnection<R, W> {
             length[1],
         ];
 
-        let seqno = inner.send_request(RequestKind::HasResponse)
+        let seqno = inner
+            .send_request(RequestKind::HasResponse)
             .expect("Sending a HasResponse request should not be blocked by syncs");
         inner.discard_reply(seqno, DiscardMode::DiscardReplyAndError);
         write_all_vectored(write, &[IoSlice::new(&request)])?;
@@ -599,10 +604,10 @@ fn write_all_vectored(write: &mut impl Write, bufs: &[IoSlice<'_>]) -> Result<()
 mod test {
     use std::io::IoSlice;
 
-    use crate::errors::ConnectError;
-    use crate::xproto::{ImageOrder, Setup, SetupAuthenticate, SetupFailed};
-    use crate::x11_utils::Serialize;
     use super::{read_setup, write_all_vectored};
+    use crate::errors::ConnectError;
+    use crate::x11_utils::Serialize;
+    use crate::xproto::{ImageOrder, Setup, SetupAuthenticate, SetupFailed};
 
     fn partial_write_test(request: &[u8], expected_err: &str) {
         let mut written = [0x21; 2];

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -628,7 +628,7 @@ mod test {
         let mut output = &mut written[..];
         let (request1, request2) = ([0; 4], [0; 0]);
         let request = [IoSlice::new(&request1), IoSlice::new(&request2)];
-        let _ = write_all_vectored(&mut output, &request).unwrap();
+        write_all_vectored(&mut output, &request).unwrap();
     }
 
     #[test]

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -387,9 +387,9 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
     ) -> Result<Option<GenericError>, ConnectionError> {
         let mut write = self.write.lock().unwrap();
         let mut inner = self.inner.lock().unwrap();
-        if !inner.prepare_check_for_reply_or_error(sequence) {
+        if inner.prepare_check_for_reply_or_error(sequence) {
             self.send_sync(&mut *inner, &mut *write)?;
-            assert!(inner.prepare_check_for_reply_or_error(sequence));
+            assert!(!inner.prepare_check_for_reply_or_error(sequence));
         }
         write.flush()?; // Ensure the request is sent
         drop(write);

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -341,7 +341,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
         sequence: SequenceNumber,
     ) -> Result<ReplyOrError<Vec<u8>>, ConnectionError> {
         let mut inner = self.inner.lock().unwrap();
-        inner.flush()?; // Ensure the request is sent
+        inner.write.flush()?; // Ensure the request is sent
         loop {
             if let Some(reply) = inner.poll_for_reply_or_error(sequence) {
                 if reply[0] == 0 {
@@ -357,7 +357,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
 
     fn wait_for_reply(&self, sequence: SequenceNumber) -> Result<Option<Vec<u8>>, ConnectionError> {
         let mut inner = self.inner.lock().unwrap();
-        inner.flush()?; // Ensure the request is sent
+        inner.write.flush()?; // Ensure the request is sent
         loop {
             match inner.poll_for_reply(sequence) {
                 PollReply::TryAgain => {}
@@ -377,7 +377,7 @@ impl<R: Read, W: Write> RequestConnection for RustConnection<R, W> {
             self.send_sync(&mut inner)?;
             assert!(inner.prepare_check_for_reply_or_error(sequence));
         }
-        inner.flush()?; // Ensure the request is sent
+        inner.write.flush()?; // Ensure the request is sent
         loop {
             match inner.poll_check_for_reply_or_error(sequence) {
                 PollReply::TryAgain => {}
@@ -461,7 +461,7 @@ impl<R: Read, W: Write> Connection for RustConnection<R, W> {
     }
 
     fn flush(&self) -> Result<(), ConnectionError> {
-        self.inner.lock().unwrap().flush()?;
+        self.inner.lock().unwrap().write.flush()?;
         Ok(())
     }
 

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -170,7 +170,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
 
         let mut guard = self.inner.lock().unwrap();
         loop {
-            match guard.send_request(kind)? {
+            match guard.send_request(kind) {
                 Some(seqno) => {
                     // Now actually send the buffers
                     // FIXME: We must always be able to read when we write
@@ -196,7 +196,7 @@ impl<R: Read, W: Write> RustConnection<R, W> {
             length[1],
         ];
 
-        let seqno = guard.send_request(RequestKind::HasResponse)?
+        let seqno = guard.send_request(RequestKind::HasResponse)
             .expect("Sending a HasResponse request should not be blocked by syncs");
         guard.discard_reply(seqno, DiscardMode::DiscardReplyAndError);
         write_all_vectored(&mut guard.write, &[IoSlice::new(&request)])?;

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -167,11 +167,10 @@ impl<R: Read, W: Write> RustConnection<R, W> {
         }
         let mut storage = Default::default();
         let bufs = compute_length_field(self, bufs, &mut storage)?;
-        self.inner
+        Ok(self.inner
             .lock()
             .unwrap()
-            .send_request(bufs, kind)
-            .or(Err(ConnectionError::UnknownError))
+            .send_request(bufs, kind)?)
     }
 
     /// Read a packet from the connection.


### PR DESCRIPTION
This moves all the actual I/O out of `ConnectionInner` into `RustConnection`. This feels to me like it improves the code structure a bit, but I mainly did this as a step towards some kind support for using `poll()` to check for "readable" and "writable" at the same time (#222).