### PR TITLE
Parse xproto::Gravity in GetWindowAttributesReply (and also use it in the screensaver extension)

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -3624,10 +3624,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 xcbdefs::TypeRef::Enum(enum_def) => enum_def.upgrade().unwrap(),
                 _ => unreachable!(),
             };
-            if is_xproto_gravity(&enum_def) && self.ns.header == "xproto" {
-                return Some(enum_def)
-            }
-            if !self.enum_has_repeated_values(&enum_def) {
+            if !self.enum_has_repeated_values(&enum_def) || is_xproto_gravity(&enum_def) {
                 // The field can only have the values from the enum,
                 // use its type.
                 Some(enum_def)

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -395,8 +395,8 @@ pub struct SetAttributesAux {
     pub background_pixel: Option<u32>,
     pub border_pixmap: Option<xproto::Pixmap>,
     pub border_pixel: Option<u32>,
-    pub bit_gravity: Option<u32>,
-    pub win_gravity: Option<u32>,
+    pub bit_gravity: Option<xproto::Gravity>,
+    pub win_gravity: Option<xproto::Gravity>,
     pub backing_store: Option<xproto::BackingStore>,
     pub backing_planes: Option<u32>,
     pub backing_pixel: Option<u32>,
@@ -428,10 +428,10 @@ impl Serialize for SetAttributesAux {
             border_pixel.serialize_into(bytes);
         }
         if let Some(bit_gravity) = self.bit_gravity {
-            bit_gravity.serialize_into(bytes);
+            u32::from(bit_gravity).serialize_into(bytes);
         }
         if let Some(win_gravity) = self.win_gravity {
-            win_gravity.serialize_into(bytes);
+            u32::from(win_gravity).serialize_into(bytes);
         }
         if let Some(backing_store) = self.backing_store {
             u32::from(backing_store).serialize_into(bytes);
@@ -539,12 +539,12 @@ impl SetAttributesAux {
         self
     }
     /// Set the `bit_gravity` field of this structure.
-    pub fn bit_gravity<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn bit_gravity<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Gravity>> {
         self.bit_gravity = value.into();
         self
     }
     /// Set the `win_gravity` field of this structure.
-    pub fn win_gravity<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn win_gravity<I>(mut self, value: I) -> Self where I: Into<Option<xproto::Gravity>> {
         self.win_gravity = value.into();
         self
     }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -7897,6 +7897,25 @@ impl From<Gravity> for Option<u32> {
         Some(u32::from(input))
     }
 }
+impl Gravity {
+    fn try_from(value: impl Into<u32>, value_for_zero: Self) -> Result<Self, ParseError> {
+        let value = value.into();
+        match value {
+            0 => Ok(value_for_zero),
+            1 => Ok(Gravity::NorthWest),
+            2 => Ok(Gravity::North),
+            3 => Ok(Gravity::NorthEast),
+            4 => Ok(Gravity::West),
+            5 => Ok(Gravity::Center),
+            6 => Ok(Gravity::East),
+            7 => Ok(Gravity::SouthWest),
+            8 => Ok(Gravity::South),
+            9 => Ok(Gravity::SouthEast),
+            10 => Ok(Gravity::Static),
+            _ => Err(ParseError::ParseError),
+        }
+    }
+}
 
 /// Opcode for the CreateWindow request
 pub const CREATE_WINDOW_REQUEST: u8 = 1;

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -7926,8 +7926,8 @@ pub struct CreateWindowAux {
     pub background_pixel: Option<u32>,
     pub border_pixmap: Option<Pixmap>,
     pub border_pixel: Option<u32>,
-    pub bit_gravity: Option<u32>,
-    pub win_gravity: Option<u32>,
+    pub bit_gravity: Option<Gravity>,
+    pub win_gravity: Option<Gravity>,
     pub backing_store: Option<BackingStore>,
     pub backing_planes: Option<u32>,
     pub backing_pixel: Option<u32>,
@@ -7959,10 +7959,10 @@ impl Serialize for CreateWindowAux {
             border_pixel.serialize_into(bytes);
         }
         if let Some(bit_gravity) = self.bit_gravity {
-            bit_gravity.serialize_into(bytes);
+            u32::from(bit_gravity).serialize_into(bytes);
         }
         if let Some(win_gravity) = self.win_gravity {
-            win_gravity.serialize_into(bytes);
+            u32::from(win_gravity).serialize_into(bytes);
         }
         if let Some(backing_store) = self.backing_store {
             u32::from(backing_store).serialize_into(bytes);
@@ -8070,12 +8070,12 @@ impl CreateWindowAux {
         self
     }
     /// Set the `bit_gravity` field of this structure.
-    pub fn bit_gravity<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn bit_gravity<I>(mut self, value: I) -> Self where I: Into<Option<Gravity>> {
         self.bit_gravity = value.into();
         self
     }
     /// Set the `win_gravity` field of this structure.
-    pub fn win_gravity<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn win_gravity<I>(mut self, value: I) -> Self where I: Into<Option<Gravity>> {
         self.win_gravity = value.into();
         self
     }
@@ -8251,8 +8251,8 @@ pub struct ChangeWindowAttributesAux {
     pub background_pixel: Option<u32>,
     pub border_pixmap: Option<Pixmap>,
     pub border_pixel: Option<u32>,
-    pub bit_gravity: Option<u32>,
-    pub win_gravity: Option<u32>,
+    pub bit_gravity: Option<Gravity>,
+    pub win_gravity: Option<Gravity>,
     pub backing_store: Option<BackingStore>,
     pub backing_planes: Option<u32>,
     pub backing_pixel: Option<u32>,
@@ -8284,10 +8284,10 @@ impl Serialize for ChangeWindowAttributesAux {
             border_pixel.serialize_into(bytes);
         }
         if let Some(bit_gravity) = self.bit_gravity {
-            bit_gravity.serialize_into(bytes);
+            u32::from(bit_gravity).serialize_into(bytes);
         }
         if let Some(win_gravity) = self.win_gravity {
-            win_gravity.serialize_into(bytes);
+            u32::from(win_gravity).serialize_into(bytes);
         }
         if let Some(backing_store) = self.backing_store {
             u32::from(backing_store).serialize_into(bytes);
@@ -8395,12 +8395,12 @@ impl ChangeWindowAttributesAux {
         self
     }
     /// Set the `bit_gravity` field of this structure.
-    pub fn bit_gravity<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn bit_gravity<I>(mut self, value: I) -> Self where I: Into<Option<Gravity>> {
         self.bit_gravity = value.into();
         self
     }
     /// Set the `win_gravity` field of this structure.
-    pub fn win_gravity<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn win_gravity<I>(mut self, value: I) -> Self where I: Into<Option<Gravity>> {
         self.win_gravity = value.into();
         self
     }
@@ -8631,8 +8631,8 @@ pub struct GetWindowAttributesReply {
     pub length: u32,
     pub visual: Visualid,
     pub class: WindowClass,
-    pub bit_gravity: u8,
-    pub win_gravity: u8,
+    pub bit_gravity: Gravity,
+    pub win_gravity: Gravity,
     pub backing_planes: u32,
     pub backing_pixel: u32,
     pub save_under: bool,
@@ -8667,6 +8667,8 @@ impl TryParse for GetWindowAttributesReply {
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let backing_store = backing_store.try_into()?;
         let class = class.try_into()?;
+        let bit_gravity = Gravity::try_from(bit_gravity, Gravity::BitForget)?;
+        let win_gravity = Gravity::try_from(win_gravity, Gravity::WinUnmap)?;
         let map_state = map_state.try_into()?;
         let result = GetWindowAttributesReply { response_type, backing_store, sequence, length, visual, class, bit_gravity, win_gravity, backing_planes, backing_pixel, save_under, map_is_installed, map_state, override_redirect, colormap, all_event_masks, your_event_mask, do_not_propagate_mask };
         Ok((result, remaining))


### PR DESCRIPTION
This fixes #351. The diff looks larger than it really is, because a new indentation level had to be added. Looking at the diff with `git diff -w` leads to less changes, but still some.