### PR TITLE
CI: Use cargo check where it makes sense

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
 
   # Build once with just the default features, i.e. without all the extensions
   # to check that this works fine.
-  - cargo build --verbose --all-targets
+  - cargo check --verbose --all-targets
 
   - cargo build --verbose --all-targets --all-features
   - cargo test --verbose --all-features

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ test_script:
   - cargo check --verbose --all-targets --features all-extensions
 
   # Also build once without any feature
-  - cargo build --verbose --all-targets --no-default-features
+  - cargo check --verbose --all-targets --no-default-features
 
   # We do not have libxcb and thus cannot build XCBConnection
   - cargo build --verbose --all-targets --no-default-features --features all-extensions


### PR DESCRIPTION
This replaced "cargo build" with "cargo check" in cases where the
following command uses different features and thus requires a
recompilation. Other cases, like "cargo build" followed by "cargo test"
make sense and are left as-is.

Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

I'm not sure how much sense this really makes. I hope that `cargo check` is faster than `cargo build`, but I am not sure if it is worth it. And how about cases where we want to make sure that all targets compile and run tests. Is `cargo build; cargo test` better or should it be `cargo check; cargo test`? The current version of this PR uses `cargo build; cargo test` and I am too lazy to really measure if this makes a difference.