### PR TITLE
Check arithmetic and conversions in generated expressions

### DIFF
--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -481,11 +481,11 @@ impl TryParse for ConnectReply {
         let (driver_name_length, remaining) = u32::try_parse(remaining)?;
         let (device_name_length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, driver_name_length as usize)?;
+        let (driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, driver_name_length.try_into().or(Err(ParseError::ParseError))?)?;
         let driver_name = driver_name.to_vec();
-        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (((driver_name_length as usize) + 3) & (!3)) - (driver_name_length as usize))?;
+        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (driver_name_length.checked_add(3u32).ok_or(ParseError::ParseError)? & (!3u32)).checked_sub(driver_name_length).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let alignment_pad = alignment_pad.to_vec();
-        let (device_name, remaining) = crate::x11_utils::parse_u8_list(remaining, device_name_length as usize)?;
+        let (device_name, remaining) = crate::x11_utils::parse_u8_list(remaining, device_name_length.try_into().or(Err(ParseError::ParseError))?)?;
         let device_name = device_name.to_vec();
         let result = ConnectReply { response_type, sequence, length, driver_name, alignment_pad, device_name };
         Ok((result, remaining))
@@ -664,7 +664,7 @@ impl TryParse for GetBuffersReply {
         let (height, remaining) = u32::try_parse(remaining)?;
         let (count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count as usize)?;
+        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetBuffersReply { response_type, sequence, length, width, height, buffers };
         Ok((result, remaining))
     }
@@ -796,7 +796,7 @@ impl TryParse for GetBuffersWithFormatReply {
         let (height, remaining) = u32::try_parse(remaining)?;
         let (count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count as usize)?;
+        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetBuffersWithFormatReply { response_type, sequence, length, width, height, buffers };
         Ok((result, remaining))
     }

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -427,8 +427,8 @@ impl TryParse for GetSupportedModifiersReply {
         let (num_window_modifiers, remaining) = u32::try_parse(remaining)?;
         let (num_screen_modifiers, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (window_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_window_modifiers as usize)?;
-        let (screen_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_screen_modifiers as usize)?;
+        let (window_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_window_modifiers.try_into().or(Err(ParseError::ParseError))?)?;
+        let (screen_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_screen_modifiers.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetSupportedModifiersReply { response_type, sequence, length, window_modifiers, screen_modifiers };
         Ok((result, remaining))
     }
@@ -594,9 +594,9 @@ impl BuffersFromPixmapReply {
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (bpp, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(6..).ok_or(ParseError::ParseError)?;
-        let (strides, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd as usize)?;
-        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd as usize)?;
-        let fds_len = nfd as usize;
+        let (strides, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_into().or(Err(ParseError::ParseError))?)?;
+        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_into().or(Err(ParseError::ParseError))?)?;
+        let fds_len = usize::try_from(nfd).or(Err(ParseError::ParseError))?;
         if fds.len() < fds_len { return Err(ParseError::ParseError) }
         let mut buffers = fds.split_off(fds_len);
         std::mem::swap(fds, &mut buffers);

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -2381,7 +2381,7 @@ impl TryParse for GetVisualConfigsReply {
         let (num_visuals, remaining) = u32::try_parse(remaining)?;
         let (num_properties, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (property_list, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
+        let (property_list, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetVisualConfigsReply { response_type, sequence, num_visuals, num_properties, property_list };
         Ok((result, remaining))
     }
@@ -2507,7 +2507,7 @@ impl TryParse for VendorPrivateWithReplyReply {
         let (retval, remaining) = u32::try_parse(remaining)?;
         let (data1, remaining) = crate::x11_utils::parse_u8_list(remaining, 24)?;
         let data1 = <[u8; 24]>::try_from(data1).unwrap();
-        let (data2, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data2, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data2 = data2.to_vec();
         let result = VendorPrivateWithReplyReply { response_type, sequence, retval, data1, data2 };
         Ok((result, remaining))
@@ -2622,7 +2622,7 @@ impl TryParse for QueryServerStringReply {
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (str_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, str_len as usize)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, str_len.try_into().or(Err(ParseError::ParseError))?)?;
         let string = string.to_vec();
         let result = QueryServerStringReply { response_type, sequence, length, string };
         Ok((result, remaining))
@@ -2720,7 +2720,7 @@ impl TryParse for GetFBConfigsReply {
         let (num_fb_configs, remaining) = u32::try_parse(remaining)?;
         let (num_properties, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (property_list, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
+        let (property_list, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetFBConfigsReply { response_type, sequence, num_fb_configs, num_properties, property_list };
         Ok((result, remaining))
     }
@@ -2906,7 +2906,7 @@ impl TryParse for QueryContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (num_attribs as usize) * 2)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryContextReply { response_type, sequence, length, attribs };
         Ok((result, remaining))
     }
@@ -3103,7 +3103,7 @@ impl TryParse for GetDrawableAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (num_attribs as usize) * 2)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetDrawableAttributesReply { response_type, sequence, length, attribs };
         Ok((result, remaining))
     }
@@ -3683,7 +3683,7 @@ impl TryParse for RenderModeReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (new_mode, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = RenderModeReply { response_type, sequence, length, ret_val, new_mode, data };
         Ok((result, remaining))
     }
@@ -3945,7 +3945,7 @@ impl TryParse for ReadPixelsReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = ReadPixelsReply { response_type, sequence, data };
         Ok((result, remaining))
@@ -4008,7 +4008,7 @@ impl TryParse for GetBooleanvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(15..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<bool>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<bool>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetBooleanvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4065,7 +4065,7 @@ impl TryParse for GetClipPlaneReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, (length as usize) / 2)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, length.checked_div(2u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetClipPlaneReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -4127,7 +4127,7 @@ impl TryParse for GetDoublevReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float64::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetDoublevReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4241,7 +4241,7 @@ impl TryParse for GetFloatvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetFloatvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4303,7 +4303,7 @@ impl TryParse for GetIntegervReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetIntegervReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4370,7 +4370,7 @@ impl TryParse for GetLightfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetLightfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4437,7 +4437,7 @@ impl TryParse for GetLightivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetLightivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4504,7 +4504,7 @@ impl TryParse for GetMapdvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float64::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetMapdvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4571,7 +4571,7 @@ impl TryParse for GetMapfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetMapfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4638,7 +4638,7 @@ impl TryParse for GetMapivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetMapivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4705,7 +4705,7 @@ impl TryParse for GetMaterialfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetMaterialfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4772,7 +4772,7 @@ impl TryParse for GetMaterialivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetMaterialivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4834,7 +4834,7 @@ impl TryParse for GetPixelMapfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetPixelMapfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4896,7 +4896,7 @@ impl TryParse for GetPixelMapuivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetPixelMapuivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -4958,7 +4958,7 @@ impl TryParse for GetPixelMapusvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u16>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u16>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetPixelMapusvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5015,7 +5015,7 @@ impl TryParse for GetPolygonStippleReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = GetPolygonStippleReply { response_type, sequence, data };
         Ok((result, remaining))
@@ -5076,7 +5076,7 @@ impl TryParse for GetStringReply {
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let (n, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, n as usize)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let string = string.to_vec();
         let result = GetStringReply { response_type, sequence, length, string };
         Ok((result, remaining))
@@ -5144,7 +5144,7 @@ impl TryParse for GetTexEnvfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexEnvfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5211,7 +5211,7 @@ impl TryParse for GetTexEnvivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexEnvivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5278,7 +5278,7 @@ impl TryParse for GetTexGendvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float64::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexGendvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5345,7 +5345,7 @@ impl TryParse for GetTexGenfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexGenfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5412,7 +5412,7 @@ impl TryParse for GetTexGenivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexGenivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5496,7 +5496,7 @@ impl TryParse for GetTexImageReply {
         let (height, remaining) = i32::try_parse(remaining)?;
         let (depth, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = GetTexImageReply { response_type, sequence, width, height, depth, data };
         Ok((result, remaining))
@@ -5564,7 +5564,7 @@ impl TryParse for GetTexParameterfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5631,7 +5631,7 @@ impl TryParse for GetTexParameterivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5703,7 +5703,7 @@ impl TryParse for GetTexLevelParameterfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexLevelParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5775,7 +5775,7 @@ impl TryParse for GetTexLevelParameterivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetTexLevelParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -5980,7 +5980,7 @@ impl TryParse for AreTexturesResidentReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (ret_val, remaining) = Bool32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<bool>(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<bool>(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = AreTexturesResidentReply { response_type, sequence, ret_val, data };
         Ok((result, remaining))
     }
@@ -6074,7 +6074,7 @@ impl TryParse for GenTexturesReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GenTexturesReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -6206,7 +6206,7 @@ impl TryParse for GetColorTableReply {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let (width, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = GetColorTableReply { response_type, sequence, width, data };
         Ok((result, remaining))
@@ -6274,7 +6274,7 @@ impl TryParse for GetColorTableParameterfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetColorTableParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6341,7 +6341,7 @@ impl TryParse for GetColorTableParameterivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetColorTableParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6418,7 +6418,7 @@ impl TryParse for GetConvolutionFilterReply {
         let (width, remaining) = i32::try_parse(remaining)?;
         let (height, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = GetConvolutionFilterReply { response_type, sequence, width, height, data };
         Ok((result, remaining))
@@ -6486,7 +6486,7 @@ impl TryParse for GetConvolutionParameterfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetConvolutionParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6553,7 +6553,7 @@ impl TryParse for GetConvolutionParameterivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetConvolutionParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6630,7 +6630,7 @@ impl TryParse for GetSeparableFilterReply {
         let (row_w, remaining) = i32::try_parse(remaining)?;
         let (col_h, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (rows_and_cols, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (rows_and_cols, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let rows_and_cols = rows_and_cols.to_vec();
         let result = GetSeparableFilterReply { response_type, sequence, row_w, col_h, rows_and_cols };
         Ok((result, remaining))
@@ -6707,7 +6707,7 @@ impl TryParse for GetHistogramReply {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let (width, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = GetHistogramReply { response_type, sequence, width, data };
         Ok((result, remaining))
@@ -6775,7 +6775,7 @@ impl TryParse for GetHistogramParameterfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetHistogramParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6842,7 +6842,7 @@ impl TryParse for GetHistogramParameterivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetHistogramParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -6915,7 +6915,7 @@ impl TryParse for GetMinmaxReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = GetMinmaxReply { response_type, sequence, data };
         Ok((result, remaining))
@@ -6983,7 +6983,7 @@ impl TryParse for GetMinmaxParameterfvReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = Float32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetMinmaxParameterfvReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -7050,7 +7050,7 @@ impl TryParse for GetMinmaxParameterivReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetMinmaxParameterivReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -7115,7 +7115,7 @@ impl TryParse for GetCompressedTexImageARBReply {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let (size, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = GetCompressedTexImageARBReply { response_type, sequence, size, data };
         Ok((result, remaining))
@@ -7210,7 +7210,7 @@ impl TryParse for GenQueriesARBReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GenQueriesARBReply { response_type, sequence, data };
         Ok((result, remaining))
     }
@@ -7334,7 +7334,7 @@ impl TryParse for GetQueryivARBReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetQueryivARBReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -7401,7 +7401,7 @@ impl TryParse for GetQueryObjectivARBReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<i32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetQueryObjectivARBReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }
@@ -7468,7 +7468,7 @@ impl TryParse for GetQueryObjectuivARBReply {
         let (n, remaining) = u32::try_parse(remaining)?;
         let (datum, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, n.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetQueryObjectuivARBReply { response_type, sequence, length, datum, data };
         Ok((result, remaining))
     }

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -382,7 +382,7 @@ impl TryParse for ClientInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (client_resource, remaining) = ClientSpec::try_parse(remaining)?;
         let (num_ranges, remaining) = u32::try_parse(remaining)?;
-        let (ranges, remaining) = crate::x11_utils::parse_list::<Range>(remaining, num_ranges as usize)?;
+        let (ranges, remaining) = crate::x11_utils::parse_list::<Range>(remaining, num_ranges.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ClientInfo { client_resource, ranges };
         Ok((result, remaining))
     }
@@ -731,7 +731,7 @@ impl TryParse for GetContextReply {
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let (num_intercepted_clients, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (intercepted_clients, remaining) = crate::x11_utils::parse_list::<ClientInfo>(remaining, num_intercepted_clients as usize)?;
+        let (intercepted_clients, remaining) = crate::x11_utils::parse_list::<ClientInfo>(remaining, num_intercepted_clients.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetContextReply { response_type, enabled, sequence, length, element_header, intercepted_clients };
         Ok((result, remaining))
     }
@@ -795,7 +795,7 @@ impl TryParse for EnableContextReply {
         let (server_time, remaining) = u32::try_parse(remaining)?;
         let (rec_sequence_num, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, (length as usize) * 4)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = EnableContextReply { response_type, category, sequence, element_header, client_swapped, xid_base, server_time, rec_sequence_num, data };
         Ok((result, remaining))

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -235,7 +235,7 @@ impl TryParse for ClientIdValue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (spec, remaining) = ClientIdSpec::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (value, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (length as usize) / 4)?;
+        let (value, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.checked_div(4u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ClientIdValue { spec, value };
         Ok((result, remaining))
     }
@@ -375,7 +375,7 @@ impl TryParse for ResourceSizeValue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (size, remaining) = ResourceSizeSpec::try_parse(remaining)?;
         let (num_cross_references, remaining) = u32::try_parse(remaining)?;
-        let (cross_references, remaining) = crate::x11_utils::parse_list::<ResourceSizeSpec>(remaining, num_cross_references as usize)?;
+        let (cross_references, remaining) = crate::x11_utils::parse_list::<ResourceSizeSpec>(remaining, num_cross_references.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ResourceSizeValue { size, cross_references };
         Ok((result, remaining))
     }
@@ -494,7 +494,7 @@ impl TryParse for QueryClientsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_clients, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (clients, remaining) = crate::x11_utils::parse_list::<Client>(remaining, num_clients as usize)?;
+        let (clients, remaining) = crate::x11_utils::parse_list::<Client>(remaining, num_clients.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryClientsReply { response_type, sequence, length, clients };
         Ok((result, remaining))
     }
@@ -548,7 +548,7 @@ impl TryParse for QueryClientResourcesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_types, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (types, remaining) = crate::x11_utils::parse_list::<Type>(remaining, num_types as usize)?;
+        let (types, remaining) = crate::x11_utils::parse_list::<Type>(remaining, num_types.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryClientResourcesReply { response_type, sequence, length, types };
         Ok((result, remaining))
     }
@@ -661,7 +661,7 @@ impl TryParse for QueryClientIdsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_ids, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (ids, remaining) = crate::x11_utils::parse_list::<ClientIdValue>(remaining, num_ids as usize)?;
+        let (ids, remaining) = crate::x11_utils::parse_list::<ClientIdValue>(remaining, num_ids.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryClientIdsReply { response_type, sequence, length, ids };
         Ok((result, remaining))
     }
@@ -725,7 +725,7 @@ impl TryParse for QueryResourceBytesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_sizes, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (sizes, remaining) = crate::x11_utils::parse_list::<ResourceSizeValue>(remaining, num_sizes as usize)?;
+        let (sizes, remaining) = crate::x11_utils::parse_list::<ResourceSizeValue>(remaining, num_sizes.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryResourceBytesReply { response_type, sequence, length, sizes };
         Ok((result, remaining))
     }

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -464,7 +464,7 @@ impl Serialize for SetAttributesAux {
 }
 impl SetAttributesAux {
     fn switch_expr(&self) -> u32 {
-        let mut expr_value: u32 = 0;
+        let mut expr_value = 0;
         if self.background_pixmap.is_some() {
             expr_value |= u32::from(xproto::CW::BackPixmap);
         }

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -707,7 +707,7 @@ impl TryParse for GetRectanglesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (rectangles_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, rectangles_len as usize)?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, rectangles_len.try_into().or(Err(ParseError::ParseError))?)?;
         let ordering = ordering.try_into()?;
         let result = GetRectanglesReply { response_type, ordering, sequence, length, rectangles };
         Ok((result, remaining))

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -375,7 +375,7 @@ impl TryParse for Systemcounter {
         let (counter, remaining) = Counter::try_parse(remaining)?;
         let (resolution, remaining) = Int64::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ParseError))?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -808,7 +808,7 @@ impl TryParse for ListSystemCountersReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (counters_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (counters, remaining) = crate::x11_utils::parse_list::<Systemcounter>(remaining, counters_len as usize)?;
+        let (counters, remaining) = crate::x11_utils::parse_list::<Systemcounter>(remaining, counters_len.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ListSystemCountersReply { response_type, sequence, length, counters };
         Ok((result, remaining))
     }
@@ -1075,7 +1075,7 @@ impl Serialize for CreateAlarmAux {
 }
 impl CreateAlarmAux {
     fn switch_expr(&self) -> u32 {
-        let mut expr_value: u32 = 0;
+        let mut expr_value = 0;
         if self.counter.is_some() {
             expr_value |= u32::from(CA::Counter);
         }
@@ -1211,7 +1211,7 @@ impl Serialize for ChangeAlarmAux {
 }
 impl ChangeAlarmAux {
     fn switch_expr(&self) -> u32 {
-        let mut expr_value: u32 = 0;
+        let mut expr_value = 0;
         if self.counter.is_some() {
             expr_value |= u32::from(CA::Counter);
         }

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -182,7 +182,7 @@ impl TryParse for GetXIDListReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (ids_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (ids, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ids_len as usize)?;
+        let (ids, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ids_len.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetXIDListReply { response_type, sequence, length, ids };
         Ok((result, remaining))
     }

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -235,7 +235,7 @@ impl TryParse for OpenConnectionReply {
         let (sarea_handle_high, remaining) = u32::try_parse(remaining)?;
         let (bus_id_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (bus_id, remaining) = crate::x11_utils::parse_u8_list(remaining, bus_id_len as usize)?;
+        let (bus_id, remaining) = crate::x11_utils::parse_u8_list(remaining, bus_id_len.try_into().or(Err(ParseError::ParseError))?)?;
         let bus_id = bus_id.to_vec();
         let result = OpenConnectionReply { response_type, sequence, length, sarea_handle_low, sarea_handle_high, bus_id };
         Ok((result, remaining))
@@ -323,7 +323,7 @@ impl TryParse for GetClientDriverNameReply {
         let (client_driver_patch_version, remaining) = u32::try_parse(remaining)?;
         let (client_driver_name_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (client_driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, client_driver_name_len as usize)?;
+        let (client_driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, client_driver_name_len.try_into().or(Err(ParseError::ParseError))?)?;
         let client_driver_name = client_driver_name.to_vec();
         let result = GetClientDriverNameReply { response_type, sequence, length, client_driver_major_version, client_driver_minor_version, client_driver_patch_version, client_driver_name };
         Ok((result, remaining))
@@ -583,8 +583,8 @@ impl TryParse for GetDrawableInfoReply {
         let (back_x, remaining) = i16::try_parse(remaining)?;
         let (back_y, remaining) = i16::try_parse(remaining)?;
         let (num_back_clip_rects, remaining) = u32::try_parse(remaining)?;
-        let (clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_clip_rects as usize)?;
-        let (back_clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_back_clip_rects as usize)?;
+        let (clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_clip_rects.try_into().or(Err(ParseError::ParseError))?)?;
+        let (back_clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_back_clip_rects.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetDrawableInfoReply { response_type, sequence, length, drawable_table_index, drawable_table_stamp, drawable_origin_x, drawable_origin_y, drawable_size_w, drawable_size_h, back_x, back_y, clip_rects, back_clip_rects };
         Ok((result, remaining))
     }
@@ -647,7 +647,7 @@ impl TryParse for GetDeviceInfoReply {
         let (framebuffer_size, remaining) = u32::try_parse(remaining)?;
         let (framebuffer_stride, remaining) = u32::try_parse(remaining)?;
         let (device_private_size, remaining) = u32::try_parse(remaining)?;
-        let (device_private, remaining) = crate::x11_utils::parse_list::<u32>(remaining, device_private_size as usize)?;
+        let (device_private, remaining) = crate::x11_utils::parse_list::<u32>(remaining, device_private_size.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetDeviceInfoReply { response_type, sequence, length, framebuffer_handle_low, framebuffer_handle_high, framebuffer_origin_offset, framebuffer_size, framebuffer_stride, device_private };
         Ok((result, remaining))
     }

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -913,7 +913,7 @@ impl TryParse for GetCursorImageReply {
         let (yhot, remaining) = u16::try_parse(remaining)?;
         let (cursor_serial, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
-        let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
+        let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(width).checked_mul(u32::from(height)).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = GetCursorImageReply { response_type, sequence, length, x, y, width, height, xhot, yhot, cursor_serial, cursor_image };
         Ok((result, remaining))
     }
@@ -1580,7 +1580,7 @@ impl TryParse for FetchRegionReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (extents, remaining) = xproto::Rectangle::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, (length as usize) / 2)?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, length.checked_div(2u32).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = FetchRegionReply { response_type, sequence, extents, rectangles };
         Ok((result, remaining))
     }
@@ -1797,7 +1797,7 @@ impl TryParse for GetCursorNameReply {
         let (atom, remaining) = xproto::Atom::try_parse(remaining)?;
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, nbytes as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, nbytes.try_into().or(Err(ParseError::ParseError))?)?;
         let name = name.to_vec();
         let result = GetCursorNameReply { response_type, sequence, length, atom, name };
         Ok((result, remaining))
@@ -1864,8 +1864,8 @@ impl TryParse for GetCursorImageAndNameReply {
         let (cursor_atom, remaining) = xproto::Atom::try_parse(remaining)?;
         let (nbytes, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
-        let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, (width as usize) * (height as usize))?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, nbytes as usize)?;
+        let (cursor_image, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(width).checked_mul(u32::from(height)).ok_or(ParseError::ParseError)?.try_into().or(Err(ParseError::ParseError))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, nbytes.try_into().or(Err(ParseError::ParseError))?)?;
         let name = name.to_vec();
         let result = GetCursorImageAndNameReply { response_type, sequence, length, x, y, width, height, xhot, yhot, cursor_serial, cursor_atom, cursor_image, name };
         Ok((result, remaining))

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -395,7 +395,7 @@ impl TryParse for QueryScreensReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (number, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (screen_info, remaining) = crate::x11_utils::parse_list::<ScreenInfo>(remaining, number as usize)?;
+        let (screen_info, remaining) = crate::x11_utils::parse_list::<ScreenInfo>(remaining, number.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryScreensReply { response_type, sequence, length, screen_info };
         Ok((result, remaining))
     }

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -48,14 +48,14 @@ impl TryParse for Printer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
         let (name_len, remaining) = u32::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ParseError))?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
         let (desc_len, remaining) = u32::try_parse(remaining)?;
-        let (description, remaining) = crate::x11_utils::parse_u8_list(remaining, desc_len as usize)?;
+        let (description, remaining) = crate::x11_utils::parse_u8_list(remaining, desc_len.try_into().or(Err(ParseError::ParseError))?)?;
         let description = description.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -481,7 +481,7 @@ impl TryParse for PrintGetPrinterListReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (list_count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (printers, remaining) = crate::x11_utils::parse_list::<Printer>(remaining, list_count as usize)?;
+        let (printers, remaining) = crate::x11_utils::parse_list::<Printer>(remaining, list_count.try_into().or(Err(ParseError::ParseError))?)?;
         let result = PrintGetPrinterListReply { response_type, sequence, length, printers };
         Ok((result, remaining))
     }
@@ -911,7 +911,7 @@ impl TryParse for PrintGetDocumentDataReply {
         let (finished_flag, remaining) = u32::try_parse(remaining)?;
         let (data_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len as usize)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = PrintGetDocumentDataReply { response_type, sequence, length, status_code, finished_flag, data };
         Ok((result, remaining))
@@ -1111,7 +1111,7 @@ impl TryParse for PrintGetAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (string_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (attributes, remaining) = crate::x11_utils::parse_u8_list(remaining, string_len as usize)?;
+        let (attributes, remaining) = crate::x11_utils::parse_u8_list(remaining, string_len.try_into().or(Err(ParseError::ParseError))?)?;
         let attributes = attributes.to_vec();
         let result = PrintGetAttributesReply { response_type, sequence, length, attributes };
         Ok((result, remaining))
@@ -1180,7 +1180,7 @@ impl TryParse for PrintGetOneAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len as usize)?;
+        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len.try_into().or(Err(ParseError::ParseError))?)?;
         let value = value.to_vec();
         let result = PrintGetOneAttributesReply { response_type, sequence, length, value };
         Ok((result, remaining))
@@ -1333,7 +1333,7 @@ impl TryParse for PrintQueryScreensReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (list_count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (roots, remaining) = crate::x11_utils::parse_list::<xproto::Window>(remaining, list_count as usize)?;
+        let (roots, remaining) = crate::x11_utils::parse_list::<xproto::Window>(remaining, list_count.try_into().or(Err(ParseError::ParseError))?)?;
         let result = PrintQueryScreensReply { response_type, sequence, length, roots };
         Ok((result, remaining))
     }

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -160,7 +160,7 @@ impl TryParse for GetDeviceCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetDeviceCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -251,7 +251,7 @@ impl TryParse for GetDeviceContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetDeviceContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -332,7 +332,7 @@ impl TryParse for GetWindowCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetWindowCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -387,7 +387,7 @@ impl TryParse for GetWindowContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetWindowContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -412,13 +412,13 @@ impl TryParse for ListItem {
         let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (object_context_len, remaining) = u32::try_parse(remaining)?;
         let (data_context_len, remaining) = u32::try_parse(remaining)?;
-        let (object_context, remaining) = crate::x11_utils::parse_u8_list(remaining, object_context_len as usize)?;
+        let (object_context, remaining) = crate::x11_utils::parse_u8_list(remaining, object_context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let object_context = object_context.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (data_context, remaining) = crate::x11_utils::parse_u8_list(remaining, data_context_len as usize)?;
+        let (data_context, remaining) = crate::x11_utils::parse_u8_list(remaining, data_context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let data_context = data_context.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -523,7 +523,7 @@ impl TryParse for GetPropertyCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetPropertyCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -604,7 +604,7 @@ impl TryParse for GetPropertyUseContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetPropertyUseContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -664,7 +664,7 @@ impl TryParse for GetPropertyContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetPropertyContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -724,7 +724,7 @@ impl TryParse for GetPropertyDataContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetPropertyDataContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -779,7 +779,7 @@ impl TryParse for ListPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (properties_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (properties, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, properties_len as usize)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, properties_len.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ListPropertiesReply { response_type, sequence, length, properties };
         Ok((result, remaining))
     }
@@ -859,7 +859,7 @@ impl TryParse for GetSelectionCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetSelectionCreateContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -940,7 +940,7 @@ impl TryParse for GetSelectionUseContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetSelectionUseContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -995,7 +995,7 @@ impl TryParse for GetSelectionContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetSelectionContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -1050,7 +1050,7 @@ impl TryParse for GetSelectionDataContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetSelectionDataContextReply { response_type, sequence, length, context };
         Ok((result, remaining))
@@ -1100,7 +1100,7 @@ impl TryParse for ListSelectionsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (selections_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (selections, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, selections_len as usize)?;
+        let (selections, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, selections_len.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ListSelectionsReply { response_type, sequence, length, selections };
         Ok((result, remaining))
     }
@@ -1154,7 +1154,7 @@ impl TryParse for GetClientContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len as usize)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ParseError))?)?;
         let context = context.to_vec();
         let result = GetClientContextReply { response_type, sequence, length, context };
         Ok((result, remaining))

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -636,13 +636,13 @@ impl TryParse for AdaptorInfo {
         let (num_formats, remaining) = u16::try_parse(remaining)?;
         let (type_, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_size as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_size.try_into().or(Err(ParseError::ParseError))?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::ParseError)?;
-        let (formats, remaining) = crate::x11_utils::parse_list::<Format>(remaining, num_formats as usize)?;
+        let (formats, remaining) = crate::x11_utils::parse_list::<Format>(remaining, num_formats.try_into().or(Err(ParseError::ParseError))?)?;
         let result = AdaptorInfo { base_id, num_ports, type_, name, formats };
         Ok((result, remaining))
     }
@@ -693,7 +693,7 @@ impl TryParse for EncodingInfo {
         let (height, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (rate, remaining) = Rational::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_size as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_size.try_into().or(Err(ParseError::ParseError))?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -747,9 +747,9 @@ impl TryParse for Image {
         let (height, remaining) = u16::try_parse(remaining)?;
         let (data_size, remaining) = u32::try_parse(remaining)?;
         let (num_planes, remaining) = u32::try_parse(remaining)?;
-        let (pitches, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes as usize)?;
-        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes as usize)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_size as usize)?;
+        let (pitches, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes.try_into().or(Err(ParseError::ParseError))?)?;
+        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes.try_into().or(Err(ParseError::ParseError))?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_size.try_into().or(Err(ParseError::ParseError))?)?;
         let data = data.to_vec();
         let result = Image { id, width, height, num_planes, pitches, offsets, data };
         Ok((result, remaining))
@@ -796,7 +796,7 @@ impl TryParse for AttributeInfo {
         let (min, remaining) = i32::try_parse(remaining)?;
         let (max, remaining) = i32::try_parse(remaining)?;
         let (size, remaining) = u32::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, size as usize)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, size.try_into().or(Err(ParseError::ParseError))?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -1609,7 +1609,7 @@ impl TryParse for QueryAdaptorsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_adaptors, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (info, remaining) = crate::x11_utils::parse_list::<AdaptorInfo>(remaining, num_adaptors as usize)?;
+        let (info, remaining) = crate::x11_utils::parse_list::<AdaptorInfo>(remaining, num_adaptors.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryAdaptorsReply { response_type, sequence, length, info };
         Ok((result, remaining))
     }
@@ -1663,7 +1663,7 @@ impl TryParse for QueryEncodingsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_encodings, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
-        let (info, remaining) = crate::x11_utils::parse_list::<EncodingInfo>(remaining, num_encodings as usize)?;
+        let (info, remaining) = crate::x11_utils::parse_list::<EncodingInfo>(remaining, num_encodings.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryEncodingsReply { response_type, sequence, length, info };
         Ok((result, remaining))
     }
@@ -2317,7 +2317,7 @@ impl TryParse for QueryPortAttributesReply {
         let (num_attributes, remaining) = u32::try_parse(remaining)?;
         let (text_size, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
-        let (attributes, remaining) = crate::x11_utils::parse_list::<AttributeInfo>(remaining, num_attributes as usize)?;
+        let (attributes, remaining) = crate::x11_utils::parse_list::<AttributeInfo>(remaining, num_attributes.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryPortAttributesReply { response_type, sequence, length, text_size, attributes };
         Ok((result, remaining))
     }
@@ -2371,7 +2371,7 @@ impl TryParse for ListImageFormatsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_formats, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (format, remaining) = crate::x11_utils::parse_list::<ImageFormatInfo>(remaining, num_formats as usize)?;
+        let (format, remaining) = crate::x11_utils::parse_list::<ImageFormatInfo>(remaining, num_formats.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ListImageFormatsReply { response_type, sequence, length, format };
         Ok((result, remaining))
     }
@@ -2444,8 +2444,8 @@ impl TryParse for QueryImageAttributesReply {
         let (width, remaining) = u16::try_parse(remaining)?;
         let (height, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (pitches, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes as usize)?;
-        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes as usize)?;
+        let (pitches, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes.try_into().or(Err(ParseError::ParseError))?)?;
+        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_planes.try_into().or(Err(ParseError::ParseError))?)?;
         let result = QueryImageAttributesReply { response_type, sequence, length, num_planes, data_size, width, height, pitches, offsets };
         Ok((result, remaining))
     }

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -220,7 +220,7 @@ impl TryParse for ListSurfaceTypesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (surfaces, remaining) = crate::x11_utils::parse_list::<SurfaceInfo>(remaining, num as usize)?;
+        let (surfaces, remaining) = crate::x11_utils::parse_list::<SurfaceInfo>(remaining, num.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ListSurfaceTypesReply { response_type, sequence, length, surfaces };
         Ok((result, remaining))
     }
@@ -299,7 +299,7 @@ impl TryParse for CreateContextReply {
         let (height_actual, remaining) = u16::try_parse(remaining)?;
         let (flags_return, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ParseError))?)?;
         let result = CreateContextReply { response_type, sequence, width_actual, height_actual, flags_return, priv_data };
         Ok((result, remaining))
     }
@@ -383,7 +383,7 @@ impl TryParse for CreateSurfaceReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::ParseError)?;
-        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ParseError))?)?;
         let result = CreateSurfaceReply { response_type, sequence, priv_data };
         Ok((result, remaining))
     }
@@ -489,7 +489,7 @@ impl TryParse for CreateSubpictureReply {
         let (component_order, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
         let component_order = <[u8; 4]>::try_from(component_order).unwrap();
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
-        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length as usize)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ParseError))?)?;
         let result = CreateSubpictureReply { response_type, sequence, width_actual, height_actual, num_palette_entries, entry_bytes, component_order, priv_data };
         Ok((result, remaining))
     }
@@ -575,7 +575,7 @@ impl TryParse for ListSubpictureTypesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
-        let (types, remaining) = crate::x11_utils::parse_list::<xv::ImageFormatInfo>(remaining, num as usize)?;
+        let (types, remaining) = crate::x11_utils::parse_list::<xv::ImageFormatInfo>(remaining, num.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ListSubpictureTypesReply { response_type, sequence, length, types };
         Ok((result, remaining))
     }


### PR DESCRIPTION
Conversions now use `try_from` and arithmetic operations now use `checked_*` functions.

In parse code, failures are propagated to the caller with a `ParseError`. In serialize code, failures produce a panic.

Additionally, expressions now always use `u32` for intermediate values. All fields involved in expressions are `CARD32` or smaller, so a lot of `T::try_from` are now `u32::from`. For list lengths, a `usize::try_from` is used to convert the final value of the expression.

Fixes https://github.com/psychon/x11rb/issues/352