### PR TITLE
Do a one-time formatting of code in doc comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,19 @@
 //!     let (conn, screen_num) = x11rb::connect(None).unwrap();
 //!     let screen = &conn.setup().roots[screen_num];
 //!     let win_id = conn.generate_id()?;
-//!     conn.create_window(COPY_DEPTH_FROM_PARENT, win_id, screen.root, 0, 0, 100, 100, 0, WindowClass::InputOutput,
-//!                        0, &CreateWindowAux::new().background_pixel(screen.white_pixel))?;
+//!     conn.create_window(
+//!         COPY_DEPTH_FROM_PARENT,
+//!         win_id,
+//!         screen.root,
+//!         0,
+//!         0,
+//!         100,
+//!         100,
+//!         0,
+//!         WindowClass::InputOutput,
+//!         0,
+//!         &CreateWindowAux::new().background_pixel(screen.white_pixel),
+//!     )?;
 //!     conn.map_window(win_id)?;
 //!     conn.flush();
 //!     loop {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -69,8 +69,10 @@ where
 ///     // ASCII values are most common and for these from_utf8() should be fine.
 ///     let class = std::str::from_utf8(wm_class.class());
 ///     let instance = std::str::from_utf8(wm_class.instance());
-///     println!("For window {:x}, class is '{:?}' and instance is '{:?}'",
-///         window, class, instance);
+///     println!(
+///         "For window {:x}, class is '{:?}' and instance is '{:?}'",
+///         window, class, instance,
+///     );
 ///     Ok(true)
 /// }
 /// ```

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -311,8 +311,7 @@ macro_rules! bitmask_binop {
 /// }
 ///
 /// #[allow(non_snake_case)]
-/// struct AtomCollectionCookie<'c, C: ConnectionExt>
-/// {
+/// struct AtomCollectionCookie<'c, C: ConnectionExt> {
 ///     _NET_WM_NAME: Cookie<'c, C, InternAtomReply>,
 ///     _NET_WM_ICON: Cookie<'c, C, InternAtomReply>,
 ///     ATOM_WITH_SPACES: Cookie<'c, C, InternAtomReply>,
@@ -320,8 +319,9 @@ macro_rules! bitmask_binop {
 /// }
 ///
 /// impl AtomCollection {
-///     pub fn new<C: ConnectionExt>(conn: &C) -> Result<AtomCollectionCookie<'_, C>, ConnectionError>
-///     {
+///     pub fn new<C: ConnectionExt>(
+///         conn: &C,
+///     ) -> Result<AtomCollectionCookie<'_, C>, ConnectionError> {
 ///         Ok(AtomCollectionCookie {
 ///             _NET_WM_NAME: conn.intern_atom(false, b"_NET_WM_NAME")?,
 ///             _NET_WM_ICON: conn.intern_atom(false, b"_NET_WM_ICON")?,
@@ -332,7 +332,8 @@ macro_rules! bitmask_binop {
 /// }
 ///
 /// impl<'c, C> AtomCollectionCookie<'c, C>
-/// where C: ConnectionExt
+/// where
+///     C: ConnectionExt,
 /// {
 ///     pub fn reply(self) -> Result<AtomCollection, ReplyError<C::Buf>> {
 ///         Ok(AtomCollection {


### PR DESCRIPTION
Did so with `cargo +nightly fmt -- --config format_code_in_doc_comments=true`.