### PR TITLE
Use read/write polling in `RustConnection`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,13 @@ gethostname = "0.2.1"
 [target.'cfg(unix)'.dependencies]
 nix = "0.17"
 
+[target.'cfg(windows)'.dependencies]
+winapi-wsapoll = "0.1.0"
+
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = ["winsock2"]
+
 [features]
 # Without this feature, all uses of `unsafe` in the crate are forbidden via
 # #![deny(unsafe_code)]. This has the effect of disabling the XCB FFI bindings.


### PR DESCRIPTION
* `set_nonblocking` has been removed
* `write`, `write_vectored`, `flush` and `read` (from `WriteFD` and `ReadFD`) are required to be always non-blocking.
* `write_all` has been removed.
* `read_exact` is required to be blocking.
* A new trait has been added to provide a `poll` function. This function has a parameter to make it blocking or non-blocking.
* `RustConnection` has been adapted accordingly. Writing always uses a blocking `poll` that checks for read and write. 