### PR TITLE
Add an x11rb version of xcb-util-cursor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ script:
         cargo fmt --all -- --check || exit 1
     fi
 
+  # Build once with just the default features, i.e. without all the extensions
+  # to check that this works fine.
+  - cargo build --verbose --all-targets
+
   - cargo build --verbose --all-targets --all-features
   - cargo test --verbose --all-features
   - cargo doc --verbose --all-features

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ install:
 
 build: false
 test_script:
+  # Build once with just the default features, i.e. without all the extensions
+  # to check that this works fine.
+  - cargo build --verbose --all-targets
+
   # We do not have libxcb and thus cannot build XCBConnection
   - cargo build --verbose --all-targets --no-default-features --features all-extensions
   - cargo test --verbose --no-default-features --features all-extensions

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -2,8 +2,8 @@ extern crate x11rb;
 
 use x11rb::connection::Connection;
 use x11rb::cursor::Handle as CursorHandle;
-use x11rb::protocol::Event;
 use x11rb::protocol::xproto::*;
+use x11rb::protocol::Event;
 use x11rb::wrapper::ConnectionExt as _;
 
 fn main() {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -1,8 +1,9 @@
 extern crate x11rb;
 
 use x11rb::connection::Connection;
-use x11rb::protocol::xproto::*;
+use x11rb::cursor::Handle as CursorHandle;
 use x11rb::protocol::Event;
+use x11rb::protocol::xproto::*;
 use x11rb::wrapper::ConnectionExt as _;
 
 fn main() {
@@ -15,6 +16,7 @@ fn main() {
     let screen = &conn.setup().roots[screen_num];
     let win_id = conn.generate_id().unwrap();
     let gc_id = conn.generate_id().unwrap();
+    let cursor_handle = CursorHandle::new(conn, screen_num).unwrap();
 
     let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS").unwrap();
     let wm_delete_window = conn.intern_atom(false, b"WM_DELETE_WINDOW").unwrap();
@@ -24,11 +26,14 @@ fn main() {
     let wm_delete_window = wm_delete_window.reply().unwrap().atom;
     let net_wm_name = net_wm_name.reply().unwrap().atom;
     let utf8_string = utf8_string.reply().unwrap().atom;
+    let cursor_handle = cursor_handle.reply().unwrap();
 
     let win_aux = CreateWindowAux::new()
         .event_mask(EventMask::Exposure | EventMask::StructureNotify | EventMask::NoEvent)
         .background_pixel(screen.white_pixel)
-        .win_gravity(Gravity::NorthWest);
+        .win_gravity(Gravity::NorthWest)
+        // Just because, we set the cursor to "wait"
+        .cursor(cursor_handle.load_cursor(conn, "wait").unwrap());
 
     let gc_aux = CreateGCAux::new().foreground(screen.black_pixel);
 

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -301,7 +301,8 @@ where
     Err(Error::NothingFound)
 }
 
-#[cfg(test)]
+// FIXME: Make these tests pass on Windows; problem is "/" vs "\\" in paths
+#[cfg(all(test, unix))]
 mod test_find_cursor {
     use super::{find_cursor_impl, Cursor, Error};
     use crate::errors::ConnectionError;

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -267,11 +267,12 @@ where
                 // Does the path begin with '~'?
                 if path.starts_with('~') {
                     theme_dir.push(&home);
-                    if path.starts_with("~/") {
-                        theme_dir.push(&path[2..]);
-                    } else {
-                        theme_dir.push(&path[1..]);
+                    let mut path = &path[1..];
+                    // Skip a path separator if there is one
+                    if path.chars().next().map(std::path::is_separator) == Some(true) {
+                        path = &path[1..];
                     }
+                    theme_dir.push(path);
                 } else {
                     theme_dir.push(path);
                 }

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -1,0 +1,454 @@
+//! Find the right cursor file from a cursor name
+
+// Based on libxcb-cursor's load_cursor.c which has:
+//
+//   Copyright © 2013 Michael Stapelberg
+//   Copyright © 2002 Keith Packard
+//
+// and is licensed under MIT/X Consortium License
+
+use std::env::var_os;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Error as IOError};
+use std::path::{Path, PathBuf};
+
+static CORE_CURSORS: &'static [(&str, u16)] = &[
+    ("X_cursor", 0),
+    ("arrow", 1),
+    ("based_arrow_down", 2),
+    ("based_arrow_up", 3),
+    ("boat", 4),
+    ("bogosity", 5),
+    ("bottom_left_corner", 6),
+    ("bottom_right_corner", 7),
+    ("bottom_side", 8),
+    ("bottom_tee", 9),
+    ("box_spiral", 10),
+    ("center_ptr", 11),
+    ("circle", 12),
+    ("clock", 13),
+    ("coffee_mug", 14),
+    ("cross", 15),
+    ("cross_reverse", 16),
+    ("crosshair", 17),
+    ("diamond_cross", 18),
+    ("dot", 19),
+    ("dotbox", 20),
+    ("double_arrow", 21),
+    ("draft_large", 22),
+    ("draft_small", 23),
+    ("draped_box", 24),
+    ("exchange", 25),
+    ("fleur", 26),
+    ("gobbler", 27),
+    ("gumby", 28),
+    ("hand1", 29),
+    ("hand2", 30),
+    ("heart", 31),
+    ("icon", 32),
+    ("iron_cross", 33),
+    ("left_ptr", 34),
+    ("left_side", 35),
+    ("left_tee", 36),
+    ("leftbutton", 37),
+    ("ll_angle", 38),
+    ("lr_angle", 39),
+    ("man", 40),
+    ("middlebutton", 41),
+    ("mouse", 42),
+    ("pencil", 43),
+    ("pirate", 44),
+    ("plus", 45),
+    ("question_arrow", 46),
+    ("right_ptr", 47),
+    ("right_side", 48),
+    ("right_tee", 49),
+    ("rightbutton", 50),
+    ("rtl_logo", 51),
+    ("sailboat", 52),
+    ("sb_down_arrow", 53),
+    ("sb_h_double_arrow", 54),
+    ("sb_left_arrow", 55),
+    ("sb_right_arrow", 56),
+    ("sb_up_arrow", 57),
+    ("sb_v_double_arrow", 58),
+    ("shuttle", 59),
+    ("sizing", 60),
+    ("spider", 61),
+    ("spraycan", 62),
+    ("star", 63),
+    ("target", 64),
+    ("tcross", 65),
+    ("top_left_arrow", 66),
+    ("top_left_corner", 67),
+    ("top_right_corner", 68),
+    ("top_side", 69),
+    ("top_tee", 70),
+    ("trek", 71),
+    ("ul_angle", 72),
+    ("umbrella", 73),
+    ("ur_angle", 74),
+    ("watch", 75),
+    ("xterm", 76),
+];
+
+/// Find a core cursor based on its name
+///
+/// This function checks a built-in list of known names.
+fn cursor_shape_to_id(name: &str) -> Option<u16> {
+    CORE_CURSORS
+        .iter()
+        .filter(|&(name2, _)| name == *name2)
+        .map(|&(_, id)| id)
+        .next()
+}
+
+/// An error that occurred while searching
+#[derive(Debug)]
+pub(crate) enum Error {
+    /// `$HOME` is not set
+    NoHomeDir,
+
+    /// No cursor file could be found
+    NothingFound,
+}
+
+/// The result of finding a cursor
+#[derive(Debug)]
+pub(crate) enum Cursor<F> {
+    /// The cursor is a core cursor that can be created with xproto's `CreateGlyphCursor`
+    CoreChar(u16),
+
+    /// A cursor file was opened
+    File(F),
+}
+
+// Get the 'Inherits' entry from an index.theme file
+fn parse_inherits(filename: &Path)
+-> Result<Vec<OsString>, IOError>
+{
+    let file = File::open(filename)?;
+    let result = parse_inherits_impl(&mut BufReader::new(file))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        let result = result.into_iter()
+            .map(|e| OsString::from_vec(e))
+            .collect();
+        Ok(result)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStringExt;
+        let result = result.into_iter()
+            .map(|e| {
+                let wide = e.into_iter()
+                    .map(u16::from)
+                    .collect::<Vec<_>>();
+                OsString::from_wide(wide)
+            })
+            .collect();
+        Ok(result)
+    }
+}
+
+// Get the 'Inherits' entry from an index.theme file
+fn parse_inherits_impl(
+    input: &mut impl BufRead,
+) -> Result<Vec<Vec<u8>>, IOError>
+{
+    let mut buffer = Vec::new();
+    loop {
+        buffer.clear();
+
+        // Read a line
+        if 0 == input.read_until(b'\n', &mut buffer)? {
+            // End of file, return an empty result
+            return Ok(Default::default())
+        }
+
+        // Remove end of line marker
+        if buffer.last() == Some(&b'\n') {
+            let _ = buffer.pop();
+        }
+
+        let begin = b"Inherits";
+        if buffer.starts_with(begin) {
+            let mut result = Vec::new();
+
+            let mut to_parse = &buffer[begin.len()..];
+
+            fn skip_while(mut slice: &[u8], f: impl Fn(u8) -> bool) -> &[u8] {
+                while !slice.is_empty() && f(slice[0]) {
+                    slice = &slice[1..]
+                }
+                slice
+            }
+
+            // Skip all spaces
+            to_parse = skip_while(to_parse, |c| c == b' ');
+
+            // Now we need an equal sign
+            if to_parse.get(0) == Some(&b'=') {
+                to_parse = &to_parse[1..];
+
+                fn should_skip(c: u8) -> bool {
+                    match c {
+                        b' ' | b'\t' | b'\n' | b';' | b',' => true,
+                        _ => false,
+                    }
+                }
+
+                // Iterate over the pieces
+                for mut part in to_parse.split(|&x| x == b':') {
+                    // Skip all leading whitespace
+                    part = skip_while(part, should_skip);
+
+                    // Skip all trailing whitespace
+                    loop {
+                        let (&last, rest) = match part.split_last() {
+                            Some(x) => x,
+                            None => break,
+                        };
+                        if !should_skip(last) {
+                            break
+                        }
+                        part = rest;
+                    }
+                    if !part.is_empty() {
+                        result.push(part.to_vec());
+                    }
+                }
+            }
+            return Ok(result);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_parse_inherits {
+    use super::parse_inherits_impl;
+    use std::io::Cursor;
+
+    #[test]
+    fn parse_inherits_successful() {
+        let input = b"Hi\nInherits = \t ; whatever ;,::; stuff : i s ,: \tthis \t \nInherits=ignored\n";
+        let mut input = Cursor::new(&input[..]);
+        let result = parse_inherits_impl(&mut input).unwrap();
+        assert_eq!(result, vec![
+                   &b"whatever"[..],
+                   &b"stuff"[..],
+                   &b"i s"[..],
+                   &b"this"[..],
+        ]);
+    }
+}
+
+#[cfg(unix)]
+fn strip_leading_tilde_slash(path: &OsStr) -> &OsStr {
+    use std::os::unix::ffi::OsStrExt;
+    let path = path.as_bytes();
+    let mut path = &path[..];
+    if let Some(b'~') = path.get(0) {
+        if let Some(b'/') = path.get(1) {
+            path = &path[2..];
+        } else {
+            path = &path[1..];
+        }
+    }
+    OsStr::from_bytes(path)
+}
+
+#[cfg(windows)]
+fn strip_leading_tilde_slash(path: &OsStr) -> OsString {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    let path = path.encode_wide.collect::<Vec<_>>();
+    let mut path = &path[..];
+    fn map_to_char(input: u16) -> u8 {
+        input.try_into().unwrap_or(0)
+    }
+    if let Some(b'~') = path.get(0).map(map_to_char) {
+        if let Some(b'/') = path.get(1).map(map_to_char) {
+            path = &path[2..];
+        } else {
+            path = &path[1..];
+        }
+    }
+    OsString::from_wide(path)
+}
+
+/// Split an `OsStr` at some separator byte
+fn split_at(input: &OsStr, separator: u8) -> Vec<OsString> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        input.as_bytes()
+            .split(|&b| b == separator)
+            .map(|chunk| OsStr::from_bytes(chunk).to_os_string())
+            .collect()
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+        let separator = u16::from(separator);
+        input.encode_wide()
+            .split(|&b| b == separator)
+            .map(|chunk| OsString::from_wide(chunk))
+            .collect()
+    }
+}
+
+/// Find a cursor file based on the name of a cursor theme and the name of the cursor.
+pub(crate) fn find_cursor(theme: &str, name: &str) -> Result<Cursor<File>, Error> {
+    let home = match var_os("HOME") {
+        Some(home) => home,
+        None => return Err(Error::NoHomeDir),
+    };
+    let cursor_path = var_os("XCURSOR_PATH")
+        .unwrap_or_else(|| "~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons".into());
+    let open_cursor = |file: &Path| File::open(file);
+    let parse_inherits = |file: &Path| parse_inherits(file);
+    find_cursor_impl(&home, &cursor_path, theme, name, open_cursor, parse_inherits)
+}
+
+fn find_cursor_impl<F, G, H>(
+    home: &OsStr,
+    cursor_path: &OsStr,
+    theme: &str,
+    name: &str,
+    mut open_cursor: G,
+    mut parse_inherits: H,
+) -> Result<Cursor<F>, Error>
+where
+    G: FnMut(&Path) -> Result<F, IOError>,
+    H: FnMut(&Path) -> Result<Vec<OsString>, IOError>,
+{
+    if theme == "core" {
+        if let Some(id) = cursor_shape_to_id(name) {
+            return Ok(Cursor::CoreChar(id));
+        }
+    }
+
+    let cursor_path = split_at(&cursor_path, b':');
+
+    let mut os_theme = OsString::new();
+    os_theme.push(theme);
+    let mut next_inherits = Vec::new();
+    let mut last_inherits = vec![os_theme];
+    while !last_inherits.is_empty() {
+        for theme in last_inherits {
+            for path in &cursor_path {
+                // Calculate the path to the theme's directory
+                let mut theme_dir = PathBuf::new();
+                // Does the path begin with '~'?
+                if path.to_string_lossy().chars().next() == Some('~') {
+                    theme_dir.push(&home);
+                    theme_dir.push(strip_leading_tilde_slash(&path));
+                } else {
+                    theme_dir.push(path);
+                }
+                theme_dir.push(&theme);
+
+                // Find the cursor in the theme
+                let mut cursor_file = theme_dir.clone();
+                cursor_file.push("cursors");
+                cursor_file.push(name);
+                if let Ok(file) = open_cursor(&cursor_file) {
+                    return Ok(Cursor::File(file));
+                }
+
+                // Get the theme's index.theme file and parse its 'Inherits' line
+                let mut index = theme_dir;
+                index.push("index.theme");
+                if let Ok(res) = parse_inherits(&index) {
+                    next_inherits.extend(res);
+                }
+            }
+        }
+
+        last_inherits = next_inherits;
+        next_inherits = Vec::new();
+    }
+
+    Err(Error::NothingFound)
+}
+
+#[cfg(test)]
+mod test_find_cursor {
+    use super::{Cursor, Error, find_cursor_impl};
+    use crate::errors::ConnectionError;
+    use std::path::Path;
+    use std::io::{Error as IOError, ErrorKind};
+
+    #[test]
+    fn core_cursor() {
+        let cb1 = |_: &Path| -> Result<(), _> { unimplemented!() };
+        let cb2 = |_: &Path| unimplemented!();
+        match find_cursor_impl("unused".as_ref(), "unused".as_ref(), "core", "heart", cb1, cb2).unwrap() {
+            Cursor::CoreChar(31) => {},
+            e => panic!("Unexpected result {:?}", e),
+        }
+    }
+
+    #[test]
+    fn nothing_found() {
+        let mut opened = Vec::new();
+        let mut inherit_parsed = Vec::new();
+        let cb1 = |path: &Path| -> Result<(), _> {
+            opened.push(path.to_str().unwrap().to_owned());
+            Err(IOError::new(ErrorKind::Other, ConnectionError::UnknownError))
+        };
+        let cb2 = |path: &Path| {
+            inherit_parsed.push(path.to_str().unwrap().to_owned());
+            Ok(Vec::new())
+        };
+        match find_cursor_impl("home".as_ref(), "path:~/some/:/entries".as_ref(), "theme", "theCursor", cb1, cb2) {
+            Err(Error::NothingFound) => {},
+            e => panic!("Unexpected result {:?}", e),
+        }
+        assert_eq!(opened, &[
+            "path/theme/cursors/theCursor",
+            "home/some/theme/cursors/theCursor",
+            "/entries/theme/cursors/theCursor",
+        ]);
+        assert_eq!(inherit_parsed, &[
+            "path/theme/index.theme",
+            "home/some/theme/index.theme",
+            "/entries/theme/index.theme",
+        ]);
+    }
+
+    #[test]
+    fn inherit() {
+        let mut opened = Vec::new();
+        let cb1 = |path: &Path| -> Result<(), _> {
+            opened.push(path.to_str().unwrap().to_owned());
+            Err(IOError::new(ErrorKind::Other, ConnectionError::UnknownError))
+        };
+        let cb2 = |path: &Path| {
+            if path.starts_with("base/theTheme") {
+                Ok(vec!["inherited".into()])
+            } else if path.starts_with("path/inherited") {
+                Ok(vec!["theEnd".into()])
+            } else {
+                Ok(vec![])
+            }
+        };
+        match find_cursor_impl("home".as_ref(), "path:base:tail".as_ref(), "theTheme", "theCursor", cb1, cb2) {
+            Err(Error::NothingFound) => {},
+            e => panic!("Unexpected result {:?}", e),
+        }
+        assert_eq!(opened, &[
+            "path/theTheme/cursors/theCursor",
+            "base/theTheme/cursors/theCursor",
+            "tail/theTheme/cursors/theCursor",
+            "path/inherited/cursors/theCursor",
+            "base/inherited/cursors/theCursor",
+            "tail/inherited/cursors/theCursor",
+            "path/theEnd/cursors/theCursor",
+            "base/theEnd/cursors/theCursor",
+            "tail/theEnd/cursors/theCursor",
+        ]);
+    }
+}

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -255,9 +255,7 @@ where
         }
     }
 
-    let cursor_path = cursor_path
-        .split(':')
-        .collect::<Vec<_>>();
+    let cursor_path = cursor_path.split(':').collect::<Vec<_>>();
 
     let mut next_inherits = Vec::new();
     let mut last_inherits = vec![theme.into()];
@@ -314,16 +312,7 @@ mod test_find_cursor {
     fn core_cursor() {
         let cb1 = |_: &Path| -> Result<(), _> { unimplemented!() };
         let cb2 = |_: &Path| unimplemented!();
-        match find_cursor_impl(
-            "unused".as_ref(),
-            "unused".as_ref(),
-            "core",
-            "heart",
-            cb1,
-            cb2,
-        )
-        .unwrap()
-        {
+        match find_cursor_impl("unused".as_ref(), "unused", "core", "heart", cb1, cb2).unwrap() {
             Cursor::CoreChar(31) => {}
             e => panic!("Unexpected result {:?}", e),
         }
@@ -346,7 +335,7 @@ mod test_find_cursor {
         };
         match find_cursor_impl(
             "home".as_ref(),
-            "path:~/some/:/entries".as_ref(),
+            "path:~/some/:/entries",
             "theme",
             "theCursor",
             cb1,
@@ -394,7 +383,7 @@ mod test_find_cursor {
         };
         match find_cursor_impl(
             "home".as_ref(),
-            "path:base:tail".as_ref(),
+            "path:base:tail",
             "theTheme",
             "theCursor",
             cb1,

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -13,7 +13,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Error as IOError};
 use std::path::{Path, PathBuf};
 
-static CORE_CURSORS: &'static [(&str, u16)] = &[
+static CORE_CURSORS: &[(&str, u16)] = &[
     ("X_cursor", 0),
     ("arrow", 1),
     ("based_arrow_down", 2),

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -125,27 +125,22 @@ pub(crate) enum Cursor<F> {
 }
 
 // Get the 'Inherits' entry from an index.theme file
-fn parse_inherits(filename: &Path)
--> Result<Vec<OsString>, IOError>
-{
+fn parse_inherits(filename: &Path) -> Result<Vec<OsString>, IOError> {
     let file = File::open(filename)?;
     let result = parse_inherits_impl(&mut BufReader::new(file))?;
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStringExt;
-        let result = result.into_iter()
-            .map(|e| OsString::from_vec(e))
-            .collect();
+        let result = result.into_iter().map(|e| OsString::from_vec(e)).collect();
         Ok(result)
     }
     #[cfg(windows)]
     {
         use std::os::windows::ffi::OsStringExt;
-        let result = result.into_iter()
+        let result = result
+            .into_iter()
             .map(|e| {
-                let wide = e.into_iter()
-                    .map(u16::from)
-                    .collect::<Vec<_>>();
+                let wide = e.into_iter().map(u16::from).collect::<Vec<_>>();
                 OsString::from_wide(wide)
             })
             .collect();
@@ -154,10 +149,7 @@ fn parse_inherits(filename: &Path)
 }
 
 // Get the 'Inherits' entry from an index.theme file
-fn parse_inherits_impl(
-    input: &mut impl BufRead,
-) -> Result<Vec<Vec<u8>>, IOError>
-{
+fn parse_inherits_impl(input: &mut impl BufRead) -> Result<Vec<Vec<u8>>, IOError> {
     let mut buffer = Vec::new();
     loop {
         buffer.clear();
@@ -165,7 +157,7 @@ fn parse_inherits_impl(
         // Read a line
         if 0 == input.read_until(b'\n', &mut buffer)? {
             // End of file, return an empty result
-            return Ok(Default::default())
+            return Ok(Default::default());
         }
 
         // Remove end of line marker
@@ -212,7 +204,7 @@ fn parse_inherits_impl(
                             None => break,
                         };
                         if !should_skip(last) {
-                            break
+                            break;
                         }
                         part = rest;
                     }
@@ -233,15 +225,14 @@ mod test_parse_inherits {
 
     #[test]
     fn parse_inherits_successful() {
-        let input = b"Hi\nInherits = \t ; whatever ;,::; stuff : i s ,: \tthis \t \nInherits=ignored\n";
+        let input =
+            b"Hi\nInherits = \t ; whatever ;,::; stuff : i s ,: \tthis \t \nInherits=ignored\n";
         let mut input = Cursor::new(&input[..]);
         let result = parse_inherits_impl(&mut input).unwrap();
-        assert_eq!(result, vec![
-                   &b"whatever"[..],
-                   &b"stuff"[..],
-                   &b"i s"[..],
-                   &b"this"[..],
-        ]);
+        assert_eq!(
+            result,
+            vec![&b"whatever"[..], &b"stuff"[..], &b"i s"[..], &b"this"[..]]
+        );
     }
 }
 
@@ -283,7 +274,8 @@ fn split_at(input: &OsStr, separator: u8) -> Vec<OsString> {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
-        input.as_bytes()
+        input
+            .as_bytes()
             .split(|&b| b == separator)
             .map(|chunk| OsStr::from_bytes(chunk).to_os_string())
             .collect()
@@ -292,7 +284,8 @@ fn split_at(input: &OsStr, separator: u8) -> Vec<OsString> {
     {
         use std::os::windows::ffi::{OsStrExt, OsStringExt};
         let separator = u16::from(separator);
-        input.encode_wide()
+        input
+            .encode_wide()
             .split(|&b| b == separator)
             .map(|chunk| OsString::from_wide(chunk))
             .collect()
@@ -305,11 +298,19 @@ pub(crate) fn find_cursor(theme: &str, name: &str) -> Result<Cursor<File>, Error
         Some(home) => home,
         None => return Err(Error::NoHomeDir),
     };
-    let cursor_path = var_os("XCURSOR_PATH")
-        .unwrap_or_else(|| "~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons".into());
+    let cursor_path = var_os("XCURSOR_PATH").unwrap_or_else(|| {
+        "~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons".into()
+    });
     let open_cursor = |file: &Path| File::open(file);
     let parse_inherits = |file: &Path| parse_inherits(file);
-    find_cursor_impl(&home, &cursor_path, theme, name, open_cursor, parse_inherits)
+    find_cursor_impl(
+        &home,
+        &cursor_path,
+        theme,
+        name,
+        open_cursor,
+        parse_inherits,
+    )
 }
 
 fn find_cursor_impl<F, G, H>(
@@ -376,17 +377,26 @@ where
 
 #[cfg(test)]
 mod test_find_cursor {
-    use super::{Cursor, Error, find_cursor_impl};
+    use super::{find_cursor_impl, Cursor, Error};
     use crate::errors::ConnectionError;
-    use std::path::Path;
     use std::io::{Error as IOError, ErrorKind};
+    use std::path::Path;
 
     #[test]
     fn core_cursor() {
         let cb1 = |_: &Path| -> Result<(), _> { unimplemented!() };
         let cb2 = |_: &Path| unimplemented!();
-        match find_cursor_impl("unused".as_ref(), "unused".as_ref(), "core", "heart", cb1, cb2).unwrap() {
-            Cursor::CoreChar(31) => {},
+        match find_cursor_impl(
+            "unused".as_ref(),
+            "unused".as_ref(),
+            "core",
+            "heart",
+            cb1,
+            cb2,
+        )
+        .unwrap()
+        {
+            Cursor::CoreChar(31) => {}
             e => panic!("Unexpected result {:?}", e),
         }
     }
@@ -397,26 +407,42 @@ mod test_find_cursor {
         let mut inherit_parsed = Vec::new();
         let cb1 = |path: &Path| -> Result<(), _> {
             opened.push(path.to_str().unwrap().to_owned());
-            Err(IOError::new(ErrorKind::Other, ConnectionError::UnknownError))
+            Err(IOError::new(
+                ErrorKind::Other,
+                ConnectionError::UnknownError,
+            ))
         };
         let cb2 = |path: &Path| {
             inherit_parsed.push(path.to_str().unwrap().to_owned());
             Ok(Vec::new())
         };
-        match find_cursor_impl("home".as_ref(), "path:~/some/:/entries".as_ref(), "theme", "theCursor", cb1, cb2) {
-            Err(Error::NothingFound) => {},
+        match find_cursor_impl(
+            "home".as_ref(),
+            "path:~/some/:/entries".as_ref(),
+            "theme",
+            "theCursor",
+            cb1,
+            cb2,
+        ) {
+            Err(Error::NothingFound) => {}
             e => panic!("Unexpected result {:?}", e),
         }
-        assert_eq!(opened, &[
-            "path/theme/cursors/theCursor",
-            "home/some/theme/cursors/theCursor",
-            "/entries/theme/cursors/theCursor",
-        ]);
-        assert_eq!(inherit_parsed, &[
-            "path/theme/index.theme",
-            "home/some/theme/index.theme",
-            "/entries/theme/index.theme",
-        ]);
+        assert_eq!(
+            opened,
+            &[
+                "path/theme/cursors/theCursor",
+                "home/some/theme/cursors/theCursor",
+                "/entries/theme/cursors/theCursor",
+            ]
+        );
+        assert_eq!(
+            inherit_parsed,
+            &[
+                "path/theme/index.theme",
+                "home/some/theme/index.theme",
+                "/entries/theme/index.theme",
+            ]
+        );
     }
 
     #[test]
@@ -424,7 +450,10 @@ mod test_find_cursor {
         let mut opened = Vec::new();
         let cb1 = |path: &Path| -> Result<(), _> {
             opened.push(path.to_str().unwrap().to_owned());
-            Err(IOError::new(ErrorKind::Other, ConnectionError::UnknownError))
+            Err(IOError::new(
+                ErrorKind::Other,
+                ConnectionError::UnknownError,
+            ))
         };
         let cb2 = |path: &Path| {
             if path.starts_with("base/theTheme") {
@@ -435,20 +464,30 @@ mod test_find_cursor {
                 Ok(vec![])
             }
         };
-        match find_cursor_impl("home".as_ref(), "path:base:tail".as_ref(), "theTheme", "theCursor", cb1, cb2) {
-            Err(Error::NothingFound) => {},
+        match find_cursor_impl(
+            "home".as_ref(),
+            "path:base:tail".as_ref(),
+            "theTheme",
+            "theCursor",
+            cb1,
+            cb2,
+        ) {
+            Err(Error::NothingFound) => {}
             e => panic!("Unexpected result {:?}", e),
         }
-        assert_eq!(opened, &[
-            "path/theTheme/cursors/theCursor",
-            "base/theTheme/cursors/theCursor",
-            "tail/theTheme/cursors/theCursor",
-            "path/inherited/cursors/theCursor",
-            "base/inherited/cursors/theCursor",
-            "tail/inherited/cursors/theCursor",
-            "path/theEnd/cursors/theCursor",
-            "base/theEnd/cursors/theCursor",
-            "tail/theEnd/cursors/theCursor",
-        ]);
+        assert_eq!(
+            opened,
+            &[
+                "path/theTheme/cursors/theCursor",
+                "base/theTheme/cursors/theCursor",
+                "tail/theTheme/cursors/theCursor",
+                "path/inherited/cursors/theCursor",
+                "base/inherited/cursors/theCursor",
+                "tail/inherited/cursors/theCursor",
+                "path/theEnd/cursors/theCursor",
+                "base/theEnd/cursors/theCursor",
+                "tail/theEnd/cursors/theCursor",
+            ]
+        );
     }
 }

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -131,7 +131,7 @@ fn parse_inherits(filename: &Path) -> Result<Vec<OsString>, IOError> {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStringExt;
-        let result = result.into_iter().map(|e| OsString::from_vec(e)).collect();
+        let result = result.into_iter().map(OsString::from_vec).collect();
         Ok(result)
     }
     #[cfg(windows)]
@@ -198,11 +198,7 @@ fn parse_inherits_impl(input: &mut impl BufRead) -> Result<Vec<Vec<u8>>, IOError
                     part = skip_while(part, should_skip);
 
                     // Skip all trailing whitespace
-                    loop {
-                        let (&last, rest) = match part.split_last() {
-                            Some(x) => x,
-                            None => break,
-                        };
+                    while let Some((&last, rest)) = part.split_last() {
                         if !should_skip(last) {
                             break;
                         }
@@ -343,7 +339,7 @@ where
                 // Calculate the path to the theme's directory
                 let mut theme_dir = PathBuf::new();
                 // Does the path begin with '~'?
-                if path.to_string_lossy().chars().next() == Some('~') {
+                if path.to_string_lossy().starts_with('~') {
                     theme_dir.push(&home);
                     theme_dir.push(strip_leading_tilde_slash(&path));
                 } else {

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -411,12 +411,16 @@ fn parse_resource_manager(rm: &[u8]) -> (Option<String>, u32, u32) {
         if let Ok(value) = std::str::from_utf8(value) {
             match key {
                 b"Xcursor.theme" => theme = Some(value.to_string()),
-                b"Xcursor.size" => if let Ok(num) = value.parse() {
-                    cursor_size = num;
-                },
-                b"Xft.dpi" => if let Ok(num) = value.parse() {
-                    xft_dpi = num;
-                },
+                b"Xcursor.size" => {
+                    if let Ok(num) = value.parse() {
+                        cursor_size = num;
+                    }
+                }
+                b"Xft.dpi" => {
+                    if let Ok(num) = value.parse() {
+                        xft_dpi = num;
+                    }
+                }
                 _ => {}
             }
         }
@@ -426,7 +430,10 @@ fn parse_resource_manager(rm: &[u8]) -> (Option<String>, u32, u32) {
 }
 
 fn get_cursor_size(rm_cursor_size: u32, rm_xft_dpi: u32, screen: &xproto::Screen) -> u32 {
-    if let Some(size) = std::env::var("XCURSOR_SIZE").ok().and_then(|s| s.parse().ok()) {
+    if let Some(size) = std::env::var("XCURSOR_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+    {
         return size;
     }
     if rm_cursor_size > 0 {

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -265,7 +265,7 @@ fn create_render_cursor<C: Connection>(
     render::free_picture(conn, picture)?;
 
     Ok(render::Animcursorelt {
-        cursor: cursor,
+        cursor,
         delay: image.delay,
     })
 }

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -1,0 +1,11 @@
+//! Utility functions for working with X11 cursors
+
+mod parse_cursor;
+
+pub(crate) use parse_cursor::parse_cursor;
+
+use std::fs::File;
+
+pub fn foo() -> *const () {
+    return parse_cursor::<File> as _;
+}

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -1,13 +1,402 @@
 //! Utility functions for working with X11 cursors
+//!
+//! For full cursor support, the `render` feature of the library must be enabled.
 
-mod parse_cursor;
-mod find_cursor;
+#![allow(unused_results)]
+
+use crate::NONE;
+use crate::connection::Connection;
+use crate::cookie::Cookie as X11Cookie;
+use crate::errors::{ConnectionError, ReplyOrIdError};
+#[cfg(feature = "render")]
+use crate::protocol::render::{self, Pictformat};
+use crate::protocol::xproto::{self, Font, Window};
 
 use std::fs::File;
 
-pub fn foo() -> *const () {
-    return parse_cursor::parse_cursor::<File> as _;
+#[cfg(feature = "render")]
+mod parse_cursor;
+mod find_cursor;
+
+/// The level of cursor support of the X11 server
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RenderSupport {
+    /// Render extension not available
+    None,
+
+    /// Static cursor support (CreateCursor added in RENDER 0.5)
+    StaticCursor,
+
+    /// Animated cursor support (CreateAnimCursor added in RENDER 0.8)
+    AnimatedCursor,
 }
-pub fn bar() -> *const() {
-    return find_cursor::find_cursor as _;
+
+/// A cookie for creating a `Handle`
+#[derive(Debug)]
+pub struct Cookie<'a, C: Connection> {
+    conn: &'a C,
+    screen: &'a xproto::Screen,
+    resource_manager: X11Cookie<'a, C, xproto::GetPropertyReply>,
+    #[cfg(feature = "render")]
+    render_info: Option<(X11Cookie<'a, C, render::QueryVersionReply>, X11Cookie<'a, C, render::QueryPictFormatsReply>)>,
+}
+
+impl<C: Connection> Cookie<'_, C> {
+    /// Get the handle from the replies from the X11 server
+    pub fn reply(self) -> Result<Handle, ReplyOrIdError<C::Buf>> {
+        let resource_manager = self.resource_manager.reply()?;
+        #[allow(unused_mut)]
+        let mut render_version = (0, 0);
+        #[allow(unused_mut)]
+        let mut picture_format = NONE;
+        #[cfg(feature = "render")]
+        {
+            if let Some((version, formats)) = self.render_info {
+                let version = version.reply()?;
+                render_version = (version.major_version, version.minor_version);
+                picture_format = find_format(formats.reply()?);
+            }
+        }
+        Ok(Self::from_replies(self.conn, self.screen, resource_manager, render_version, picture_format)?)
+    }
+
+    /// Get the handle from the replies from the X11 server
+    pub fn reply_unchecked(self) -> Result<Option<Handle>, ReplyOrIdError<C::Buf>> {
+        let resource_manager = self.resource_manager.reply_unchecked()?;
+        #[allow(unused_mut)]
+        let mut render_version = (0, 0);
+        #[allow(unused_mut)]
+        let mut picture_format = NONE;
+        #[cfg(feature = "render")]
+        {
+            if let Some((version, formats)) = self.render_info {
+                match (version.reply_unchecked()?, formats.reply_unchecked()?) {
+                    (Some(version), Some(formats)) => {
+                        render_version = (version.major_version, version.minor_version);
+                        picture_format = find_format(formats);
+                    },
+                    _ => return Ok(None),
+                }
+            }
+        }
+        let resource_manager = match resource_manager {
+            None => return Ok(None),
+            Some(resource_manager) => resource_manager,
+        };
+        Ok(Some(Self::from_replies(self.conn, self.screen, resource_manager, render_version, picture_format)?))
+    }
+
+    fn from_replies(
+        conn: &C,
+        screen: &xproto::Screen,
+        resource_manager: xproto::GetPropertyReply,
+        render_version: (u32, u32),
+        _picture_format: u32,
+    ) -> Result<Handle, ReplyOrIdError<C::Buf>> {
+        let render_support = if render_version.0 >= 1 || render_version.1 >= 8 {
+            RenderSupport::AnimatedCursor
+        } else if render_version.0 >= 1 || render_version.1 >= 5 {
+            RenderSupport::StaticCursor
+        } else {
+            RenderSupport::None
+        };
+        let (theme, cursor_size, xft_dpi) = parse_resource_manager(&resource_manager.value);
+        let cursor_size = get_cursor_size(cursor_size, xft_dpi, screen);
+        let cursor_font = conn.generate_id()?;
+        xproto::open_font(conn, cursor_font, b"cursor")?;
+        Ok(Handle {
+            root: screen.root,
+            cursor_font,
+            #[cfg(feature = "render")]
+            picture_format: _picture_format,
+            render_support,
+            theme,
+            cursor_size,
+        })
+    }
+}
+
+/// A handle necessary for loading cursors
+#[derive(Debug)]
+pub struct Handle {
+    root: Window,
+    cursor_font: Font,
+    #[cfg(feature = "render")]
+    picture_format: Pictformat,
+    render_support: RenderSupport,
+    theme: Option<String>,
+    cursor_size: u32,
+}
+
+impl Handle {
+    /// Create a new cursor handle for creating cursors on the given screen.
+    ///
+    /// This function returns a cookie that can be used to later get the actual handle.
+    ///
+    /// For full cursor support, the `render` feature of the library must be enabled.
+    ///
+    /// If you want this function not to block, you should prefetch the RENDER extension's data on
+    /// the connection.
+    pub fn new<C: Connection>(conn: &C, screen: usize) -> Result<Cookie<'_, C>, ConnectionError> {
+        let screen = &conn.setup().roots[screen];
+        let root = screen.root;
+        let resource_manager = xproto::get_property(
+            conn,
+            false,
+            root,
+            xproto::AtomEnum::RESOURCE_MANAGER,
+            xproto::AtomEnum::STRING,
+            0,
+            1 << 20,
+        )?;
+        #[allow(unused_mut)]
+        let mut render_info = None;
+        #[cfg(feature = "render")]
+        {
+            if conn.extension_information(render::X11_EXTENSION_NAME)?.is_some() {
+                let render_version = render::query_version(conn, 0, 8)?;
+                let render_pict_format = render::query_pict_formats(conn)?;
+                render_info = Some((render_version, render_pict_format));
+            }
+        }
+        #[cfg(not(feature = "render"))]
+        {
+            // Needed to make type inference happy
+            let _: Option<()> = render_info;
+        }
+        Ok(Cookie {
+            conn,
+            screen,
+            resource_manager,
+            #[cfg(feature = "render")]
+            render_info,
+        })
+    }
+
+    /// Loads the specified cursor, either from the cursor theme or by falling back to the X11
+    /// "cursor" font.
+    pub fn load_cursor<C>(&self, conn: &C, name: &str) -> Result<xproto::Cursor, ReplyOrIdError<C::Buf>>
+    where
+        C: Connection
+    {
+        load_cursor(conn, self, name)
+    }
+}
+
+fn open_cursor(theme: &Option<String>, name: &str) -> Option<find_cursor::Cursor<File>> {
+    if let Some(theme) = theme {
+        if let Ok(cursor) = find_cursor::find_cursor(theme, name) {
+            return Some(cursor)
+        }
+    }
+    if let Ok(cursor) = find_cursor::find_cursor("default", name) {
+        Some(cursor)
+    } else {
+        None
+    }
+}
+
+fn create_core_cursor<C: Connection>(conn: &C, cursor_font: Font, cursor: u16) -> Result<xproto::Cursor, ReplyOrIdError<C::Buf>> {
+    let result = conn.generate_id()?;
+    xproto::create_glyph_cursor(
+        conn,
+        result,
+        cursor_font,
+        cursor_font,
+        cursor,
+        cursor + 1,
+        // foreground color
+        0,
+        0,
+        0,
+        // background color
+        u16::max_value(),
+        u16::max_value(),
+        u16::max_value(),
+    )?;
+    Ok(result)
+}
+
+#[cfg(feature = "render")]
+fn create_render_cursor<C: Connection>(
+    conn: &C,
+    handle: &Handle,
+    image: &parse_cursor::Image,
+    storage: &mut Option<(xproto::Pixmap, xproto::Gcontext, u16, u16)>,
+) -> Result<render::Animcursorelt, ReplyOrIdError<C::Buf>> {
+    let (cursor, picture) = (conn.generate_id()?, conn.generate_id()?);
+
+    // Get a pixmap of the right size and a gc for it
+    let (pixmap, gc) = if storage.map(|(_, _, w, h)| (w, h)) == Some((image.width, image.height)) {
+        storage.map(|(pixmap, gc, _, _)| (pixmap, gc)).unwrap()
+    } else {
+        let (pixmap, gc) = if let Some((pixmap, gc, _, _)) = storage {
+            xproto::free_gc(conn, *gc)?;
+            xproto::free_pixmap(conn, *pixmap)?;
+            (*pixmap, *gc)
+        } else {
+            (conn.generate_id()?, conn.generate_id()?)
+        };
+        xproto::create_pixmap(conn, 32, pixmap, handle.root, image.width, image.height)?;
+        xproto::create_gc(conn, gc, pixmap, &Default::default())?;
+
+        *storage = Some((pixmap, gc, image.width, image.height));
+        (pixmap, gc)
+    };
+
+    // Sigh. We need the pixel data as a bunch of bytes.
+    let pixels = crate::x11_utils::Serialize::serialize(&image.pixels[..]);
+    xproto::put_image(
+        conn,
+        xproto::ImageFormat::ZPixmap,
+        pixmap,
+        gc,
+        image.width,
+        image.height,
+        0,
+        0,
+        0,
+        32,
+        &pixels,
+    )?;
+
+    render::create_picture(conn, picture, pixmap, handle.picture_format, &Default::default())?;
+    render::create_cursor(conn, cursor, picture, image.x_hot, image.y_hot)?;
+    render::free_picture(conn, picture)?;
+
+    Ok(render::Animcursorelt {
+        cursor: cursor,
+        delay: image.delay,
+    })
+}
+
+fn load_cursor<C: Connection>(conn: &C, handle: &Handle, name: &str) -> Result<xproto::Cursor, ReplyOrIdError<C::Buf>> {
+    // Find the right cursor, load it directly if it is a core cursor
+    let cursor_file = match open_cursor(&handle.theme, name) {
+        None => return Ok(NONE),
+        Some(find_cursor::Cursor::CoreChar(c)) => return create_core_cursor(conn, handle.cursor_font, c),
+        Some(find_cursor::Cursor::File(f)) => f,
+    };
+
+    // We have to load a file and use RENDER to create a cursor
+    if handle.render_support == RenderSupport::None {
+        return Ok(NONE);
+    }
+
+    #[cfg(not(feature = "render"))]
+    {
+        // No render support, no render cursors
+        drop(cursor_file);
+        Ok(NONE)
+    }
+    #[cfg(feature = "render")]
+    {
+        // Load the cursor from the file
+        use std::io::BufReader;
+        let images = parse_cursor::parse_cursor(&mut BufReader::new(cursor_file), handle.cursor_size)
+            .or(Err(crate::errors::ParseError::ParseError))?;
+        let mut images = &images[..];
+
+        // No animated cursor support? Only use the first image
+        if handle.render_support == RenderSupport::StaticCursor {
+            images = &images[0..1];
+        }
+
+        // Now transfer the cursors to the X11 server
+        let mut storage = None;
+        let cursors = images.iter()
+            .map(|image| create_render_cursor(conn, handle, image, &mut storage))
+            .collect::<Result<Vec<_>, _>>()?;
+        if let Some((pixmap, gc, _, _)) = storage {
+            xproto::free_gc(conn, gc)?;
+            xproto::free_pixmap(conn, pixmap)?;
+        }
+
+        if cursors.len() == 1 {
+            Ok(cursors[0].cursor)
+        } else {
+            let result = conn.generate_id()?;
+            render::create_anim_cursor(conn, result, &cursors)?;
+            for elem in cursors {
+                xproto::free_cursor(conn, elem.cursor)?;
+            }
+            Ok(result)
+        }
+    }
+}
+
+#[cfg(feature = "render")]
+fn find_format(reply: render::QueryPictFormatsReply) -> Pictformat {
+    reply.formats.iter()
+        .filter(|format|
+                format.type_ == render::PictType::Direct &&
+                format.depth == 32 &&
+                format.direct.red_shift == 16 &&
+                format.direct.red_mask == 0xff &&
+                format.direct.green_shift == 8 &&
+                format.direct.green_mask == 0xff &&
+                format.direct.blue_shift == 0 &&
+                format.direct.blue_mask == 0xff &&
+                format.direct.alpha_shift == 24 &&
+                format.direct.alpha_mask == 0xff
+                )
+        .map(|format| format.id)
+        .next()
+        .expect("The X11 server is missing the RENDER ARGB_32 standard format!")
+}
+
+fn parse_resource_manager(rm: &[u8]) -> (Option<String>, u32, u32) {
+    let (mut theme, mut cursor_size, mut xft_dpi) = (None, 0, 0);
+
+    for line in rm.split(|&c| c == b'\n') {
+        // Split line at first ':'
+        let pos = match line.iter()
+            .enumerate()
+            .find(|&(_, &c)| c == b':') {
+            None => continue,
+            Some((pos, _)) => pos,
+        };
+        let (key, mut value) = line.split_at(pos);
+
+        // Skip leading whitespace
+        while value.get(0).map(|&c| char::from(c).is_whitespace()) == Some(true) {
+            value = &value[1..];
+        }
+        // Skip trailing whitespace
+        while value.last().map(|&c| char::from(c).is_whitespace()) == Some(true) {
+            value = &value[..value.len() - 1];
+        }
+
+        match std::str::from_utf8(value) {
+            Ok(value) => match key {
+                b"Xcursor.theme" => theme = Some(value.to_string()),
+                b"Xcursor.size" => match value.parse() {
+                    Ok(num) => cursor_size = num,
+                    _ => {},
+                }
+                b"Xft.dpi" => match value.parse() {
+                    Ok(num) => xft_dpi = num,
+                    _ => {},
+                }
+                _ => {},
+            }
+            _ => {},
+        }
+    }
+
+    (theme, cursor_size, xft_dpi)
+}
+
+fn get_cursor_size(rm_cursor_size: u32, rm_xft_dpi: u32, screen: &xproto::Screen) -> u32 {
+    match std::env::var("XCURSOR_SIZE").map(|s| s.parse()) {
+        Ok(Ok(size)) => return size,
+        _ => {},
+    }
+    if rm_cursor_size > 0 {
+        return rm_cursor_size;
+    }
+    if rm_xft_dpi > 0 {
+        return rm_xft_dpi * 16 / 72;
+    }
+    u32::from(screen.height_in_pixels.min(screen.width_in_pixels) / 48)
 }

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -1,11 +1,13 @@
 //! Utility functions for working with X11 cursors
 
 mod parse_cursor;
-
-pub(crate) use parse_cursor::parse_cursor;
+mod find_cursor;
 
 use std::fs::File;
 
 pub fn foo() -> *const () {
-    return parse_cursor::<File> as _;
+    return parse_cursor::parse_cursor::<File> as _;
+}
+pub fn bar() -> *const() {
+    return find_cursor::find_cursor as _;
 }

--- a/src/cursor/parse_cursor.rs
+++ b/src/cursor/parse_cursor.rs
@@ -62,7 +62,12 @@ pub(crate) struct Image {
 impl Image {
     /// Read an `Image` from a reader
     fn read<R: Read>(read: &mut R, expected_kind: u32, expected_size: u32) -> Result<Self, Error> {
-        let (_header, kind, size, _version) = (read_u32(read)?, read_u32(read)?, read_u32(read)?, read_u32(read)?);
+        let (_header, kind, size, _version) = (
+            read_u32(read)?,
+            read_u32(read)?,
+            read_u32(read)?,
+            read_u32(read)?,
+        );
         if (kind, size) != (expected_kind, expected_size) {
             return Err(Error::CorruptImage);
         }
@@ -127,7 +132,7 @@ fn find_best_size(toc: &[TocEntry], desired_size: u32) -> Result<u32, Error> {
     fn is_better(desired_size: u32, entry: &TocEntry, result: &Result<u32, Error>) -> bool {
         match result {
             Err(_) => true,
-            Ok(size) => distance(entry.size, desired_size) < distance(*size, desired_size)
+            Ok(size) => distance(entry.size, desired_size) < distance(*size, desired_size),
         }
     }
 
@@ -145,9 +150,13 @@ fn find_best_size(toc: &[TocEntry], desired_size: u32) -> Result<u32, Error> {
 pub(crate) fn parse_cursor<R: Read + Seek>(
     input: &mut R,
     desired_size: u32,
-) -> Result<Vec<Image>, Error>
-{
-    let (magic, header, _version, ntoc) = (read_u32(input)?, read_u32(input)?, read_u32(input)?, read_u32(input)?);
+) -> Result<Vec<Image>, Error> {
+    let (magic, header, _version, ntoc) = (
+        read_u32(input)?,
+        read_u32(input)?,
+        read_u32(input)?,
+        read_u32(input)?,
+    );
 
     if magic != FILE_MAGIC {
         return Err(Error::InvalidMagic);
@@ -170,7 +179,7 @@ pub(crate) fn parse_cursor<R: Read + Seek>(
     let mut result = Vec::new();
     for entry in toc {
         if entry.kind != IMAGE_TYPE || entry.size != size {
-            continue
+            continue;
         }
         let _ = input.seek(SeekFrom::Start(entry.position.into()))?;
         result.push(Image::read(input, entry.kind, entry.size)?);
@@ -181,7 +190,7 @@ pub(crate) fn parse_cursor<R: Read + Seek>(
 
 #[cfg(test)]
 mod test {
-    use super::{Error, Image, TocEntry, IMAGE_TYPE, find_best_size, parse_cursor};
+    use super::{find_best_size, parse_cursor, Error, Image, TocEntry, IMAGE_TYPE};
     use std::io::{Cursor, ErrorKind};
 
     #[test]
@@ -197,20 +206,10 @@ mod test {
             0x08, 0x00, 0x00, 0x00, // y_hot 8
             0x2a, 0x00, 0x00, 0x00, // delay 42
             // pixels
-            0x01, 0x02, 0x03, 0x04,
-            0x05, 0x06, 0x07, 0x08,
-            0x09, 0x0a, 0x0b, 0x0c,
-            0x0d, 0x0e, 0x0f, 0x10,
-            0x11, 0x12, 0x13, 0x14,
-            0x15, 0x16, 0x17, 0x18,
-            0x19, 0x1a, 0x1b, 0x1c,
-            0x1d, 0x1e, 0x1f, 0x20,
-            0x21, 0x22, 0x23, 0x24,
-            0x25, 0x26, 0x27, 0x28,
-            0x29, 0x2a, 0x2b, 0x2c,
-            0x2d, 0x2e, 0x2f, 0x30,
-            0x31, 0x32, 0x33, 0x34,
-            0x35, 0x36, 0x37, 0x38,
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+            0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a,
+            0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
             0x39, 0x3a, 0x3b, 0x3c,
         ];
         let image = Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4).unwrap();
@@ -219,12 +218,26 @@ mod test {
         assert_eq!(image.x_hot, 7);
         assert_eq!(image.y_hot, 8);
         assert_eq!(image.delay, 42);
-        assert_eq!(image.pixels, &[
-                   0x0403_0201, 0x0807_0605, 0x0c0b_0a09, 0x100f_0e0d,
-                   0x1413_1211, 0x1817_1615, 0x1c1b_1a19, 0x201f_1e1d,
-                   0x2423_2221, 0x2827_2625, 0x2c2b_2a29, 0x302f_2e2d,
-                   0x3433_3231, 0x3837_3635, 0x3c3b_3a39,
-        ]);
+        assert_eq!(
+            image.pixels,
+            &[
+                0x0403_0201,
+                0x0807_0605,
+                0x0c0b_0a09,
+                0x100f_0e0d,
+                0x1413_1211,
+                0x1817_1615,
+                0x1c1b_1a19,
+                0x201f_1e1d,
+                0x2423_2221,
+                0x2827_2625,
+                0x2c2b_2a29,
+                0x302f_2e2d,
+                0x3433_3231,
+                0x3837_3635,
+                0x3c3b_3a39,
+            ]
+        );
     }
 
     #[test]
@@ -241,7 +254,7 @@ mod test {
             0x00, 0x00, 0x00, 0x00, // delay 0
         ];
         match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
-            Err(Error::CorruptImage) => {},
+            Err(Error::CorruptImage) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -260,7 +273,7 @@ mod test {
             0x00, 0x00, 0x00, 0x00, // delay 0
         ];
         match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 42) {
-            Err(Error::CorruptImage) => {},
+            Err(Error::CorruptImage) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -279,7 +292,7 @@ mod test {
             0x00, 0x00, 0x00, 0x00, // delay 0
         ];
         match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
-            Err(Error::ImageTooLarge) => {},
+            Err(Error::ImageTooLarge) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -298,7 +311,7 @@ mod test {
             0x00, 0x00, 0x00, 0x00, // delay 0
         ];
         match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
-            Err(Error::ImageTooLarge) => {},
+            Err(Error::ImageTooLarge) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -307,7 +320,7 @@ mod test {
     fn read_image_too_short() {
         let data = [];
         match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
-            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {},
+            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -316,20 +329,18 @@ mod test {
     fn find_best_size_empty_input() {
         let res = find_best_size(&[], 42);
         match res {
-            Err(Error::NoImages) => {},
+            Err(Error::NoImages) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
 
     #[test]
     fn find_best_size_one_input() {
-        let input = [
-            TocEntry {
-                kind: IMAGE_TYPE,
-                size: 42,
-                position: 42,
-            },
-        ];
+        let input = [TocEntry {
+            kind: IMAGE_TYPE,
+            size: 42,
+            position: 42,
+        }];
         assert_eq!(42, find_best_size(&input, 10).unwrap());
     }
 
@@ -369,7 +380,7 @@ mod test {
     fn parse_cursor_too_short() {
         let data = [];
         match parse_cursor(&mut Cursor::new(&data[..]), 10) {
-            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {},
+            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -383,7 +394,7 @@ mod test {
             0x00, 0x00, 0x00, 0x00, // num TOC entries
         ];
         match parse_cursor(&mut Cursor::new(&data[..]), 10) {
-            Err(Error::InvalidMagic) =>  {},
+            Err(Error::InvalidMagic) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -397,7 +408,7 @@ mod test {
             0x01, 0x00, 0x01, 0x00, // num TOC entries, limit + 1
         ];
         match parse_cursor(&mut Cursor::new(&data[..]), 10) {
-            Err(Error::TooManyEntries) =>  {},
+            Err(Error::TooManyEntries) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -411,7 +422,7 @@ mod test {
             0x00, 0x00, 0x00, 0x00, // num TOC entries, 0
         ];
         match parse_cursor(&mut Cursor::new(&data[..]), 10) {
-            Err(Error::NoImages) => {},
+            Err(Error::NoImages) => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -438,16 +449,14 @@ mod test {
             0x00, 0x00, 0x00, 0x00, // y_hot 0
             0x00, 0x00, 0x00, 0x00, // delay 0
         ];
-        let expected = [
-            Image {
-                width: 0,
-                height: 0,
-                x_hot: 0,
-                y_hot: 0,
-                delay: 0,
-                pixels: vec![],
-            }
-        ];
+        let expected = [Image {
+            width: 0,
+            height: 0,
+            x_hot: 0,
+            y_hot: 0,
+            delay: 0,
+            pixels: vec![],
+        }];
         let actual = parse_cursor(&mut Cursor::new(&data[..]), 10).unwrap();
         assert_same_images(&expected, &actual);
     }
@@ -505,12 +514,54 @@ mod test {
     fn assert_same_images(a: &[Image], b: &[Image]) {
         assert_eq!(a.len(), b.len(), "{:?} == {:?}", a, b);
         for (i, (im1, im2)) in a.iter().zip(b.iter()).enumerate() {
-            assert_eq!(im1.width, im2.width, "Width image {}: {} == {}", i + 1, im1.width, im2.width);
-            assert_eq!(im1.height, im2.height, "Height image {}: {} == {}", i + 1, im1.height, im2.height);
-            assert_eq!(im1.x_hot, im2.x_hot, "X-hot image {}: {} == {}", i + 1, im1.x_hot, im2.x_hot);
-            assert_eq!(im1.y_hot, im2.y_hot, "Y-hot image {}: {} == {}", i + 1, im1.y_hot, im2.y_hot);
-            assert_eq!(im1.delay, im2.delay, "Delay image {}: {} == {}", i + 1, im1.delay, im2.delay);
-            assert_eq!(im1.pixels, im2.pixels, "Pixels image {}: {:?} == {:?}", i + 1, im1.pixels, im2.pixels);
+            assert_eq!(
+                im1.width,
+                im2.width,
+                "Width image {}: {} == {}",
+                i + 1,
+                im1.width,
+                im2.width
+            );
+            assert_eq!(
+                im1.height,
+                im2.height,
+                "Height image {}: {} == {}",
+                i + 1,
+                im1.height,
+                im2.height
+            );
+            assert_eq!(
+                im1.x_hot,
+                im2.x_hot,
+                "X-hot image {}: {} == {}",
+                i + 1,
+                im1.x_hot,
+                im2.x_hot
+            );
+            assert_eq!(
+                im1.y_hot,
+                im2.y_hot,
+                "Y-hot image {}: {} == {}",
+                i + 1,
+                im1.y_hot,
+                im2.y_hot
+            );
+            assert_eq!(
+                im1.delay,
+                im2.delay,
+                "Delay image {}: {} == {}",
+                i + 1,
+                im1.delay,
+                im2.delay
+            );
+            assert_eq!(
+                im1.pixels,
+                im2.pixels,
+                "Pixels image {}: {:?} == {:?}",
+                i + 1,
+                im1.pixels,
+                im2.pixels
+            );
         }
     }
 }

--- a/src/cursor/parse_cursor.rs
+++ b/src/cursor/parse_cursor.rs
@@ -320,7 +320,7 @@ mod test {
     fn read_image_too_short() {
         let data = [];
         match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
-            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {}
+            Err(Error::IO(ref e)) if e.kind() == ErrorKind::UnexpectedEof => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }
@@ -380,7 +380,7 @@ mod test {
     fn parse_cursor_too_short() {
         let data = [];
         match parse_cursor(&mut Cursor::new(&data[..]), 10) {
-            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {}
+            Err(Error::IO(ref e)) if e.kind() == ErrorKind::UnexpectedEof => {}
             r => panic!("Unexpected result {:?}", r),
         }
     }

--- a/src/cursor/parse_cursor.rs
+++ b/src/cursor/parse_cursor.rs
@@ -79,7 +79,10 @@ impl Image {
                 .ok_or(Error::ImageTooLarge)
         }
 
-        let (width, height) = (convert_size(read_u32(read)?)?, convert_size(read_u32(read)?)?);
+        let (width, height) = (
+            convert_size(read_u32(read)?)?,
+            convert_size(read_u32(read)?)?,
+        );
         let (x_hot, y_hot) = (read_u32(read)?, read_u32(read)?);
         let delay = read_u32(read)?;
         let x_hot = x_hot.try_into().or(Err(Error::ImageTooLarge))?;

--- a/src/cursor/parse_cursor.rs
+++ b/src/cursor/parse_cursor.rs
@@ -1,0 +1,509 @@
+//! Parse the contents of a cursor file
+
+// This code is loosely based on parse_cursor_file.c from libxcb-cursor, which is:
+//   Copyright © 2013 Michael Stapelberg
+// and is covered by MIT/X Consortium License
+
+use std::io::{Read, Seek, SeekFrom};
+
+const FILE_MAGIC: u32 = 0x72756358;
+const IMAGE_TYPE: u32 = 0xfffd0002;
+const IMAGE_MAX_SIZE: u32 = 0x7fff;
+
+/// An error that occurred while parsing
+#[derive(Debug)]
+pub(crate) enum Error {
+    /// An I/O error occurred
+    IO(std::io::Error),
+
+    /// The file did not begin with the expected magic
+    InvalidMagic,
+
+    /// The file contained unrealistically many images
+    TooManyEntries,
+
+    /// The file contains no images
+    NoImages,
+
+    /// Some image's entry is corrupt and not self-consistent
+    CorruptImage,
+
+    /// An entry is larger than the maximum size
+    ImageTooLarge,
+}
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Error::IO(value)
+    }
+}
+
+/// Read a single `u32` from a cursor file
+///
+/// The file stores these entries in little endian.
+fn read_u32<R: Read>(read: &mut R) -> Result<u32, Error> {
+    let mut buffer = [0; 4];
+    read.read_exact(&mut buffer)?;
+    Ok(u32::from_le_bytes(buffer))
+}
+
+/// A single cursor image
+#[derive(Debug)]
+pub(crate) struct Image {
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) x_hot: u32,
+    pub(crate) y_hot: u32,
+    pub(crate) delay: u32,
+    pub(crate) pixels: Vec<u32>,
+}
+
+impl Image {
+    /// Read an `Image` from a reader
+    fn read<R: Read>(read: &mut R, expected_kind: u32, expected_size: u32) -> Result<Self, Error> {
+        let (_header, kind, size, _version) = (read_u32(read)?, read_u32(read)?, read_u32(read)?, read_u32(read)?);
+        if (kind, size) != (expected_kind, expected_size) {
+            return Err(Error::CorruptImage);
+        }
+
+        let (width, height) = (read_u32(read)?, read_u32(read)?);
+        let (x_hot, y_hot) = (read_u32(read)?, read_u32(read)?);
+        let delay = read_u32(read)?;
+
+        if width > IMAGE_MAX_SIZE || height > IMAGE_MAX_SIZE {
+            return Err(Error::ImageTooLarge);
+        }
+
+        // IMAGE_MAX_SIZE fits into 15 bits, so the following multiplication cannot overflow
+        assert!(IMAGE_MAX_SIZE.checked_mul(IMAGE_MAX_SIZE).is_some());
+        let num_pixels = width * height;
+        let pixels = (0..num_pixels)
+            .map(|_| read_u32(read))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Image {
+            width,
+            height,
+            x_hot,
+            y_hot,
+            delay,
+            pixels,
+        })
+    }
+}
+
+/// A TOC entry in a cursor file
+#[derive(Debug)]
+struct TocEntry {
+    kind: u32,
+    size: u32,
+    position: u32,
+}
+
+impl TocEntry {
+    /// Read a `TocEntry` from a reader
+    fn read<R: Read>(read: &mut R) -> Result<Self, Error> {
+        Ok(TocEntry {
+            kind: read_u32(read)?,
+            size: read_u32(read)?,
+            position: read_u32(read)?,
+        })
+    }
+}
+
+/// Find the size of the image in the toc with a size as close as possible to the desired size.
+fn find_best_size(toc: &[TocEntry], desired_size: u32) -> Result<u32, Error> {
+    fn distance(a: u32, b: u32) -> u32 {
+        a.max(b) - a.min(b)
+    }
+
+    fn is_better(desired_size: u32, entry: &TocEntry, result: &Result<u32, Error>) -> bool {
+        match result {
+            Err(_) => true,
+            Ok(size) => distance(entry.size, desired_size) < distance(*size, desired_size)
+        }
+    }
+
+    let mut result = Err(Error::NoImages);
+    for entry in toc {
+        // If this is better than the best so far, replace best
+        if entry.kind == IMAGE_TYPE && is_better(desired_size, entry, &result) {
+            result = Ok(entry.size)
+        }
+    }
+    result
+}
+
+/// Parse a complete cursor file
+pub(crate) fn parse_cursor<R: Read + Seek>(
+    input: &mut R,
+    desired_size: u32,
+) -> Result<Vec<Image>, Error>
+{
+    let (magic, header, _version, ntoc) = (read_u32(input)?, read_u32(input)?, read_u32(input)?, read_u32(input)?);
+
+    if magic != FILE_MAGIC {
+        return Err(Error::InvalidMagic);
+    }
+
+    if ntoc > 0x1_0000 {
+        return Err(Error::TooManyEntries);
+    }
+
+    // Read the table of contents
+    let _ = input.seek(SeekFrom::Start(header.into()))?;
+    let toc = (0..ntoc)
+        .map(|_| TocEntry::read(input))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Find the cursor size that we should load
+    let size = find_best_size(&toc, desired_size)?;
+
+    // Now load all cursors that have the right size
+    let mut result = Vec::new();
+    for entry in toc {
+        if entry.kind != IMAGE_TYPE || entry.size != size {
+            continue
+        }
+        let _ = input.seek(SeekFrom::Start(entry.position.into()))?;
+        result.push(Image::read(input, entry.kind, entry.size)?);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Error, Image, TocEntry, IMAGE_TYPE, find_best_size, parse_cursor};
+    use std::io::{Cursor, ErrorKind};
+
+    #[test]
+    fn read_3x5_image() {
+        let data = [
+            0x00, 0x00, 0x00, 0x00, // header(?)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x03, 0x00, 0x00, 0x00, // width 3
+            0x05, 0x00, 0x00, 0x00, // height 5
+            0x07, 0x00, 0x00, 0x00, // x_hot 7
+            0x08, 0x00, 0x00, 0x00, // y_hot 8
+            0x2a, 0x00, 0x00, 0x00, // delay 42
+            // pixels
+            0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0a, 0x0b, 0x0c,
+            0x0d, 0x0e, 0x0f, 0x10,
+            0x11, 0x12, 0x13, 0x14,
+            0x15, 0x16, 0x17, 0x18,
+            0x19, 0x1a, 0x1b, 0x1c,
+            0x1d, 0x1e, 0x1f, 0x20,
+            0x21, 0x22, 0x23, 0x24,
+            0x25, 0x26, 0x27, 0x28,
+            0x29, 0x2a, 0x2b, 0x2c,
+            0x2d, 0x2e, 0x2f, 0x30,
+            0x31, 0x32, 0x33, 0x34,
+            0x35, 0x36, 0x37, 0x38,
+            0x39, 0x3a, 0x3b, 0x3c,
+        ];
+        let image = Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4).unwrap();
+        assert_eq!(image.width, 3);
+        assert_eq!(image.height, 5);
+        assert_eq!(image.x_hot, 7);
+        assert_eq!(image.y_hot, 8);
+        assert_eq!(image.delay, 42);
+        assert_eq!(image.pixels, &[
+                   0x04030201, 0x08070605, 0x0c0b0a09, 0x100f0e0d,
+                   0x14131211, 0x18171615, 0x1c1b1a19, 0x201f1e1d,
+                   0x24232221, 0x28272625, 0x2c2b2a29, 0x302f2e2d,
+                   0x34333231, 0x38373635, 0x3c3b3a39,
+        ]);
+    }
+
+    #[test]
+    fn read_corrupt_image_wrong_kind() {
+        let data = [
+            0x00, 0x00, 0x00, 0x00, // header(?)
+            0x01, 0x00, 0xfd, 0xff, // IMAGE_TYPE - 1
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x00, 0x00, 0x00, // width 0
+            0x00, 0x00, 0x00, 0x00, // height 0
+            0x00, 0x00, 0x00, 0x00, // x_hot 0
+            0x00, 0x00, 0x00, 0x00, // y_hot 0
+            0x00, 0x00, 0x00, 0x00, // delay 0
+        ];
+        match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
+            Err(Error::CorruptImage) => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn read_corrupt_image_wrong_size() {
+        let data = [
+            0x00, 0x00, 0x00, 0x00, // header(?)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x00, 0x00, 0x00, // width 0
+            0x00, 0x00, 0x00, 0x00, // height 0
+            0x00, 0x00, 0x00, 0x00, // x_hot 0
+            0x00, 0x00, 0x00, 0x00, // y_hot 0
+            0x00, 0x00, 0x00, 0x00, // delay 0
+        ];
+        match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 42) {
+            Err(Error::CorruptImage) => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn read_image_too_large_width() {
+        let data = [
+            0x00, 0x00, 0x00, 0x00, // header(?)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x80, 0x00, 0x00, // width IMAGE_MAX_SIZE + 1
+            0x00, 0x00, 0x00, 0x00, // height 0
+            0x00, 0x00, 0x00, 0x00, // x_hot 0
+            0x00, 0x00, 0x00, 0x00, // y_hot 0
+            0x00, 0x00, 0x00, 0x00, // delay 0
+        ];
+        match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
+            Err(Error::ImageTooLarge) => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn read_image_too_large_height() {
+        let data = [
+            0x00, 0x00, 0x00, 0x00, // header(?)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x00, 0x00, 0x00, // width 0
+            0x00, 0x80, 0x00, 0x00, // height IMAGE_MAX_SIZE + 1
+            0x00, 0x00, 0x00, 0x00, // x_hot 0
+            0x00, 0x00, 0x00, 0x00, // y_hot 0
+            0x00, 0x00, 0x00, 0x00, // delay 0
+        ];
+        match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
+            Err(Error::ImageTooLarge) => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn read_image_too_short() {
+        let data = [];
+        match Image::read(&mut Cursor::new(&data[..]), IMAGE_TYPE, 4) {
+            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn find_best_size_empty_input() {
+        let res = find_best_size(&[], 42);
+        match res {
+            Err(Error::NoImages) => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn find_best_size_one_input() {
+        let input = [
+            TocEntry {
+                kind: IMAGE_TYPE,
+                size: 42,
+                position: 42,
+            },
+        ];
+        assert_eq!(42, find_best_size(&input, 10).unwrap());
+    }
+
+    #[test]
+    fn find_best_size_selects_better() {
+        let input = [
+            TocEntry {
+                kind: IMAGE_TYPE,
+                size: 42,
+                position: 42,
+            },
+            TocEntry {
+                kind: IMAGE_TYPE,
+                size: 32,
+                position: 42,
+            },
+            TocEntry {
+                kind: IMAGE_TYPE,
+                size: 3,
+                position: 42,
+            },
+            TocEntry {
+                kind: IMAGE_TYPE,
+                size: 22,
+                position: 42,
+            },
+            TocEntry {
+                kind: 0,
+                size: 10,
+                position: 42,
+            },
+        ];
+        assert_eq!(3, find_best_size(&input, 10).unwrap());
+    }
+
+    #[test]
+    fn parse_cursor_too_short() {
+        let data = [];
+        match parse_cursor(&mut Cursor::new(&data[..]), 10) {
+            Err(Error::IO(e)) if e.kind() == ErrorKind::UnexpectedEof => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn parse_cursor_incorrect_magic() {
+        let data = [
+            0x00, 0x00, 0x00, 0x00, // magic
+            0x00, 0x00, 0x00, 0x00, // header file offset
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x00, 0x00, 0x00, // num TOC entries
+        ];
+        match parse_cursor(&mut Cursor::new(&data[..]), 10) {
+            Err(Error::InvalidMagic) =>  {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn parse_cursor_too_many_entries() {
+        let data = [
+            b'X', b'c', b'u', b'r', // magic
+            0x00, 0x00, 0x00, 0x00, // header file offset
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x01, 0x00, 0x01, 0x00, // num TOC entries, limit + 1
+        ];
+        match parse_cursor(&mut Cursor::new(&data[..]), 10) {
+            Err(Error::TooManyEntries) =>  {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn parse_cursor_empty_toc() {
+        let data = [
+            b'X', b'c', b'u', b'r', // magic
+            0x10, 0x00, 0x00, 0x00, // header file offset (16)
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x00, 0x00, 0x00, // num TOC entries, 0
+        ];
+        match parse_cursor(&mut Cursor::new(&data[..]), 10) {
+            Err(Error::NoImages) => {},
+            r => panic!("Unexpected result {:?}", r),
+        }
+    }
+
+    #[test]
+    fn parse_cursor_one_image() {
+        let data = [
+            b'X', b'c', b'u', b'r', // magic
+            0x10, 0x00, 0x00, 0x00, // header file offset (16)
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x01, 0x00, 0x00, 0x00, // num TOC entries, 1
+            // TOC
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x1c, 0x00, 0x00, 0x00, // image offset (28)
+            // image
+            0x00, 0x00, 0x00, 0x00, // header(?)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x00, 0x00, 0x00, // width 0
+            0x00, 0x00, 0x00, 0x00, // height 0
+            0x00, 0x00, 0x00, 0x00, // x_hot 0
+            0x00, 0x00, 0x00, 0x00, // y_hot 0
+            0x00, 0x00, 0x00, 0x00, // delay 0
+        ];
+        let expected = [
+            Image {
+                width: 0,
+                height: 0,
+                x_hot: 0,
+                y_hot: 0,
+                delay: 0,
+                pixels: vec![],
+            }
+        ];
+        let actual = parse_cursor(&mut Cursor::new(&data[..]), 10).unwrap();
+        assert_same_images(&expected, &actual);
+    }
+
+    #[test]
+    fn parse_cursor_two_images_plus_one_ignored() {
+        let data = [
+            b'X', b'c', b'u', b'r', // magic
+            0x10, 0x00, 0x00, 0x00, // header file offset (16)
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x03, 0x00, 0x00, 0x00, // num TOC entries, 3
+            // TOC
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x34, 0x00, 0x00, 0x00, // image offset (52)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x03, 0x00, 0x00, 0x00, // size 3
+            0x34, 0x00, 0x00, 0x00, // image offset (52)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x34, 0x00, 0x00, 0x00, // image offset (52)
+            // image
+            0x00, 0x00, 0x00, 0x00, // header(?)
+            0x02, 0x00, 0xfd, 0xff, // IMAGE_TYPE
+            0x04, 0x00, 0x00, 0x00, // size 4
+            0x00, 0x00, 0x00, 0x00, // version(?)
+            0x00, 0x00, 0x00, 0x00, // width 0
+            0x00, 0x00, 0x00, 0x00, // height 0
+            0x00, 0x00, 0x00, 0x00, // x_hot 0
+            0x00, 0x00, 0x00, 0x00, // y_hot 0
+            0x00, 0x00, 0x00, 0x00, // delay 0
+        ];
+        let expected = [
+            Image {
+                width: 0,
+                height: 0,
+                x_hot: 0,
+                y_hot: 0,
+                delay: 0,
+                pixels: vec![],
+            },
+            Image {
+                width: 0,
+                height: 0,
+                x_hot: 0,
+                y_hot: 0,
+                delay: 0,
+                pixels: vec![],
+            },
+        ];
+        let actual = parse_cursor(&mut Cursor::new(&data[..]), 10).unwrap();
+        assert_same_images(&expected, &actual);
+    }
+
+    fn assert_same_images(a: &[Image], b: &[Image]) {
+        assert_eq!(a.len(), b.len(), "{:?} == {:?}", a, b);
+        for (i, (im1, im2)) in a.iter().zip(b.iter()).enumerate() {
+            assert_eq!(im1.width, im2.width, "Width image {}: {} == {}", i + 1, im1.width, im2.width);
+            assert_eq!(im1.height, im2.height, "Height image {}: {} == {}", i + 1, im1.height, im2.height);
+            assert_eq!(im1.x_hot, im2.x_hot, "X-hot image {}: {} == {}", i + 1, im1.x_hot, im2.x_hot);
+            assert_eq!(im1.y_hot, im2.y_hot, "Y-hot image {}: {} == {}", i + 1, im1.y_hot, im2.y_hot);
+            assert_eq!(im1.delay, im2.delay, "Delay image {}: {} == {}", i + 1, im1.delay, im2.delay);
+            assert_eq!(im1.pixels, im2.pixels, "Pixels image {}: {:?} == {:?}", i + 1, im1.pixels, im2.pixels);
+        }
+    }
+}

--- a/src/cursor/parse_cursor.rs
+++ b/src/cursor/parse_cursor.rs
@@ -7,8 +7,8 @@
 use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom};
 
-const FILE_MAGIC: u32 = 0x72756358;
-const IMAGE_TYPE: u32 = 0xfffd0002;
+const FILE_MAGIC: u32 = 0x7275_6358;
+const IMAGE_TYPE: u32 = 0xfffd_0002;
 const IMAGE_MAX_SIZE: u32 = 0x7fff;
 
 /// An error that occurred while parsing
@@ -220,10 +220,10 @@ mod test {
         assert_eq!(image.y_hot, 8);
         assert_eq!(image.delay, 42);
         assert_eq!(image.pixels, &[
-                   0x04030201, 0x08070605, 0x0c0b0a09, 0x100f0e0d,
-                   0x14131211, 0x18171615, 0x1c1b1a19, 0x201f1e1d,
-                   0x24232221, 0x28272625, 0x2c2b2a29, 0x302f2e2d,
-                   0x34333231, 0x38373635, 0x3c3b3a39,
+                   0x0403_0201, 0x0807_0605, 0x0c0b_0a09, 0x100f_0e0d,
+                   0x1413_1211, 0x1817_1615, 0x1c1b_1a19, 0x201f_1e1d,
+                   0x2423_2221, 0x2827_2625, 0x2c2b_2a29, 0x302f_2e2d,
+                   0x3433_3231, 0x3837_3635, 0x3c3b_3a39,
         ]);
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -231,6 +231,12 @@ impl<B: AsRef<[u8]> + std::fmt::Debug> std::fmt::Display for ReplyOrIdError<B> {
 
 impl<B: AsRef<[u8]> + std::fmt::Debug> std::error::Error for ReplyOrIdError<B> {}
 
+impl<B: AsRef<[u8]> + std::fmt::Debug> From<ParseError> for ReplyOrIdError<B> {
+    fn from(err: ParseError) -> Self {
+        ConnectionError::from(err).into()
+    }
+}
+
 impl<B: AsRef<[u8]> + std::fmt::Debug> From<ConnectionError> for ReplyOrIdError<B> {
     fn from(err: ConnectionError) -> Self {
         ReplyOrIdError::ConnectionError(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod xcb_ffi;
 pub mod x11_utils;
 pub mod connection;
 pub mod cookie;
+pub mod cursor;
 pub mod errors;
 pub mod extension_manager;
 pub mod properties;


### PR DESCRIPTION
This is related to #316: it adds a version of xcb-util-cursor to this library. Thanks a lot to @stapelberg for this library.

All the testing that I did on this can be seen here. In the end, I was too lazy to do unit tests and just added something to `examples/simple_window.rs`. The actual low-level code has some basic unit tests.

I'm not sure if this code should just be disabled without render support or not. For now, I made both options work (with and without render), but this is a bit complicated to get right.