### PR TITLE
Remove clap dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ OUT=src/protocol
 
 generate:
 	mkdir -p "$(OUT)"
-	cargo run -p x11rb-generator -- -i "$(PROTO)/src" -o "$(OUT)"
+	cargo run -p x11rb-generator -- "$(PROTO)/src" "$(OUT)"
 
 .PHONY: generate

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -10,7 +10,3 @@ publish = false
 fxhash = "0.2.1"
 roxmltree = "0.10.1"
 xcbgen = { path = "../xcbgen-rs" }
-
-[dependencies.clap]
-version = "2.33.0"
-default-features = false

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -146,32 +146,14 @@ fn replace_file_if_different(file_path: &Path, data: &[u8]) -> Result<(), Error>
 }
 
 fn main2() -> Result<u8, Error> {
-    let args_defs = clap::App::new("x11rb generator")
-        .arg(
-            clap::Arg::with_name("input")
-                .short("i")
-                .value_name("INPUT_DIR")
-                .help("Input directory")
-                .required(true),
-        )
-        .arg(
-            clap::Arg::with_name("output")
-                .short("o")
-                .value_name("OUTPUT_DIR")
-                .help("Output directory")
-                .required(true),
-        );
-
-    let arg_matches = match args_defs.get_matches_safe() {
-        Ok(arg_matches) => arg_matches,
-        Err(e) => {
-            eprintln!("{}", e);
-            return Ok(1);
-        }
-    };
-
-    let input_dir_path = Path::new(arg_matches.value_of_os("input").unwrap());
-    let output_dir_path = Path::new(arg_matches.value_of_os("output").unwrap());
+    let args: Vec<_> = std::env::args_os().collect();
+    if args.len() != 3 {
+        eprintln!("USAGE:");
+        eprintln!("    {} <INPUT_DIR> <OUTPUT_DIR>", args[0].to_string_lossy());
+        return Ok(1);
+    }
+    let input_dir_path = Path::new(&args[1]);
+    let output_dir_path = Path::new(&args[2]);
 
     let xml_files = list_xmls(input_dir_path)?;
     let module = xcbgen::defs::Module::new();


### PR DESCRIPTION
It was used to parse command line arguments. However, it is a quite heavy dependency and the command line arguments of the generator are pretty simple, so parsing is now done manually.