### PR TITLE
Make RustConnection use a nonblocking stream

### DIFF
--- a/src/rust_connection/fd_read_write.rs
+++ b/src/rust_connection/fd_read_write.rs
@@ -151,6 +151,20 @@ impl<W: WriteFD + std::fmt::Debug> BufWriteFD<W> {
         }
     }
 
+    /// Gets a mutable reference to the underlying FD writer.
+    ///
+    /// It is inadvisable to directly write to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Gets a reference to the underlying FD writer.
+    ///
+    /// It is inadvisable to directly write to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        &self.inner
+    }
+
     fn flush_buffer(&mut self) -> Result<()> {
         let mut written = 0;
         let mut ret = Ok(());
@@ -320,6 +334,20 @@ impl<R: ReadFD + std::fmt::Debug> BufReadFD<R> {
             start: 0,
             end: 0,
         }
+    }
+
+    /// Gets a mutable reference to the underlying FD reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Gets a reference to the underlying FD reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub fn get_ref(&self) -> &R {
+        &self.inner
     }
 }
 

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -152,10 +152,17 @@ impl ConnectionInner {
         Some(full_number)
     }
 
-    /// An X11 packet was received from the connection and is now enqueued into our state.
-    pub(crate) fn enqueue_packet(&mut self, packet: Vec<u8>, fds: Vec<RawFdContainer>) {
+    /// Add FDs that were received to the internal state.
+    ///
+    /// This must be called before the corresponding packets are enqueued.
+    pub(crate) fn enqueue_fds(&mut self, fds: Vec<RawFdContainer>) {
         self.pending_fds.extend(fds);
+    }
 
+    /// An X11 packet was received from the connection and is now enqueued into our state.
+    ///
+    /// Any FDs that were received must already be enqueued before this can be called.
+    pub(crate) fn enqueue_packet(&mut self, packet: Vec<u8>) {
         let kind = packet[0];
 
         // extract_sequence_number() updates our state and is thus important to call even when we

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -255,7 +255,8 @@ impl RustConnection {
 
                 // 2.2. Block the thread until a packet is received.
                 let mut fds = Vec::new();
-                let packet = lock.read_x11_packet(&mut fds)?;
+                let raw_fd = lock.get_ref().get_ref().as_raw_fd();
+                let packet = polling_repeat(raw_fd, || lock.read_x11_packet(&mut fds))?;
 
                 // 2.3. Relock `inner` to enqueue the packet.
                 inner = self.inner.lock().unwrap();

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -653,7 +653,8 @@ fn write_all_vectored(
         }
     }
     if !fds.is_empty() {
-        write.write_all(&[], fds)?;
+        let count = write_polling_repeat(write_fd, || write.write(&[], &mut fds))?;
+        assert_eq!(count, 0);
     }
     Ok(())
 }

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -262,7 +262,8 @@ impl RustConnection {
                 drop(lock);
 
                 // 2.5. Actually enqueue the read packet.
-                inner.enqueue_packet(packet, fds);
+                inner.enqueue_fds(fds);
+                inner.enqueue_packet(packet);
 
                 // 2.6. Notify threads that a packet has been enqueued,
                 // so other threads waiting on 1.1 can return.

--- a/src/rust_connection/packet_reader.rs
+++ b/src/rust_connection/packet_reader.rs
@@ -38,6 +38,21 @@ impl<R: ReadFD + Debug> PacketReader<R> {
         }
     }
 
+    /// Gets a mutable reference to the underlying FD reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    #[allow(dead_code)] // This function exists for completeness with `get_ref`.
+    pub(crate) fn get_mut(&mut self) -> &mut BufReadFD<R> {
+        &mut self.inner
+    }
+
+    /// Gets a reference to the underlying FD reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub(crate) fn get_ref(&self) -> &BufReadFD<R> {
+        &self.inner
+    }
+
     /// Try to read an X11 packet from the inner reader.
     pub(crate) fn read_x11_packet(
         &mut self,

--- a/src/rust_connection/packet_reader.rs
+++ b/src/rust_connection/packet_reader.rs
@@ -1,0 +1,84 @@
+//! Read X11 packets from a reader
+
+use std::convert::TryInto;
+use std::fmt::Debug;
+use std::io::Result;
+
+use super::fd_read_write::{BufReadFD, ReadFD};
+use crate::utils::RawFdContainer;
+
+/// Minimal length of an X11 packet
+const MINIMAL_PACKET_LENGTH: usize = 32;
+
+/// A wrapper around a reader that reads X11 packet.
+#[derive(Debug)]
+pub(crate) struct PacketReader<R: ReadFD + Debug> {
+    pub(crate) inner: BufReadFD<R>,
+
+    // A packet that was partially read. The `Vec` is the partial packet and the `usize` describes
+    // up to where the packet was already read.
+    pending_packet: Option<(Vec<u8>, usize)>,
+}
+
+impl<R: ReadFD + Debug> PacketReader<R> {
+    /// Create a new `PacketReader` that reads from the given stream.
+    pub(crate) fn new(inner: BufReadFD<R>) -> Self {
+        Self {
+            inner,
+            pending_packet: None,
+        }
+    }
+
+    /// Try to read a packet from the inner reader.
+    pub(crate) fn read_packet(
+        &mut self,
+        fd_storage: &mut Vec<RawFdContainer>,
+    ) -> Result<Vec<u8>> {
+        if self.pending_packet.is_none() {
+            self.pending_packet = Some((vec![0; MINIMAL_PACKET_LENGTH], 0));
+        }
+
+        // Get mutable reference to the pending packet
+        let (packet, already_read) = self.pending_packet.as_mut().unwrap();
+
+        // Until the packet was fully read...
+        while packet.len() != *already_read {
+            // ...continue reading the packet
+            let nread = self.inner.read(&mut packet[*already_read..], fd_storage)?;
+            *already_read += nread;
+
+             // Do we still need to compute the length field? (length == MINIMAL_PACKET_LENGTH)
+             if let Ok(array) = packet[..].try_into() {
+                 // Yes, then compute the packet length and resize the `Vec` to its final size.
+                 let extra = extra_length(array);
+                 packet.reserve_exact(extra);
+                 packet.resize(MINIMAL_PACKET_LENGTH + extra, 0);
+             }
+        }
+
+        // Check that we really read the whole packet
+        let initial_packet = &packet[0..MINIMAL_PACKET_LENGTH].try_into().unwrap();
+        let extra = extra_length(&initial_packet);
+        assert_eq!(packet.len(), MINIMAL_PACKET_LENGTH + extra);
+
+        // Packet successfully read
+        Ok(self.pending_packet.take().unwrap().0)
+    }
+}
+
+// Compute the length beyond `MINIMAL_PACKET_LENGTH` of an X11 packet.
+fn extra_length(buffer: &[u8; MINIMAL_PACKET_LENGTH]) -> usize {
+    use crate::protocol::xproto::GE_GENERIC_EVENT;
+
+    let response_type = buffer[0];
+
+    const REPLY: u8 = 1;
+    if response_type == REPLY || response_type & 0x7f == GE_GENERIC_EVENT {
+        let length_field = buffer[4..8].try_into().unwrap();
+        let length_field = u32::from_ne_bytes(length_field) as usize;
+        4 * length_field
+    } else {
+        // Fixed size packet: error or event that is not GE_GENERIC_EVENT
+        0
+    }
+}

--- a/src/rust_connection/stream.rs
+++ b/src/rust_connection/stream.rs
@@ -246,3 +246,13 @@ impl ReadFD for Stream {
         }
     }
 }
+
+#[cfg(unix)]
+impl AsRawFd for Stream {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            Stream::TcpStream(stream) => stream.as_raw_fd(),
+            Stream::UnixStream(stream) => stream.as_raw_fd(),
+        }
+    }
+}


### PR DESCRIPTION
This is my attempt at fixing #408. This PR makes `RustConnection` use a nonblocking stream. This allows `poll_for_event()` to actually try to read something without blocking.

An open problem is: What to do on Window? I guess we need some safe API to call `WSAPoll` or something like it. Besides that, I think this is actually relatively okay. I was hoping to also fix #222, but that is left as future work.

Suggestions on how to make this nicer are welcome.
Suggestions on what to do with Windows are especially welcome.
Suggestions on how to introduce generic types are also welcome (#417).