### PR TITLE
Read as much as possible from the connection before writing

### DIFF
--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -271,36 +271,46 @@ impl<R: ReadFD, W: WriteFD> RustConnection<R, W> {
                 // (Even in case of errors)
                 let _notify = NotifyOnDrop(&self.reader_condition);
 
-                // 2.2. Block the thread until a packet is received.
-                mode.set_on_reader(&mut lock)?;
+                // 2.2. Block the thread until at least one packet is received.
                 let mut fds = Vec::new();
-                use std::io::ErrorKind::WouldBlock;
-                let packet = lock.read_packet(&mut fds);
+                let mut packets = Vec::new();
+
+                let err = || -> std::io::Result<()> {
+                    // Read one packet
+                    mode.set_on_reader(&mut lock)?;
+                    packets.push(lock.read_packet(&mut fds)?);
+
+                    // And then read as many packages as possible
+                    BlockingMode::NonBlocking.set_on_reader(&mut lock)?;
+                    loop {
+                        packets.push(lock.read_packet(&mut fds)?);
+                    }
+                }();
 
                 // 2.3. Relock `inner` to enqueue the packet.
                 inner = self.inner.lock().unwrap();
 
-                let packet = match packet {
-                    Err(ref e) if e.kind() == WouldBlock => return Ok(inner),
-                    Err(e) => return Err(e),
-                    Ok(packet) => packet,
-                };
-
                 // 2.4. Once `inner` has been relocked, drop the
                 // lock on `read`. While inner is locked, other
-                // threads cannot arrive 0.1 anyways.
+                // threads cannot arrive at 0.1 anyways.
                 //
                 // `read` cannot unlocked before `inner` is relocked
                 // because it could let another thread wait on 2.2
                 // for a reply that has been read but not enqueued yet.
                 drop(lock);
 
-                // 2.5. Actually enqueue the read packet.
+                // 2.5. Actually enqueue the read packets.
                 inner.enqueue_fds(fds);
-                inner.enqueue_packet(packet);
+                packets.into_iter().for_each(|packet| inner.enqueue_packet(packet));
 
                 // 2.6. Return the locked `inner` to the caller.
-                Ok(inner)
+                // If an error occurred while reading packets, the error is returned instead.
+                use std::io::ErrorKind::WouldBlock;
+                match err {
+                    Ok(()) => Ok(inner),
+                    Err(ref e) if e.kind() == WouldBlock => Ok(inner),
+                    Err(e) => Err(e),
+                }
             }
         }
     }

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -308,7 +308,9 @@ impl<R: ReadFD, W: WriteFD> RustConnection<R, W> {
 
                 // 2.5. Actually enqueue the read packets.
                 inner.enqueue_fds(fds);
-                packets.into_iter().for_each(|packet| inner.enqueue_packet(packet));
+                packets
+                    .into_iter()
+                    .for_each(|packet| inner.enqueue_packet(packet));
 
                 // 2.6. Return the locked `inner` to the caller.
                 // If an error occurred while reading packets, the error is returned instead.

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -178,11 +178,7 @@ mod fake_stream {
     }
 
     impl WriteFD for FakeStreamWrite {
-        fn write(
-            &mut self,
-            buf: &[u8],
-            fds: &mut Vec<RawFdContainer>,
-        ) -> Result<usize, Error> {
+        fn write(&mut self, buf: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<usize, Error> {
             assert!(fds.is_empty());
             if self.skip > 0 {
                 assert_eq!(self.skip, buf.len());


### PR DESCRIPTION
This is half a hack to fix #222. Before writing, we now read as much as possible from the connection. That should make it impossible to deadlock with the server while writing.