### PR TITLE
Some changes to `RawFdContainer`

### DIFF
--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -158,6 +158,7 @@ extern "C" {
         vector: *mut iovec,
         request: *const xcb_protocol_request_t,
     ) -> u64;
+    #[cfg(unix)]
     pub(crate) fn xcb_send_request_with_fds64(
         c: *mut xcb_connection_t,
         flags: c_int,
@@ -305,6 +306,7 @@ mod mock {
         unimplemented!();
     }
 
+    #[cfg(unix)]
     pub(crate) unsafe fn xcb_send_request_with_fds64(
         _c: *mut xcb_connection_t,
         _flags: c_int,


### PR DESCRIPTION
* Methods are not provided at all on non-unix systems or when `allow-unsafe-code` is disabled. Trying to create a `RawFdContainer` when it is not available will cause a compile error instead of panicking at runtime.
* `drop` does not panic on failure. Instead, a `close` method is provided that allows the caller to check for errors.
* A `try_clone` method has been added. It allows to clone a `RawFdContainer` creating a new FD with `dup`.