### PR TITLE
RustConnection: Be nonblocking when needed

### DIFF
--- a/src/rust_connection/fd_read_write.rs
+++ b/src/rust_connection/fd_read_write.rs
@@ -301,7 +301,7 @@ impl<R: Read> ReadFD for ReadFDWrapper<R> {
     }
 
     fn set_nonblocking(&mut self, _nonblocking: bool) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/src/rust_connection/fd_read_write.rs
+++ b/src/rust_connection/fd_read_write.rs
@@ -268,6 +268,13 @@ pub trait ReadFD {
         }
         Ok(())
     }
+
+    /// Moves this reader into or out of nonblocking mode.
+    ///
+    /// In nonblocking mode, reading becomes nonblocking. This means that such calls immediately
+    /// return. If an immediate result is not possible, an error with kind
+    /// [`std::io::ErrorKind::WouldBlock`] is returned.
+    fn set_nonblocking(&mut self, nonblocking: bool) -> Result<()>;
 }
 
 /// Wraps a [`std::io::Read`] to implement the [`ReadFD`] trait.
@@ -291,6 +298,10 @@ impl<R: Read> ReadFD for ReadFDWrapper<R> {
 
     fn read_exact(&mut self, buf: &mut [u8], _fd_storage: &mut Vec<RawFdContainer>) -> Result<()> {
         self.0.read_exact(buf)
+    }
+
+    fn set_nonblocking(&mut self, _nonblocking: bool) -> Result<()> {
+        todo!()
     }
 }
 
@@ -339,5 +350,9 @@ impl<R: ReadFD> ReadFD for BufReadFD<R> {
         let nread = (&self.buf[self.start..self.end]).read(buf)?;
         self.start += nread;
         Ok(nread)
+    }
+
+    fn set_nonblocking(&mut self, nonblocking: bool) -> Result<()> {
+        self.inner.set_nonblocking(nonblocking)
     }
 }

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -152,10 +152,17 @@ impl ConnectionInner {
         Some(full_number)
     }
 
-    /// An X11 packet was received from the connection and is now enqueued into our state.
-    pub(crate) fn enqueue_packet(&mut self, packet: Vec<u8>, fds: Vec<RawFdContainer>) {
+    /// Add FDs that were received to the internal state.
+    ///
+    /// This must be called before the corresponding packets are enqueued.
+    pub(crate) fn enqueue_fds(&mut self, fds: Vec<RawFdContainer>) {
         self.pending_fds.extend(fds);
+    }
 
+    /// An X11 packet was received from the connection and is now enqueued into our state.
+    ///
+    /// Any FDs that were received must already be enqueued before this can be called.
+    pub(crate) fn enqueue_packet(&mut self, packet: Vec<u8>) {
         let kind = packet[0];
 
         // extract_sequence_number() updates our state and is thus important to call even when we

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -259,7 +259,8 @@ impl<R: ReadFD, W: WriteFD> RustConnection<R, W> {
                 drop(lock);
 
                 // 2.5. Actually enqueue the read packet.
-                inner.enqueue_packet(packet, fds);
+                inner.enqueue_fds(fds);
+                inner.enqueue_packet(packet);
 
                 // 2.6. Notify threads that a packet has been enqueued,
                 // so other threads waiting on 1.1 can return.

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -248,7 +248,7 @@ impl<R: ReadFD, W: WriteFD> RustConnection<R, W> {
                 // In non-blocking mode, we just return immediately
                 match mode {
                     BlockingMode::NonBlocking => return Ok(inner),
-                    BlockingMode::Blocking => {},
+                    BlockingMode::Blocking => {}
                 }
 
                 // 1.1. Someone else is reading (other thread is at 2.2);

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -625,6 +625,10 @@ mod test {
         fn read(&mut self, buf: &mut [u8], _fd_storage: &mut Vec<RawFdContainer>) -> Result<usize> {
             self.0.read(buf)
         }
+
+        fn set_nonblocking(&mut self, _nonblocking: bool) -> Result<()> {
+            todo!()
+        }
     }
 
     fn partial_write_test(request: &[u8], expected_err: &str) {

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -282,7 +282,7 @@ impl<R: ReadFD, W: WriteFD> RustConnection<R, W> {
 
                 let packet = match packet {
                     Err(e) if e.kind() == WouldBlock => return Ok(inner),
-                    Err(e) => return Err(e.into()),
+                    Err(e) => return Err(e),
                     Ok(packet) => packet,
                 };
 

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -281,7 +281,7 @@ impl<R: ReadFD, W: WriteFD> RustConnection<R, W> {
                 inner = self.inner.lock().unwrap();
 
                 let packet = match packet {
-                    Err(e) if e.kind() == WouldBlock => return Ok(inner),
+                    Err(ref e) if e.kind() == WouldBlock => return Ok(inner),
                     Err(e) => return Err(e),
                     Ok(packet) => packet,
                 };

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -55,7 +55,7 @@ pub(crate) enum BlockingMode {
 }
 
 impl BlockingMode {
-    fn set_on_reader(self, read: &mut impl ReadFD) -> std::io::Result<()> {
+    fn set_on_reader(self, read: &mut PacketReader<impl ReadFD>) -> std::io::Result<()> {
         match self {
             BlockingMode::Blocking => read.set_nonblocking(false),
             BlockingMode::NonBlocking => read.set_nonblocking(true),
@@ -272,7 +272,7 @@ impl<R: ReadFD, W: WriteFD> RustConnection<R, W> {
                 let _notify = NotifyOnDrop(&self.reader_condition);
 
                 // 2.2. Block the thread until a packet is received.
-                mode.set_on_reader(lock.get_mut())?;
+                mode.set_on_reader(&mut lock)?;
                 let mut fds = Vec::new();
                 use std::io::ErrorKind::WouldBlock;
                 let packet = lock.read_packet(&mut fds);

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -673,7 +673,7 @@ mod test {
         }
 
         fn set_nonblocking(&mut self, _nonblocking: bool) -> Result<()> {
-            todo!()
+            unimplemented!()
         }
     }
 

--- a/src/rust_connection/packet_reader.rs
+++ b/src/rust_connection/packet_reader.rs
@@ -1,0 +1,80 @@
+//! Read X11 packets from a reader
+
+use std::convert::TryInto;
+use std::io::Result;
+
+use super::fd_read_write::ReadFD;
+use crate::utils::RawFdContainer;
+
+/// Minimal length of an X11 packet
+const MINIMAL_PACKET_LENGTH: usize = 32;
+
+/// A wrapper around a reader that reads X11 packet.
+#[derive(Debug)]
+pub(crate) struct PacketReader<R: ReadFD> {
+    inner: R,
+
+    // A packet that was partially read. The `Vec` is the partial packet and the `usize` describes
+    // up to where the packet was already read.
+    pending_packet: Option<(Vec<u8>, usize)>,
+}
+
+impl<R: ReadFD> PacketReader<R> {
+    /// Create a new `PacketReader` that reads from the given stream.
+    pub(crate) fn new(inner: R) -> Self {
+        Self {
+            inner,
+            pending_packet: None,
+        }
+    }
+
+    /// Try to read a packet from the inner reader.
+    pub(crate) fn read_packet(&mut self, fd_storage: &mut Vec<RawFdContainer>) -> Result<Vec<u8>> {
+        if self.pending_packet.is_none() {
+            self.pending_packet = Some((vec![0; MINIMAL_PACKET_LENGTH], 0));
+        }
+
+        // Get mutable reference to the pending packet
+        let (packet, already_read) = self.pending_packet.as_mut().unwrap();
+
+        // Until the packet was fully read...
+        while packet.len() != *already_read {
+            // ...continue reading the packet
+            let nread = self.inner.read(&mut packet[*already_read..], fd_storage)?;
+            *already_read += nread;
+
+            // Do we still need to compute the length field? (length == MINIMAL_PACKET_LENGTH)
+            if let Ok(array) = packet[..].try_into() {
+                // Yes, then compute the packet length and resize the `Vec` to its final size.
+                let extra = extra_length(array);
+                packet.reserve_exact(extra);
+                packet.resize(MINIMAL_PACKET_LENGTH + extra, 0);
+            }
+        }
+
+        // Check that we really read the whole packet
+        let initial_packet = &packet[0..MINIMAL_PACKET_LENGTH].try_into().unwrap();
+        let extra = extra_length(&initial_packet);
+        assert_eq!(packet.len(), MINIMAL_PACKET_LENGTH + extra);
+
+        // Packet successfully read
+        Ok(self.pending_packet.take().unwrap().0)
+    }
+}
+
+// Compute the length beyond `MINIMAL_PACKET_LENGTH` of an X11 packet.
+fn extra_length(buffer: &[u8; MINIMAL_PACKET_LENGTH]) -> usize {
+    use crate::protocol::xproto::GE_GENERIC_EVENT;
+
+    let response_type = buffer[0];
+
+    const REPLY: u8 = 1;
+    if response_type == REPLY || response_type & 0x7f == GE_GENERIC_EVENT {
+        let length_field = buffer[4..8].try_into().unwrap();
+        let length_field = u32::from_ne_bytes(length_field) as usize;
+        4 * length_field
+    } else {
+        // Fixed size packet: error or event that is not GE_GENERIC_EVENT
+        0
+    }
+}

--- a/src/rust_connection/packet_reader.rs
+++ b/src/rust_connection/packet_reader.rs
@@ -28,6 +28,11 @@ impl<R: ReadFD> PacketReader<R> {
         }
     }
 
+    /// Get a mutable reference to the inner reader
+    pub(crate) fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
     /// Try to read a packet from the inner reader.
     pub(crate) fn read_packet(&mut self, fd_storage: &mut Vec<RawFdContainer>) -> Result<Vec<u8>> {
         if self.pending_packet.is_none() {

--- a/src/rust_connection/stream.rs
+++ b/src/rust_connection/stream.rs
@@ -245,4 +245,12 @@ impl ReadFD for Stream {
             }
         }
     }
+
+    fn set_nonblocking(&mut self, nonblocking: bool) -> Result<()> {
+        match self {
+            Stream::TcpStream(stream) => stream.set_nonblocking(nonblocking),
+            #[cfg(unix)]
+            Stream::UnixStream(stream) => stream.set_nonblocking(nonblocking),
+        }
+    }
 }

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -156,7 +156,8 @@ mod fake_stream {
         }
 
         fn set_nonblocking(&mut self, nonblocking: bool) -> std::io::Result<()> {
-            todo!()
+            assert!(nonblocking == false);
+            Ok(())
         }
     }
 

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -154,6 +154,10 @@ mod fake_stream {
             self.pending.drain(..len);
             Ok(len)
         }
+
+        fn set_nonblocking(&mut self, nonblocking: bool) -> std::io::Result<()> {
+            todo!()
+        }
     }
 
     #[derive(Debug)]

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -156,7 +156,7 @@ mod fake_stream {
         }
 
         fn set_nonblocking(&mut self, nonblocking: bool) -> std::io::Result<()> {
-            assert!(nonblocking == false);
+            assert!(!nonblocking);
             Ok(())
         }
     }

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -1,0 +1,197 @@
+use std::sync::Arc;
+
+use x11rb::connection::Connection as _;
+use x11rb::protocol::xproto::{
+    ClientMessageData, ClientMessageEvent, ConnectionExt as _, EventMask, CLIENT_MESSAGE_EVENT,
+};
+
+// Regression test for https://github.com/psychon/x11rb/issues/231
+#[test]
+fn multithread_test() {
+    let conn = fake_stream::connect().unwrap();
+    let conn = Arc::new(conn);
+
+    // Auxiliary thread: send requests and wait for replies
+    let conn1 = conn.clone();
+    let join = std::thread::spawn(move || {
+        // Bug #231 sometimes caused `reply` to hang forever.
+        // Send a huge amount of requests and wait for the reply
+        // to check if it hangs at some point.
+        for i in 1..=1_000_000 {
+            let cookie = conn1.get_input_focus().unwrap();
+            cookie.reply().unwrap();
+
+            if (i % 50_000) == 0 {
+                eprintln!("{}", i);
+            }
+        }
+        eprintln!("all replies received successfully");
+
+        let event = ClientMessageEvent {
+            response_type: CLIENT_MESSAGE_EVENT,
+            format: 32,
+            sequence: 0,
+            window: 0,
+            // Just anything, we don't care
+            type_: 1,
+            data: ClientMessageData::from([0, 0, 0, 0, 0]),
+        };
+
+        conn1
+            .send_event(false, 0u32, EventMask::NoEvent, &event)
+            .unwrap();
+        conn1.flush().unwrap();
+    });
+
+    // Main thread: wait for events until finished
+    loop {
+        let event = conn.wait_for_raw_event().unwrap();
+        if event[0] == CLIENT_MESSAGE_EVENT {
+            break;
+        }
+    }
+
+    join.join().unwrap();
+}
+
+/// Implementations of `Read` and `Write` that do enough for the test to work.
+mod fake_stream {
+    use std::sync::mpsc::{channel, Receiver, Sender};
+
+    use x11rb::connection::SequenceNumber;
+    use x11rb::errors::ConnectError;
+    use x11rb::protocol::xproto::{
+        ImageOrder, Setup, CLIENT_MESSAGE_EVENT, GET_INPUT_FOCUS_REQUEST, SEND_EVENT_REQUEST,
+    };
+    use x11rb::rust_connection::{ReadFD, RustConnection, WriteFD};
+    use x11rb::utils::RawFdContainer;
+
+    /// Create a new `RustConnection` connected to a fake stream
+    pub(crate) fn connect() -> Result<RustConnection<FakeStreamRead, FakeStreamWrite>, ConnectError>
+    {
+        let setup = Setup {
+            status: 0,
+            protocol_major_version: 0,
+            protocol_minor_version: 0,
+            length: 0,
+            release_number: 0,
+            resource_id_base: 0,
+            resource_id_mask: 0xff,
+            motion_buffer_size: 0,
+            maximum_request_length: 0,
+            image_byte_order: ImageOrder::LSBFirst,
+            bitmap_format_bit_order: ImageOrder::LSBFirst,
+            bitmap_format_scanline_unit: 0,
+            bitmap_format_scanline_pad: 0,
+            min_keycode: 0,
+            max_keycode: 0,
+            vendor: Vec::new(),
+            pixmap_formats: Vec::new(),
+            roots: Vec::new(),
+        };
+        let (read, write) = fake_stream();
+        RustConnection::for_connected_stream(read, write, setup)
+    }
+
+    /// Get a pair of fake streams that are connected to each other
+    fn fake_stream() -> (FakeStreamRead, FakeStreamWrite) {
+        let (send, recv) = channel();
+        let pending = Vec::new();
+        let read = FakeStreamRead { recv, pending };
+        let write = FakeStreamWrite {
+            send,
+            seqno: 0,
+            skip: 0,
+        };
+        (read, write)
+    }
+
+    /// A packet that still needs to be read from FakeStreamRead
+    #[derive(Debug)]
+    enum Packet {
+        GetInputFocusReply(SequenceNumber),
+        Event,
+    }
+
+    impl Packet {
+        fn to_raw(&self) -> Vec<u8> {
+            match self {
+                Packet::GetInputFocusReply(seqno) => {
+                    let seqno = (*seqno as u16).to_ne_bytes();
+                    let mut reply = vec![0; 32];
+                    reply[0] = 1; // This is a reply
+                    reply[2..4].copy_from_slice(&seqno);
+                    reply
+                }
+                Packet::Event => {
+                    let mut reply = vec![0; 32];
+                    reply[0] = CLIENT_MESSAGE_EVENT;
+                    reply
+                }
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct FakeStreamRead {
+        recv: Receiver<Packet>,
+        pending: Vec<u8>,
+    }
+
+    impl ReadFD for FakeStreamRead {
+        fn read(
+            &mut self,
+            buf: &mut [u8],
+            _fd_storage: &mut Vec<RawFdContainer>,
+        ) -> Result<usize, std::io::Error> {
+            if self.pending.is_empty() {
+                let packet = self.recv.recv().unwrap();
+                self.pending.extend(packet.to_raw());
+            }
+
+            let len = self.pending.len().min(buf.len());
+            buf[..len].copy_from_slice(&self.pending[..len]);
+            self.pending.drain(..len);
+            Ok(len)
+        }
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct FakeStreamWrite {
+        send: Sender<Packet>,
+        seqno: SequenceNumber,
+        skip: usize,
+    }
+
+    impl WriteFD for FakeStreamWrite {
+        fn write(
+            &mut self,
+            buf: &[u8],
+            fds: &mut Vec<RawFdContainer>,
+        ) -> Result<usize, std::io::Error> {
+            assert!(fds.is_empty());
+            if self.skip > 0 {
+                assert_eq!(self.skip, buf.len());
+                self.skip = 0;
+                return Ok(buf.len());
+            }
+
+            self.seqno += 1;
+            match buf[0] {
+                GET_INPUT_FOCUS_REQUEST => self
+                    .send
+                    .send(Packet::GetInputFocusReply(self.seqno))
+                    .unwrap(),
+                SEND_EVENT_REQUEST => self.send.send(Packet::Event).unwrap(),
+                _ => unimplemented!(),
+            }
+            // Compute how much of the package was not yet received
+            self.skip = usize::from(u16::from_ne_bytes([buf[2], buf[3]])) * 4 - buf.len();
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
This fixes #417 and #408. The underlying reader is made nonblocking when we need it to be. This allows to check if any new events came in without blocking in `read()`.