### PR TITLE
Add accessors for length fields

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -1994,6 +1994,13 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             })
             .collect::<Vec<_>>();
         if !deducible.is_empty() {
+            if deducible
+                .iter()
+                .any(|(field, _)| field.name() == Some("len"))
+            {
+                let comment = "This is not a container and is_empty() makes no sense";
+                outln!(out, "#[allow(clippy::len_without_is_empty)] // {}", comment);
+            }
             outln!(out, "impl {} {{", name);
             for (field, (list_name, op)) in deducible {
                 let field_type = self.field_to_rust_type(field, switch_prefix);

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2011,8 +2011,8 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     outln!(out, "///");
                     outln!(out, "/// # Panics");
                     outln!(out, "///");
-                    outln!(out, "/// Panics if the value cannot be represented in the target type. This can");
-                    outln!(out, "/// not happen with values of the struct received from the X11 server.");
+                    outln!(out, "/// Panics if the value cannot be represented in the target type. This");
+                    outln!(out, "/// cannot happen with values of the struct received from the X11 server.");
                     outln!(out, "pub fn {}(&self) -> {} {{", to_rust_variable_name(&name), field_type);
                     out.indented(|out| {
                         outln!(out, "self.{}.len()", to_rust_variable_name(&list_name));

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -499,8 +499,8 @@ impl ConnectReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn driver_name_length(&self) -> u32 {
         self.driver_name.len()
             .try_into().unwrap()
@@ -512,8 +512,8 @@ impl ConnectReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn device_name_length(&self) -> u32 {
         self.device_name.len()
             .try_into().unwrap()
@@ -705,8 +705,8 @@ impl GetBuffersReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn count(&self) -> u32 {
         self.buffers.len()
             .try_into().unwrap()
@@ -852,8 +852,8 @@ impl GetBuffersWithFormatReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn count(&self) -> u32 {
         self.buffers.len()
             .try_into().unwrap()

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -491,6 +491,34 @@ impl TryFrom<&[u8]> for ConnectReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ConnectReply {
+    /// Get the value of the `driver_name_length` field.
+    ///
+    /// The `driver_name_length` field is used as the length field of the `driver_name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn driver_name_length(&self) -> u32 {
+        self.driver_name.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `device_name_length` field.
+    ///
+    /// The `device_name_length` field is used as the length field of the `device_name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn device_name_length(&self) -> u32 {
+        self.device_name.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the Authenticate request
 pub const AUTHENTICATE_REQUEST: u8 = 2;
@@ -669,6 +697,21 @@ impl TryFrom<&[u8]> for GetBuffersReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetBuffersReply {
+    /// Get the value of the `count` field.
+    ///
+    /// The `count` field is used as the length field of the `buffers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn count(&self) -> u32 {
+        self.buffers.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 6;
@@ -799,6 +842,21 @@ impl TryFrom<&[u8]> for GetBuffersWithFormatReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetBuffersWithFormatReply {
+    /// Get the value of the `count` field.
+    ///
+    /// The `count` field is used as the length field of the `buffers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn count(&self) -> u32 {
+        self.buffers.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -433,6 +433,34 @@ impl TryFrom<&[u8]> for GetSupportedModifiersReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetSupportedModifiersReply {
+    /// Get the value of the `num_window_modifiers` field.
+    ///
+    /// The `num_window_modifiers` field is used as the length field of the `window_modifiers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_window_modifiers(&self) -> u32 {
+        self.window_modifiers.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_screen_modifiers` field.
+    ///
+    /// The `num_screen_modifiers` field is used as the length field of the `screen_modifiers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_screen_modifiers(&self) -> u32 {
+        self.screen_modifiers.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the PixmapFromBuffers request
 pub const PIXMAP_FROM_BUFFERS_REQUEST: u8 = 7;
@@ -602,6 +630,21 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for BuffersFromPixmapReply {
     fn try_from(value: (&[u8], Vec<RawFdContainer>)) -> Result<Self, Self::Error> {
         let (value, mut fds) = value;
         Ok(Self::try_parse_fd(value, &mut fds)?.0)
+    }
+}
+impl BuffersFromPixmapReply {
+    /// Get the value of the `nfd` field.
+    ///
+    /// The `nfd` field is used as the length field of the `strides` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn nfd(&self) -> u8 {
+        self.strides.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -441,8 +441,8 @@ impl GetSupportedModifiersReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_window_modifiers(&self) -> u32 {
         self.window_modifiers.len()
             .try_into().unwrap()
@@ -454,8 +454,8 @@ impl GetSupportedModifiersReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_screen_modifiers(&self) -> u32 {
         self.screen_modifiers.len()
             .try_into().unwrap()
@@ -640,8 +640,8 @@ impl BuffersFromPixmapReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn nfd(&self) -> u8 {
         self.strides.len()
             .try_into().unwrap()

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -1156,8 +1156,8 @@ impl GetVisualConfigsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.property_list.len()
             .try_into().unwrap()
@@ -1298,8 +1298,8 @@ impl VendorPrivateWithReplyReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data2.len()
             .checked_div(4).unwrap()
@@ -1429,8 +1429,8 @@ impl QueryServerStringReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn str_len(&self) -> u32 {
         self.string.len()
             .try_into().unwrap()
@@ -1541,8 +1541,8 @@ impl GetFBConfigsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.property_list.len()
             .try_into().unwrap()
@@ -1742,8 +1742,8 @@ impl QueryContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_attribs(&self) -> u32 {
         self.attribs.len()
             .checked_div(2).unwrap()
@@ -1955,8 +1955,8 @@ impl GetDrawableAttributesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_attribs(&self) -> u32 {
         self.attribs.len()
             .checked_div(2).unwrap()
@@ -2551,8 +2551,8 @@ impl RenderModeReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -2829,8 +2829,8 @@ impl ReadPixelsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -2907,8 +2907,8 @@ impl GetBooleanvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -2979,8 +2979,8 @@ impl GetClipPlaneReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_mul(2).unwrap()
@@ -3057,8 +3057,8 @@ impl GetDoublevReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3186,8 +3186,8 @@ impl GetFloatvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3263,8 +3263,8 @@ impl GetIntegervReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3345,8 +3345,8 @@ impl GetLightfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3427,8 +3427,8 @@ impl GetLightivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3509,8 +3509,8 @@ impl GetMapdvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3591,8 +3591,8 @@ impl GetMapfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3673,8 +3673,8 @@ impl GetMapivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3755,8 +3755,8 @@ impl GetMaterialfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3837,8 +3837,8 @@ impl GetMaterialivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3914,8 +3914,8 @@ impl GetPixelMapfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -3991,8 +3991,8 @@ impl GetPixelMapuivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4068,8 +4068,8 @@ impl GetPixelMapusvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4141,8 +4141,8 @@ impl GetPolygonStippleReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -4218,8 +4218,8 @@ impl GetStringReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.string.len()
             .try_into().unwrap()
@@ -4300,8 +4300,8 @@ impl GetTexEnvfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4382,8 +4382,8 @@ impl GetTexEnvivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4464,8 +4464,8 @@ impl GetTexGendvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4546,8 +4546,8 @@ impl GetTexGenfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4628,8 +4628,8 @@ impl GetTexGenivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4728,8 +4728,8 @@ impl GetTexImageReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -4811,8 +4811,8 @@ impl GetTexParameterfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4893,8 +4893,8 @@ impl GetTexParameterivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -4980,8 +4980,8 @@ impl GetTexLevelParameterfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -5067,8 +5067,8 @@ impl GetTexLevelParameterivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -5287,8 +5287,8 @@ impl AreTexturesResidentReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -5397,8 +5397,8 @@ impl GenTexturesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -5545,8 +5545,8 @@ impl GetColorTableReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -5628,8 +5628,8 @@ impl GetColorTableParameterfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -5710,8 +5710,8 @@ impl GetColorTableParameterivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -5803,8 +5803,8 @@ impl GetConvolutionFilterReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -5886,8 +5886,8 @@ impl GetConvolutionParameterfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -5968,8 +5968,8 @@ impl GetConvolutionParameterivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -6061,8 +6061,8 @@ impl GetSeparableFilterReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.rows_and_cols.len()
             .checked_div(4).unwrap()
@@ -6154,8 +6154,8 @@ impl GetHistogramReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -6237,8 +6237,8 @@ impl GetHistogramParameterfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -6319,8 +6319,8 @@ impl GetHistogramParameterivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -6408,8 +6408,8 @@ impl GetMinmaxReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -6491,8 +6491,8 @@ impl GetMinmaxParameterfvReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -6573,8 +6573,8 @@ impl GetMinmaxParameterivReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -6654,8 +6654,8 @@ impl GetCompressedTexImageARBReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -6764,8 +6764,8 @@ impl GenQueriesARBReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -6903,8 +6903,8 @@ impl GetQueryivARBReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -6985,8 +6985,8 @@ impl GetQueryObjectivARBReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -7067,8 +7067,8 @@ impl GetQueryObjectuivARBReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -1148,6 +1148,21 @@ impl TryFrom<&[u8]> for GetVisualConfigsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetVisualConfigsReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `property_list` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.property_list.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the DestroyGLXPixmap request
 pub const DESTROY_GLX_PIXMAP_REQUEST: u8 = 15;
@@ -1275,6 +1290,22 @@ impl TryFrom<&[u8]> for VendorPrivateWithReplyReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl VendorPrivateWithReplyReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data2` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data2.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryExtensionsString request
 pub const QUERY_EXTENSIONS_STRING_REQUEST: u8 = 18;
@@ -1390,6 +1421,21 @@ impl TryFrom<&[u8]> for QueryServerStringReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryServerStringReply {
+    /// Get the value of the `str_len` field.
+    ///
+    /// The `str_len` field is used as the length field of the `string` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn str_len(&self) -> u32 {
+        self.string.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ClientInfo request
 pub const CLIENT_INFO_REQUEST: u8 = 20;
@@ -1485,6 +1531,21 @@ impl TryFrom<&[u8]> for GetFBConfigsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetFBConfigsReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `property_list` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.property_list.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1671,6 +1732,22 @@ impl TryFrom<&[u8]> for QueryContextReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryContextReply {
+    /// Get the value of the `num_attribs` field.
+    ///
+    /// The `num_attribs` field is used as the length field of the `attribs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_attribs(&self) -> u32 {
+        self.attribs.len()
+            .checked_div(2).unwrap()
+            .try_into().unwrap()
     }
 }
 
@@ -1868,6 +1945,22 @@ impl TryFrom<&[u8]> for GetDrawableAttributesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetDrawableAttributesReply {
+    /// Get the value of the `num_attribs` field.
+    ///
+    /// The `num_attribs` field is used as the length field of the `attribs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_attribs(&self) -> u32 {
+        self.attribs.len()
+            .checked_div(2).unwrap()
+            .try_into().unwrap()
     }
 }
 
@@ -2450,6 +2543,21 @@ impl TryFrom<&[u8]> for RenderModeReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl RenderModeReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
@@ -2713,6 +2821,22 @@ impl TryFrom<&[u8]> for ReadPixelsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ReadPixelsReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetBooleanv request
 pub const GET_BOOLEANV_REQUEST: u8 = 112;
@@ -2775,6 +2899,21 @@ impl TryFrom<&[u8]> for GetBooleanvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetBooleanvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetClipPlane request
 pub const GET_CLIP_PLANE_REQUEST: u8 = 113;
@@ -2830,6 +2969,22 @@ impl TryFrom<&[u8]> for GetClipPlaneReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetClipPlaneReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_mul(2).unwrap()
+            .try_into().unwrap()
     }
 }
 
@@ -2892,6 +3047,21 @@ impl TryFrom<&[u8]> for GetDoublevReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetDoublevReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3008,6 +3178,21 @@ impl TryFrom<&[u8]> for GetFloatvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetFloatvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetIntegerv request
 pub const GET_INTEGERV_REQUEST: u8 = 117;
@@ -3068,6 +3253,21 @@ impl TryFrom<&[u8]> for GetIntegervReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetIntegervReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3137,6 +3337,21 @@ impl TryFrom<&[u8]> for GetLightfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetLightfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetLightiv request
 pub const GET_LIGHTIV_REQUEST: u8 = 119;
@@ -3202,6 +3417,21 @@ impl TryFrom<&[u8]> for GetLightivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetLightivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3271,6 +3501,21 @@ impl TryFrom<&[u8]> for GetMapdvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetMapdvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetMapfv request
 pub const GET_MAPFV_REQUEST: u8 = 121;
@@ -3336,6 +3581,21 @@ impl TryFrom<&[u8]> for GetMapfvReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetMapfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3405,6 +3665,21 @@ impl TryFrom<&[u8]> for GetMapivReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetMapivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetMaterialfv request
 pub const GET_MATERIALFV_REQUEST: u8 = 123;
@@ -3470,6 +3745,21 @@ impl TryFrom<&[u8]> for GetMaterialfvReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetMaterialfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3539,6 +3829,21 @@ impl TryFrom<&[u8]> for GetMaterialivReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetMaterialivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetPixelMapfv request
 pub const GET_PIXEL_MAPFV_REQUEST: u8 = 125;
@@ -3599,6 +3904,21 @@ impl TryFrom<&[u8]> for GetPixelMapfvReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetPixelMapfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3663,6 +3983,21 @@ impl TryFrom<&[u8]> for GetPixelMapuivReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetPixelMapuivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetPixelMapusv request
 pub const GET_PIXEL_MAPUSV_REQUEST: u8 = 127;
@@ -3725,6 +4060,21 @@ impl TryFrom<&[u8]> for GetPixelMapusvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetPixelMapusvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetPolygonStipple request
 pub const GET_POLYGON_STIPPLE_REQUEST: u8 = 128;
@@ -3781,6 +4131,22 @@ impl TryFrom<&[u8]> for GetPolygonStippleReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetPolygonStippleReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
     }
 }
 
@@ -3842,6 +4208,21 @@ impl TryFrom<&[u8]> for GetStringReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetStringReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `string` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.string.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3911,6 +4292,21 @@ impl TryFrom<&[u8]> for GetTexEnvfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetTexEnvfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetTexEnviv request
 pub const GET_TEX_ENVIV_REQUEST: u8 = 131;
@@ -3976,6 +4372,21 @@ impl TryFrom<&[u8]> for GetTexEnvivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetTexEnvivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -4045,6 +4456,21 @@ impl TryFrom<&[u8]> for GetTexGendvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetTexGendvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetTexGenfv request
 pub const GET_TEX_GENFV_REQUEST: u8 = 133;
@@ -4112,6 +4538,21 @@ impl TryFrom<&[u8]> for GetTexGenfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetTexGenfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetTexGeniv request
 pub const GET_TEX_GENIV_REQUEST: u8 = 134;
@@ -4177,6 +4618,21 @@ impl TryFrom<&[u8]> for GetTexGenivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetTexGenivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -4264,6 +4720,22 @@ impl TryFrom<&[u8]> for GetTexImageReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetTexImageReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetTexParameterfv request
 pub const GET_TEX_PARAMETERFV_REQUEST: u8 = 136;
@@ -4331,6 +4803,21 @@ impl TryFrom<&[u8]> for GetTexParameterfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetTexParameterfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetTexParameteriv request
 pub const GET_TEX_PARAMETERIV_REQUEST: u8 = 137;
@@ -4396,6 +4883,21 @@ impl TryFrom<&[u8]> for GetTexParameterivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetTexParameterivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -4470,6 +4972,21 @@ impl TryFrom<&[u8]> for GetTexLevelParameterfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetTexLevelParameterfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetTexLevelParameteriv request
 pub const GET_TEX_LEVEL_PARAMETERIV_REQUEST: u8 = 139;
@@ -4540,6 +5057,21 @@ impl TryFrom<&[u8]> for GetTexLevelParameterivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetTexLevelParameterivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -4747,6 +5279,22 @@ impl TryFrom<&[u8]> for AreTexturesResidentReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl AreTexturesResidentReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the DeleteTextures request
 pub const DELETE_TEXTURES_REQUEST: u8 = 144;
@@ -4839,6 +5387,21 @@ impl TryFrom<&[u8]> for GenTexturesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GenTexturesReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -4974,6 +5537,22 @@ impl TryFrom<&[u8]> for GetColorTableReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetColorTableReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetColorTableParameterfv request
 pub const GET_COLOR_TABLE_PARAMETERFV_REQUEST: u8 = 148;
@@ -5041,6 +5620,21 @@ impl TryFrom<&[u8]> for GetColorTableParameterfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetColorTableParameterfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetColorTableParameteriv request
 pub const GET_COLOR_TABLE_PARAMETERIV_REQUEST: u8 = 149;
@@ -5106,6 +5700,21 @@ impl TryFrom<&[u8]> for GetColorTableParameterivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetColorTableParameterivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -5186,6 +5795,22 @@ impl TryFrom<&[u8]> for GetConvolutionFilterReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetConvolutionFilterReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetConvolutionParameterfv request
 pub const GET_CONVOLUTION_PARAMETERFV_REQUEST: u8 = 151;
@@ -5253,6 +5878,21 @@ impl TryFrom<&[u8]> for GetConvolutionParameterfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetConvolutionParameterfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetConvolutionParameteriv request
 pub const GET_CONVOLUTION_PARAMETERIV_REQUEST: u8 = 152;
@@ -5318,6 +5958,21 @@ impl TryFrom<&[u8]> for GetConvolutionParameterivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetConvolutionParameterivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -5398,6 +6053,22 @@ impl TryFrom<&[u8]> for GetSeparableFilterReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetSeparableFilterReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `rows_and_cols` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.rows_and_cols.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetHistogram request
 pub const GET_HISTOGRAM_REQUEST: u8 = 154;
@@ -5475,6 +6146,22 @@ impl TryFrom<&[u8]> for GetHistogramReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetHistogramReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetHistogramParameterfv request
 pub const GET_HISTOGRAM_PARAMETERFV_REQUEST: u8 = 155;
@@ -5542,6 +6229,21 @@ impl TryFrom<&[u8]> for GetHistogramParameterfvReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetHistogramParameterfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetHistogramParameteriv request
 pub const GET_HISTOGRAM_PARAMETERIV_REQUEST: u8 = 156;
@@ -5607,6 +6309,21 @@ impl TryFrom<&[u8]> for GetHistogramParameterivReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetHistogramParameterivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -5683,6 +6400,22 @@ impl TryFrom<&[u8]> for GetMinmaxReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetMinmaxReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetMinmaxParameterfv request
 pub const GET_MINMAX_PARAMETERFV_REQUEST: u8 = 158;
@@ -5748,6 +6481,21 @@ impl TryFrom<&[u8]> for GetMinmaxParameterfvReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetMinmaxParameterfvReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -5817,6 +6565,21 @@ impl TryFrom<&[u8]> for GetMinmaxParameterivReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetMinmaxParameterivReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetCompressedTexImageARB request
 pub const GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST: u8 = 160;
@@ -5881,6 +6644,22 @@ impl TryFrom<&[u8]> for GetCompressedTexImageARBReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetCompressedTexImageARBReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
     }
 }
 
@@ -5975,6 +6754,21 @@ impl TryFrom<&[u8]> for GenQueriesARBReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GenQueriesARBReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -6101,6 +6895,21 @@ impl TryFrom<&[u8]> for GetQueryivARBReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetQueryivARBReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetQueryObjectivARB request
 pub const GET_QUERY_OBJECTIV_ARB_REQUEST: u8 = 165;
@@ -6168,6 +6977,21 @@ impl TryFrom<&[u8]> for GetQueryObjectivARBReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetQueryObjectivARBReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetQueryObjectuivARB request
 pub const GET_QUERY_OBJECTUIV_ARB_REQUEST: u8 = 166;
@@ -6233,6 +7057,21 @@ impl TryFrom<&[u8]> for GetQueryObjectuivARBReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetQueryObjectuivARBReply {
+    /// Get the value of the `n` field.
+    ///
+    /// The `n` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -482,6 +482,21 @@ impl Serialize for RefreshRates {
         self.rates.serialize_into(bytes);
     }
 }
+impl RefreshRates {
+    /// Get the value of the `nRates` field.
+    ///
+    /// The `nRates` field is used as the length field of the `rates` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_rates(&self) -> u16 {
+        self.rates.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
@@ -881,6 +896,21 @@ impl TryFrom<&[u8]> for GetScreenInfoReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetScreenInfoReply {
+    /// Get the value of the `nSizes` field.
+    ///
+    /// The `nSizes` field is used as the length field of the `sizes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_sizes(&self) -> u16 {
+        self.sizes.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetScreenSizeRange request
 pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
@@ -1244,6 +1274,60 @@ impl TryFrom<&[u8]> for GetScreenResourcesReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetScreenResourcesReply {
+    /// Get the value of the `num_crtcs` field.
+    ///
+    /// The `num_crtcs` field is used as the length field of the `crtcs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_crtcs(&self) -> u16 {
+        self.crtcs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_outputs` field.
+    ///
+    /// The `num_outputs` field is used as the length field of the `outputs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_outputs(&self) -> u16 {
+        self.outputs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_modes` field.
+    ///
+    /// The `num_modes` field is used as the length field of the `modes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_modes(&self) -> u16 {
+        self.modes.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `names_len` field.
+    ///
+    /// The `names_len` field is used as the length field of the `names` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn names_len(&self) -> u16 {
+        self.names.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -1395,6 +1479,60 @@ impl TryFrom<&[u8]> for GetOutputInfoReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetOutputInfoReply {
+    /// Get the value of the `num_crtcs` field.
+    ///
+    /// The `num_crtcs` field is used as the length field of the `crtcs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_crtcs(&self) -> u16 {
+        self.crtcs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_modes` field.
+    ///
+    /// The `num_modes` field is used as the length field of the `modes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_modes(&self) -> u16 {
+        self.modes.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_clones` field.
+    ///
+    /// The `num_clones` field is used as the length field of the `clones` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_clones(&self) -> u16 {
+        self.clones.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ListOutputProperties request
 pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
@@ -1447,6 +1585,21 @@ impl TryFrom<&[u8]> for ListOutputPropertiesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListOutputPropertiesReply {
+    /// Get the value of the `num_atoms` field.
+    ///
+    /// The `num_atoms` field is used as the length field of the `atoms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_atoms(&self) -> u16 {
+        self.atoms.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1510,6 +1663,21 @@ impl TryFrom<&[u8]> for QueryOutputPropertyReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryOutputPropertyReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `validValues` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.valid_values.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1986,6 +2154,34 @@ impl TryFrom<&[u8]> for GetCrtcInfoReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetCrtcInfoReply {
+    /// Get the value of the `num_outputs` field.
+    ///
+    /// The `num_outputs` field is used as the length field of the `outputs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_outputs(&self) -> u16 {
+        self.outputs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_possible_outputs` field.
+    ///
+    /// The `num_possible_outputs` field is used as the length field of the `possible` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_possible_outputs(&self) -> u16 {
+        self.possible.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetCrtcConfig request
 pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
@@ -2184,6 +2380,21 @@ impl TryFrom<&[u8]> for GetCrtcGammaReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetCrtcGammaReply {
+    /// Get the value of the `size` field.
+    ///
+    /// The `size` field is used as the length field of the `red` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn size(&self) -> u16 {
+        self.red.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetCrtcGamma request
 pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
@@ -2293,6 +2504,60 @@ impl TryFrom<&[u8]> for GetScreenResourcesCurrentReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetScreenResourcesCurrentReply {
+    /// Get the value of the `num_crtcs` field.
+    ///
+    /// The `num_crtcs` field is used as the length field of the `crtcs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_crtcs(&self) -> u16 {
+        self.crtcs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_outputs` field.
+    ///
+    /// The `num_outputs` field is used as the length field of the `outputs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_outputs(&self) -> u16 {
+        self.outputs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_modes` field.
+    ///
+    /// The `num_modes` field is used as the length field of the `modes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_modes(&self) -> u16 {
+        self.modes.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `names_len` field.
+    ///
+    /// The `names_len` field is used as the length field of the `names` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn names_len(&self) -> u16 {
+        self.names.len()
+            .try_into().unwrap()
     }
 }
 
@@ -2520,6 +2785,60 @@ impl TryFrom<&[u8]> for GetCrtcTransformReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetCrtcTransformReply {
+    /// Get the value of the `pending_len` field.
+    ///
+    /// The `pending_len` field is used as the length field of the `pending_filter_name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn pending_len(&self) -> u16 {
+        self.pending_filter_name.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `pending_nparams` field.
+    ///
+    /// The `pending_nparams` field is used as the length field of the `pending_params` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn pending_nparams(&self) -> u16 {
+        self.pending_params.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `current_len` field.
+    ///
+    /// The `current_len` field is used as the length field of the `current_filter_name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn current_len(&self) -> u16 {
+        self.current_filter_name.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `current_nparams` field.
+    ///
+    /// The `current_nparams` field is used as the length field of the `current_params` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn current_nparams(&self) -> u16 {
+        self.current_params.len()
+            .try_into().unwrap()
     }
 }
 
@@ -2835,6 +3154,21 @@ impl TryFrom<&[u8]> for GetProvidersReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetProvidersReply {
+    /// Get the value of the `num_providers` field.
+    ///
+    /// The `num_providers` field is used as the length field of the `providers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_providers(&self) -> u16 {
+        self.providers.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -2980,6 +3314,60 @@ impl TryFrom<&[u8]> for GetProviderInfoReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetProviderInfoReply {
+    /// Get the value of the `num_crtcs` field.
+    ///
+    /// The `num_crtcs` field is used as the length field of the `crtcs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_crtcs(&self) -> u16 {
+        self.crtcs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_outputs` field.
+    ///
+    /// The `num_outputs` field is used as the length field of the `outputs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_outputs(&self) -> u16 {
+        self.outputs.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_associated_providers` field.
+    ///
+    /// The `num_associated_providers` field is used as the length field of the `associated_providers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_associated_providers(&self) -> u16 {
+        self.associated_providers.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetProviderOffloadSink request
 pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
@@ -3108,6 +3496,21 @@ impl TryFrom<&[u8]> for ListProviderPropertiesReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ListProviderPropertiesReply {
+    /// Get the value of the `num_atoms` field.
+    ///
+    /// The `num_atoms` field is used as the length field of the `atoms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_atoms(&self) -> u16 {
+        self.atoms.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryProviderProperty request
 pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
@@ -3169,6 +3572,21 @@ impl TryFrom<&[u8]> for QueryProviderPropertyReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryProviderPropertyReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `valid_values` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.valid_values.len()
+            .try_into().unwrap()
     }
 }
 
@@ -4091,6 +4509,21 @@ impl Serialize for MonitorInfo {
         self.outputs.serialize_into(bytes);
     }
 }
+impl MonitorInfo {
+    /// Get the value of the `nOutput` field.
+    ///
+    /// The `nOutput` field is used as the length field of the `outputs` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_output(&self) -> u16 {
+        self.outputs.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetMonitors request
 pub const GET_MONITORS_REQUEST: u8 = 42;
@@ -4152,6 +4585,21 @@ impl TryFrom<&[u8]> for GetMonitorsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetMonitorsReply {
+    /// Get the value of the `nMonitors` field.
+    ///
+    /// The `nMonitors` field is used as the length field of the `monitors` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_monitors(&self) -> u32 {
+        self.monitors.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -490,8 +490,8 @@ impl RefreshRates {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_rates(&self) -> u16 {
         self.rates.len()
             .try_into().unwrap()
@@ -904,8 +904,8 @@ impl GetScreenInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_sizes(&self) -> u16 {
         self.sizes.len()
             .try_into().unwrap()
@@ -1282,8 +1282,8 @@ impl GetScreenResourcesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_crtcs(&self) -> u16 {
         self.crtcs.len()
             .try_into().unwrap()
@@ -1295,8 +1295,8 @@ impl GetScreenResourcesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_outputs(&self) -> u16 {
         self.outputs.len()
             .try_into().unwrap()
@@ -1308,8 +1308,8 @@ impl GetScreenResourcesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_modes(&self) -> u16 {
         self.modes.len()
             .try_into().unwrap()
@@ -1321,8 +1321,8 @@ impl GetScreenResourcesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn names_len(&self) -> u16 {
         self.names.len()
             .try_into().unwrap()
@@ -1487,8 +1487,8 @@ impl GetOutputInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_crtcs(&self) -> u16 {
         self.crtcs.len()
             .try_into().unwrap()
@@ -1500,8 +1500,8 @@ impl GetOutputInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_modes(&self) -> u16 {
         self.modes.len()
             .try_into().unwrap()
@@ -1513,8 +1513,8 @@ impl GetOutputInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_clones(&self) -> u16 {
         self.clones.len()
             .try_into().unwrap()
@@ -1526,8 +1526,8 @@ impl GetOutputInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -1595,8 +1595,8 @@ impl ListOutputPropertiesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_atoms(&self) -> u16 {
         self.atoms.len()
             .try_into().unwrap()
@@ -1673,8 +1673,8 @@ impl QueryOutputPropertyReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.valid_values.len()
             .try_into().unwrap()
@@ -2162,8 +2162,8 @@ impl GetCrtcInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_outputs(&self) -> u16 {
         self.outputs.len()
             .try_into().unwrap()
@@ -2175,8 +2175,8 @@ impl GetCrtcInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_possible_outputs(&self) -> u16 {
         self.possible.len()
             .try_into().unwrap()
@@ -2388,8 +2388,8 @@ impl GetCrtcGammaReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn size(&self) -> u16 {
         self.red.len()
             .try_into().unwrap()
@@ -2514,8 +2514,8 @@ impl GetScreenResourcesCurrentReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_crtcs(&self) -> u16 {
         self.crtcs.len()
             .try_into().unwrap()
@@ -2527,8 +2527,8 @@ impl GetScreenResourcesCurrentReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_outputs(&self) -> u16 {
         self.outputs.len()
             .try_into().unwrap()
@@ -2540,8 +2540,8 @@ impl GetScreenResourcesCurrentReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_modes(&self) -> u16 {
         self.modes.len()
             .try_into().unwrap()
@@ -2553,8 +2553,8 @@ impl GetScreenResourcesCurrentReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn names_len(&self) -> u16 {
         self.names.len()
             .try_into().unwrap()
@@ -2795,8 +2795,8 @@ impl GetCrtcTransformReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn pending_len(&self) -> u16 {
         self.pending_filter_name.len()
             .try_into().unwrap()
@@ -2808,8 +2808,8 @@ impl GetCrtcTransformReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn pending_nparams(&self) -> u16 {
         self.pending_params.len()
             .try_into().unwrap()
@@ -2821,8 +2821,8 @@ impl GetCrtcTransformReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn current_len(&self) -> u16 {
         self.current_filter_name.len()
             .try_into().unwrap()
@@ -2834,8 +2834,8 @@ impl GetCrtcTransformReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn current_nparams(&self) -> u16 {
         self.current_params.len()
             .try_into().unwrap()
@@ -3162,8 +3162,8 @@ impl GetProvidersReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_providers(&self) -> u16 {
         self.providers.len()
             .try_into().unwrap()
@@ -3322,8 +3322,8 @@ impl GetProviderInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_crtcs(&self) -> u16 {
         self.crtcs.len()
             .try_into().unwrap()
@@ -3335,8 +3335,8 @@ impl GetProviderInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_outputs(&self) -> u16 {
         self.outputs.len()
             .try_into().unwrap()
@@ -3348,8 +3348,8 @@ impl GetProviderInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_associated_providers(&self) -> u16 {
         self.associated_providers.len()
             .try_into().unwrap()
@@ -3361,8 +3361,8 @@ impl GetProviderInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -3504,8 +3504,8 @@ impl ListProviderPropertiesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_atoms(&self) -> u16 {
         self.atoms.len()
             .try_into().unwrap()
@@ -3582,8 +3582,8 @@ impl QueryProviderPropertyReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.valid_values.len()
             .try_into().unwrap()
@@ -4517,8 +4517,8 @@ impl MonitorInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_output(&self) -> u16 {
         self.outputs.len()
             .try_into().unwrap()
@@ -4595,8 +4595,8 @@ impl GetMonitorsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_monitors(&self) -> u32 {
         self.monitors.len()
             .try_into().unwrap()

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -402,6 +402,21 @@ impl Serialize for ClientInfo {
         self.ranges.serialize_into(bytes);
     }
 }
+impl ClientInfo {
+    /// Get the value of the `num_ranges` field.
+    ///
+    /// The `num_ranges` field is used as the length field of the `ranges` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_ranges(&self) -> u32 {
+        self.ranges.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the BadContext error
 pub const BAD_CONTEXT_ERROR: u8 = 0;
@@ -726,6 +741,21 @@ impl TryFrom<&[u8]> for GetContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetContextReply {
+    /// Get the value of the `num_intercepted_clients` field.
+    ///
+    /// The `num_intercepted_clients` field is used as the length field of the `intercepted_clients` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_intercepted_clients(&self) -> u32 {
+        self.intercepted_clients.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the EnableContext request
 pub const ENABLE_CONTEXT_REQUEST: u8 = 5;
@@ -789,6 +819,22 @@ impl TryFrom<&[u8]> for EnableContextReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl EnableContextReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -410,8 +410,8 @@ impl ClientInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_ranges(&self) -> u32 {
         self.ranges.len()
             .try_into().unwrap()
@@ -749,8 +749,8 @@ impl GetContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_intercepted_clients(&self) -> u32 {
         self.intercepted_clients.len()
             .try_into().unwrap()
@@ -829,8 +829,8 @@ impl EnableContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1342,8 +1342,8 @@ impl Pictdepth {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_visuals(&self) -> u16 {
         self.visuals.len()
             .try_into().unwrap()
@@ -1393,8 +1393,8 @@ impl Pictscreen {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_depths(&self) -> u32 {
         self.depths.len()
             .try_into().unwrap()
@@ -1941,8 +1941,8 @@ impl QueryPictFormatsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_formats(&self) -> u32 {
         self.formats.len()
             .try_into().unwrap()
@@ -1954,8 +1954,8 @@ impl QueryPictFormatsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_screens(&self) -> u32 {
         self.screens.len()
             .try_into().unwrap()
@@ -1967,8 +1967,8 @@ impl QueryPictFormatsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_subpixel(&self) -> u32 {
         self.subpixels.len()
             .try_into().unwrap()
@@ -2036,8 +2036,8 @@ impl QueryPictIndexValuesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_values(&self) -> u32 {
         self.values.len()
             .try_into().unwrap()
@@ -3474,8 +3474,8 @@ impl QueryFiltersReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_aliases(&self) -> u32 {
         self.aliases.len()
             .try_into().unwrap()
@@ -3487,8 +3487,8 @@ impl QueryFiltersReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_filters(&self) -> u32 {
         self.filters.len()
             .try_into().unwrap()

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1334,6 +1334,21 @@ impl Serialize for Pictdepth {
         self.visuals.serialize_into(bytes);
     }
 }
+impl Pictdepth {
+    /// Get the value of the `num_visuals` field.
+    ///
+    /// The `num_visuals` field is used as the length field of the `visuals` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_visuals(&self) -> u16 {
+        self.visuals.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pictscreen {
@@ -1368,6 +1383,21 @@ impl Serialize for Pictscreen {
         num_depths.serialize_into(bytes);
         self.fallback.serialize_into(bytes);
         self.depths.serialize_into(bytes);
+    }
+}
+impl Pictscreen {
+    /// Get the value of the `num_depths` field.
+    ///
+    /// The `num_depths` field is used as the length field of the `depths` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_depths(&self) -> u32 {
+        self.depths.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1903,6 +1933,47 @@ impl TryFrom<&[u8]> for QueryPictFormatsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryPictFormatsReply {
+    /// Get the value of the `num_formats` field.
+    ///
+    /// The `num_formats` field is used as the length field of the `formats` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_formats(&self) -> u32 {
+        self.formats.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_screens` field.
+    ///
+    /// The `num_screens` field is used as the length field of the `screens` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_screens(&self) -> u32 {
+        self.screens.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_subpixel` field.
+    ///
+    /// The `num_subpixel` field is used as the length field of the `subpixels` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_subpixel(&self) -> u32 {
+        self.subpixels.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryPictIndexValues request
 pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
@@ -1955,6 +2026,21 @@ impl TryFrom<&[u8]> for QueryPictIndexValuesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryPictIndexValuesReply {
+    /// Get the value of the `num_values` field.
+    ///
+    /// The `num_values` field is used as the length field of the `values` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_values(&self) -> u32 {
+        self.values.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3378,6 +3464,34 @@ impl TryFrom<&[u8]> for QueryFiltersReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryFiltersReply {
+    /// Get the value of the `num_aliases` field.
+    ///
+    /// The `num_aliases` field is used as the length field of the `aliases` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_aliases(&self) -> u32 {
+        self.aliases.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_filters` field.
+    ///
+    /// The `num_filters` field is used as the length field of the `filters` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_filters(&self) -> u32 {
+        self.filters.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -263,8 +263,8 @@ impl ClientIdValue {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.value.len()
             .checked_mul(4).unwrap()
@@ -419,8 +419,8 @@ impl ResourceSizeValue {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_cross_references(&self) -> u32 {
         self.cross_references.len()
             .try_into().unwrap()
@@ -538,8 +538,8 @@ impl QueryClientsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_clients(&self) -> u32 {
         self.clients.len()
             .try_into().unwrap()
@@ -607,8 +607,8 @@ impl QueryClientResourcesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_types(&self) -> u32 {
         self.types.len()
             .try_into().unwrap()
@@ -735,8 +735,8 @@ impl QueryClientIdsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_ids(&self) -> u32 {
         self.ids.len()
             .try_into().unwrap()
@@ -814,8 +814,8 @@ impl QueryResourceBytesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_sizes(&self) -> u32 {
         self.sizes.len()
             .try_into().unwrap()

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -255,6 +255,22 @@ impl Serialize for ClientIdValue {
         self.value.serialize_into(bytes);
     }
 }
+impl ClientIdValue {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `value` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.value.len()
+            .checked_mul(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResourceIdSpec {
@@ -395,6 +411,21 @@ impl Serialize for ResourceSizeValue {
         self.cross_references.serialize_into(bytes);
     }
 }
+impl ResourceSizeValue {
+    /// Get the value of the `num_cross_references` field.
+    ///
+    /// The `num_cross_references` field is used as the length field of the `cross_references` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_cross_references(&self) -> u32 {
+        self.cross_references.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
@@ -499,6 +530,21 @@ impl TryFrom<&[u8]> for QueryClientsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryClientsReply {
+    /// Get the value of the `num_clients` field.
+    ///
+    /// The `num_clients` field is used as the length field of the `clients` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_clients(&self) -> u32 {
+        self.clients.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryClientResources request
 pub const QUERY_CLIENT_RESOURCES_REQUEST: u8 = 2;
@@ -551,6 +597,21 @@ impl TryFrom<&[u8]> for QueryClientResourcesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryClientResourcesReply {
+    /// Get the value of the `num_types` field.
+    ///
+    /// The `num_types` field is used as the length field of the `types` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_types(&self) -> u32 {
+        self.types.len()
+            .try_into().unwrap()
     }
 }
 
@@ -666,6 +727,21 @@ impl TryFrom<&[u8]> for QueryClientIdsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryClientIdsReply {
+    /// Get the value of the `num_ids` field.
+    ///
+    /// The `num_ids` field is used as the length field of the `ids` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_ids(&self) -> u32 {
+        self.ids.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryResourceBytes request
 pub const QUERY_RESOURCE_BYTES_REQUEST: u8 = 5;
@@ -728,6 +804,21 @@ impl TryFrom<&[u8]> for QueryResourceBytesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryResourceBytesReply {
+    /// Get the value of the `num_sizes` field.
+    ///
+    /// The `num_sizes` field is used as the length field of the `sizes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_sizes(&self) -> u32 {
+        self.sizes.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -708,8 +708,8 @@ impl GetRectanglesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn rectangles_len(&self) -> u32 {
         self.rectangles.len()
             .try_into().unwrap()

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -700,6 +700,21 @@ impl TryFrom<&[u8]> for GetRectanglesReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetRectanglesReply {
+    /// Get the value of the `rectangles_len` field.
+    ///
+    /// The `rectangles_len` field is used as the length field of the `rectangles` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn rectangles_len(&self) -> u32 {
+        self.rectangles.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -402,6 +402,21 @@ impl Serialize for Systemcounter {
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
     }
 }
+impl Systemcounter {
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Trigger {
@@ -791,6 +806,21 @@ impl TryFrom<&[u8]> for ListSystemCountersReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListSystemCountersReply {
+    /// Get the value of the `counters_len` field.
+    ///
+    /// The `counters_len` field is used as the length field of the `counters` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn counters_len(&self) -> u32 {
+        self.counters.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -410,8 +410,8 @@ impl Systemcounter {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -816,8 +816,8 @@ impl ListSystemCountersReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn counters_len(&self) -> u32 {
         self.counters.len()
             .try_into().unwrap()

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -195,8 +195,8 @@ impl GetXIDListReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn ids_len(&self) -> u32 {
         self.ids.len()
             .try_into().unwrap()

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -187,6 +187,21 @@ impl TryFrom<&[u8]> for GetXIDListReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetXIDListReply {
+    /// Get the value of the `ids_len` field.
+    ///
+    /// The `ids_len` field is used as the length field of the `ids` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn ids_len(&self) -> u32 {
+        self.ids.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -241,6 +241,21 @@ impl TryFrom<&[u8]> for OpenConnectionReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl OpenConnectionReply {
+    /// Get the value of the `bus_id_len` field.
+    ///
+    /// The `bus_id_len` field is used as the length field of the `bus_id` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn bus_id_len(&self) -> u32 {
+        self.bus_id.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the CloseConnection request
 pub const CLOSE_CONNECTION_REQUEST: u8 = 3;
@@ -327,6 +342,21 @@ impl TryFrom<&[u8]> for GetClientDriverNameReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetClientDriverNameReply {
+    /// Get the value of the `client_driver_name_len` field.
+    ///
+    /// The `client_driver_name_len` field is used as the length field of the `client_driver_name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn client_driver_name_len(&self) -> u32 {
+        self.client_driver_name.len()
+            .try_into().unwrap()
     }
 }
 
@@ -589,6 +619,34 @@ impl TryFrom<&[u8]> for GetDrawableInfoReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetDrawableInfoReply {
+    /// Get the value of the `num_clip_rects` field.
+    ///
+    /// The `num_clip_rects` field is used as the length field of the `clip_rects` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_clip_rects(&self) -> u32 {
+        self.clip_rects.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_back_clip_rects` field.
+    ///
+    /// The `num_back_clip_rects` field is used as the length field of the `back_clip_rects` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_back_clip_rects(&self) -> u32 {
+        self.back_clip_rects.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetDeviceInfo request
 pub const GET_DEVICE_INFO_REQUEST: u8 = 10;
@@ -650,6 +708,21 @@ impl TryFrom<&[u8]> for GetDeviceInfoReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetDeviceInfoReply {
+    /// Get the value of the `device_private_size` field.
+    ///
+    /// The `device_private_size` field is used as the length field of the `device_private` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn device_private_size(&self) -> u32 {
+        self.device_private.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -249,8 +249,8 @@ impl OpenConnectionReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn bus_id_len(&self) -> u32 {
         self.bus_id.len()
             .try_into().unwrap()
@@ -352,8 +352,8 @@ impl GetClientDriverNameReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn client_driver_name_len(&self) -> u32 {
         self.client_driver_name.len()
             .try_into().unwrap()
@@ -627,8 +627,8 @@ impl GetDrawableInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_clip_rects(&self) -> u32 {
         self.clip_rects.len()
             .try_into().unwrap()
@@ -640,8 +640,8 @@ impl GetDrawableInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_back_clip_rects(&self) -> u32 {
         self.back_clip_rects.len()
             .try_into().unwrap()
@@ -718,8 +718,8 @@ impl GetDeviceInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn device_private_size(&self) -> u32 {
         self.device_private.len()
             .try_into().unwrap()

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -489,6 +489,21 @@ impl TryFrom<&[u8]> for GetModeLineReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetModeLineReply {
+    /// Get the value of the `privsize` field.
+    ///
+    /// The `privsize` field is used as the length field of the `private` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn privsize(&self) -> u32 {
+        self.private.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ModModeLine request
 pub const MOD_MODE_LINE_REQUEST: u8 = 2;
@@ -669,6 +684,60 @@ impl TryFrom<&[u8]> for GetMonitorReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetMonitorReply {
+    /// Get the value of the `vendor_length` field.
+    ///
+    /// The `vendor_length` field is used as the length field of the `vendor` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn vendor_length(&self) -> u8 {
+        self.vendor.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `model_length` field.
+    ///
+    /// The `model_length` field is used as the length field of the `model` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn model_length(&self) -> u8 {
+        self.model.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_hsync` field.
+    ///
+    /// The `num_hsync` field is used as the length field of the `hsync` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_hsync(&self) -> u8 {
+        self.hsync.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_vsync` field.
+    ///
+    /// The `num_vsync` field is used as the length field of the `vsync` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_vsync(&self) -> u8 {
+        self.vsync.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the LockModeSwitch request
 pub const LOCK_MODE_SWITCH_REQUEST: u8 = 5;
@@ -749,6 +818,21 @@ impl TryFrom<&[u8]> for GetAllModeLinesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetAllModeLinesReply {
+    /// Get the value of the `modecount` field.
+    ///
+    /// The `modecount` field is used as the length field of the `modeinfo` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn modecount(&self) -> u32 {
+        self.modeinfo.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -497,8 +497,8 @@ impl GetModeLineReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn privsize(&self) -> u32 {
         self.private.len()
             .try_into().unwrap()
@@ -692,8 +692,8 @@ impl GetMonitorReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn vendor_length(&self) -> u8 {
         self.vendor.len()
             .try_into().unwrap()
@@ -705,8 +705,8 @@ impl GetMonitorReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn model_length(&self) -> u8 {
         self.model.len()
             .try_into().unwrap()
@@ -718,8 +718,8 @@ impl GetMonitorReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_hsync(&self) -> u8 {
         self.hsync.len()
             .try_into().unwrap()
@@ -731,8 +731,8 @@ impl GetMonitorReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_vsync(&self) -> u8 {
         self.vsync.len()
             .try_into().unwrap()
@@ -828,8 +828,8 @@ impl GetAllModeLinesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn modecount(&self) -> u32 {
         self.modeinfo.len()
             .try_into().unwrap()

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -1549,6 +1549,22 @@ impl TryFrom<&[u8]> for FetchRegionReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl FetchRegionReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `rectangles` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.rectangles.len()
+            .checked_mul(2).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetGCClipRegion request
 pub const SET_GC_CLIP_REGION_REQUEST: u8 = 20;
@@ -1767,6 +1783,21 @@ impl TryFrom<&[u8]> for GetCursorNameReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetCursorNameReply {
+    /// Get the value of the `nbytes` field.
+    ///
+    /// The `nbytes` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn nbytes(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetCursorImageAndName request
 pub const GET_CURSOR_IMAGE_AND_NAME_REQUEST: u8 = 25;
@@ -1833,6 +1864,21 @@ impl TryFrom<&[u8]> for GetCursorImageAndNameReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetCursorImageAndNameReply {
+    /// Get the value of the `nbytes` field.
+    ///
+    /// The `nbytes` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn nbytes(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -1557,8 +1557,8 @@ impl FetchRegionReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.rectangles.len()
             .checked_mul(2).unwrap()
@@ -1791,8 +1791,8 @@ impl GetCursorNameReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn nbytes(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -1874,8 +1874,8 @@ impl GetCursorImageAndNameReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn nbytes(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -400,6 +400,21 @@ impl TryFrom<&[u8]> for QueryScreensReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryScreensReply {
+    /// Get the value of the `number` field.
+    ///
+    /// The `number` field is used as the length field of the `screen_info` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn number(&self) -> u32 {
+        self.screen_info.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -408,8 +408,8 @@ impl QueryScreensReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn number(&self) -> u32 {
         self.screen_info.len()
             .try_into().unwrap()

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -905,6 +905,7 @@ impl Serialize for DeviceName {
         bytes.extend_from_slice(&self.string);
     }
 }
+#[allow(clippy::len_without_is_empty)] // This is not a container and is_empty() makes no sense
 impl DeviceName {
     /// Get the value of the `len` field.
     ///

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -611,6 +611,21 @@ impl Serialize for ValuatorInfo {
         self.axes.serialize_into(bytes);
     }
 }
+impl ValuatorInfo {
+    /// Get the value of the `axes_len` field.
+    ///
+    /// The `axes_len` field is used as the length field of the `axes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn axes_len(&self) -> u8 {
+        self.axes.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InputInfoInfoKey {
@@ -725,6 +740,21 @@ impl Serialize for InputInfoInfoValuator {
         u8::from(self.mode).serialize_into(bytes);
         self.motion_size.serialize_into(bytes);
         self.axes.serialize_into(bytes);
+    }
+}
+impl InputInfoInfoValuator {
+    /// Get the value of the `axes_len` field.
+    ///
+    /// The `axes_len` field is used as the length field of the `axes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn axes_len(&self) -> u8 {
+        self.axes.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -875,6 +905,21 @@ impl Serialize for DeviceName {
         bytes.extend_from_slice(&self.string);
     }
 }
+impl DeviceName {
+    /// Get the value of the `len` field.
+    ///
+    /// The `len` field is used as the length field of the `string` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn len(&self) -> u8 {
+        self.string.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ListInputDevices request
 pub const LIST_INPUT_DEVICES_REQUEST: u8 = 2;
@@ -932,6 +977,21 @@ impl TryFrom<&[u8]> for ListInputDevicesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListInputDevicesReply {
+    /// Get the value of the `devices_len` field.
+    ///
+    /// The `devices_len` field is used as the length field of the `devices` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn devices_len(&self) -> u8 {
+        self.devices.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1031,6 +1091,21 @@ impl TryFrom<&[u8]> for OpenDeviceReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl OpenDeviceReply {
+    /// Get the value of the `num_classes` field.
+    ///
+    /// The `num_classes` field is used as the length field of the `class_info` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_classes(&self) -> u8 {
+        self.class_info.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1211,6 +1286,34 @@ impl TryFrom<&[u8]> for GetSelectedExtensionEventsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetSelectedExtensionEventsReply {
+    /// Get the value of the `num_this_classes` field.
+    ///
+    /// The `num_this_classes` field is used as the length field of the `this_classes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_this_classes(&self) -> u16 {
+        self.this_classes.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_all_classes` field.
+    ///
+    /// The `num_all_classes` field is used as the length field of the `all_classes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_all_classes(&self) -> u16 {
+        self.all_classes.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -1374,6 +1477,21 @@ impl TryFrom<&[u8]> for GetDeviceDontPropagateListReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetDeviceDontPropagateListReply {
+    /// Get the value of the `num_classes` field.
+    ///
+    /// The `num_classes` field is used as the length field of the `classes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_classes(&self) -> u16 {
+        self.classes.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeviceTimeCoord {
@@ -1479,6 +1597,21 @@ impl TryFrom<&[u8]> for GetDeviceMotionEventsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetDeviceMotionEventsReply {
+    /// Get the value of the `num_events` field.
+    ///
+    /// The `num_events` field is used as the length field of the `events` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_events(&self) -> u32 {
+        self.events.len()
+            .try_into().unwrap()
     }
 }
 
@@ -2559,6 +2692,21 @@ impl Serialize for StringFeedbackState {
         self.keysyms.serialize_into(bytes);
     }
 }
+impl StringFeedbackState {
+    /// Get the value of the `num_keysyms` field.
+    ///
+    /// The `num_keysyms` field is used as the length field of the `keysyms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_keysyms(&self) -> u16 {
+        self.keysyms.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BellFeedbackState {
@@ -2871,6 +3019,21 @@ impl Serialize for FeedbackStateDataString {
         let num_keysyms = u16::try_from(self.keysyms.len()).expect("`keysyms` has too many elements");
         num_keysyms.serialize_into(bytes);
         self.keysyms.serialize_into(bytes);
+    }
+}
+impl FeedbackStateDataString {
+    /// Get the value of the `num_keysyms` field.
+    ///
+    /// The `num_keysyms` field is used as the length field of the `keysyms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_keysyms(&self) -> u16 {
+        self.keysyms.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3228,6 +3391,21 @@ impl TryFrom<&[u8]> for GetFeedbackControlReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetFeedbackControlReply {
+    /// Get the value of the `num_feedbacks` field.
+    ///
+    /// The `num_feedbacks` field is used as the length field of the `feedbacks` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_feedbacks(&self) -> u16 {
+        self.feedbacks.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KbdFeedbackCtl {
@@ -3478,6 +3656,21 @@ impl Serialize for StringFeedbackCtl {
         let num_keysyms = u16::try_from(self.keysyms.len()).expect("`keysyms` has too many elements");
         num_keysyms.serialize_into(bytes);
         self.keysyms.serialize_into(bytes);
+    }
+}
+impl StringFeedbackCtl {
+    /// Get the value of the `num_keysyms` field.
+    ///
+    /// The `num_keysyms` field is used as the length field of the `keysyms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_keysyms(&self) -> u16 {
+        self.keysyms.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3757,6 +3950,21 @@ impl Serialize for FeedbackCtlDataString {
         let num_keysyms = u16::try_from(self.keysyms.len()).expect("`keysyms` has too many elements");
         num_keysyms.serialize_into(bytes);
         self.keysyms.serialize_into(bytes);
+    }
+}
+impl FeedbackCtlDataString {
+    /// Get the value of the `num_keysyms` field.
+    ///
+    /// The `num_keysyms` field is used as the length field of the `keysyms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_keysyms(&self) -> u16 {
+        self.keysyms.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4201,6 +4409,21 @@ impl TryFrom<&[u8]> for GetDeviceKeyMappingReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetDeviceKeyMappingReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `keysyms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.keysyms.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ChangeDeviceKeyMapping request
 pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
@@ -4290,6 +4513,22 @@ impl TryFrom<&[u8]> for GetDeviceModifierMappingReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetDeviceModifierMappingReply {
+    /// Get the value of the `keycodes_per_modifier` field.
+    ///
+    /// The `keycodes_per_modifier` field is used as the length field of the `keymaps` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn keycodes_per_modifier(&self) -> u8 {
+        self.keymaps.len()
+            .checked_div(8).unwrap()
+            .try_into().unwrap()
     }
 }
 
@@ -4412,6 +4651,21 @@ impl TryFrom<&[u8]> for GetDeviceButtonMappingReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetDeviceButtonMappingReply {
+    /// Get the value of the `map_size` field.
+    ///
+    /// The `map_size` field is used as the length field of the `map` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn map_size(&self) -> u8 {
+        self.map.len()
+            .try_into().unwrap()
     }
 }
 
@@ -4742,6 +4996,21 @@ impl Serialize for ValuatorState {
         self.valuators.serialize_into(bytes);
     }
 }
+impl ValuatorState {
+    /// Get the value of the `num_valuators` field.
+    ///
+    /// The `num_valuators` field is used as the length field of the `valuators` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_valuators(&self) -> u8 {
+        self.valuators.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InputStateDataKey {
@@ -4916,6 +5185,21 @@ impl Serialize for InputStateDataValuator {
         self.valuators.serialize_into(bytes);
     }
 }
+impl InputStateDataValuator {
+    /// Get the value of the `num_valuators` field.
+    ///
+    /// The `num_valuators` field is used as the length field of the `valuators` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_valuators(&self) -> u8 {
+        self.valuators.len()
+            .try_into().unwrap()
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InputStateData {
     Key(InputStateDataKey),
@@ -5084,6 +5368,21 @@ impl TryFrom<&[u8]> for QueryDeviceStateReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryDeviceStateReply {
+    /// Get the value of the `num_classes` field.
+    ///
+    /// The `num_classes` field is used as the length field of the `classes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_classes(&self) -> u8 {
+        self.classes.len()
+            .try_into().unwrap()
     }
 }
 
@@ -5295,6 +5594,21 @@ impl Serialize for DeviceResolutionState {
         self.resolution_min.serialize_into(bytes);
         assert_eq!(self.resolution_max.len(), usize::try_from(num_valuators).unwrap(), "`resolution_max` has an incorrect length");
         self.resolution_max.serialize_into(bytes);
+    }
+}
+impl DeviceResolutionState {
+    /// Get the value of the `num_valuators` field.
+    ///
+    /// The `num_valuators` field is used as the length field of the `resolution_values` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_valuators(&self) -> u32 {
+        self.resolution_values.len()
+            .try_into().unwrap()
     }
 }
 
@@ -5627,6 +5941,21 @@ impl Serialize for DeviceStateDataResolution {
         self.resolution_min.serialize_into(bytes);
         assert_eq!(self.resolution_max.len(), usize::try_from(num_valuators).unwrap(), "`resolution_max` has an incorrect length");
         self.resolution_max.serialize_into(bytes);
+    }
+}
+impl DeviceStateDataResolution {
+    /// Get the value of the `num_valuators` field.
+    ///
+    /// The `num_valuators` field is used as the length field of the `resolution_values` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_valuators(&self) -> u32 {
+        self.resolution_values.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6083,6 +6412,21 @@ impl Serialize for DeviceResolutionCtl {
         self.resolution_values.serialize_into(bytes);
     }
 }
+impl DeviceResolutionCtl {
+    /// Get the value of the `num_valuators` field.
+    ///
+    /// The `num_valuators` field is used as the length field of the `resolution_values` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_valuators(&self) -> u8 {
+        self.resolution_values.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeviceAbsCalibCtl {
@@ -6407,6 +6751,21 @@ impl Serialize for DeviceCtlDataResolution {
         num_valuators.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
         self.resolution_values.serialize_into(bytes);
+    }
+}
+impl DeviceCtlDataResolution {
+    /// Get the value of the `num_valuators` field.
+    ///
+    /// The `num_valuators` field is used as the length field of the `resolution_values` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_valuators(&self) -> u8 {
+        self.resolution_values.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6869,6 +7228,21 @@ impl TryFrom<&[u8]> for ListDevicePropertiesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListDevicePropertiesReply {
+    /// Get the value of the `num_atoms` field.
+    ///
+    /// The `num_atoms` field is used as the length field of the `atoms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_atoms(&self) -> u16 {
+        self.atoms.len()
+            .try_into().unwrap()
     }
 }
 
@@ -7486,6 +7860,21 @@ impl TryFrom<&[u8]> for XIQueryPointerReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl XIQueryPointerReply {
+    /// Get the value of the `buttons_len` field.
+    ///
+    /// The `buttons_len` field is used as the length field of the `buttons` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn buttons_len(&self) -> u16 {
+        self.buttons.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the XIWarpPointer request
 pub const XI_WARP_POINTER_REQUEST: u8 = 41;
@@ -7773,6 +8162,21 @@ impl Serialize for AddMaster {
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
     }
 }
+impl AddMaster {
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RemoveMaster {
@@ -7983,6 +8387,21 @@ impl Serialize for HierarchyChangeDataAddMaster {
         self.enable.serialize_into(bytes);
         bytes.extend_from_slice(&self.name);
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+    }
+}
+impl HierarchyChangeDataAddMaster {
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8500,6 +8919,21 @@ impl Serialize for EventMask {
         self.mask.serialize_into(bytes);
     }
 }
+impl EventMask {
+    /// Get the value of the `mask_len` field.
+    ///
+    /// The `mask_len` field is used as the length field of the `mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn mask_len(&self) -> u16 {
+        self.mask.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the XISelectEvents request
 pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
@@ -8969,6 +9403,21 @@ impl Serialize for ButtonClass {
         self.labels.serialize_into(bytes);
     }
 }
+impl ButtonClass {
+    /// Get the value of the `num_buttons` field.
+    ///
+    /// The `num_buttons` field is used as the length field of the `labels` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_buttons(&self) -> u16 {
+        self.labels.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyClass {
@@ -9010,6 +9459,21 @@ impl Serialize for KeyClass {
         let num_keys = u16::try_from(self.keys.len()).expect("`keys` has too many elements");
         num_keys.serialize_into(bytes);
         self.keys.serialize_into(bytes);
+    }
+}
+impl KeyClass {
+    /// Get the value of the `num_keys` field.
+    ///
+    /// The `num_keys` field is used as the length field of the `keys` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_keys(&self) -> u16 {
+        self.keys.len()
+            .try_into().unwrap()
     }
 }
 
@@ -9296,6 +9760,21 @@ impl Serialize for DeviceClassDataKey {
         self.keys.serialize_into(bytes);
     }
 }
+impl DeviceClassDataKey {
+    /// Get the value of the `num_keys` field.
+    ///
+    /// The `num_keys` field is used as the length field of the `keys` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_keys(&self) -> u16 {
+        self.keys.len()
+            .try_into().unwrap()
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeviceClassDataButton {
     pub state: Vec<u32>,
@@ -9329,6 +9808,21 @@ impl Serialize for DeviceClassDataButton {
         assert_eq!(self.state.len(), usize::try_from(u32::from(num_buttons).checked_add(31u32).unwrap().checked_div(32u32).unwrap()).unwrap(), "`state` has an incorrect length");
         self.state.serialize_into(bytes);
         self.labels.serialize_into(bytes);
+    }
+}
+impl DeviceClassDataButton {
+    /// Get the value of the `num_buttons` field.
+    ///
+    /// The `num_buttons` field is used as the length field of the `labels` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_buttons(&self) -> u16 {
+        self.labels.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9732,6 +10226,34 @@ impl Serialize for XIDeviceInfo {
         self.classes.serialize_into(bytes);
     }
 }
+impl XIDeviceInfo {
+    /// Get the value of the `num_classes` field.
+    ///
+    /// The `num_classes` field is used as the length field of the `classes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_classes(&self) -> u16 {
+        self.classes.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the XIQueryDevice request
 pub const XI_QUERY_DEVICE_REQUEST: u8 = 48;
@@ -9786,6 +10308,21 @@ impl TryFrom<&[u8]> for XIQueryDeviceReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl XIQueryDeviceReply {
+    /// Get the value of the `num_infos` field.
+    ///
+    /// The `num_infos` field is used as the length field of the `infos` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_infos(&self) -> u16 {
+        self.infos.len()
+            .try_into().unwrap()
     }
 }
 
@@ -10512,6 +11049,21 @@ impl TryFrom<&[u8]> for XIPassiveGrabDeviceReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl XIPassiveGrabDeviceReply {
+    /// Get the value of the `num_modifiers` field.
+    ///
+    /// The `num_modifiers` field is used as the length field of the `modifiers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_modifiers(&self) -> u16 {
+        self.modifiers.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the XIPassiveUngrabDevice request
 pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
@@ -10616,6 +11168,21 @@ impl TryFrom<&[u8]> for XIListPropertiesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl XIListPropertiesReply {
+    /// Get the value of the `num_properties` field.
+    ///
+    /// The `num_properties` field is used as the length field of the `properties` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_properties(&self) -> u16 {
+        self.properties.len()
+            .try_into().unwrap()
     }
 }
 
@@ -10970,6 +11537,21 @@ impl TryFrom<&[u8]> for XIGetSelectedEventsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl XIGetSelectedEventsReply {
+    /// Get the value of the `num_masks` field.
+    ///
+    /// The `num_masks` field is used as the length field of the `masks` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_masks(&self) -> u16 {
+        self.masks.len()
+            .try_into().unwrap()
     }
 }
 
@@ -12326,6 +12908,21 @@ impl TryFrom<&[u8]> for DeviceChangedEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl DeviceChangedEvent {
+    /// Get the value of the `num_classes` field.
+    ///
+    /// The `num_classes` field is used as the length field of the `classes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_classes(&self) -> u16 {
+        self.classes.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -12417,6 +13014,34 @@ impl TryFrom<&[u8]> for KeyPressEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl KeyPressEvent {
+    /// Get the value of the `buttons_len` field.
+    ///
+    /// The `buttons_len` field is used as the length field of the `button_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn buttons_len(&self) -> u16 {
+        self.button_mask.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `valuators_len` field.
+    ///
+    /// The `valuators_len` field is used as the length field of the `valuator_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn valuators_len(&self) -> u16 {
+        self.valuator_mask.len()
+            .try_into().unwrap()
     }
 }
 
@@ -12514,6 +13139,34 @@ impl TryFrom<&[u8]> for ButtonPressEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ButtonPressEvent {
+    /// Get the value of the `buttons_len` field.
+    ///
+    /// The `buttons_len` field is used as the length field of the `button_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn buttons_len(&self) -> u16 {
+        self.button_mask.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `valuators_len` field.
+    ///
+    /// The `valuators_len` field is used as the length field of the `valuator_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn valuators_len(&self) -> u16 {
+        self.valuator_mask.len()
+            .try_into().unwrap()
     }
 }
 
@@ -12743,6 +13396,21 @@ impl TryFrom<&[u8]> for EnterEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl EnterEvent {
+    /// Get the value of the `buttons_len` field.
+    ///
+    /// The `buttons_len` field is used as the length field of the `buttons` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn buttons_len(&self) -> u16 {
+        self.buttons.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the Leave event
 pub const LEAVE_EVENT: u16 = 8;
@@ -12935,6 +13603,21 @@ impl TryFrom<&[u8]> for HierarchyEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl HierarchyEvent {
+    /// Get the value of the `num_infos` field.
+    ///
+    /// The `num_infos` field is used as the length field of the `infos` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_infos(&self) -> u16 {
+        self.infos.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -13084,6 +13767,21 @@ impl TryFrom<&[u8]> for RawKeyPressEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl RawKeyPressEvent {
+    /// Get the value of the `valuators_len` field.
+    ///
+    /// The `valuators_len` field is used as the length field of the `valuator_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn valuators_len(&self) -> u16 {
+        self.valuator_mask.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the RawKeyRelease event
 pub const RAW_KEY_RELEASE_EVENT: u16 = 14;
@@ -13132,6 +13830,21 @@ impl TryFrom<&[u8]> for RawButtonPressEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl RawButtonPressEvent {
+    /// Get the value of the `valuators_len` field.
+    ///
+    /// The `valuators_len` field is used as the length field of the `valuator_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn valuators_len(&self) -> u16 {
+        self.valuator_mask.len()
+            .try_into().unwrap()
     }
 }
 
@@ -13236,6 +13949,34 @@ impl TryFrom<&[u8]> for TouchBeginEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl TouchBeginEvent {
+    /// Get the value of the `buttons_len` field.
+    ///
+    /// The `buttons_len` field is used as the length field of the `button_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn buttons_len(&self) -> u16 {
+        self.button_mask.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `valuators_len` field.
+    ///
+    /// The `valuators_len` field is used as the length field of the `valuator_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn valuators_len(&self) -> u16 {
+        self.valuator_mask.len()
+            .try_into().unwrap()
     }
 }
 
@@ -13396,6 +14137,21 @@ impl TryFrom<&[u8]> for RawTouchBeginEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl RawTouchBeginEvent {
+    /// Get the value of the `valuators_len` field.
+    ///
+    /// The `valuators_len` field is used as the length field of the `valuator_mask` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn valuators_len(&self) -> u16 {
+        self.valuator_mask.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -619,8 +619,8 @@ impl ValuatorInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn axes_len(&self) -> u8 {
         self.axes.len()
             .try_into().unwrap()
@@ -750,8 +750,8 @@ impl InputInfoInfoValuator {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn axes_len(&self) -> u8 {
         self.axes.len()
             .try_into().unwrap()
@@ -913,8 +913,8 @@ impl DeviceName {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn len(&self) -> u8 {
         self.string.len()
             .try_into().unwrap()
@@ -987,8 +987,8 @@ impl ListInputDevicesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn devices_len(&self) -> u8 {
         self.devices.len()
             .try_into().unwrap()
@@ -1101,8 +1101,8 @@ impl OpenDeviceReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_classes(&self) -> u8 {
         self.class_info.len()
             .try_into().unwrap()
@@ -1294,8 +1294,8 @@ impl GetSelectedExtensionEventsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_this_classes(&self) -> u16 {
         self.this_classes.len()
             .try_into().unwrap()
@@ -1307,8 +1307,8 @@ impl GetSelectedExtensionEventsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_all_classes(&self) -> u16 {
         self.all_classes.len()
             .try_into().unwrap()
@@ -1485,8 +1485,8 @@ impl GetDeviceDontPropagateListReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_classes(&self) -> u16 {
         self.classes.len()
             .try_into().unwrap()
@@ -1607,8 +1607,8 @@ impl GetDeviceMotionEventsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_events(&self) -> u32 {
         self.events.len()
             .try_into().unwrap()
@@ -2700,8 +2700,8 @@ impl StringFeedbackState {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_keysyms(&self) -> u16 {
         self.keysyms.len()
             .try_into().unwrap()
@@ -3029,8 +3029,8 @@ impl FeedbackStateDataString {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_keysyms(&self) -> u16 {
         self.keysyms.len()
             .try_into().unwrap()
@@ -3399,8 +3399,8 @@ impl GetFeedbackControlReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_feedbacks(&self) -> u16 {
         self.feedbacks.len()
             .try_into().unwrap()
@@ -3666,8 +3666,8 @@ impl StringFeedbackCtl {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_keysyms(&self) -> u16 {
         self.keysyms.len()
             .try_into().unwrap()
@@ -3960,8 +3960,8 @@ impl FeedbackCtlDataString {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_keysyms(&self) -> u16 {
         self.keysyms.len()
             .try_into().unwrap()
@@ -4417,8 +4417,8 @@ impl GetDeviceKeyMappingReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.keysyms.len()
             .try_into().unwrap()
@@ -4523,8 +4523,8 @@ impl GetDeviceModifierMappingReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn keycodes_per_modifier(&self) -> u8 {
         self.keymaps.len()
             .checked_div(8).unwrap()
@@ -4661,8 +4661,8 @@ impl GetDeviceButtonMappingReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn map_size(&self) -> u8 {
         self.map.len()
             .try_into().unwrap()
@@ -5004,8 +5004,8 @@ impl ValuatorState {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_valuators(&self) -> u8 {
         self.valuators.len()
             .try_into().unwrap()
@@ -5193,8 +5193,8 @@ impl InputStateDataValuator {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_valuators(&self) -> u8 {
         self.valuators.len()
             .try_into().unwrap()
@@ -5378,8 +5378,8 @@ impl QueryDeviceStateReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_classes(&self) -> u8 {
         self.classes.len()
             .try_into().unwrap()
@@ -5604,8 +5604,8 @@ impl DeviceResolutionState {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_valuators(&self) -> u32 {
         self.resolution_values.len()
             .try_into().unwrap()
@@ -5951,8 +5951,8 @@ impl DeviceStateDataResolution {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_valuators(&self) -> u32 {
         self.resolution_values.len()
             .try_into().unwrap()
@@ -6420,8 +6420,8 @@ impl DeviceResolutionCtl {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_valuators(&self) -> u8 {
         self.resolution_values.len()
             .try_into().unwrap()
@@ -6761,8 +6761,8 @@ impl DeviceCtlDataResolution {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_valuators(&self) -> u8 {
         self.resolution_values.len()
             .try_into().unwrap()
@@ -7238,8 +7238,8 @@ impl ListDevicePropertiesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_atoms(&self) -> u16 {
         self.atoms.len()
             .try_into().unwrap()
@@ -7868,8 +7868,8 @@ impl XIQueryPointerReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn buttons_len(&self) -> u16 {
         self.buttons.len()
             .try_into().unwrap()
@@ -8170,8 +8170,8 @@ impl AddMaster {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -8397,8 +8397,8 @@ impl HierarchyChangeDataAddMaster {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -8927,8 +8927,8 @@ impl EventMask {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn mask_len(&self) -> u16 {
         self.mask.len()
             .try_into().unwrap()
@@ -9411,8 +9411,8 @@ impl ButtonClass {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_buttons(&self) -> u16 {
         self.labels.len()
             .try_into().unwrap()
@@ -9469,8 +9469,8 @@ impl KeyClass {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_keys(&self) -> u16 {
         self.keys.len()
             .try_into().unwrap()
@@ -9768,8 +9768,8 @@ impl DeviceClassDataKey {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_keys(&self) -> u16 {
         self.keys.len()
             .try_into().unwrap()
@@ -9818,8 +9818,8 @@ impl DeviceClassDataButton {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_buttons(&self) -> u16 {
         self.labels.len()
             .try_into().unwrap()
@@ -10234,8 +10234,8 @@ impl XIDeviceInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_classes(&self) -> u16 {
         self.classes.len()
             .try_into().unwrap()
@@ -10247,8 +10247,8 @@ impl XIDeviceInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -10318,8 +10318,8 @@ impl XIQueryDeviceReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_infos(&self) -> u16 {
         self.infos.len()
             .try_into().unwrap()
@@ -11057,8 +11057,8 @@ impl XIPassiveGrabDeviceReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_modifiers(&self) -> u16 {
         self.modifiers.len()
             .try_into().unwrap()
@@ -11178,8 +11178,8 @@ impl XIListPropertiesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_properties(&self) -> u16 {
         self.properties.len()
             .try_into().unwrap()
@@ -11547,8 +11547,8 @@ impl XIGetSelectedEventsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_masks(&self) -> u16 {
         self.masks.len()
             .try_into().unwrap()
@@ -12916,8 +12916,8 @@ impl DeviceChangedEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_classes(&self) -> u16 {
         self.classes.len()
             .try_into().unwrap()
@@ -13024,8 +13024,8 @@ impl KeyPressEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn buttons_len(&self) -> u16 {
         self.button_mask.len()
             .try_into().unwrap()
@@ -13037,8 +13037,8 @@ impl KeyPressEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
@@ -13149,8 +13149,8 @@ impl ButtonPressEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn buttons_len(&self) -> u16 {
         self.button_mask.len()
             .try_into().unwrap()
@@ -13162,8 +13162,8 @@ impl ButtonPressEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
@@ -13404,8 +13404,8 @@ impl EnterEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn buttons_len(&self) -> u16 {
         self.buttons.len()
             .try_into().unwrap()
@@ -13611,8 +13611,8 @@ impl HierarchyEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_infos(&self) -> u16 {
         self.infos.len()
             .try_into().unwrap()
@@ -13775,8 +13775,8 @@ impl RawKeyPressEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
@@ -13840,8 +13840,8 @@ impl RawButtonPressEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
@@ -13959,8 +13959,8 @@ impl TouchBeginEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn buttons_len(&self) -> u16 {
         self.button_mask.len()
             .try_into().unwrap()
@@ -13972,8 +13972,8 @@ impl TouchBeginEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
@@ -14147,8 +14147,8 @@ impl RawTouchBeginEvent {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -2643,8 +2643,8 @@ impl CountedString16 {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u16 {
         self.string.len()
             .try_into().unwrap()
@@ -2768,8 +2768,8 @@ impl KeyType {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_map_entries(&self) -> u8 {
         self.map.len()
             .try_into().unwrap()
@@ -2826,8 +2826,8 @@ impl KeySymMap {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_syms(&self) -> u16 {
         self.syms.len()
             .try_into().unwrap()
@@ -3468,8 +3468,8 @@ impl SetKeyType {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_map_entries(&self) -> u8 {
         self.entries.len()
             .try_into().unwrap()
@@ -3523,8 +3523,8 @@ impl Outline {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_points(&self) -> u8 {
         self.points.len()
             .try_into().unwrap()
@@ -3582,8 +3582,8 @@ impl Shape {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_outlines(&self) -> u8 {
         self.outlines.len()
             .try_into().unwrap()
@@ -3727,8 +3727,8 @@ impl OverlayRow {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_keys(&self) -> u8 {
         self.keys.len()
             .try_into().unwrap()
@@ -3780,8 +3780,8 @@ impl Overlay {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_rows(&self) -> u8 {
         self.rows.len()
             .try_into().unwrap()
@@ -3839,8 +3839,8 @@ impl Row {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_keys(&self) -> u8 {
         self.keys.len()
             .try_into().unwrap()
@@ -3968,8 +3968,8 @@ impl Listing {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u16 {
         self.string.len()
             .try_into().unwrap()
@@ -7863,8 +7863,8 @@ impl GetCompatMapReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_si_rtrn(&self) -> u16 {
         self.si_rtrn.len()
             .try_into().unwrap()
@@ -8958,8 +8958,8 @@ impl ListComponentsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_keymaps(&self) -> u16 {
         self.keymaps.len()
             .try_into().unwrap()
@@ -8971,8 +8971,8 @@ impl ListComponentsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_keycodes(&self) -> u16 {
         self.keycodes.len()
             .try_into().unwrap()
@@ -8984,8 +8984,8 @@ impl ListComponentsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_types(&self) -> u16 {
         self.types.len()
             .try_into().unwrap()
@@ -8997,8 +8997,8 @@ impl ListComponentsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_compat_maps(&self) -> u16 {
         self.compat_maps.len()
             .try_into().unwrap()
@@ -9010,8 +9010,8 @@ impl ListComponentsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_symbols(&self) -> u16 {
         self.symbols.len()
             .try_into().unwrap()
@@ -9023,8 +9023,8 @@ impl ListComponentsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_geometries(&self) -> u16 {
         self.geometries.len()
             .try_into().unwrap()
@@ -9308,8 +9308,8 @@ impl GetKbdByNameRepliesCompatMap {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_si_rtrn(&self) -> u16 {
         self.si_rtrn.len()
             .try_into().unwrap()
@@ -9354,8 +9354,8 @@ impl GetKbdByNameRepliesIndicatorMaps {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_indicators(&self) -> u8 {
         self.maps.len()
             .try_into().unwrap()
@@ -9822,8 +9822,8 @@ impl GetDeviceInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_device_led_f_bs(&self) -> u16 {
         self.leds.len()
             .try_into().unwrap()
@@ -9835,8 +9835,8 @@ impl GetDeviceInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn n_btns_rtrn(&self) -> u8 {
         self.btn_actions.len()
             .try_into().unwrap()
@@ -9848,8 +9848,8 @@ impl GetDeviceInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -2635,6 +2635,21 @@ impl Serialize for CountedString16 {
         bytes.extend_from_slice(&self.alignment_pad);
     }
 }
+impl CountedString16 {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `string` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u16 {
+        self.string.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KTMapEntry {
@@ -2745,6 +2760,21 @@ impl Serialize for KeyType {
         self.preserve.serialize_into(bytes);
     }
 }
+impl KeyType {
+    /// Get the value of the `nMapEntries` field.
+    ///
+    /// The `nMapEntries` field is used as the length field of the `map` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_map_entries(&self) -> u8 {
+        self.map.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeySymMap {
@@ -2786,6 +2816,21 @@ impl Serialize for KeySymMap {
         let n_syms = u16::try_from(self.syms.len()).expect("`syms` has too many elements");
         n_syms.serialize_into(bytes);
         self.syms.serialize_into(bytes);
+    }
+}
+impl KeySymMap {
+    /// Get the value of the `nSyms` field.
+    ///
+    /// The `nSyms` field is used as the length field of the `syms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_syms(&self) -> u16 {
+        self.syms.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3415,6 +3460,21 @@ impl Serialize for SetKeyType {
         self.preserve_entries.serialize_into(bytes);
     }
 }
+impl SetKeyType {
+    /// Get the value of the `nMapEntries` field.
+    ///
+    /// The `nMapEntries` field is used as the length field of the `entries` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_map_entries(&self) -> u8 {
+        self.entries.len()
+            .try_into().unwrap()
+    }
+}
 
 pub type String8 = u8;
 
@@ -3453,6 +3513,21 @@ impl Serialize for Outline {
         self.corner_radius.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
         self.points.serialize_into(bytes);
+    }
+}
+impl Outline {
+    /// Get the value of the `nPoints` field.
+    ///
+    /// The `nPoints` field is used as the length field of the `points` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_points(&self) -> u8 {
+        self.points.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3497,6 +3572,21 @@ impl Serialize for Shape {
         self.approx_ndx.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
         self.outlines.serialize_into(bytes);
+    }
+}
+impl Shape {
+    /// Get the value of the `nOutlines` field.
+    ///
+    /// The `nOutlines` field is used as the length field of the `outlines` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_outlines(&self) -> u8 {
+        self.outlines.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3629,6 +3719,21 @@ impl Serialize for OverlayRow {
         self.keys.serialize_into(bytes);
     }
 }
+impl OverlayRow {
+    /// Get the value of the `nKeys` field.
+    ///
+    /// The `nKeys` field is used as the length field of the `keys` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_keys(&self) -> u8 {
+        self.keys.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Overlay {
@@ -3665,6 +3770,21 @@ impl Serialize for Overlay {
         n_rows.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 3]);
         self.rows.serialize_into(bytes);
+    }
+}
+impl Overlay {
+    /// Get the value of the `nRows` field.
+    ///
+    /// The `nRows` field is used as the length field of the `rows` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_rows(&self) -> u8 {
+        self.rows.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3709,6 +3829,21 @@ impl Serialize for Row {
         self.vertical.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
         self.keys.serialize_into(bytes);
+    }
+}
+impl Row {
+    /// Get the value of the `nKeys` field.
+    ///
+    /// The `nKeys` field is used as the length field of the `keys` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_keys(&self) -> u8 {
+        self.keys.len()
+            .try_into().unwrap()
     }
 }
 
@@ -3823,6 +3958,21 @@ impl Serialize for Listing {
         length.serialize_into(bytes);
         bytes.extend_from_slice(&self.string);
         bytes.extend_from_slice(&[0; 1][..(2 - (bytes.len() % 2)) % 2]);
+    }
+}
+impl Listing {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `string` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u16 {
+        self.string.len()
+            .try_into().unwrap()
     }
 }
 
@@ -7705,6 +7855,21 @@ impl TryFrom<&[u8]> for GetCompatMapReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetCompatMapReply {
+    /// Get the value of the `nSIRtrn` field.
+    ///
+    /// The `nSIRtrn` field is used as the length field of the `si_rtrn` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_si_rtrn(&self) -> u16 {
+        self.si_rtrn.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetCompatMap request
 pub const SET_COMPAT_MAP_REQUEST: u8 = 11;
@@ -8785,6 +8950,86 @@ impl TryFrom<&[u8]> for ListComponentsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ListComponentsReply {
+    /// Get the value of the `nKeymaps` field.
+    ///
+    /// The `nKeymaps` field is used as the length field of the `keymaps` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_keymaps(&self) -> u16 {
+        self.keymaps.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `nKeycodes` field.
+    ///
+    /// The `nKeycodes` field is used as the length field of the `keycodes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_keycodes(&self) -> u16 {
+        self.keycodes.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `nTypes` field.
+    ///
+    /// The `nTypes` field is used as the length field of the `types` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_types(&self) -> u16 {
+        self.types.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `nCompatMaps` field.
+    ///
+    /// The `nCompatMaps` field is used as the length field of the `compatMaps` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_compat_maps(&self) -> u16 {
+        self.compat_maps.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `nSymbols` field.
+    ///
+    /// The `nSymbols` field is used as the length field of the `symbols` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_symbols(&self) -> u16 {
+        self.symbols.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `nGeometries` field.
+    ///
+    /// The `nGeometries` field is used as the length field of the `geometries` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_geometries(&self) -> u16 {
+        self.geometries.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetKbdByName request
 pub const GET_KBD_BY_NAME_REQUEST: u8 = 23;
@@ -9055,6 +9300,21 @@ impl TryFrom<&[u8]> for GetKbdByNameRepliesCompatMap {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetKbdByNameRepliesCompatMap {
+    /// Get the value of the `nSIRtrn` field.
+    ///
+    /// The `nSIRtrn` field is used as the length field of the `si_rtrn` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_si_rtrn(&self) -> u16 {
+        self.si_rtrn.len()
+            .try_into().unwrap()
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetKbdByNameRepliesIndicatorMaps {
     pub indicatormap_type: u8,
@@ -9084,6 +9344,21 @@ impl TryFrom<&[u8]> for GetKbdByNameRepliesIndicatorMaps {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetKbdByNameRepliesIndicatorMaps {
+    /// Get the value of the `nIndicators` field.
+    ///
+    /// The `nIndicators` field is used as the length field of the `maps` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_indicators(&self) -> u8 {
+        self.maps.len()
+            .try_into().unwrap()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9537,6 +9812,47 @@ impl TryFrom<&[u8]> for GetDeviceInfoReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetDeviceInfoReply {
+    /// Get the value of the `nDeviceLedFBs` field.
+    ///
+    /// The `nDeviceLedFBs` field is used as the length field of the `leds` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_device_led_f_bs(&self) -> u16 {
+        self.leds.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `nBtnsRtrn` field.
+    ///
+    /// The `nBtnsRtrn` field is used as the length field of the `btnActions` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn n_btns_rtrn(&self) -> u8 {
+        self.btn_actions.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `nameLen` field.
+    ///
+    /// The `nameLen` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -83,6 +83,34 @@ impl Serialize for Printer {
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
     }
 }
+impl Printer {
+    /// Get the value of the `nameLen` field.
+    ///
+    /// The `nameLen` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u32 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `descLen` field.
+    ///
+    /// The `descLen` field is used as the length field of the `description` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn desc_len(&self) -> u32 {
+        self.description.len()
+            .try_into().unwrap()
+    }
+}
 
 pub type Pcontext = u32;
 
@@ -484,6 +512,21 @@ impl TryFrom<&[u8]> for PrintGetPrinterListReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl PrintGetPrinterListReply {
+    /// Get the value of the `listCount` field.
+    ///
+    /// The `listCount` field is used as the length field of the `printers` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn list_count(&self) -> u32 {
+        self.printers.len()
+            .try_into().unwrap()
     }
 }
 
@@ -917,6 +960,21 @@ impl TryFrom<&[u8]> for PrintGetDocumentDataReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl PrintGetDocumentDataReply {
+    /// Get the value of the `dataLen` field.
+    ///
+    /// The `dataLen` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn data_len(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the PrintStartPage request
 pub const PRINT_START_PAGE_REQUEST: u8 = 13;
@@ -1117,6 +1175,21 @@ impl TryFrom<&[u8]> for PrintGetAttributesReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl PrintGetAttributesReply {
+    /// Get the value of the `stringLen` field.
+    ///
+    /// The `stringLen` field is used as the length field of the `attributes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn string_len(&self) -> u32 {
+        self.attributes.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the PrintGetOneAttributes request
 pub const PRINT_GET_ONE_ATTRIBUTES_REQUEST: u8 = 19;
@@ -1184,6 +1257,21 @@ impl TryFrom<&[u8]> for PrintGetOneAttributesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl PrintGetOneAttributesReply {
+    /// Get the value of the `valueLen` field.
+    ///
+    /// The `valueLen` field is used as the length field of the `value` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn value_len(&self) -> u32 {
+        self.value.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1336,6 +1424,21 @@ impl TryFrom<&[u8]> for PrintQueryScreensReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl PrintQueryScreensReply {
+    /// Get the value of the `listCount` field.
+    ///
+    /// The `listCount` field is used as the length field of the `roots` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn list_count(&self) -> u32 {
+        self.roots.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -91,8 +91,8 @@ impl Printer {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u32 {
         self.name.len()
             .try_into().unwrap()
@@ -104,8 +104,8 @@ impl Printer {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn desc_len(&self) -> u32 {
         self.description.len()
             .try_into().unwrap()
@@ -522,8 +522,8 @@ impl PrintGetPrinterListReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn list_count(&self) -> u32 {
         self.printers.len()
             .try_into().unwrap()
@@ -968,8 +968,8 @@ impl PrintGetDocumentDataReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn data_len(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -1183,8 +1183,8 @@ impl PrintGetAttributesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn string_len(&self) -> u32 {
         self.attributes.len()
             .try_into().unwrap()
@@ -1267,8 +1267,8 @@ impl PrintGetOneAttributesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn value_len(&self) -> u32 {
         self.value.len()
             .try_into().unwrap()
@@ -1434,8 +1434,8 @@ impl PrintQueryScreensReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn list_count(&self) -> u32 {
         self.roots.len()
             .try_into().unwrap()

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -480,6 +480,21 @@ impl Serialize for Depth {
         self.visuals.serialize_into(bytes);
     }
 }
+impl Depth {
+    /// Get the value of the `visuals_len` field.
+    ///
+    /// The `visuals_len` field is used as the length field of the `visuals` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn visuals_len(&self) -> u16 {
+        self.visuals.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -727,6 +742,21 @@ impl Serialize for Screen {
         self.allowed_depths.serialize_into(bytes);
     }
 }
+impl Screen {
+    /// Get the value of the `allowed_depths_len` field.
+    ///
+    /// The `allowed_depths_len` field is used as the length field of the `allowed_depths` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn allowed_depths_len(&self) -> u8 {
+        self.allowed_depths.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupRequest {
@@ -792,6 +822,34 @@ impl Serialize for SetupRequest {
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
     }
 }
+impl SetupRequest {
+    /// Get the value of the `authorization_protocol_name_len` field.
+    ///
+    /// The `authorization_protocol_name_len` field is used as the length field of the `authorization_protocol_name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn authorization_protocol_name_len(&self) -> u16 {
+        self.authorization_protocol_name.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `authorization_protocol_data_len` field.
+    ///
+    /// The `authorization_protocol_data_len` field is used as the length field of the `authorization_protocol_data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn authorization_protocol_data_len(&self) -> u16 {
+        self.authorization_protocol_data.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupFailed {
@@ -838,6 +896,21 @@ impl Serialize for SetupFailed {
         bytes.extend_from_slice(&self.reason);
     }
 }
+impl SetupFailed {
+    /// Get the value of the `reason_len` field.
+    ///
+    /// The `reason_len` field is used as the length field of the `reason` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn reason_len(&self) -> u8 {
+        self.reason.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupAuthenticate {
@@ -876,6 +949,22 @@ impl Serialize for SetupAuthenticate {
         let length = u16::try_from(self.reason.len() / 4).expect("`reason` has too many elements");
         length.serialize_into(bytes);
         bytes.extend_from_slice(&self.reason);
+    }
+}
+impl SetupAuthenticate {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `reason` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u16 {
+        self.reason.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
     }
 }
 
@@ -1049,6 +1138,47 @@ impl Serialize for Setup {
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
         self.pixmap_formats.serialize_into(bytes);
         self.roots.serialize_into(bytes);
+    }
+}
+impl Setup {
+    /// Get the value of the `vendor_len` field.
+    ///
+    /// The `vendor_len` field is used as the length field of the `vendor` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn vendor_len(&self) -> u16 {
+        self.vendor.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `roots_len` field.
+    ///
+    /// The `roots_len` field is used as the length field of the `roots` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn roots_len(&self) -> u8 {
+        self.roots.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `pixmap_formats_len` field.
+    ///
+    /// The `pixmap_formats_len` field is used as the length field of the `pixmap_formats` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn pixmap_formats_len(&self) -> u8 {
+        self.pixmap_formats.len()
+            .try_into().unwrap()
     }
 }
 
@@ -7458,6 +7588,21 @@ impl TryFrom<&[u8]> for QueryTreeReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryTreeReply {
+    /// Get the value of the `children_len` field.
+    ///
+    /// The `children_len` field is used as the length field of the `children` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn children_len(&self) -> u16 {
+        self.children.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the InternAtom request
 pub const INTERN_ATOM_REQUEST: u8 = 16;
@@ -7609,6 +7754,21 @@ impl TryFrom<&[u8]> for GetAtomNameReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetAtomNameReply {
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
     }
 }
 
@@ -8254,6 +8414,21 @@ impl TryFrom<&[u8]> for ListPropertiesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListPropertiesReply {
+    /// Get the value of the `atoms_len` field.
+    ///
+    /// The `atoms_len` field is used as the length field of the `atoms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn atoms_len(&self) -> u16 {
+        self.atoms.len()
+            .try_into().unwrap()
     }
 }
 
@@ -10119,6 +10294,21 @@ impl TryFrom<&[u8]> for GetMotionEventsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetMotionEventsReply {
+    /// Get the value of the `events_len` field.
+    ///
+    /// The `events_len` field is used as the length field of the `events` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn events_len(&self) -> u32 {
+        self.events.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the TranslateCoordinates request
 pub const TRANSLATE_COORDINATES_REQUEST: u8 = 40;
@@ -10860,6 +11050,34 @@ impl TryFrom<&[u8]> for QueryFontReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryFontReply {
+    /// Get the value of the `properties_len` field.
+    ///
+    /// The `properties_len` field is used as the length field of the `properties` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn properties_len(&self) -> u16 {
+        self.properties.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `char_infos_len` field.
+    ///
+    /// The `char_infos_len` field is used as the length field of the `char_infos` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn char_infos_len(&self) -> u32 {
+        self.char_infos.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryTextExtents request
 pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
@@ -10998,6 +11216,21 @@ impl Serialize for Str {
         bytes.extend_from_slice(&self.name);
     }
 }
+impl Str {
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u8 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ListFonts request
 pub const LIST_FONTS_REQUEST: u8 = 49;
@@ -11069,6 +11302,21 @@ impl TryFrom<&[u8]> for ListFontsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListFontsReply {
+    /// Get the value of the `names_len` field.
+    ///
+    /// The `names_len` field is used as the length field of the `names` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn names_len(&self) -> u16 {
+        self.names.len()
+            .try_into().unwrap()
     }
 }
 
@@ -11186,6 +11434,34 @@ impl TryFrom<&[u8]> for ListFontsWithInfoReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ListFontsWithInfoReply {
+    /// Get the value of the `name_len` field.
+    ///
+    /// The `name_len` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_len(&self) -> u8 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `properties_len` field.
+    ///
+    /// The `properties_len` field is used as the length field of the `properties` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn properties_len(&self) -> u16 {
+        self.properties.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetFontPath request
 pub const SET_FONT_PATH_REQUEST: u8 = 51;
@@ -11261,6 +11537,21 @@ impl TryFrom<&[u8]> for GetFontPathReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetFontPathReply {
+    /// Get the value of the `path_len` field.
+    ///
+    /// The `path_len` field is used as the length field of the `path` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn path_len(&self) -> u16 {
+        self.path.len()
+            .try_into().unwrap()
     }
 }
 
@@ -14015,6 +14306,22 @@ impl TryFrom<&[u8]> for GetImageReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetImageReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.data.len()
+            .checked_div(4).unwrap()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the PolyText8 request
 pub const POLY_TEXT8_REQUEST: u8 = 74;
@@ -14508,6 +14815,21 @@ impl TryFrom<&[u8]> for ListInstalledColormapsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ListInstalledColormapsReply {
+    /// Get the value of the `cmaps_len` field.
+    ///
+    /// The `cmaps_len` field is used as the length field of the `cmaps` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn cmaps_len(&self) -> u16 {
+        self.cmaps.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the AllocColor request
 pub const ALLOC_COLOR_REQUEST: u8 = 84;
@@ -14727,6 +15049,34 @@ impl TryFrom<&[u8]> for AllocColorCellsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl AllocColorCellsReply {
+    /// Get the value of the `pixels_len` field.
+    ///
+    /// The `pixels_len` field is used as the length field of the `pixels` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn pixels_len(&self) -> u16 {
+        self.pixels.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `masks_len` field.
+    ///
+    /// The `masks_len` field is used as the length field of the `masks` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn masks_len(&self) -> u16 {
+        self.masks.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the AllocColorPlanes request
 pub const ALLOC_COLOR_PLANES_REQUEST: u8 = 87;
@@ -14797,6 +15147,21 @@ impl TryFrom<&[u8]> for AllocColorPlanesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl AllocColorPlanesReply {
+    /// Get the value of the `pixels_len` field.
+    ///
+    /// The `pixels_len` field is used as the length field of the `pixels` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn pixels_len(&self) -> u16 {
+        self.pixels.len()
+            .try_into().unwrap()
     }
 }
 
@@ -15132,6 +15497,21 @@ impl TryFrom<&[u8]> for QueryColorsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryColorsReply {
+    /// Get the value of the `colors_len` field.
+    ///
+    /// The `colors_len` field is used as the length field of the `colors` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn colors_len(&self) -> u16 {
+        self.colors.len()
+            .try_into().unwrap()
     }
 }
 
@@ -15814,6 +16194,21 @@ impl TryFrom<&[u8]> for ListExtensionsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ListExtensionsReply {
+    /// Get the value of the `names_len` field.
+    ///
+    /// The `names_len` field is used as the length field of the `names` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn names_len(&self) -> u8 {
+        self.names.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ChangeKeyboardMapping request
 pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
@@ -15896,6 +16291,21 @@ impl TryFrom<&[u8]> for GetKeyboardMappingReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetKeyboardMappingReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `keysyms` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.keysyms.len()
+            .try_into().unwrap()
     }
 }
 
@@ -16864,6 +17274,21 @@ impl Serialize for Host {
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
     }
 }
+impl Host {
+    /// Get the value of the `address_len` field.
+    ///
+    /// The `address_len` field is used as the length field of the `address` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn address_len(&self) -> u16 {
+        self.address.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ListHosts request
 pub const LIST_HOSTS_REQUEST: u8 = 110;
@@ -16911,6 +17336,21 @@ impl TryFrom<&[u8]> for ListHostsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListHostsReply {
+    /// Get the value of the `hosts_len` field.
+    ///
+    /// The `hosts_len` field is used as the length field of the `hosts` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn hosts_len(&self) -> u16 {
+        self.hosts.len()
+            .try_into().unwrap()
     }
 }
 
@@ -17484,6 +17924,21 @@ impl TryFrom<&[u8]> for GetPointerMappingReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetPointerMappingReply {
+    /// Get the value of the `map_len` field.
+    ///
+    /// The `map_len` field is used as the length field of the `map` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn map_len(&self) -> u8 {
+        self.map.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -17660,6 +18115,22 @@ impl TryFrom<&[u8]> for GetModifierMappingReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetModifierMappingReply {
+    /// Get the value of the `keycodes_per_modifier` field.
+    ///
+    /// The `keycodes_per_modifier` field is used as the length field of the `keycodes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn keycodes_per_modifier(&self) -> u8 {
+        self.keycodes.len()
+            .checked_div(8).unwrap()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -488,8 +488,8 @@ impl Depth {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn visuals_len(&self) -> u16 {
         self.visuals.len()
             .try_into().unwrap()
@@ -750,8 +750,8 @@ impl Screen {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn allowed_depths_len(&self) -> u8 {
         self.allowed_depths.len()
             .try_into().unwrap()
@@ -830,8 +830,8 @@ impl SetupRequest {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn authorization_protocol_name_len(&self) -> u16 {
         self.authorization_protocol_name.len()
             .try_into().unwrap()
@@ -843,8 +843,8 @@ impl SetupRequest {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn authorization_protocol_data_len(&self) -> u16 {
         self.authorization_protocol_data.len()
             .try_into().unwrap()
@@ -904,8 +904,8 @@ impl SetupFailed {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn reason_len(&self) -> u8 {
         self.reason.len()
             .try_into().unwrap()
@@ -959,8 +959,8 @@ impl SetupAuthenticate {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u16 {
         self.reason.len()
             .checked_div(4).unwrap()
@@ -1148,8 +1148,8 @@ impl Setup {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn vendor_len(&self) -> u16 {
         self.vendor.len()
             .try_into().unwrap()
@@ -1161,8 +1161,8 @@ impl Setup {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn roots_len(&self) -> u8 {
         self.roots.len()
             .try_into().unwrap()
@@ -1174,8 +1174,8 @@ impl Setup {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn pixmap_formats_len(&self) -> u8 {
         self.pixmap_formats.len()
             .try_into().unwrap()
@@ -7596,8 +7596,8 @@ impl QueryTreeReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn children_len(&self) -> u16 {
         self.children.len()
             .try_into().unwrap()
@@ -7764,8 +7764,8 @@ impl GetAtomNameReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -8424,8 +8424,8 @@ impl ListPropertiesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn atoms_len(&self) -> u16 {
         self.atoms.len()
             .try_into().unwrap()
@@ -10302,8 +10302,8 @@ impl GetMotionEventsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn events_len(&self) -> u32 {
         self.events.len()
             .try_into().unwrap()
@@ -11058,8 +11058,8 @@ impl QueryFontReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn properties_len(&self) -> u16 {
         self.properties.len()
             .try_into().unwrap()
@@ -11071,8 +11071,8 @@ impl QueryFontReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn char_infos_len(&self) -> u32 {
         self.char_infos.len()
             .try_into().unwrap()
@@ -11224,8 +11224,8 @@ impl Str {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u8 {
         self.name.len()
             .try_into().unwrap()
@@ -11312,8 +11312,8 @@ impl ListFontsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn names_len(&self) -> u16 {
         self.names.len()
             .try_into().unwrap()
@@ -11442,8 +11442,8 @@ impl ListFontsWithInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_len(&self) -> u8 {
         self.name.len()
             .try_into().unwrap()
@@ -11455,8 +11455,8 @@ impl ListFontsWithInfoReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn properties_len(&self) -> u16 {
         self.properties.len()
             .try_into().unwrap()
@@ -11547,8 +11547,8 @@ impl GetFontPathReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn path_len(&self) -> u16 {
         self.path.len()
             .try_into().unwrap()
@@ -14314,8 +14314,8 @@ impl GetImageReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.data.len()
             .checked_div(4).unwrap()
@@ -14823,8 +14823,8 @@ impl ListInstalledColormapsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn cmaps_len(&self) -> u16 {
         self.cmaps.len()
             .try_into().unwrap()
@@ -15057,8 +15057,8 @@ impl AllocColorCellsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn pixels_len(&self) -> u16 {
         self.pixels.len()
             .try_into().unwrap()
@@ -15070,8 +15070,8 @@ impl AllocColorCellsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn masks_len(&self) -> u16 {
         self.masks.len()
             .try_into().unwrap()
@@ -15157,8 +15157,8 @@ impl AllocColorPlanesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn pixels_len(&self) -> u16 {
         self.pixels.len()
             .try_into().unwrap()
@@ -15507,8 +15507,8 @@ impl QueryColorsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn colors_len(&self) -> u16 {
         self.colors.len()
             .try_into().unwrap()
@@ -16202,8 +16202,8 @@ impl ListExtensionsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn names_len(&self) -> u8 {
         self.names.len()
             .try_into().unwrap()
@@ -16301,8 +16301,8 @@ impl GetKeyboardMappingReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.keysyms.len()
             .try_into().unwrap()
@@ -17282,8 +17282,8 @@ impl Host {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn address_len(&self) -> u16 {
         self.address.len()
             .try_into().unwrap()
@@ -17346,8 +17346,8 @@ impl ListHostsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn hosts_len(&self) -> u16 {
         self.hosts.len()
             .try_into().unwrap()
@@ -17932,8 +17932,8 @@ impl GetPointerMappingReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn map_len(&self) -> u8 {
         self.map.len()
             .try_into().unwrap()
@@ -18125,8 +18125,8 @@ impl GetModifierMappingReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn keycodes_per_modifier(&self) -> u8 {
         self.keycodes.len()
             .checked_div(8).unwrap()

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -166,6 +166,21 @@ impl TryFrom<&[u8]> for GetDeviceCreateContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetDeviceCreateContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetDeviceContext request
 pub const SET_DEVICE_CONTEXT_REQUEST: u8 = 3;
@@ -257,6 +272,21 @@ impl TryFrom<&[u8]> for GetDeviceContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetDeviceContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetWindowCreateContext request
 pub const SET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 5;
@@ -338,6 +368,21 @@ impl TryFrom<&[u8]> for GetWindowCreateContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetWindowCreateContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetWindowContext request
 pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
@@ -393,6 +438,21 @@ impl TryFrom<&[u8]> for GetWindowContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetWindowContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListItem {
@@ -446,6 +506,34 @@ impl Serialize for ListItem {
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
         bytes.extend_from_slice(&self.data_context);
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+    }
+}
+impl ListItem {
+    /// Get the value of the `object_context_len` field.
+    ///
+    /// The `object_context_len` field is used as the length field of the `object_context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn object_context_len(&self) -> u32 {
+        self.object_context.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `data_context_len` field.
+    ///
+    /// The `data_context_len` field is used as the length field of the `data_context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn data_context_len(&self) -> u32 {
+        self.data_context.len()
+            .try_into().unwrap()
     }
 }
 
@@ -529,6 +617,21 @@ impl TryFrom<&[u8]> for GetPropertyCreateContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetPropertyCreateContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetPropertyUseContext request
 pub const SET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 10;
@@ -610,6 +713,21 @@ impl TryFrom<&[u8]> for GetPropertyUseContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetPropertyUseContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetPropertyContext request
 pub const GET_PROPERTY_CONTEXT_REQUEST: u8 = 12;
@@ -668,6 +786,21 @@ impl TryFrom<&[u8]> for GetPropertyContextReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetPropertyContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
     }
 }
 
@@ -730,6 +863,21 @@ impl TryFrom<&[u8]> for GetPropertyDataContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetPropertyDataContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 14;
@@ -782,6 +930,21 @@ impl TryFrom<&[u8]> for ListPropertiesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListPropertiesReply {
+    /// Get the value of the `properties_len` field.
+    ///
+    /// The `properties_len` field is used as the length field of the `properties` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn properties_len(&self) -> u32 {
+        self.properties.len()
+            .try_into().unwrap()
     }
 }
 
@@ -865,6 +1028,21 @@ impl TryFrom<&[u8]> for GetSelectionCreateContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetSelectionCreateContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the SetSelectionUseContext request
 pub const SET_SELECTION_USE_CONTEXT_REQUEST: u8 = 17;
@@ -946,6 +1124,21 @@ impl TryFrom<&[u8]> for GetSelectionUseContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetSelectionUseContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the GetSelectionContext request
 pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
@@ -999,6 +1192,21 @@ impl TryFrom<&[u8]> for GetSelectionContextReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetSelectionContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1056,6 +1264,21 @@ impl TryFrom<&[u8]> for GetSelectionDataContextReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl GetSelectionDataContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ListSelections request
 pub const LIST_SELECTIONS_REQUEST: u8 = 21;
@@ -1103,6 +1326,21 @@ impl TryFrom<&[u8]> for ListSelectionsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListSelectionsReply {
+    /// Get the value of the `selections_len` field.
+    ///
+    /// The `selections_len` field is used as the length field of the `selections` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn selections_len(&self) -> u32 {
+        self.selections.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1158,6 +1396,21 @@ impl TryFrom<&[u8]> for GetClientContextReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GetClientContextReply {
+    /// Get the value of the `context_len` field.
+    ///
+    /// The `context_len` field is used as the length field of the `context` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn context_len(&self) -> u32 {
+        self.context.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -174,8 +174,8 @@ impl GetDeviceCreateContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -280,8 +280,8 @@ impl GetDeviceContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -376,8 +376,8 @@ impl GetWindowCreateContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -446,8 +446,8 @@ impl GetWindowContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -516,8 +516,8 @@ impl ListItem {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn object_context_len(&self) -> u32 {
         self.object_context.len()
             .try_into().unwrap()
@@ -529,8 +529,8 @@ impl ListItem {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn data_context_len(&self) -> u32 {
         self.data_context.len()
             .try_into().unwrap()
@@ -625,8 +625,8 @@ impl GetPropertyCreateContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -721,8 +721,8 @@ impl GetPropertyUseContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -796,8 +796,8 @@ impl GetPropertyContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -871,8 +871,8 @@ impl GetPropertyDataContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -940,8 +940,8 @@ impl ListPropertiesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn properties_len(&self) -> u32 {
         self.properties.len()
             .try_into().unwrap()
@@ -1036,8 +1036,8 @@ impl GetSelectionCreateContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -1132,8 +1132,8 @@ impl GetSelectionUseContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -1202,8 +1202,8 @@ impl GetSelectionContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -1272,8 +1272,8 @@ impl GetSelectionDataContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()
@@ -1336,8 +1336,8 @@ impl ListSelectionsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn selections_len(&self) -> u32 {
         self.selections.len()
             .try_into().unwrap()
@@ -1406,8 +1406,8 @@ impl GetClientContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn context_len(&self) -> u32 {
         self.context.len()
             .try_into().unwrap()

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -677,8 +677,8 @@ impl AdaptorInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_size(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -690,8 +690,8 @@ impl AdaptorInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_formats(&self) -> u16 {
         self.formats.len()
             .try_into().unwrap()
@@ -759,8 +759,8 @@ impl EncodingInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn name_size(&self) -> u16 {
         self.name.len()
             .try_into().unwrap()
@@ -827,8 +827,8 @@ impl Image {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn data_size(&self) -> u32 {
         self.data.len()
             .try_into().unwrap()
@@ -840,8 +840,8 @@ impl Image {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_planes(&self) -> u32 {
         self.pitches.len()
             .try_into().unwrap()
@@ -904,8 +904,8 @@ impl AttributeInfo {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn size(&self) -> u32 {
         self.name.len()
             .try_into().unwrap()
@@ -1653,8 +1653,8 @@ impl QueryAdaptorsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_adaptors(&self) -> u16 {
         self.info.len()
             .try_into().unwrap()
@@ -1722,8 +1722,8 @@ impl QueryEncodingsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_encodings(&self) -> u16 {
         self.info.len()
             .try_into().unwrap()
@@ -2391,8 +2391,8 @@ impl QueryPortAttributesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_attributes(&self) -> u32 {
         self.attributes.len()
             .try_into().unwrap()
@@ -2460,8 +2460,8 @@ impl ListImageFormatsReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_formats(&self) -> u32 {
         self.format.len()
             .try_into().unwrap()
@@ -2548,8 +2548,8 @@ impl QueryImageAttributesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num_planes(&self) -> u32 {
         self.pitches.len()
             .try_into().unwrap()

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -669,6 +669,34 @@ impl Serialize for AdaptorInfo {
         self.formats.serialize_into(bytes);
     }
 }
+impl AdaptorInfo {
+    /// Get the value of the `name_size` field.
+    ///
+    /// The `name_size` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_size(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_formats` field.
+    ///
+    /// The `num_formats` field is used as the length field of the `formats` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_formats(&self) -> u16 {
+        self.formats.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncodingInfo {
@@ -721,6 +749,21 @@ impl Serialize for EncodingInfo {
         self.rate.serialize_into(bytes);
         bytes.extend_from_slice(&self.name);
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+    }
+}
+impl EncodingInfo {
+    /// Get the value of the `name_size` field.
+    ///
+    /// The `name_size` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn name_size(&self) -> u16 {
+        self.name.len()
+            .try_into().unwrap()
     }
 }
 
@@ -776,6 +819,34 @@ impl Serialize for Image {
         bytes.extend_from_slice(&self.data);
     }
 }
+impl Image {
+    /// Get the value of the `data_size` field.
+    ///
+    /// The `data_size` field is used as the length field of the `data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn data_size(&self) -> u32 {
+        self.data.len()
+            .try_into().unwrap()
+    }
+    /// Get the value of the `num_planes` field.
+    ///
+    /// The `num_planes` field is used as the length field of the `pitches` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_planes(&self) -> u32 {
+        self.pitches.len()
+            .try_into().unwrap()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttributeInfo {
@@ -823,6 +894,21 @@ impl Serialize for AttributeInfo {
         size.serialize_into(bytes);
         bytes.extend_from_slice(&self.name);
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+    }
+}
+impl AttributeInfo {
+    /// Get the value of the `size` field.
+    ///
+    /// The `size` field is used as the length field of the `name` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn size(&self) -> u32 {
+        self.name.len()
+            .try_into().unwrap()
     }
 }
 
@@ -1559,6 +1645,21 @@ impl TryFrom<&[u8]> for QueryAdaptorsReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryAdaptorsReply {
+    /// Get the value of the `num_adaptors` field.
+    ///
+    /// The `num_adaptors` field is used as the length field of the `info` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_adaptors(&self) -> u16 {
+        self.info.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the QueryEncodings request
 pub const QUERY_ENCODINGS_REQUEST: u8 = 2;
@@ -1611,6 +1712,21 @@ impl TryFrom<&[u8]> for QueryEncodingsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryEncodingsReply {
+    /// Get the value of the `num_encodings` field.
+    ///
+    /// The `num_encodings` field is used as the length field of the `info` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_encodings(&self) -> u16 {
+        self.info.len()
+            .try_into().unwrap()
     }
 }
 
@@ -2267,6 +2383,21 @@ impl TryFrom<&[u8]> for QueryPortAttributesReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl QueryPortAttributesReply {
+    /// Get the value of the `num_attributes` field.
+    ///
+    /// The `num_attributes` field is used as the length field of the `attributes` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_attributes(&self) -> u32 {
+        self.attributes.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the ListImageFormats request
 pub const LIST_IMAGE_FORMATS_REQUEST: u8 = 16;
@@ -2319,6 +2450,21 @@ impl TryFrom<&[u8]> for ListImageFormatsReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListImageFormatsReply {
+    /// Get the value of the `num_formats` field.
+    ///
+    /// The `num_formats` field is used as the length field of the `format` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_formats(&self) -> u32 {
+        self.format.len()
+            .try_into().unwrap()
     }
 }
 
@@ -2392,6 +2538,21 @@ impl TryFrom<&[u8]> for QueryImageAttributesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl QueryImageAttributesReply {
+    /// Get the value of the `num_planes` field.
+    ///
+    /// The `num_planes` field is used as the length field of the `pitches` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num_planes(&self) -> u32 {
+        self.pitches.len()
+            .try_into().unwrap()
     }
 }
 

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -233,8 +233,8 @@ impl ListSurfaceTypesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num(&self) -> u32 {
         self.surfaces.len()
             .try_into().unwrap()
@@ -327,8 +327,8 @@ impl CreateContextReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.priv_data.len()
             .try_into().unwrap()
@@ -426,8 +426,8 @@ impl CreateSurfaceReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.priv_data.len()
             .try_into().unwrap()
@@ -547,8 +547,8 @@ impl CreateSubpictureReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn length(&self) -> u32 {
         self.priv_data.len()
             .try_into().unwrap()
@@ -648,8 +648,8 @@ impl ListSubpictureTypesReply {
     ///
     /// # Panics
     ///
-    /// Panics if the value cannot be represented in the target type. This can
-    /// not happen with values of the struct received from the X11 server.
+    /// Panics if the value cannot be represented in the target type. This
+    /// cannot happen with values of the struct received from the X11 server.
     pub fn num(&self) -> u32 {
         self.types.len()
             .try_into().unwrap()

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -225,6 +225,21 @@ impl TryFrom<&[u8]> for ListSurfaceTypesReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ListSurfaceTypesReply {
+    /// Get the value of the `num` field.
+    ///
+    /// The `num` field is used as the length field of the `surfaces` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num(&self) -> u32 {
+        self.surfaces.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
@@ -302,6 +317,21 @@ impl TryFrom<&[u8]> for CreateContextReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl CreateContextReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `priv_data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.priv_data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -386,6 +416,21 @@ impl TryFrom<&[u8]> for CreateSurfaceReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl CreateSurfaceReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `priv_data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.priv_data.len()
+            .try_into().unwrap()
     }
 }
 
@@ -494,6 +539,21 @@ impl TryFrom<&[u8]> for CreateSubpictureReply {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl CreateSubpictureReply {
+    /// Get the value of the `length` field.
+    ///
+    /// The `length` field is used as the length field of the `priv_data` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn length(&self) -> u32 {
+        self.priv_data.len()
+            .try_into().unwrap()
+    }
+}
 
 /// Opcode for the DestroySubpicture request
 pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
@@ -578,6 +638,21 @@ impl TryFrom<&[u8]> for ListSubpictureTypesReply {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl ListSubpictureTypesReply {
+    /// Get the value of the `num` field.
+    ///
+    /// The `num` field is used as the length field of the `types` field.
+    /// This function computes the field's value again based on the length of the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value cannot be represented in the target type. This can
+    /// not happen with values of the struct received from the X11 server.
+    pub fn num(&self) -> u32 {
+        self.types.len()
+            .try_into().unwrap()
     }
 }
 


### PR DESCRIPTION
This commit adds accessor methods for length fields that are left out of
the actual struct as they are implicitly represented as the length of
some Vec. These length fields can sometimes still be useful to users.

Fixes: https://github.com/psychon/x11rb/issues/411
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

@exit91 what do you think about this? Would you call it a fix?