### PR TITLE
Do not use `Self::Bytes` in `fn serialize`, use directly the corresponding type

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -1261,7 +1261,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "impl Serialize for {} {{", rust_name);
         out.indented(|out| {
             outln!(out, "type Bytes = [u8; {}];", union_size);
-            outln!(out, "fn serialize(&self) -> Self::Bytes {{");
+            outln!(out, "fn serialize(&self) -> [u8; {}] {{", union_size);
             outln!(out.indent(), "self.0");
             outln!(out, "}}");
             outln!(out, "fn serialize_into(&self, bytes: &mut Vec<u8>) {{");
@@ -1439,7 +1439,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "impl Serialize for {} {{", rust_name);
         out.indented(|out| {
             outln!(out, "type Bytes = [u8; 32];");
-            outln!(out, "fn serialize(&self) -> Self::Bytes {{");
+            outln!(out, "fn serialize(&self) -> [u8; 32] {{");
             outln!(out.indent(), "self.0");
             outln!(out, "}}");
             outln!(out, "fn serialize_into(&self, bytes: &mut Vec<u8>) {{");
@@ -2002,7 +2002,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "impl Serialize for {} {{", name);
         out.indented(|out| {
             outln!(out, "type Bytes = [u8; {}];", size);
-            outln!(out, "fn serialize(&self) -> Self::Bytes {{");
+            outln!(out, "fn serialize(&self) -> [u8; {}] {{", size);
             out.indented(|out| {
                 // This gathers the bytes of the result
                 let mut result_bytes = Vec::new();
@@ -2051,7 +2051,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "impl Serialize for {} {{", name);
         out.indented(|out| {
             outln!(out, "type Bytes = Vec<u8>;");
-            outln!(out, "fn serialize(&self) -> Self::Bytes {{");
+            outln!(out, "fn serialize(&self) -> Vec<u8> {{");
             out.indented(|out| {
                 outln!(out, "let mut result = Vec::new();");
                 outln!(out, "self.serialize_into(&mut result);");
@@ -2598,7 +2598,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "impl Serialize for {} {{", name);
         out.indented(|out| {
             outln!(out, "type Bytes = [u8; {}];", size);
-            outln!(out, "fn serialize(&self) -> Self::Bytes {{");
+            outln!(out, "fn serialize(&self) -> [u8; {}] {{", size);
             out.indented(|out| {
                 outln!(out, "match self {{");
                 out.indented(|out| {
@@ -2718,7 +2718,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "impl Serialize for {} {{", name);
         out.indented(|out| {
             outln!(out, "type Bytes = Vec<u8>;");
-            outln!(out, "fn serialize(&self) -> Self::Bytes {{");
+            outln!(out, "fn serialize(&self) -> Vec<u8> {{");
             out.indented(|out| {
                 outln!(out, "let mut result = Vec::new();");
                 outln!(out, "self.serialize_into(&mut result);");

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -290,7 +290,7 @@ impl TryFrom<&[u8]> for DRI2Buffer {
 }
 impl Serialize for DRI2Buffer {
     type Bytes = [u8; 20];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 20] {
         let attachment_bytes = u32::from(self.attachment).serialize();
         let name_bytes = self.name.serialize();
         let pitch_bytes = self.pitch.serialize();
@@ -351,7 +351,7 @@ impl TryFrom<&[u8]> for AttachFormat {
 }
 impl Serialize for AttachFormat {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let attachment_bytes = u32::from(self.attachment).serialize();
         let format_bytes = self.format.serialize();
         [

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -480,7 +480,7 @@ impl TryFrom<&[u8]> for Notify {
 }
 impl Serialize for Notify {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let window_bytes = self.window.serialize();
         let serial_bytes = self.serial.serialize();
         [

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -472,7 +472,7 @@ impl TryFrom<&[u8]> for ScreenSize {
 }
 impl Serialize for ScreenSize {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mwidth_bytes = self.mwidth.serialize();
@@ -517,7 +517,7 @@ impl TryFrom<&[u8]> for RefreshRates {
 }
 impl Serialize for RefreshRates {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -1156,7 +1156,7 @@ impl TryFrom<&[u8]> for ModeInfo {
 }
 impl Serialize for ModeInfo {
     type Bytes = [u8; 32];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 32] {
         let id_bytes = self.id.serialize();
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
@@ -3658,7 +3658,7 @@ impl TryFrom<&[u8]> for CrtcChange {
 }
 impl Serialize for CrtcChange {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let timestamp_bytes = self.timestamp.serialize();
         let window_bytes = self.window.serialize();
         let crtc_bytes = self.crtc.serialize();
@@ -3751,7 +3751,7 @@ impl TryFrom<&[u8]> for OutputChange {
 }
 impl Serialize for OutputChange {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let timestamp_bytes = self.timestamp.serialize();
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let window_bytes = self.window.serialize();
@@ -3835,7 +3835,7 @@ impl TryFrom<&[u8]> for OutputProperty {
 }
 impl Serialize for OutputProperty {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let window_bytes = self.window.serialize();
         let output_bytes = self.output.serialize();
         let atom_bytes = self.atom.serialize();
@@ -3907,7 +3907,7 @@ impl TryFrom<&[u8]> for ProviderChange {
 }
 impl Serialize for ProviderChange {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let timestamp_bytes = self.timestamp.serialize();
         let window_bytes = self.window.serialize();
         let provider_bytes = self.provider.serialize();
@@ -3979,7 +3979,7 @@ impl TryFrom<&[u8]> for ProviderProperty {
 }
 impl Serialize for ProviderProperty {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let window_bytes = self.window.serialize();
         let provider_bytes = self.provider.serialize();
         let atom_bytes = self.atom.serialize();
@@ -4049,7 +4049,7 @@ impl TryFrom<&[u8]> for ResourceChange {
 }
 impl Serialize for ResourceChange {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let timestamp_bytes = self.timestamp.serialize();
         let window_bytes = self.window.serialize();
         [
@@ -4129,7 +4129,7 @@ impl TryFrom<&[u8]> for MonitorInfo {
 }
 impl Serialize for MonitorInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -4410,7 +4410,7 @@ impl TryFrom<&[u8]> for LeaseNotify {
 }
 impl Serialize for LeaseNotify {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let timestamp_bytes = self.timestamp.serialize();
         let window_bytes = self.window.serialize();
         let lease_bytes = self.lease.serialize();
@@ -4518,7 +4518,7 @@ impl NotifyData {
 }
 impl Serialize for NotifyData {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         self.0
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -59,7 +59,7 @@ impl TryFrom<&[u8]> for Range8 {
 }
 impl Serialize for Range8 {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let first_bytes = self.first.serialize();
         let last_bytes = self.last.serialize();
         [
@@ -95,7 +95,7 @@ impl TryFrom<&[u8]> for Range16 {
 }
 impl Serialize for Range16 {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let first_bytes = self.first.serialize();
         let last_bytes = self.last.serialize();
         [
@@ -133,7 +133,7 @@ impl TryFrom<&[u8]> for ExtRange {
 }
 impl Serialize for ExtRange {
     type Bytes = [u8; 6];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 6] {
         let major_bytes = self.major.serialize();
         let minor_bytes = self.minor.serialize();
         [
@@ -187,7 +187,7 @@ impl TryFrom<&[u8]> for Range {
 }
 impl Serialize for Range {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let core_requests_bytes = self.core_requests.serialize();
         let core_replies_bytes = self.core_replies.serialize();
         let ext_requests_bytes = self.ext_requests.serialize();
@@ -395,7 +395,7 @@ impl TryFrom<&[u8]> for ClientInfo {
 }
 impl Serialize for ClientInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1191,7 +1191,7 @@ impl TryFrom<&[u8]> for Directformat {
 }
 impl Serialize for Directformat {
     type Bytes = [u8; 16];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 16] {
         let red_shift_bytes = self.red_shift.serialize();
         let red_mask_bytes = self.red_mask.serialize();
         let green_shift_bytes = self.green_shift.serialize();
@@ -1261,7 +1261,7 @@ impl TryFrom<&[u8]> for Pictforminfo {
 }
 impl Serialize for Pictforminfo {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let id_bytes = self.id.serialize();
         let type_bytes = u8::from(self.type_).serialize();
         let depth_bytes = self.depth.serialize();
@@ -1330,7 +1330,7 @@ impl TryFrom<&[u8]> for Pictvisual {
 }
 impl Serialize for Pictvisual {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let visual_bytes = self.visual.serialize();
         let format_bytes = self.format.serialize();
         [
@@ -1375,7 +1375,7 @@ impl TryFrom<&[u8]> for Pictdepth {
 }
 impl Serialize for Pictdepth {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -1413,7 +1413,7 @@ impl TryFrom<&[u8]> for Pictscreen {
 }
 impl Serialize for Pictscreen {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -1454,7 +1454,7 @@ impl TryFrom<&[u8]> for Indexvalue {
 }
 impl Serialize for Indexvalue {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let pixel_bytes = self.pixel.serialize();
         let red_bytes = self.red.serialize();
         let green_bytes = self.green.serialize();
@@ -1510,7 +1510,7 @@ impl TryFrom<&[u8]> for Color {
 }
 impl Serialize for Color {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let red_bytes = self.red.serialize();
         let green_bytes = self.green.serialize();
         let blue_bytes = self.blue.serialize();
@@ -1556,7 +1556,7 @@ impl TryFrom<&[u8]> for Pointfix {
 }
 impl Serialize for Pointfix {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         [
@@ -1598,7 +1598,7 @@ impl TryFrom<&[u8]> for Linefix {
 }
 impl Serialize for Linefix {
     type Bytes = [u8; 16];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 16] {
         let p1_bytes = self.p1.serialize();
         let p2_bytes = self.p2.serialize();
         [
@@ -1650,7 +1650,7 @@ impl TryFrom<&[u8]> for Triangle {
 }
 impl Serialize for Triangle {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let p1_bytes = self.p1.serialize();
         let p2_bytes = self.p2.serialize();
         let p3_bytes = self.p3.serialize();
@@ -1714,7 +1714,7 @@ impl TryFrom<&[u8]> for Trapezoid {
 }
 impl Serialize for Trapezoid {
     type Bytes = [u8; 40];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 40] {
         let top_bytes = self.top.serialize();
         let bottom_bytes = self.bottom.serialize();
         let left_bytes = self.left.serialize();
@@ -1800,7 +1800,7 @@ impl TryFrom<&[u8]> for Glyphinfo {
 }
 impl Serialize for Glyphinfo {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let x_bytes = self.x.serialize();
@@ -2035,7 +2035,7 @@ pub struct CreatePictureAux {
 }
 impl Serialize for CreatePictureAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -2265,7 +2265,7 @@ pub struct ChangePictureAux {
 }
 impl Serialize for ChangePictureAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3253,7 +3253,7 @@ impl TryFrom<&[u8]> for Transform {
 }
 impl Serialize for Transform {
     type Bytes = [u8; 36];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 36] {
         let matrix11_bytes = self.matrix11.serialize();
         let matrix12_bytes = self.matrix12.serialize();
         let matrix13_bytes = self.matrix13.serialize();
@@ -3498,7 +3498,7 @@ impl TryFrom<&[u8]> for Animcursorelt {
 }
 impl Serialize for Animcursorelt {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let cursor_bytes = self.cursor.serialize();
         let delay_bytes = self.delay.serialize();
         [
@@ -3573,7 +3573,7 @@ impl TryFrom<&[u8]> for Spanfix {
 }
 impl Serialize for Spanfix {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let l_bytes = self.l.serialize();
         let r_bytes = self.r.serialize();
         let y_bytes = self.y.serialize();
@@ -3621,7 +3621,7 @@ impl TryFrom<&[u8]> for Trap {
 }
 impl Serialize for Trap {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let top_bytes = self.top.serialize();
         let bot_bytes = self.bot.serialize();
         [

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -58,7 +58,7 @@ impl TryFrom<&[u8]> for Client {
 }
 impl Serialize for Client {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let resource_base_bytes = self.resource_base.serialize();
         let resource_mask_bytes = self.resource_mask.serialize();
         [
@@ -100,7 +100,7 @@ impl TryFrom<&[u8]> for Type {
 }
 impl Serialize for Type {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let resource_type_bytes = self.resource_type.serialize();
         let count_bytes = self.count.serialize();
         [
@@ -205,7 +205,7 @@ impl TryFrom<&[u8]> for ClientIdSpec {
 }
 impl Serialize for ClientIdSpec {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let client_bytes = self.client.serialize();
         let mask_bytes = self.mask.serialize();
         [
@@ -248,7 +248,7 @@ impl TryFrom<&[u8]> for ClientIdValue {
 }
 impl Serialize for ClientIdValue {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -283,7 +283,7 @@ impl TryFrom<&[u8]> for ResourceIdSpec {
 }
 impl Serialize for ResourceIdSpec {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let resource_bytes = self.resource.serialize();
         let type_bytes = self.type_.serialize();
         [
@@ -329,7 +329,7 @@ impl TryFrom<&[u8]> for ResourceSizeSpec {
 }
 impl Serialize for ResourceSizeSpec {
     type Bytes = [u8; 20];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 20] {
         let spec_bytes = self.spec.serialize();
         let bytes_bytes = self.bytes.serialize();
         let ref_count_bytes = self.ref_count.serialize();
@@ -388,7 +388,7 @@ impl TryFrom<&[u8]> for ResourceSizeValue {
 }
 impl Serialize for ResourceSizeValue {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -409,7 +409,7 @@ pub struct SetAttributesAux {
 }
 impl Serialize for SetAttributesAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -342,7 +342,7 @@ impl TryFrom<&[u8]> for Int64 {
 }
 impl Serialize for Int64 {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let hi_bytes = self.hi.serialize();
         let lo_bytes = self.lo.serialize();
         [
@@ -393,7 +393,7 @@ impl TryFrom<&[u8]> for Systemcounter {
 }
 impl Serialize for Systemcounter {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -436,7 +436,7 @@ impl TryFrom<&[u8]> for Trigger {
 }
 impl Serialize for Trigger {
     type Bytes = [u8; 20];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 20] {
         let counter_bytes = self.counter.serialize();
         let wait_type_bytes = u32::from(self.wait_type).serialize();
         let wait_value_bytes = self.wait_value.serialize();
@@ -494,7 +494,7 @@ impl TryFrom<&[u8]> for Waitcondition {
 }
 impl Serialize for Waitcondition {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let trigger_bytes = self.trigger.serialize();
         let event_threshold_bytes = self.event_threshold.serialize();
         [
@@ -1047,7 +1047,7 @@ pub struct CreateAlarmAux {
 }
 impl Serialize for CreateAlarmAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -1183,7 +1183,7 @@ pub struct ChangeAlarmAux {
 }
 impl Serialize for ChangeAlarmAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -282,7 +282,7 @@ impl TryFrom<&[u8]> for Event {
 }
 impl Serialize for Event {
     type Bytes = [u8; 32];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 32] {
         [
             0,
             0,

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -61,7 +61,7 @@ impl TryFrom<&[u8]> for DrmClipRect {
 }
 impl Serialize for DrmClipRect {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let x1_bytes = self.x1.serialize();
         let y1_bytes = self.y1.serialize();
         let x2_bytes = self.x2.serialize();

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -286,7 +286,7 @@ impl TryFrom<&[u8]> for ModeInfo {
 }
 impl Serialize for ModeInfo {
     type Bytes = [u8; 48];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 48] {
         let dotclock_bytes = self.dotclock.serialize();
         let hdisplay_bytes = self.hdisplay.serialize();
         let hsyncstart_bytes = self.hsyncstart.serialize();

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -62,7 +62,7 @@ impl TryFrom<&[u8]> for ScreenInfo {
 }
 impl Serialize for ScreenInfo {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let x_org_bytes = self.x_org.serialize();
         let y_org_bytes = self.y_org.serialize();
         let width_bytes = self.width.serialize();

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -67,7 +67,7 @@ impl TryFrom<&[u8]> for Fp3232 {
 }
 impl Serialize for Fp3232 {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let integral_bytes = self.integral.serialize();
         let frac_bytes = self.frac.serialize();
         [
@@ -395,7 +395,7 @@ impl TryFrom<&[u8]> for DeviceInfo {
 }
 impl Serialize for DeviceInfo {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let device_type_bytes = self.device_type.serialize();
         let device_id_bytes = self.device_id.serialize();
         let num_class_info_bytes = self.num_class_info.serialize();
@@ -450,7 +450,7 @@ impl TryFrom<&[u8]> for KeyInfo {
 }
 impl Serialize for KeyInfo {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let len_bytes = self.len.serialize();
         let min_keycode_bytes = self.min_keycode.serialize();
@@ -502,7 +502,7 @@ impl TryFrom<&[u8]> for ButtonInfo {
 }
 impl Serialize for ButtonInfo {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let len_bytes = self.len.serialize();
         let num_buttons_bytes = self.num_buttons.serialize();
@@ -544,7 +544,7 @@ impl TryFrom<&[u8]> for AxisInfo {
 }
 impl Serialize for AxisInfo {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let resolution_bytes = self.resolution.serialize();
         let minimum_bytes = self.minimum.serialize();
         let maximum_bytes = self.maximum.serialize();
@@ -601,7 +601,7 @@ impl TryFrom<&[u8]> for ValuatorInfo {
 }
 impl Serialize for ValuatorInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -642,7 +642,7 @@ impl TryFrom<&[u8]> for InputInfoInfoKey {
 }
 impl Serialize for InputInfoInfoKey {
     type Bytes = [u8; 6];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 6] {
         let min_keycode_bytes = self.min_keycode.serialize();
         let max_keycode_bytes = self.max_keycode.serialize();
         let num_keys_bytes = self.num_keys.serialize();
@@ -682,7 +682,7 @@ impl TryFrom<&[u8]> for InputInfoInfoButton {
 }
 impl Serialize for InputInfoInfoButton {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let num_buttons_bytes = self.num_buttons.serialize();
         [
             num_buttons_bytes[0],
@@ -719,7 +719,7 @@ impl TryFrom<&[u8]> for InputInfoInfoValuator {
 }
 impl Serialize for InputInfoInfoValuator {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -790,7 +790,7 @@ impl InputInfoInfo {
 }
 impl Serialize for InputInfoInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -835,7 +835,7 @@ impl TryFrom<&[u8]> for InputInfo {
 }
 impl Serialize for InputInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -870,7 +870,7 @@ impl TryFrom<&[u8]> for DeviceName {
 }
 impl Serialize for DeviceName {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -965,7 +965,7 @@ impl TryFrom<&[u8]> for InputClassInfo {
 }
 impl Serialize for InputClassInfo {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let event_type_base_bytes = self.event_type_base.serialize();
         [
@@ -1397,7 +1397,7 @@ impl DeviceTimeCoord {
 // Skipping TryFrom implementations because of unresolved members
 impl Serialize for DeviceTimeCoord {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -2304,7 +2304,7 @@ impl TryFrom<&[u8]> for KbdFeedbackState {
 }
 impl Serialize for KbdFeedbackState {
     type Bytes = [u8; 52];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 52] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -2418,7 +2418,7 @@ impl TryFrom<&[u8]> for PtrFeedbackState {
 }
 impl Serialize for PtrFeedbackState {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -2482,7 +2482,7 @@ impl TryFrom<&[u8]> for IntegerFeedbackState {
 }
 impl Serialize for IntegerFeedbackState {
     type Bytes = [u8; 16];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 16] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -2548,7 +2548,7 @@ impl TryFrom<&[u8]> for StringFeedbackState {
 }
 impl Serialize for StringFeedbackState {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -2596,7 +2596,7 @@ impl TryFrom<&[u8]> for BellFeedbackState {
 }
 impl Serialize for BellFeedbackState {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -2658,7 +2658,7 @@ impl TryFrom<&[u8]> for LedFeedbackState {
 }
 impl Serialize for LedFeedbackState {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -2724,7 +2724,7 @@ impl TryFrom<&[u8]> for FeedbackStateDataKeyboard {
 }
 impl Serialize for FeedbackStateDataKeyboard {
     type Bytes = [u8; 48];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 48] {
         let pitch_bytes = self.pitch.serialize();
         let duration_bytes = self.duration.serialize();
         let led_mask_bytes = self.led_mask.serialize();
@@ -2820,7 +2820,7 @@ impl TryFrom<&[u8]> for FeedbackStateDataPointer {
 }
 impl Serialize for FeedbackStateDataPointer {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let accel_num_bytes = self.accel_num.serialize();
         let accel_denom_bytes = self.accel_denom.serialize();
         let threshold_bytes = self.threshold.serialize();
@@ -2865,7 +2865,7 @@ impl TryFrom<&[u8]> for FeedbackStateDataString {
 }
 impl Serialize for FeedbackStateDataString {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -2901,7 +2901,7 @@ impl TryFrom<&[u8]> for FeedbackStateDataInteger {
 }
 impl Serialize for FeedbackStateDataInteger {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let resolution_bytes = self.resolution.serialize();
         let min_value_bytes = self.min_value.serialize();
         let max_value_bytes = self.max_value.serialize();
@@ -2948,7 +2948,7 @@ impl TryFrom<&[u8]> for FeedbackStateDataLed {
 }
 impl Serialize for FeedbackStateDataLed {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let led_mask_bytes = self.led_mask.serialize();
         let led_values_bytes = self.led_values.serialize();
         [
@@ -2992,7 +2992,7 @@ impl TryFrom<&[u8]> for FeedbackStateDataBell {
 }
 impl Serialize for FeedbackStateDataBell {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let percent_bytes = self.percent.serialize();
         let pitch_bytes = self.pitch.serialize();
         let duration_bytes = self.duration.serialize();
@@ -3111,7 +3111,7 @@ impl FeedbackStateData {
 }
 impl Serialize for FeedbackStateData {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3164,7 +3164,7 @@ impl TryFrom<&[u8]> for FeedbackState {
 }
 impl Serialize for FeedbackState {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3274,7 +3274,7 @@ impl TryFrom<&[u8]> for KbdFeedbackCtl {
 }
 impl Serialize for KbdFeedbackCtl {
     type Bytes = [u8; 20];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 20] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -3356,7 +3356,7 @@ impl TryFrom<&[u8]> for PtrFeedbackCtl {
 }
 impl Serialize for PtrFeedbackCtl {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -3416,7 +3416,7 @@ impl TryFrom<&[u8]> for IntegerFeedbackCtl {
 }
 impl Serialize for IntegerFeedbackCtl {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -3469,7 +3469,7 @@ impl TryFrom<&[u8]> for StringFeedbackCtl {
 }
 impl Serialize for StringFeedbackCtl {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3517,7 +3517,7 @@ impl TryFrom<&[u8]> for BellFeedbackCtl {
 }
 impl Serialize for BellFeedbackCtl {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -3579,7 +3579,7 @@ impl TryFrom<&[u8]> for LedFeedbackCtl {
 }
 impl Serialize for LedFeedbackCtl {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let len_bytes = self.len.serialize();
@@ -3643,7 +3643,7 @@ impl TryFrom<&[u8]> for FeedbackCtlDataKeyboard {
 }
 impl Serialize for FeedbackCtlDataKeyboard {
     type Bytes = [u8; 16];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 16] {
         let key_bytes = self.key.serialize();
         let auto_repeat_mode_bytes = self.auto_repeat_mode.serialize();
         let key_click_percent_bytes = self.key_click_percent.serialize();
@@ -3707,7 +3707,7 @@ impl TryFrom<&[u8]> for FeedbackCtlDataPointer {
 }
 impl Serialize for FeedbackCtlDataPointer {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let num_bytes = self.num.serialize();
         let denom_bytes = self.denom.serialize();
         let threshold_bytes = self.threshold.serialize();
@@ -3751,7 +3751,7 @@ impl TryFrom<&[u8]> for FeedbackCtlDataString {
 }
 impl Serialize for FeedbackCtlDataString {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3783,7 +3783,7 @@ impl TryFrom<&[u8]> for FeedbackCtlDataInteger {
 }
 impl Serialize for FeedbackCtlDataInteger {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let int_to_display_bytes = self.int_to_display.serialize();
         [
             int_to_display_bytes[0],
@@ -3818,7 +3818,7 @@ impl TryFrom<&[u8]> for FeedbackCtlDataLed {
 }
 impl Serialize for FeedbackCtlDataLed {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let led_mask_bytes = self.led_mask.serialize();
         let led_values_bytes = self.led_values.serialize();
         [
@@ -3862,7 +3862,7 @@ impl TryFrom<&[u8]> for FeedbackCtlDataBell {
 }
 impl Serialize for FeedbackCtlDataBell {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let percent_bytes = self.percent.serialize();
         let pitch_bytes = self.pitch.serialize();
         let duration_bytes = self.duration.serialize();
@@ -3981,7 +3981,7 @@ impl FeedbackCtlData {
 }
 impl Serialize for FeedbackCtlData {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -4034,7 +4034,7 @@ impl TryFrom<&[u8]> for FeedbackCtl {
 }
 impl Serialize for FeedbackCtl {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -4508,7 +4508,7 @@ impl TryFrom<&[u8]> for KeyState {
 }
 impl Serialize for KeyState {
     type Bytes = [u8; 36];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 36] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let len_bytes = self.len.serialize();
         let num_keys_bytes = self.num_keys.serialize();
@@ -4589,7 +4589,7 @@ impl TryFrom<&[u8]> for ButtonState {
 }
 impl Serialize for ButtonState {
     type Bytes = [u8; 36];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 36] {
         let class_id_bytes = u8::from(self.class_id).serialize();
         let len_bytes = self.len.serialize();
         let num_buttons_bytes = self.num_buttons.serialize();
@@ -4732,7 +4732,7 @@ impl TryFrom<&[u8]> for ValuatorState {
 }
 impl Serialize for ValuatorState {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -4771,7 +4771,7 @@ impl TryFrom<&[u8]> for InputStateDataKey {
 }
 impl Serialize for InputStateDataKey {
     type Bytes = [u8; 34];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 34] {
         let num_keys_bytes = self.num_keys.serialize();
         [
             num_keys_bytes[0],
@@ -4840,7 +4840,7 @@ impl TryFrom<&[u8]> for InputStateDataButton {
 }
 impl Serialize for InputStateDataButton {
     type Bytes = [u8; 34];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 34] {
         let num_buttons_bytes = self.num_buttons.serialize();
         [
             num_buttons_bytes[0],
@@ -4908,7 +4908,7 @@ impl TryFrom<&[u8]> for InputStateDataValuator {
 }
 impl Serialize for InputStateDataValuator {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -4978,7 +4978,7 @@ impl InputStateData {
 }
 impl Serialize for InputStateData {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -5023,7 +5023,7 @@ impl TryFrom<&[u8]> for InputState {
 }
 impl Serialize for InputState {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -5284,7 +5284,7 @@ impl TryFrom<&[u8]> for DeviceResolutionState {
 }
 impl Serialize for DeviceResolutionState {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -5339,7 +5339,7 @@ impl TryFrom<&[u8]> for DeviceAbsCalibState {
 }
 impl Serialize for DeviceAbsCalibState {
     type Bytes = [u8; 36];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 36] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let min_x_bytes = self.min_x.serialize();
@@ -5438,7 +5438,7 @@ impl TryFrom<&[u8]> for DeviceAbsAreaState {
 }
 impl Serialize for DeviceAbsAreaState {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let offset_x_bytes = self.offset_x.serialize();
@@ -5518,7 +5518,7 @@ impl TryFrom<&[u8]> for DeviceCoreState {
 }
 impl Serialize for DeviceCoreState {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let status_bytes = self.status.serialize();
@@ -5569,7 +5569,7 @@ impl TryFrom<&[u8]> for DeviceEnableState {
 }
 impl Serialize for DeviceEnableState {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let enable_bytes = self.enable.serialize();
@@ -5617,7 +5617,7 @@ impl TryFrom<&[u8]> for DeviceStateDataResolution {
 }
 impl Serialize for DeviceStateDataResolution {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -5663,7 +5663,7 @@ impl TryFrom<&[u8]> for DeviceStateDataAbsCalib {
 }
 impl Serialize for DeviceStateDataAbsCalib {
     type Bytes = [u8; 32];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 32] {
         let min_x_bytes = self.min_x.serialize();
         let max_x_bytes = self.max_x.serialize();
         let min_y_bytes = self.min_y.serialize();
@@ -5741,7 +5741,7 @@ impl TryFrom<&[u8]> for DeviceStateDataCore {
 }
 impl Serialize for DeviceStateDataCore {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let status_bytes = self.status.serialize();
         let iscore_bytes = self.iscore.serialize();
         [
@@ -5787,7 +5787,7 @@ impl TryFrom<&[u8]> for DeviceStateDataAbsArea {
 }
 impl Serialize for DeviceStateDataAbsArea {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let offset_x_bytes = self.offset_x.serialize();
         let offset_y_bytes = self.offset_y.serialize();
         let width_bytes = self.width.serialize();
@@ -5916,7 +5916,7 @@ impl DeviceStateData {
 }
 impl Serialize for DeviceStateData {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -5969,7 +5969,7 @@ impl TryFrom<&[u8]> for DeviceState {
 }
 impl Serialize for DeviceState {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -6068,7 +6068,7 @@ impl TryFrom<&[u8]> for DeviceResolutionCtl {
 }
 impl Serialize for DeviceResolutionCtl {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -6123,7 +6123,7 @@ impl TryFrom<&[u8]> for DeviceAbsCalibCtl {
 }
 impl Serialize for DeviceAbsCalibCtl {
     type Bytes = [u8; 36];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 36] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let min_x_bytes = self.min_x.serialize();
@@ -6222,7 +6222,7 @@ impl TryFrom<&[u8]> for DeviceAbsAreaCtrl {
 }
 impl Serialize for DeviceAbsAreaCtrl {
     type Bytes = [u8; 28];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 28] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let offset_x_bytes = self.offset_x.serialize();
@@ -6300,7 +6300,7 @@ impl TryFrom<&[u8]> for DeviceCoreCtrl {
 }
 impl Serialize for DeviceCoreCtrl {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let status_bytes = self.status.serialize();
@@ -6349,7 +6349,7 @@ impl TryFrom<&[u8]> for DeviceEnableCtrl {
 }
 impl Serialize for DeviceEnableCtrl {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let control_id_bytes = u16::from(self.control_id).serialize();
         let len_bytes = self.len.serialize();
         let enable_bytes = self.enable.serialize();
@@ -6396,7 +6396,7 @@ impl TryFrom<&[u8]> for DeviceCtlDataResolution {
 }
 impl Serialize for DeviceCtlDataResolution {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -6443,7 +6443,7 @@ impl TryFrom<&[u8]> for DeviceCtlDataAbsCalib {
 }
 impl Serialize for DeviceCtlDataAbsCalib {
     type Bytes = [u8; 32];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 32] {
         let min_x_bytes = self.min_x.serialize();
         let max_x_bytes = self.max_x.serialize();
         let min_y_bytes = self.min_y.serialize();
@@ -6519,7 +6519,7 @@ impl TryFrom<&[u8]> for DeviceCtlDataCore {
 }
 impl Serialize for DeviceCtlDataCore {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let status_bytes = self.status.serialize();
         [
             status_bytes[0],
@@ -6563,7 +6563,7 @@ impl TryFrom<&[u8]> for DeviceCtlDataAbsArea {
 }
 impl Serialize for DeviceCtlDataAbsArea {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let offset_x_bytes = self.offset_x.serialize();
         let offset_y_bytes = self.offset_y.serialize();
         let width_bytes = self.width.serialize();
@@ -6692,7 +6692,7 @@ impl DeviceCtlData {
 }
 impl Serialize for DeviceCtlData {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -6745,7 +6745,7 @@ impl TryFrom<&[u8]> for DeviceCtl {
 }
 impl Serialize for DeviceCtl {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -6968,7 +6968,7 @@ impl ChangeDevicePropertyAux {
 }
 impl Serialize for ChangeDevicePropertyAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -7327,7 +7327,7 @@ impl TryFrom<&[u8]> for GroupInfo {
 }
 impl Serialize for GroupInfo {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let base_bytes = self.base.serialize();
         let latched_bytes = self.latched.serialize();
         let locked_bytes = self.locked.serialize();
@@ -7373,7 +7373,7 @@ impl TryFrom<&[u8]> for ModifierInfo {
 }
 impl Serialize for ModifierInfo {
     type Bytes = [u8; 16];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 16] {
         let base_bytes = self.base.serialize();
         let latched_bytes = self.latched.serialize();
         let locked_bytes = self.locked.serialize();
@@ -7754,7 +7754,7 @@ impl TryFrom<&[u8]> for AddMaster {
 }
 impl Serialize for AddMaster {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -7804,7 +7804,7 @@ impl TryFrom<&[u8]> for RemoveMaster {
 }
 impl Serialize for RemoveMaster {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let type_bytes = u16::from(self.type_).serialize();
         let len_bytes = self.len.serialize();
         let deviceid_bytes = self.deviceid.serialize();
@@ -7864,7 +7864,7 @@ impl TryFrom<&[u8]> for AttachSlave {
 }
 impl Serialize for AttachSlave {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u16::from(self.type_).serialize();
         let len_bytes = self.len.serialize();
         let deviceid_bytes = self.deviceid.serialize();
@@ -7914,7 +7914,7 @@ impl TryFrom<&[u8]> for DetachSlave {
 }
 impl Serialize for DetachSlave {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u16::from(self.type_).serialize();
         let len_bytes = self.len.serialize();
         let deviceid_bytes = self.deviceid.serialize();
@@ -7968,7 +7968,7 @@ impl TryFrom<&[u8]> for HierarchyChangeDataAddMaster {
 }
 impl Serialize for HierarchyChangeDataAddMaster {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8010,7 +8010,7 @@ impl TryFrom<&[u8]> for HierarchyChangeDataRemoveMaster {
 }
 impl Serialize for HierarchyChangeDataRemoveMaster {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let deviceid_bytes = self.deviceid.serialize();
         let return_mode_bytes = u8::from(self.return_mode).serialize();
         let return_pointer_bytes = self.return_pointer.serialize();
@@ -8056,7 +8056,7 @@ impl TryFrom<&[u8]> for HierarchyChangeDataAttachSlave {
 }
 impl Serialize for HierarchyChangeDataAttachSlave {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let deviceid_bytes = self.deviceid.serialize();
         let master_bytes = self.master.serialize();
         [
@@ -8092,7 +8092,7 @@ impl TryFrom<&[u8]> for HierarchyChangeDataDetachSlave {
 }
 impl Serialize for HierarchyChangeDataDetachSlave {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let deviceid_bytes = self.deviceid.serialize();
         [
             deviceid_bytes[0],
@@ -8177,7 +8177,7 @@ impl HierarchyChangeData {
 }
 impl Serialize for HierarchyChangeData {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8224,7 +8224,7 @@ impl TryFrom<&[u8]> for HierarchyChange {
 }
 impl Serialize for HierarchyChange {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8485,7 +8485,7 @@ impl TryFrom<&[u8]> for EventMask {
 }
 impl Serialize for EventMask {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8950,7 +8950,7 @@ impl TryFrom<&[u8]> for ButtonClass {
 }
 impl Serialize for ButtonClass {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8994,7 +8994,7 @@ impl TryFrom<&[u8]> for KeyClass {
 }
 impl Serialize for KeyClass {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -9044,7 +9044,7 @@ impl TryFrom<&[u8]> for ScrollClass {
 }
 impl Serialize for ScrollClass {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let type_bytes = u16::from(self.type_).serialize();
         let len_bytes = self.len.serialize();
         let sourceid_bytes = self.sourceid.serialize();
@@ -9121,7 +9121,7 @@ impl TryFrom<&[u8]> for TouchClass {
 }
 impl Serialize for TouchClass {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u16::from(self.type_).serialize();
         let len_bytes = self.len.serialize();
         let sourceid_bytes = self.sourceid.serialize();
@@ -9188,7 +9188,7 @@ impl TryFrom<&[u8]> for ValuatorClass {
 }
 impl Serialize for ValuatorClass {
     type Bytes = [u8; 44];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 44] {
         let type_bytes = u16::from(self.type_).serialize();
         let len_bytes = self.len.serialize();
         let sourceid_bytes = self.sourceid.serialize();
@@ -9282,7 +9282,7 @@ impl TryFrom<&[u8]> for DeviceClassDataKey {
 }
 impl Serialize for DeviceClassDataKey {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -9315,7 +9315,7 @@ impl TryFrom<&[u8]> for DeviceClassDataButton {
 }
 impl Serialize for DeviceClassDataButton {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -9360,7 +9360,7 @@ impl TryFrom<&[u8]> for DeviceClassDataValuator {
 }
 impl Serialize for DeviceClassDataValuator {
     type Bytes = [u8; 38];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 38] {
         let number_bytes = self.number.serialize();
         let label_bytes = self.label.serialize();
         let min_bytes = self.min.serialize();
@@ -9448,7 +9448,7 @@ impl TryFrom<&[u8]> for DeviceClassDataScroll {
 }
 impl Serialize for DeviceClassDataScroll {
     type Bytes = [u8; 18];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 18] {
         let number_bytes = self.number.serialize();
         let scroll_type_bytes = u16::from(self.scroll_type).serialize();
         let flags_bytes = self.flags.serialize();
@@ -9505,7 +9505,7 @@ impl TryFrom<&[u8]> for DeviceClassDataTouch {
 }
 impl Serialize for DeviceClassDataTouch {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let mode_bytes = u8::from(self.mode).serialize();
         let num_touches_bytes = self.num_touches.serialize();
         [
@@ -9602,7 +9602,7 @@ impl DeviceClassData {
 }
 impl Serialize for DeviceClassData {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -9653,7 +9653,7 @@ impl TryFrom<&[u8]> for DeviceClass {
 }
 impl Serialize for DeviceClass {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -9707,7 +9707,7 @@ impl TryFrom<&[u8]> for XIDeviceInfo {
 }
 impl Serialize for XIDeviceInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -10387,7 +10387,7 @@ impl TryFrom<&[u8]> for GrabModifierInfo {
 }
 impl Serialize for GrabModifierInfo {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let modifiers_bytes = self.modifiers.serialize();
         let status_bytes = u8::from(self.status).serialize();
         [
@@ -10645,7 +10645,7 @@ impl XIChangePropertyAux {
 }
 impl Serialize for XIChangePropertyAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -10990,7 +10990,7 @@ impl TryFrom<&[u8]> for BarrierReleasePointerInfo {
 }
 impl Serialize for BarrierReleasePointerInfo {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let deviceid_bytes = self.deviceid.serialize();
         let barrier_bytes = self.barrier.serialize();
         let eventid_bytes = self.eventid.serialize();
@@ -14251,7 +14251,7 @@ impl TryFrom<&[u8]> for HierarchyInfo {
 }
 impl Serialize for HierarchyInfo {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let deviceid_bytes = self.deviceid.serialize();
         let attachment_bytes = self.attachment.serialize();
         let type_bytes = u8::from(self.type_).serialize();
@@ -15596,7 +15596,7 @@ impl EventForSend {
 }
 impl Serialize for EventForSend {
     type Bytes = [u8; 32];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 32] {
         self.0
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -2078,7 +2078,7 @@ impl TryFrom<&[u8]> for IndicatorMap {
 }
 impl Serialize for IndicatorMap {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let flags_bytes = u8::from(self.flags).serialize();
         let which_groups_bytes = u8::from(self.which_groups).serialize();
         let groups_bytes = u8::from(self.groups).serialize();
@@ -2509,7 +2509,7 @@ impl TryFrom<&[u8]> for ModDef {
 }
 impl Serialize for ModDef {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let mask_bytes = self.mask.serialize();
         let real_mods_bytes = self.real_mods.serialize();
         let vmods_bytes = self.vmods.serialize();
@@ -2548,7 +2548,7 @@ impl TryFrom<&[u8]> for KeyName {
 }
 impl Serialize for KeyName {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         [
             self.name[0],
             self.name[1],
@@ -2585,7 +2585,7 @@ impl TryFrom<&[u8]> for KeyAlias {
 }
 impl Serialize for KeyAlias {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         [
             self.real[0],
             self.real[1],
@@ -2628,7 +2628,7 @@ impl TryFrom<&[u8]> for CountedString16 {
 }
 impl Serialize for CountedString16 {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -2669,7 +2669,7 @@ impl TryFrom<&[u8]> for KTMapEntry {
 }
 impl Serialize for KTMapEntry {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let active_bytes = self.active.serialize();
         let mods_mask_bytes = self.mods_mask.serialize();
         let level_bytes = self.level.serialize();
@@ -2730,7 +2730,7 @@ impl TryFrom<&[u8]> for KeyType {
 }
 impl Serialize for KeyType {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -2777,7 +2777,7 @@ impl TryFrom<&[u8]> for KeySymMap {
 }
 impl Serialize for KeySymMap {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -2814,7 +2814,7 @@ impl TryFrom<&[u8]> for CommonBehavior {
 }
 impl Serialize for CommonBehavior {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let type_bytes = self.type_.serialize();
         let data_bytes = self.data.serialize();
         [
@@ -2849,7 +2849,7 @@ impl TryFrom<&[u8]> for DefaultBehavior {
 }
 impl Serialize for DefaultBehavior {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let type_bytes = self.type_.serialize();
         [
             type_bytes[0],
@@ -2886,7 +2886,7 @@ impl TryFrom<&[u8]> for RadioGroupBehavior {
 }
 impl Serialize for RadioGroupBehavior {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let type_bytes = self.type_.serialize();
         let group_bytes = self.group.serialize();
         [
@@ -2922,7 +2922,7 @@ impl TryFrom<&[u8]> for OverlayBehavior {
 }
 impl Serialize for OverlayBehavior {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let type_bytes = self.type_.serialize();
         let key_bytes = self.key.serialize();
         [
@@ -3037,7 +3037,7 @@ impl Behavior {
 }
 impl Serialize for Behavior {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         self.0
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
@@ -3194,7 +3194,7 @@ impl TryFrom<&[u8]> for SetBehavior {
 }
 impl Serialize for SetBehavior {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let keycode_bytes = self.keycode.serialize();
         let behavior_bytes = self.behavior.serialize();
         [
@@ -3233,7 +3233,7 @@ impl TryFrom<&[u8]> for SetExplicit {
 }
 impl Serialize for SetExplicit {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let keycode_bytes = self.keycode.serialize();
         let explicit_bytes = self.explicit.serialize();
         [
@@ -3269,7 +3269,7 @@ impl TryFrom<&[u8]> for KeyModMap {
 }
 impl Serialize for KeyModMap {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let keycode_bytes = self.keycode.serialize();
         let mods_bytes = self.mods.serialize();
         [
@@ -3306,7 +3306,7 @@ impl TryFrom<&[u8]> for KeyVModMap {
 }
 impl Serialize for KeyVModMap {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let keycode_bytes = self.keycode.serialize();
         let vmods_bytes = self.vmods.serialize();
         [
@@ -3347,7 +3347,7 @@ impl TryFrom<&[u8]> for KTSetMapEntry {
 }
 impl Serialize for KTSetMapEntry {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let level_bytes = self.level.serialize();
         let real_mods_bytes = self.real_mods.serialize();
         let virtual_mods_bytes = self.virtual_mods.serialize();
@@ -3399,7 +3399,7 @@ impl TryFrom<&[u8]> for SetKeyType {
 }
 impl Serialize for SetKeyType {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3444,7 +3444,7 @@ impl TryFrom<&[u8]> for Outline {
 }
 impl Serialize for Outline {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3486,7 +3486,7 @@ impl TryFrom<&[u8]> for Shape {
 }
 impl Serialize for Shape {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3529,7 +3529,7 @@ impl TryFrom<&[u8]> for Key {
 }
 impl Serialize for Key {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let gap_bytes = self.gap.serialize();
         let shape_ndx_bytes = self.shape_ndx.serialize();
         let color_ndx_bytes = self.color_ndx.serialize();
@@ -3576,7 +3576,7 @@ impl TryFrom<&[u8]> for OverlayKey {
 }
 impl Serialize for OverlayKey {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         [
             self.over[0],
             self.over[1],
@@ -3618,7 +3618,7 @@ impl TryFrom<&[u8]> for OverlayRow {
 }
 impl Serialize for OverlayRow {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3656,7 +3656,7 @@ impl TryFrom<&[u8]> for Overlay {
 }
 impl Serialize for Overlay {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3698,7 +3698,7 @@ impl TryFrom<&[u8]> for Row {
 }
 impl Serialize for Row {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3814,7 +3814,7 @@ impl TryFrom<&[u8]> for Listing {
 }
 impl Serialize for Listing {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -3863,7 +3863,7 @@ impl TryFrom<&[u8]> for DeviceLedInfo {
 }
 impl Serialize for DeviceLedInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -4220,7 +4220,7 @@ impl TryFrom<&[u8]> for SANoAction {
 }
 impl Serialize for SANoAction {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         [
             type_bytes[0],
@@ -4271,7 +4271,7 @@ impl TryFrom<&[u8]> for SASetMods {
 }
 impl Serialize for SASetMods {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let mask_bytes = self.mask.serialize();
@@ -4330,7 +4330,7 @@ impl TryFrom<&[u8]> for SASetGroup {
 }
 impl Serialize for SASetGroup {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let group_bytes = self.group.serialize();
@@ -4455,7 +4455,7 @@ impl TryFrom<&[u8]> for SAMovePtr {
 }
 impl Serialize for SAMovePtr {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let x_high_bytes = self.x_high.serialize();
@@ -4512,7 +4512,7 @@ impl TryFrom<&[u8]> for SAPtrBtn {
 }
 impl Serialize for SAPtrBtn {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let count_bytes = self.count.serialize();
@@ -4564,7 +4564,7 @@ impl TryFrom<&[u8]> for SALockPtrBtn {
 }
 impl Serialize for SALockPtrBtn {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let button_bytes = self.button.serialize();
@@ -4679,7 +4679,7 @@ impl TryFrom<&[u8]> for SASetPtrDflt {
 }
 impl Serialize for SASetPtrDflt {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let affect_bytes = self.affect.serialize();
@@ -4854,7 +4854,7 @@ impl TryFrom<&[u8]> for SAIsoLock {
 }
 impl Serialize for SAIsoLock {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let mask_bytes = self.mask.serialize();
@@ -4908,7 +4908,7 @@ impl TryFrom<&[u8]> for SATerminate {
 }
 impl Serialize for SATerminate {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         [
             type_bytes[0],
@@ -5016,7 +5016,7 @@ impl TryFrom<&[u8]> for SASwitchScreen {
 }
 impl Serialize for SASwitchScreen {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let new_screen_bytes = self.new_screen.serialize();
@@ -5219,7 +5219,7 @@ impl TryFrom<&[u8]> for SASetControls {
 }
 impl Serialize for SASetControls {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let bool_ctrls_high_bytes = self.bool_ctrls_high.serialize();
         let bool_ctrls_low_bytes = self.bool_ctrls_low.serialize();
@@ -5337,7 +5337,7 @@ impl TryFrom<&[u8]> for SAActionMessage {
 }
 impl Serialize for SAActionMessage {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         [
@@ -5393,7 +5393,7 @@ impl TryFrom<&[u8]> for SARedirectKey {
 }
 impl Serialize for SARedirectKey {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let newkey_bytes = self.newkey.serialize();
         let mask_bytes = self.mask.serialize();
@@ -5455,7 +5455,7 @@ impl TryFrom<&[u8]> for SADeviceBtn {
 }
 impl Serialize for SADeviceBtn {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let count_bytes = self.count.serialize();
@@ -5574,7 +5574,7 @@ impl TryFrom<&[u8]> for SALockDeviceBtn {
 }
 impl Serialize for SALockDeviceBtn {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let flags_bytes = self.flags.serialize();
         let button_bytes = self.button.serialize();
@@ -5711,7 +5711,7 @@ impl TryFrom<&[u8]> for SADeviceValuator {
 }
 impl Serialize for SADeviceValuator {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let device_bytes = self.device.serialize();
         let val1what_bytes = u8::from(self.val1what).serialize();
@@ -5767,7 +5767,7 @@ impl TryFrom<&[u8]> for SIAction {
 }
 impl Serialize for SIAction {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         [
             type_bytes[0],
@@ -5816,7 +5816,7 @@ impl TryFrom<&[u8]> for SymInterpret {
 }
 impl Serialize for SymInterpret {
     type Bytes = [u8; 16];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 16] {
         let sym_bytes = self.sym.serialize();
         let mods_bytes = self.mods.serialize();
         let match_bytes = self.match_.serialize();
@@ -6036,7 +6036,7 @@ impl Action {
 }
 impl Serialize for Action {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         self.0
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
@@ -6232,7 +6232,7 @@ pub struct SelectEventsAuxBitcase1 {
 }
 impl Serialize for SelectEventsAuxBitcase1 {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let affect_new_keyboard_bytes = self.affect_new_keyboard.serialize();
         let new_keyboard_details_bytes = self.new_keyboard_details.serialize();
         [
@@ -6255,7 +6255,7 @@ pub struct SelectEventsAuxBitcase2 {
 }
 impl Serialize for SelectEventsAuxBitcase2 {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let affect_state_bytes = self.affect_state.serialize();
         let state_details_bytes = self.state_details.serialize();
         [
@@ -6278,7 +6278,7 @@ pub struct SelectEventsAuxBitcase3 {
 }
 impl Serialize for SelectEventsAuxBitcase3 {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let affect_ctrls_bytes = self.affect_ctrls.serialize();
         let ctrl_details_bytes = self.ctrl_details.serialize();
         [
@@ -6305,7 +6305,7 @@ pub struct SelectEventsAuxBitcase4 {
 }
 impl Serialize for SelectEventsAuxBitcase4 {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let affect_indicator_state_bytes = self.affect_indicator_state.serialize();
         let indicator_state_details_bytes = self.indicator_state_details.serialize();
         [
@@ -6332,7 +6332,7 @@ pub struct SelectEventsAuxBitcase5 {
 }
 impl Serialize for SelectEventsAuxBitcase5 {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let affect_indicator_map_bytes = self.affect_indicator_map.serialize();
         let indicator_map_details_bytes = self.indicator_map_details.serialize();
         [
@@ -6359,7 +6359,7 @@ pub struct SelectEventsAuxBitcase6 {
 }
 impl Serialize for SelectEventsAuxBitcase6 {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let affect_names_bytes = self.affect_names.serialize();
         let names_details_bytes = self.names_details.serialize();
         [
@@ -6382,7 +6382,7 @@ pub struct SelectEventsAuxBitcase7 {
 }
 impl Serialize for SelectEventsAuxBitcase7 {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let affect_compat_bytes = self.affect_compat.serialize();
         let compat_details_bytes = self.compat_details.serialize();
         [
@@ -6403,7 +6403,7 @@ pub struct SelectEventsAuxBitcase8 {
 }
 impl Serialize for SelectEventsAuxBitcase8 {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let affect_bell_bytes = self.affect_bell.serialize();
         let bell_details_bytes = self.bell_details.serialize();
         [
@@ -6424,7 +6424,7 @@ pub struct SelectEventsAuxBitcase9 {
 }
 impl Serialize for SelectEventsAuxBitcase9 {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let affect_msg_details_bytes = self.affect_msg_details.serialize();
         let msg_details_bytes = self.msg_details.serialize();
         [
@@ -6445,7 +6445,7 @@ pub struct SelectEventsAuxBitcase10 {
 }
 impl Serialize for SelectEventsAuxBitcase10 {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let affect_access_x_bytes = self.affect_access_x.serialize();
         let access_x_details_bytes = self.access_x_details.serialize();
         [
@@ -6468,7 +6468,7 @@ pub struct SelectEventsAuxBitcase11 {
 }
 impl Serialize for SelectEventsAuxBitcase11 {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let affect_ext_dev_bytes = self.affect_ext_dev.serialize();
         let extdev_details_bytes = self.extdev_details.serialize();
         [
@@ -6501,7 +6501,7 @@ pub struct SelectEventsAux {
 }
 impl Serialize for SelectEventsAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -7412,7 +7412,7 @@ pub struct SetMapAuxBitcase3 {
 }
 impl Serialize for SetMapAuxBitcase3 {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -7437,7 +7437,7 @@ pub struct SetMapAux {
 }
 impl Serialize for SetMapAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8338,7 +8338,7 @@ pub struct SetNamesAuxBitcase8 {
 }
 impl Serialize for SetNamesAuxBitcase8 {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8369,7 +8369,7 @@ pub struct SetNamesAux {
 }
 impl Serialize for SetNamesAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -73,7 +73,7 @@ impl TryFrom<&[u8]> for Printer {
 }
 impl Serialize for Printer {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -47,7 +47,7 @@ impl TryFrom<&[u8]> for Char2b {
 }
 impl Serialize for Char2b {
     type Bytes = [u8; 2];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 2] {
         let byte1_bytes = self.byte1.serialize();
         let byte2_bytes = self.byte2.serialize();
         [
@@ -115,7 +115,7 @@ impl TryFrom<&[u8]> for Point {
 }
 impl Serialize for Point {
     type Bytes = [u8; 4];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 4] {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         [
@@ -157,7 +157,7 @@ impl TryFrom<&[u8]> for Rectangle {
 }
 impl Serialize for Rectangle {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let width_bytes = self.width.serialize();
@@ -211,7 +211,7 @@ impl TryFrom<&[u8]> for Arc {
 }
 impl Serialize for Arc {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let width_bytes = self.width.serialize();
@@ -268,7 +268,7 @@ impl TryFrom<&[u8]> for Format {
 }
 impl Serialize for Format {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let depth_bytes = self.depth.serialize();
         let bits_per_pixel_bytes = self.bits_per_pixel.serialize();
         let scanline_pad_bytes = self.scanline_pad.serialize();
@@ -399,7 +399,7 @@ impl TryFrom<&[u8]> for Visualtype {
 }
 impl Serialize for Visualtype {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let visual_id_bytes = self.visual_id.serialize();
         let class_bytes = u8::from(self.class).serialize();
         let bits_per_rgb_value_bytes = self.bits_per_rgb_value.serialize();
@@ -471,7 +471,7 @@ impl TryFrom<&[u8]> for Depth {
 }
 impl Serialize for Depth {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -706,7 +706,7 @@ impl TryFrom<&[u8]> for Screen {
 }
 impl Serialize for Screen {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -776,7 +776,7 @@ impl TryFrom<&[u8]> for SetupRequest {
 }
 impl Serialize for SetupRequest {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -828,7 +828,7 @@ impl TryFrom<&[u8]> for SetupFailed {
 }
 impl Serialize for SetupFailed {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -869,7 +869,7 @@ impl TryFrom<&[u8]> for SetupAuthenticate {
 }
 impl Serialize for SetupAuthenticate {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -1021,7 +1021,7 @@ impl TryFrom<&[u8]> for Setup {
 }
 impl Serialize for Setup {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -5586,7 +5586,7 @@ impl ClientMessageData {
 }
 impl Serialize for ClientMessageData {
     type Bytes = [u8; 20];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 20] {
         self.0
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
@@ -7921,7 +7921,7 @@ pub struct CreateWindowAux {
 }
 impl Serialize for CreateWindowAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -8246,7 +8246,7 @@ pub struct ChangeWindowAttributesAux {
 }
 impl Serialize for ChangeWindowAttributesAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -9239,7 +9239,7 @@ pub struct ConfigureWindowAux {
 }
 impl Serialize for ConfigureWindowAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -12314,7 +12314,7 @@ impl TryFrom<&[u8]> for Timecoord {
 }
 impl Serialize for Timecoord {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let time_bytes = self.time.serialize();
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
@@ -12963,7 +12963,7 @@ impl TryFrom<&[u8]> for Fontprop {
 }
 impl Serialize for Fontprop {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let name_bytes = self.name.serialize();
         let value_bytes = self.value.serialize();
         [
@@ -13013,7 +13013,7 @@ impl TryFrom<&[u8]> for Charinfo {
 }
 impl Serialize for Charinfo {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let left_side_bearing_bytes = self.left_side_bearing.serialize();
         let right_side_bearing_bytes = self.right_side_bearing.serialize();
         let character_width_bytes = self.character_width.serialize();
@@ -13270,7 +13270,7 @@ impl TryFrom<&[u8]> for Str {
 }
 impl Serialize for Str {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -14451,7 +14451,7 @@ pub struct CreateGCAux {
 }
 impl Serialize for CreateGCAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -14817,7 +14817,7 @@ pub struct ChangeGCAux {
 }
 impl Serialize for ChangeGCAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -15759,7 +15759,7 @@ impl TryFrom<&[u8]> for Segment {
 }
 impl Serialize for Segment {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let x1_bytes = self.x1.serialize();
         let y1_bytes = self.y1.serialize();
         let x2_bytes = self.x2.serialize();
@@ -17211,7 +17211,7 @@ impl TryFrom<&[u8]> for Coloritem {
 }
 impl Serialize for Coloritem {
     type Bytes = [u8; 12];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 12] {
         let pixel_bytes = self.pixel.serialize();
         let red_bytes = self.red.serialize();
         let green_bytes = self.green.serialize();
@@ -17338,7 +17338,7 @@ impl TryFrom<&[u8]> for Rgb {
 }
 impl Serialize for Rgb {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let red_bytes = self.red.serialize();
         let green_bytes = self.green.serialize();
         let blue_bytes = self.blue.serialize();
@@ -18414,7 +18414,7 @@ pub struct ChangeKeyboardControlAux {
 }
 impl Serialize for ChangeKeyboardControlAux {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -19132,7 +19132,7 @@ impl TryFrom<&[u8]> for Host {
 }
 impl Serialize for Host {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -436,7 +436,7 @@ impl TryFrom<&[u8]> for ListItem {
 }
 impl Serialize for ListItem {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -554,7 +554,7 @@ impl TryFrom<&[u8]> for Rational {
 }
 impl Serialize for Rational {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let numerator_bytes = self.numerator.serialize();
         let denominator_bytes = self.denominator.serialize();
         [
@@ -597,7 +597,7 @@ impl TryFrom<&[u8]> for Format {
 }
 impl Serialize for Format {
     type Bytes = [u8; 8];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 8] {
         let visual_bytes = self.visual.serialize();
         let depth_bytes = self.depth.serialize();
         [
@@ -655,7 +655,7 @@ impl TryFrom<&[u8]> for AdaptorInfo {
 }
 impl Serialize for AdaptorInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -711,7 +711,7 @@ impl TryFrom<&[u8]> for EncodingInfo {
 }
 impl Serialize for EncodingInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -762,7 +762,7 @@ impl TryFrom<&[u8]> for Image {
 }
 impl Serialize for Image {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -814,7 +814,7 @@ impl TryFrom<&[u8]> for AttributeInfo {
 }
 impl Serialize for AttributeInfo {
     type Bytes = Vec<u8>;
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result);
         result
@@ -903,7 +903,7 @@ impl TryFrom<&[u8]> for ImageFormatInfo {
 }
 impl Serialize for ImageFormatInfo {
     type Bytes = [u8; 128];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 128] {
         let id_bytes = self.id.serialize();
         let type_bytes = u8::from(self.type_).serialize();
         let byte_order_bytes = u8::from(self.byte_order).serialize();

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -78,7 +78,7 @@ impl TryFrom<&[u8]> for SurfaceInfo {
 }
 impl Serialize for SurfaceInfo {
     type Bytes = [u8; 24];
-    fn serialize(&self) -> Self::Bytes {
+    fn serialize(&self) -> [u8; 24] {
         let id_bytes = self.id.serialize();
         let chroma_format_bytes = self.chroma_format.serialize();
         let pad0_bytes = self.pad0.serialize();


### PR DESCRIPTION
I have spitted this from https://github.com/psychon/x11rb/pull/382, in order to make the diff easier to review.