### PR TITLE
Convert the result of `switch_expr()` to the correct type

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -3523,11 +3523,14 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 }
             }
             DeducibleField::CaseSwitchExpr(switch_field_name) => {
-                if let xcbdefs::FieldDef::Normal(_) = field {
+                if let xcbdefs::FieldDef::Normal(normal_field) = field {
+                    let rust_field_type =
+                        self.type_to_rust_type(normal_field.type_.type_.def.get().unwrap());
                     outln!(
                         out,
-                        "let {} = {}{}.switch_expr();",
+                        "let {} = {}::try_from({}{}.switch_expr()).unwrap();",
                         dst_var_name,
+                        rust_field_type,
                         obj_name,
                         to_rust_variable_name(switch_field_name),
                     );
@@ -3536,12 +3539,15 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 }
             }
             DeducibleField::BitCaseSwitchExpr(switch_field_name) => {
-                if let xcbdefs::FieldDef::Normal(_) = field {
+                if let xcbdefs::FieldDef::Normal(normal_field) = field {
                     // TODO: Try to handle xkb::SelectEvents
+                    let rust_field_type =
+                        self.type_to_rust_type(normal_field.type_.type_.def.get().unwrap());
                     outln!(
                         out,
-                        "let {} = {}{}.switch_expr();",
+                        "let {} = {}::try_from({}{}.switch_expr()).unwrap();",
                         dst_var_name,
+                        rust_field_type,
                         obj_name,
                         to_rust_variable_name(switch_field_name),
                     )

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -2209,7 +2209,7 @@ where
     let pid_bytes = pid.serialize();
     let drawable_bytes = drawable.serialize();
     let format_bytes = format.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         extension_information.major_opcode,
@@ -2437,7 +2437,7 @@ where
         .ok_or(ConnectionError::UnsupportedExtension)?;
     let length_so_far = 0;
     let picture_bytes = picture.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         extension_information.major_opcode,

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -611,7 +611,7 @@ where
     let class_bytes = u8::from(class).serialize();
     let depth_bytes = depth.serialize();
     let visual_bytes = visual.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         extension_information.major_opcode,

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -1142,7 +1142,7 @@ where
         .ok_or(ConnectionError::UnsupportedExtension)?;
     let length_so_far = 0;
     let id_bytes = id.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         extension_information.major_opcode,
@@ -1278,7 +1278,7 @@ where
         .ok_or(ConnectionError::UnsupportedExtension)?;
     let length_so_far = 0;
     let id_bytes = id.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         extension_information.major_opcode,

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -842,7 +842,7 @@ impl Serialize for InputInfo {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
-        let class_id = self.info.switch_expr();
+        let class_id = u8::try_from(self.info.switch_expr()).unwrap();
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.info.serialize_into(bytes);
@@ -3172,7 +3172,7 @@ impl Serialize for FeedbackState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let class_id = self.data.switch_expr();
+        let class_id = u8::try_from(self.data.switch_expr()).unwrap();
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
@@ -4042,7 +4042,7 @@ impl Serialize for FeedbackCtl {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let class_id = self.data.switch_expr();
+        let class_id = u8::try_from(self.data.switch_expr()).unwrap();
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
@@ -5031,7 +5031,7 @@ impl Serialize for InputState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
-        let class_id = self.data.switch_expr();
+        let class_id = u8::try_from(self.data.switch_expr()).unwrap();
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes);
@@ -5977,7 +5977,7 @@ impl Serialize for DeviceState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let control_id = self.data.switch_expr();
+        let control_id = u16::try_from(self.data.switch_expr()).unwrap();
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes);
@@ -6753,7 +6753,7 @@ impl Serialize for DeviceCtl {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let control_id = self.data.switch_expr();
+        let control_id = u16::try_from(self.data.switch_expr()).unwrap();
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes);
@@ -7010,7 +7010,7 @@ where
     let property_bytes = property.serialize();
     let type_bytes = type_.serialize();
     let device_id_bytes = device_id.serialize();
-    let format = items.switch_expr();
+    let format = u8::try_from(items.switch_expr()).unwrap();
     let format_bytes = format.serialize();
     let mode_bytes = u8::from(mode).serialize();
     let num_items_bytes = num_items.serialize();
@@ -8232,7 +8232,7 @@ impl Serialize for HierarchyChange {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let type_ = self.data.switch_expr();
+        let type_ = u16::try_from(self.data.switch_expr()).unwrap();
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes);
@@ -9661,7 +9661,7 @@ impl Serialize for DeviceClass {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(6);
-        let type_ = self.data.switch_expr();
+        let type_ = u16::try_from(self.data.switch_expr()).unwrap();
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
@@ -10688,7 +10688,7 @@ where
     let length_so_far = 0;
     let deviceid_bytes = deviceid.serialize();
     let mode_bytes = u8::from(mode).serialize();
-    let format = items.switch_expr();
+    let format = u8::try_from(items.switch_expr()).unwrap();
     let format_bytes = format.serialize();
     let property_bytes = property.serialize();
     let type_bytes = type_.serialize();

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -7559,7 +7559,7 @@ where
     let virtual_mods: u16 = virtual_mods.into();
     let length_so_far = 0;
     let device_spec_bytes = device_spec.serialize();
-    let present = values.switch_expr();
+    let present = u16::try_from(values.switch_expr()).unwrap();
     let present_bytes = present.serialize();
     let flags_bytes = flags.serialize();
     let min_key_code_bytes = min_key_code.serialize();
@@ -8557,7 +8557,7 @@ where
     let length_so_far = 0;
     let device_spec_bytes = device_spec.serialize();
     let virtual_mods_bytes = virtual_mods.serialize();
-    let which = values.switch_expr();
+    let which = u32::try_from(values.switch_expr()).unwrap();
     let which_bytes = which.serialize();
     let first_type_bytes = first_type.serialize();
     let n_types_bytes = n_types.serialize();

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -8176,7 +8176,7 @@ where
     let border_width_bytes = border_width.serialize();
     let class_bytes = u16::from(class).serialize();
     let visual_bytes = visual.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         CREATE_WINDOW_REQUEST,
@@ -8459,7 +8459,7 @@ where
 {
     let length_so_far = 0;
     let window_bytes = window.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         CHANGE_WINDOW_ATTRIBUTES_REQUEST,
@@ -9393,7 +9393,7 @@ where
 {
     let length_so_far = 0;
     let window_bytes = window.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u16::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         CONFIGURE_WINDOW_REQUEST,
@@ -14755,7 +14755,7 @@ where
     let length_so_far = 0;
     let cid_bytes = cid.serialize();
     let drawable_bytes = drawable.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         CREATE_GC_REQUEST,
@@ -15142,7 +15142,7 @@ where
 {
     let length_so_far = 0;
     let gc_bytes = gc.serialize();
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         CHANGE_GC_REQUEST,
@@ -18528,7 +18528,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let length_so_far = 0;
-    let value_mask = value_list.switch_expr();
+    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
     let value_mask_bytes = value_mask.serialize();
     let mut request0 = [
         CHANGE_KEYBOARD_CONTROL_REQUEST,


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/psychon/x11rb/pull/371