### PR TITLE
Generate and use structs to serialize requests.

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -567,7 +567,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                     bytes_name,
                                     rust_field_name,
                                 );
-                                next_slice = Some(format!("{}", bytes_name));
+                                next_slice = Some(bytes_name);
                             }
                         }
                     }
@@ -607,7 +607,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                     bytes_name,
                                     rust_field_name,
                                 );
-                                next_slice = Some(format!("{}", bytes_name));
+                                next_slice = Some(bytes_name);
                             } else {
                                 let bytes_name = postfix_var_name(&rust_field_name, "bytes");
                                 outln!(tmp_out, "let mut {} = Vec::new();", bytes_name);
@@ -622,7 +622,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                     );
                                 });
                                 outln!(tmp_out, "}}");
-                                next_slice = Some(format!("{}", bytes_name));
+                                next_slice = Some(bytes_name);
                             }
                         }
                     }
@@ -651,7 +651,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 fixed_fields_bytes.push(format!("{}[{}]", bytes_name, i));
                             }
                         } else {
-                            next_slice = Some(format!("{}", bytes_name));
+                            next_slice = Some(bytes_name);
                         }
                     }
                     xcbdefs::FieldDef::Fd(_) => {}

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -510,11 +510,11 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 fixed_fields_bytes
                                     .push(String::from("extension_information.major_opcode"));
                             } else {
-                                fixed_fields_bytes.push(format!("{}Request::opcode()", name));
+                                fixed_fields_bytes.push(String::from("Self::opcode()"));
                             }
                         } else if normal_field.name == "minor_opcode" {
                             assert!(ns.ext_info.is_some());
-                            fixed_fields_bytes.push(format!("{}Request::opcode()", name));
+                            fixed_fields_bytes.push(String::from("Self::opcode()"));
                         } else if normal_field.name == "length" {
                             // the actual length will be calculated later
                             fixed_fields_bytes.push(String::from("0"));

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -899,7 +899,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             outln!(out, "let request0 = {}Request{}", name, members_start);
             out.indented(|out| {
                 for (arg_name, _) in gathered.args.iter() {
-                    outln!(out, "{}: {},", arg_name, arg_name);
+                    outln!(out, "{},", arg_name);
                 }
             });
             if has_members {

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -73,6 +73,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "#![allow(clippy::trivially_copy_pass_by_ref)]");
         outln!(out, "#![allow(clippy::eq_op)]");
         outln!(out, "");
+        outln!(out, "use std::borrow::Cow;");
         outln!(out, "use std::convert::TryFrom;");
         outln!(out, "#[allow(unused_imports)]");
         outln!(out, "use std::convert::TryInto;");
@@ -209,14 +210,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     ) {
         let name = to_rust_type_name(&request_def.name);
 
-        outln!(out, "/// Opcode for the {} request", name);
-        outln!(
-            out,
-            "pub const {}_REQUEST: u8 = {};",
-            super::camel_case_to_upper_snake(&name),
-            request_def.opcode,
-        );
-
         let mut function_name = super::camel_case_to_lower_snake(&name);
         if function_name == "await" {
             function_name.push('_');
@@ -255,14 +248,9 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
         let gathered = self.gather_request_fields(request_def, &deducible_fields);
 
-        self.emit_request_function(
-            request_def,
-            &name,
-            &function_name,
-            &deducible_fields,
-            &gathered,
-            out,
-        );
+        self.emit_request_struct(request_def, &name, &deducible_fields, &gathered, out);
+
+        self.emit_request_function(request_def, &name, &function_name, &gathered, out);
         self.emit_request_trait_function(request_def, &name, &function_name, &gathered, trait_out);
 
         special_cases::handle_request(request_def, out);
@@ -374,131 +362,127 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "");
     }
 
-    fn emit_request_function(
+    fn emit_request_struct(
         &self,
         request_def: &xcbdefs::RequestDef,
         name: &str,
-        function_name: &str,
         deducible_fields: &FxHashMap<String, DeducibleField>,
         gathered: &GatheredRequestFields,
         out: &mut Output,
     ) {
-        let mut generic_params = String::new();
-        if gathered.needs_lifetime {
-            generic_params.push_str("'c, 'input, Conn");
-        } else {
-            generic_params.push_str("Conn");
-        }
-        for (param_name, _) in gathered.generics.iter() {
-            generic_params.push_str(", ");
-            generic_params.push_str(param_name);
-        }
-
         let ns = request_def.namespace.upgrade().unwrap();
-        let is_send_event = request_def.name == "SendEvent" && ns.header == "xproto";
-        let is_list_fonts_with_info =
-            request_def.name == "ListFontsWithInfo" && ns.header == "xproto";
-
-        let ret_lifetime = if gathered.needs_lifetime { "'c" } else { "'_" };
-        let ret_type = if is_list_fonts_with_info {
-            assert!(request_def.reply.is_some());
-            assert!(!gathered.reply_has_fds);
-            format!("ListFontsWithInfoCookie<{}, Conn>", ret_lifetime)
-        } else {
-            match (request_def.reply.is_some(), gathered.reply_has_fds) {
-                (false, _) => format!("VoidCookie<{}, Conn>", ret_lifetime),
-                (true, false) => format!("Cookie<{}, Conn, {}Reply>", ret_lifetime, name),
-                (true, true) => format!("CookieWithFds<{}, Conn, {}Reply>", ret_lifetime, name),
-            }
-        };
-
-        let mut args = String::new();
-        if gathered.needs_lifetime {
-            args.push_str("conn: &'c Conn");
-        } else {
-            args.push_str("conn: &Conn");
-        }
-        for (arg_name, arg_type) in gathered.args.iter() {
-            args.push_str(", ");
-            args.push_str(arg_name);
-            args.push_str(": ");
-            args.push_str(arg_type);
-        }
 
         if let Some(ref doc) = request_def.doc {
             self.emit_doc(doc, out);
         }
+
+        let mut derives = Derives::all();
+        self.filter_derives_for_fields(&mut derives, &request_def.fields.borrow());
+        let derives = derives.to_list();
+        if !derives.is_empty() {
+            outln!(out, "#[derive({})]", derives.join(", "));
+        }
+
+        let (struct_lifetime_block, serialize_lifetime_block) = if gathered.needs_lifetime {
+            ("<'input>", "")
+        } else {
+            ("", "'input, ")
+        };
+
+        let has_members = !gathered.request_args.is_empty();
+        let members_start = if has_members { " {" } else { ";" };
         outln!(
             out,
-            "pub fn {}<{}>({}) -> Result<{}, ConnectionError>",
-            function_name,
-            generic_params,
-            args,
-            ret_type,
+            "pub struct {name}Request{lifetime}{members_start}",
+            name = name,
+            lifetime = struct_lifetime_block,
+            members_start = members_start
         );
-        outln!(out, "where");
-        outln!(out.indent(), "Conn: RequestConnection + ?Sized,");
-        for (param_name, where_) in gathered.generics.iter() {
-            outln!(out.indent(), "{}: {},", param_name, where_);
-        }
-        outln!(out, "{{");
-        #[allow(clippy::cognitive_complexity)]
         out.indented(|out| {
-            if ns.ext_info.is_some() {
-                outln!(
-                    out,
-                    "let extension_information = conn.extension_information(X11_EXTENSION_NAME)?",
-                );
-                outln!(
-                    out.indent(),
-                    ".ok_or(ConnectionError::UnsupportedExtension)?;"
-                );
+            for (member_name, member_type) in gathered.request_args.iter() {
+                outln!(out, "pub {name}: {type},",
+                       name=member_name,
+                       type=member_type);
             }
+        });
+        if has_members {
+            outln!(out, "}}",);
+        }
 
-            for preamble in gathered.preamble.iter() {
-                outln!(out, "{}", preamble);
-            }
+        // Methods implemented on every request
+        outln!(
+            out,
+            "impl{lifetime} {name}Request{lifetime} {{",
+            lifetime = struct_lifetime_block,
+            name = name
+        );
+        out.indented(|out| {
+            outln!(out, "/// Opcode for the {} request", name);
+            outln!(
+                out,
+                "pub const fn opcode() -> u8 {{ {opcode} }}",
+                opcode=request_def.opcode
+            );
 
-            let fields = request_def.fields.borrow();
-
-            let has_expr_fields = fields.iter().any(|field| {
-                if let xcbdefs::FieldDef::Expr(_) = field {
-                    true
-                } else {
-                    false
+            outln!(out, "/// Serialize this request into bytes for the provided connection");
+            outln!(out, "#[allow(unused)]");
+            outln!(out, "fn serialize<{lifetime}Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>",
+                   lifetime=serialize_lifetime_block);
+            outln!(out, "where");
+            outln!(out.indent(), "Conn: RequestConnection + ?Sized,");
+            outln!(out, "{{");
+            out.indented(|out| {
+                if ns.ext_info.is_some() {
+                    outln!(
+                        out,
+                        "let extension_information = conn.extension_information(X11_EXTENSION_NAME)?",
+                    );
+                    outln!(
+                        out.indent(),
+                        ".ok_or(ConnectionError::UnsupportedExtension)?;"
+                    );
                 }
-            });
-            // Calculate `VirtualLen` field values because they
-            // may be used by <exprfield>s.
-            if has_expr_fields {
-                for field in fields.iter() {
-                    if let xcbdefs::FieldDef::VirtualLen(virtual_len_field) = field {
-                        outln!(
-                            out,
-                            "let {} = u32::try_from({}.len()).unwrap();",
-                            to_rust_variable_name(&virtual_len_field.name),
-                            to_rust_variable_name(&virtual_len_field.list_name),
-                        );
+
+                let fields = request_def.fields.borrow();
+
+                let has_expr_fields = fields.iter().any(|field| {
+                    if let xcbdefs::FieldDef::Expr(_) = field {
+                        true
+                    } else {
+                        false
+                    }
+                });
+                // Calculate `VirtualLen` field values because they
+                // may be used by <exprfield>s.
+                if has_expr_fields {
+                    for field in fields.iter() {
+                        if let xcbdefs::FieldDef::VirtualLen(virtual_len_field) = field {
+                            outln!(
+                                out,
+                                "let {} = u32::try_from(self.{}.len()).unwrap();",
+                                to_rust_variable_name(&virtual_len_field.name),
+                                to_rust_variable_name(&virtual_len_field.list_name),
+                            );
+                        }
                     }
                 }
-            }
 
-            outln!(out, "let length_so_far = 0;");
+                outln!(out, "let length_so_far = 0;");
 
-            let mut request_size = fields
-                .iter()
-                .try_fold(0, |sum, field| Some(sum + field.size()?));
+                let mut request_size = fields
+                    .iter()
+                    .try_fold(0, |sum, field| Some(sum + field.size()?));
 
-            let mut request_slices = Vec::new();
-            let mut fixed_fields_bytes = Vec::new();
-            let mut num_fixed_len_slices = 0;
-            let mut pad_count = 0;
+                let mut request_slices = Vec::new();
+                let mut fixed_fields_bytes = Vec::new();
+                let mut num_fixed_len_slices = 0;
+                let mut pad_count = 0;
 
-            for (field_i, field) in fields.iter().enumerate() {
+                for (field_i, field) in fields.iter().enumerate() {
                 let mut next_slice = None;
 
                 let mut tmp_out = Output::new();
-                self.emit_assert_for_field_serialize(field, deducible_fields, "", &mut tmp_out);
+                self.emit_assert_for_field_serialize(field, deducible_fields, "self.", &mut tmp_out);
                 match field {
                     xcbdefs::FieldDef::Pad(pad_field) => match pad_field.kind {
                         xcbdefs::PadKind::Bytes(bytes) => {
@@ -516,7 +500,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 align,
                                 align,
                             );
-                            next_slice = Some(format!("&padding{}", pad_count));
+                            next_slice = Some(format!("padding{}", pad_count));
                             pad_count += 1;
                         }
                     },
@@ -526,17 +510,11 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 fixed_fields_bytes
                                     .push(String::from("extension_information.major_opcode"));
                             } else {
-                                fixed_fields_bytes.push(format!(
-                                    "{}_REQUEST",
-                                    super::camel_case_to_upper_snake(name),
-                                ));
+                                fixed_fields_bytes.push(format!("{}Request::opcode()", name));
                             }
                         } else if normal_field.name == "minor_opcode" {
                             assert!(ns.ext_info.is_some());
-                            fixed_fields_bytes.push(format!(
-                                "{}_REQUEST",
-                                super::camel_case_to_upper_snake(name),
-                            ));
+                            fixed_fields_bytes.push(format!("{}Request::opcode()", name));
                         } else if normal_field.name == "length" {
                             // the actual length will be calculated later
                             fixed_fields_bytes.push(String::from("0"));
@@ -550,7 +528,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 self.emit_calc_deducible_field(
                                     field,
                                     deducible_field,
-                                    "",
+                                    "self.",
                                     &rust_field_name,
                                     out,
                                 );
@@ -561,13 +539,21 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
                             let bytes_name = postfix_var_name(&rust_field_name, "bytes");
                             if let Some(field_size) = normal_field.type_.size() {
+                                let field_name = if was_deduced {
+                                    // If we deduced this value it comes from a local.
+                                    rust_field_name
+                                } else {
+                                    // Otherwise a member.
+                                    format!("self.{}", rust_field_name)
+                                };
+
                                 outln!(
                                     out,
                                     "let {} = {};",
                                     bytes_name,
                                     self.emit_value_serialize(
                                         &normal_field.type_,
-                                        &rust_field_name,
+                                        &field_name,
                                         was_deduced,
                                     ),
                                 );
@@ -577,11 +563,11 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                             } else {
                                 outln!(
                                     tmp_out,
-                                    "let {} = {}.serialize();",
+                                    "let {} = self.{}.serialize();",
                                     bytes_name,
-                                    rust_field_name
+                                    rust_field_name,
                                 );
-                                next_slice = Some(format!("&{}", bytes_name));
+                                next_slice = Some(format!("{}", bytes_name));
                             }
                         }
                     }
@@ -589,15 +575,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         let rust_field_name = to_rust_variable_name(&list_field.name);
                         let list_length = list_field.length();
                         if self.rust_value_type_is_u8(&list_field.element_type) {
-                            if list_length.is_some() {
-                                if is_send_event && list_field.name == "event" {
-                                    next_slice = Some(format!("&{}", rust_field_name));
-                                } else {
-                                    next_slice = Some(rust_field_name);
-                                }
-                            } else {
-                                next_slice = Some(rust_field_name);
-                            }
+                            next_slice = Some(format!("(&self.{}[..])", rust_field_name));
                         } else {
                             let element_size = list_field.element_type.size();
                             if let (Some(list_length), Some(element_size)) =
@@ -625,11 +603,11 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 let bytes_name = postfix_var_name(&rust_field_name, "bytes");
                                 outln!(
                                     tmp_out,
-                                    "let {} = {}.serialize();",
+                                    "let {} = self.{}.serialize();",
                                     bytes_name,
                                     rust_field_name,
                                 );
-                                next_slice = Some(format!("&{}", bytes_name));
+                                next_slice = Some(format!("{}", bytes_name));
                             } else {
                                 let bytes_name = postfix_var_name(&rust_field_name, "bytes");
                                 outln!(tmp_out, "let mut {} = Vec::new();", bytes_name);
@@ -644,7 +622,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                     );
                                 });
                                 outln!(tmp_out, "}}");
-                                next_slice = Some(format!("&{}", bytes_name));
+                                next_slice = Some(format!("{}", bytes_name));
                             }
                         }
                     }
@@ -653,12 +631,18 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         let bytes_name = postfix_var_name(&rust_field_name, "bytes");
                         outln!(
                             tmp_out,
-                            "let {} = {}.serialize({});",
+                            "let {} = self.{}.serialize({});",
                             bytes_name,
                             rust_field_name,
                             self.ext_params_to_call_args(
                                 false,
-                                to_rust_variable_name,
+                                |name| {
+                                    if deducible_fields.get(name).is_some() {
+                                        to_rust_variable_name(name)
+                                    } else {
+                                        format!("self.{}", to_rust_variable_name(name))
+                                    }
+                                },
                                 &*switch_field.external_params.borrow(),
                             )
                         );
@@ -667,7 +651,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 fixed_fields_bytes.push(format!("{}[{}]", bytes_name, i));
                             }
                         } else {
-                            next_slice = Some(format!("&{}", bytes_name));
+                            next_slice = Some(format!("{}", bytes_name));
                         }
                     }
                     xcbdefs::FieldDef::Fd(_) => {}
@@ -730,7 +714,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         } else {
                             ""
                         };
-                        outln!(out, "let {}request{} = [", maybe_mut, num_fixed_len_slices);
+                        outln!(out, "let {}request{} = vec![", maybe_mut, num_fixed_len_slices);
                         for byte in fixed_fields_bytes.iter() {
                             outln!(out.indent(), "{},", byte);
                         }
@@ -740,128 +724,210 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                             "let length_so_far = length_so_far + request{}.len();",
                             num_fixed_len_slices,
                         );
-                        request_slices.push(format!("&request{}", num_fixed_len_slices));
+                        request_slices.push(format!("request{}.into()", num_fixed_len_slices));
                         fixed_fields_bytes.clear();
                         num_fixed_len_slices += 1;
                     }
                     if let Some(next_slice) = next_slice {
-                        let next_slice_for_len = if next_slice.starts_with('&') {
-                            &next_slice[1..]
-                        } else {
-                            next_slice.as_str()
-                        };
                         outln!(
                             tmp_out,
                             "let length_so_far = length_so_far + {}.len();",
-                            next_slice_for_len,
+                            next_slice,
                         );
-                        request_slices.push(next_slice);
+                        request_slices.push(format!("{}.into()", next_slice));
                     }
                 }
 
                 out!(out, "{}", tmp_out.into_data());
-            }
-
-            // The XML does not describe trailing padding in requests. Requests
-            // are implicitly padded to a four byte boundary.
-            if let Some(request_size) = request_size {
-                let req_size_rem = request_size % 4;
-                if req_size_rem != 0 {
-                    assert_eq!(pad_count, 0);
-                    outln!(out, "let padding = [0; {}];", 4 - req_size_rem);
-                    outln!(out, "let length_so_far = length_so_far + padding.len();");
-                    request_slices.push(String::from("&padding"));
                 }
-            } else {
-                outln!(
-                    out,
-                    "let padding{} = &[0; 3][..(4 - (length_so_far % 4)) % 4];",
-                    pad_count,
-                );
-                outln!(
-                    out,
-                    "let length_so_far = length_so_far + padding{}.len();",
-                    pad_count,
-                );
-                request_slices.push(format!("&padding{}", pad_count));
-            }
-
-            outln!(out, "assert_eq!(length_so_far % 4, 0);");
-            // Set the length in the request.
-            // If it does not fit into u16, compute_length_field will use BigRequests.
-            outln!(
-                out,
-                "let length = u16::try_from(length_so_far / 4).unwrap_or(0);",
-            );
-            outln!(
-                out,
-                "request0[2..4].copy_from_slice(&length.to_ne_bytes());",
-            );
-
-            let fds_arg = if gathered.fd_lists.is_empty() {
-                format!("vec![{}]", gathered.single_fds.join(", "))
-            } else if gathered.fd_lists.len() == 1 && gathered.single_fds.is_empty() {
-                gathered.fd_lists[0].clone()
-            } else {
-                outln!(out, "let mut fds = Vec::new();");
-                for field in fields.iter() {
-                    match field {
-                        xcbdefs::FieldDef::Fd(fd_field) => {
-                            outln!(out, "fds.push({});", to_rust_variable_name(&fd_field.name));
-                        }
-                        xcbdefs::FieldDef::FdList(fd_list_field) => {
-                            outln!(
-                                out,
-                                "fds.extend({});",
-                                to_rust_variable_name(&fd_list_field.name)
-                            );
-                        }
-                        _ => {}
+                // The XML does not describe trailing padding in requests. Requests
+                // are implicitly padded to a four byte boundary.
+                if let Some(request_size) = request_size {
+                    let req_size_rem = request_size % 4;
+                    if req_size_rem != 0 {
+                        assert_eq!(pad_count, 0);
+                        outln!(out, "let padding = [0; {}];", 4 - req_size_rem);
+                        outln!(out, "let length_so_far = length_so_far + padding.len();");
+                        request_slices.push("Cow::Borrowed(&padding)".into());
                     }
+                } else {
+                    outln!(
+                        out,
+                        "let padding{} = &[0; 3][..(4 - (length_so_far % 4)) % 4];",
+                        pad_count,
+                    );
+                    outln!(
+                        out,
+                        "let length_so_far = length_so_far + padding{}.len();",
+                        pad_count,
+                    );
+                    request_slices.push(format!("Cow::Borrowed(&padding{})", pad_count));
                 }
-                String::from("fds")
-            };
 
-            let mut slices_arg = String::new();
-            for (i, request_slices) in request_slices.iter().enumerate() {
-                if i != 0 {
-                    slices_arg.push_str(", ");
+                outln!(out, "assert_eq!(length_so_far % 4, 0);");
+                // Set the length in the request.
+                // If it does not fit into u16, compute_length_field will use BigRequests.
+                outln!(
+                    out,
+                    "let length = u16::try_from(length_so_far / 4).unwrap_or(0);",
+                );
+                outln!(
+                    out,
+                    "request0[2..4].copy_from_slice(&length.to_ne_bytes());",
+                );
+
+                let fds_arg = if gathered.fd_lists.is_empty() {
+                    format!("vec![{}]", gathered.single_fds.iter().enumerate().map(|(i, single_fd)| {
+                        let sep = if i == 0 {
+                            ""
+                        } else {
+                            ", "
+                        };
+                        format!("{}self.{}", sep, single_fd)
+                    }).collect::<String>())
+                } else if gathered.fd_lists.len() == 1 && gathered.single_fds.is_empty() {
+                    format!("self.{}", gathered.fd_lists[0])
+                } else {
+                    outln!(out, "let mut fds = Vec::new();");
+                    for field in fields.iter() {
+                        match field {
+                            xcbdefs::FieldDef::Fd(fd_field) => {
+                                outln!(out, "fds.push({});", to_rust_variable_name(&fd_field.name));
+                            }
+                            xcbdefs::FieldDef::FdList(fd_list_field) => {
+                                outln!(
+                                    out,
+                                    "fds.extend({});",
+                                    to_rust_variable_name(&fd_list_field.name)
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
+                    String::from("fds")
+                };
+
+                let mut slices_arg = String::new();
+                for (i, request_slices) in request_slices.iter().enumerate() {
+                    if i != 0 {
+                        slices_arg.push_str(", ");
+                    }
+                    slices_arg.push_str(request_slices);
                 }
-                slices_arg.push_str("IoSlice::new(");
-                slices_arg.push_str(request_slices);
-                slices_arg.push(')');
+
+                outln!(out, "Ok((vec![{slices}], {fds}))", slices=slices_arg, fds=fds_arg);
+            });
+            outln!(out, "}}");
+        });
+        outln!(out, "}}",);
+    }
+
+    fn emit_request_function(
+        &self,
+        request_def: &xcbdefs::RequestDef,
+        name: &str,
+        function_name: &str,
+        gathered: &GatheredRequestFields,
+        out: &mut Output,
+    ) {
+        let mut generic_params = String::new();
+        if gathered.needs_lifetime {
+            generic_params.push_str("'c, 'input, Conn");
+        } else {
+            generic_params.push_str("Conn");
+        }
+        for (param_name, _) in gathered.generics.iter() {
+            generic_params.push_str(", ");
+            generic_params.push_str(param_name);
+        }
+
+        let ns = request_def.namespace.upgrade().unwrap();
+        let is_list_fonts_with_info =
+            request_def.name == "ListFontsWithInfo" && ns.header == "xproto";
+
+        let ret_lifetime = if gathered.needs_lifetime { "'c" } else { "'_" };
+        let ret_type = if is_list_fonts_with_info {
+            assert!(request_def.reply.is_some());
+            assert!(!gathered.reply_has_fds);
+            format!("ListFontsWithInfoCookie<{}, Conn>", ret_lifetime)
+        } else {
+            match (request_def.reply.is_some(), gathered.reply_has_fds) {
+                (false, _) => format!("VoidCookie<{}, Conn>", ret_lifetime),
+                (true, false) => format!("Cookie<{}, Conn, {}Reply>", ret_lifetime, name),
+                (true, true) => format!("CookieWithFds<{}, Conn, {}Reply>", ret_lifetime, name),
             }
+        };
+
+        let mut args = String::new();
+        if gathered.needs_lifetime {
+            args.push_str("conn: &'c Conn");
+        } else {
+            args.push_str("conn: &Conn");
+        }
+        for (arg_name, arg_type) in gathered.args.iter() {
+            args.push_str(", ");
+            args.push_str(arg_name);
+            args.push_str(": ");
+            args.push_str(arg_type);
+        }
+
+        if let Some(ref doc) = request_def.doc {
+            self.emit_doc(doc, out);
+        }
+        outln!(
+            out,
+            "pub fn {}<{}>({}) -> Result<{}, ConnectionError>",
+            function_name,
+            generic_params,
+            args,
+            ret_type,
+        );
+        outln!(out, "where");
+        outln!(out.indent(), "Conn: RequestConnection + ?Sized,");
+        for (param_name, where_) in gathered.generics.iter() {
+            outln!(out.indent(), "{}: {},", param_name, where_);
+        }
+        outln!(out, "{{");
+        #[allow(clippy::cognitive_complexity)]
+        out.indented(|out| {
+            for preamble in gathered.preamble.iter() {
+                outln!(out, "{}", preamble);
+            }
+
+            let has_members = !gathered.request_args.is_empty();
+            let members_start = if has_members { " {" } else { ";" };
+            outln!(out, "let request0 = {}Request{}", name, members_start);
+            out.indented(|out| {
+                for (arg_name, _) in gathered.args.iter() {
+                    outln!(out, "{}: {},", arg_name, arg_name);
+                }
+            });
+            if has_members {
+                outln!(out, "}};");
+            }
+
+            outln!(out, "let (bytes, fds) = request0.serialize(conn)?;");
+            outln!(
+                out,
+                "let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();"
+            );
 
             if is_list_fonts_with_info {
                 outln!(
                     out,
-                    "Ok(ListFontsWithInfoCookie::new(conn.send_request_with_reply(&[{}], {})?))",
-                    slices_arg,
-                    fds_arg,
+                    "Ok(ListFontsWithInfoCookie::new(conn.send_request_with_reply(&slices, fds)?))",
                 )
             } else if request_def.reply.is_some() {
                 if gathered.reply_has_fds {
                     outln!(
                         out,
-                        "Ok(conn.send_request_with_reply_with_fds(&[{}], {})?)",
-                        slices_arg,
-                        fds_arg,
+                        "Ok(conn.send_request_with_reply_with_fds(&slices, fds)?)",
                     );
                 } else {
-                    outln!(
-                        out,
-                        "Ok(conn.send_request_with_reply(&[{}], {})?)",
-                        slices_arg,
-                        fds_arg,
-                    );
+                    outln!(out, "Ok(conn.send_request_with_reply(&slices, fds)?)",);
                 }
             } else {
-                outln!(
-                    out,
-                    "Ok(conn.send_request_without_reply(&[{}], {})?)",
-                    slices_arg,
-                    fds_arg
-                );
+                outln!(out, "Ok(conn.send_request_without_reply(&slices, fds)?)",);
             }
         });
         outln!(out, "}}");
@@ -4351,6 +4417,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
         let mut needs_lifetime = false;
         let mut args = Vec::new();
+        let mut request_args = Vec::new();
         let mut generics = Vec::new();
         let mut preamble = Vec::new();
         let mut single_fds = Vec::new();
@@ -4396,19 +4463,24 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         );
                         let generic_param = format!("{}", char::from(letter_iter.next().unwrap()));
                         let where_ = format!("Into<{}>", rust_field_type);
-                        args.push((rust_field_name, generic_param.clone()));
+                        args.push((rust_field_name.clone(), generic_param.clone()));
+                        request_args.push((rust_field_name, rust_field_type));
                         generics.push((generic_param, where_));
                         preamble.push(preamble_part);
                     } else {
-                        args.push((rust_field_name, rust_field_type));
+                        args.push((rust_field_name.clone(), rust_field_type.clone()));
+                        request_args.push((rust_field_name, rust_field_type));
                     }
                 }
                 xcbdefs::FieldDef::List(list_field) => {
                     if is_send_event && list_field.name == "event" {
                         let generic_param = format!("{}", char::from(letter_iter.next().unwrap()));
                         args.push((list_field.name.clone(), generic_param.clone()));
+                        request_args.push((list_field.name.clone(), "&'input [u8; 32]".into()));
                         generics.push((generic_param, String::from("Into<[u8; 32]>")));
                         preamble.push(String::from("let event: [u8; 32] = event.into();"));
+                        preamble.push(String::from("let event = &event;"));
+                        needs_lifetime = true;
                     } else {
                         let element_type =
                             self.field_value_type_to_rust_type(&list_field.element_type);
@@ -4418,7 +4490,8 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         } else {
                             format!("&'input [{}]", element_type)
                         };
-                        args.push((rust_field_name, rust_field_type));
+                        args.push((rust_field_name.clone(), rust_field_type.clone()));
+                        request_args.push((rust_field_name, rust_field_type));
                         needs_lifetime = true;
                     }
                 }
@@ -4426,7 +4499,8 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     let rust_field_name = to_rust_variable_name(&switch_field.name);
                     let rust_field_type =
                         format!("&'input {}Aux", to_rust_type_name(&request_def.name));
-                    args.push((rust_field_name, rust_field_type));
+                    args.push((rust_field_name.clone(), rust_field_type.clone()));
+                    request_args.push((rust_field_name, rust_field_type));
                     needs_lifetime = true;
                 }
                 xcbdefs::FieldDef::Fd(fd_field) => {
@@ -4436,14 +4510,16 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         "let {}: RawFdContainer = {}.into();",
                         rust_field_name, rust_field_name,
                     );
-                    args.push((rust_field_name, generic_param.clone()));
+                    args.push((rust_field_name.clone(), generic_param.clone()));
+                    request_args.push((rust_field_name, "RawFdContainer".into()));
                     generics.push((generic_param, "Into<RawFdContainer>".into()));
                     preamble.push(preamble_part);
                     single_fds.push(fd_field.name.clone());
                 }
                 xcbdefs::FieldDef::FdList(fd_list_field) => {
                     let rust_field_name = to_rust_variable_name(&fd_list_field.name);
-                    args.push((rust_field_name, "Vec<RawFdContainer>".into()));
+                    args.push((rust_field_name.clone(), "Vec<RawFdContainer>".into()));
+                    request_args.push((rust_field_name, "Vec<RawFdContainer>".into()));
                     fd_lists.push(fd_list_field.name.clone());
                 }
                 xcbdefs::FieldDef::Expr(_) => unreachable!(),
@@ -4463,10 +4539,12 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             })
             .unwrap_or(false);
 
+        assert_eq!(args.len(), request_args.len());
         GatheredRequestFields {
             reply_has_fds,
             needs_lifetime,
             args,
+            request_args,
             generics,
             preamble,
             single_fds,
@@ -4737,8 +4815,9 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 derives.eq = false;
             }
             xcbdefs::TypeRef::EventStruct(_) => {
-                // Only appears in requests
-                unreachable!();
+                // Event structs don't support equality tests.
+                derives.partial_eq = false;
+                derives.eq = false;
             }
             xcbdefs::TypeRef::Xid(_) => {}
             xcbdefs::TypeRef::XidUnion(_) => {}
@@ -5008,6 +5087,10 @@ struct GatheredRequestFields {
     /// Function arguments
     /// `(name, type)`
     args: Vec<(String, String)>,
+    /// Request arguments
+    /// The type here has been converted as necessary.
+    /// `(name, type)`
+    request_args: Vec<(String, String)>,
     /// Generic type parameters
     ///
     /// `(name, where clause)`

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -374,6 +374,14 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     ) {
         let ns = request_def.namespace.upgrade().unwrap();
 
+        outln!(out, "/// Opcode for the {} request", name);
+        outln!(
+            out,
+            "pub const {}_REQUEST: u8 = {};",
+            super::camel_case_to_upper_snake(&name),
+            request_def.opcode,
+        );
+
         if let Some(ref doc) = request_def.doc {
             self.emit_doc(doc, out);
         }
@@ -419,13 +427,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             name = name
         );
         out.indented(|out| {
-            outln!(out, "/// Opcode for the {} request", name);
-            outln!(
-                out,
-                "pub const fn opcode() -> u8 {{ {opcode} }}",
-                opcode=request_def.opcode
-            );
-
             outln!(out, "/// Serialize this request into bytes for the provided connection");
             outln!(out, "fn serialize<{lifetime}Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>",
                    lifetime=serialize_lifetime_block);
@@ -514,11 +515,12 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 fixed_fields_bytes
                                     .push(String::from("extension_information.major_opcode"));
                             } else {
-                                fixed_fields_bytes.push(String::from("Self::opcode()"));
+                                fixed_fields_bytes.push(format!("{}_REQUEST",
+                                                               super::camel_case_to_upper_snake(&name)));
                             }
                         } else if normal_field.name == "minor_opcode" {
                             assert!(ns.ext_info.is_some());
-                            fixed_fields_bytes.push(String::from("Self::opcode()"));
+                            fixed_fields_bytes.push(format!("{}_REQUEST", super::camel_case_to_upper_snake(&name)));
                         } else if normal_field.name == "length" {
                             // the actual length will be calculated later
                             fixed_fields_bytes.push(String::from("0"));

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -4433,8 +4433,8 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         let mut fd_lists = Vec::new();
 
         let ns = request_def.namespace.upgrade().unwrap();
-        let is_change_propery = request_def.name == "ChangeProperty" && ns.header == "xproto";
-        let is_get_propery = request_def.name == "GetProperty" && ns.header == "xproto";
+        let is_change_property = request_def.name == "ChangeProperty" && ns.header == "xproto";
+        let is_get_property = request_def.name == "GetProperty" && ns.header == "xproto";
         let is_send_event = request_def.name == "SendEvent" && ns.header == "xproto";
 
         for field in request_def.fields.borrow().iter() {
@@ -4451,9 +4451,9 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 xcbdefs::FieldDef::Normal(normal_field) => {
                     let rust_field_name = to_rust_variable_name(&normal_field.name);
                     let rust_field_type = self.field_value_type_to_rust_type(&normal_field.type_);
-                    let use_into = if ((is_change_propery || is_get_propery)
+                    let use_into = if ((is_change_property || is_get_property)
                         && normal_field.name == "property")
-                        || (is_change_propery && normal_field.name == "type")
+                        || (is_change_property && normal_field.name == "type")
                     {
                         true
                     } else if self.use_enum_type_in_field(&normal_field.type_).is_none() {

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -425,7 +425,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             );
 
             outln!(out, "/// Serialize this request into bytes for the provided connection");
-            outln!(out, "#[allow(unused)]");
             outln!(out, "fn serialize<{lifetime}Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>",
                    lifetime=serialize_lifetime_block);
             outln!(out, "where");
@@ -441,6 +440,9 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         out.indent(),
                         ".ok_or(ConnectionError::UnsupportedExtension)?;"
                     );
+                } else {
+                    // Silence a warning about an unused `conn`.
+                    outln!(out, "let _ = conn;");
                 }
 
                 let fields = request_def.fields.borrow();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -40,6 +40,7 @@
 //! | Get    | `Cookie::reply`                    | `Cookie::reply_unchecked` |
 //! | Ignore | `Cookie::discard_reply_and_errors` | Just drop the cookie      |
 
+use std::borrow::Cow;
 use std::convert::{TryFrom, TryInto};
 use std::io::IoSlice;
 
@@ -63,6 +64,7 @@ pub type SequenceNumber = u64;
 pub type BufWithFds<B> = (B, Vec<RawFdContainer>);
 pub type EventAndSeqNumber = (Event, SequenceNumber);
 pub type RawEventAndSeqNumber<B> = (B, SequenceNumber);
+pub type PiecewiseBuf<'a> = Vec<Cow<'a, [u8]>>;
 
 /// Either a raw reply or a raw error response to an X11 request.
 #[derive(Debug)]

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -39,7 +38,7 @@ impl EnableRequest {
     /// Opcode for the Enable request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -32,11 +32,11 @@ pub const X11_EXTENSION_NAME: &str = "BIG-REQUESTS";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 
+/// Opcode for the Enable request
+pub const ENABLE_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnableRequest;
 impl EnableRequest {
-    /// Opcode for the Enable request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -47,7 +47,7 @@ impl EnableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ENABLE_REQUEST,
             0,
             0,
         ];

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -39,7 +39,6 @@ impl EnableRequest {
     /// Opcode for the Enable request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -49,7 +49,7 @@ impl EnableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            EnableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -32,26 +33,41 @@ pub const X11_EXTENSION_NAME: &str = "BIG-REQUESTS";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 
-/// Opcode for the Enable request
-pub const ENABLE_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnableRequest;
+impl EnableRequest {
+    /// Opcode for the Enable request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            EnableRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn enable<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, EnableReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        ENABLE_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = EnableRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -126,7 +126,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -207,7 +207,7 @@ impl RedirectWindowRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RedirectWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -260,7 +260,7 @@ impl RedirectSubwindowsRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RedirectSubwindowsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -313,7 +313,7 @@ impl UnredirectWindowRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UnredirectWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -366,7 +366,7 @@ impl UnredirectSubwindowsRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UnredirectSubwindowsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -419,7 +419,7 @@ impl CreateRegionFromBorderClipRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRegionFromBorderClipRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -472,7 +472,7 @@ impl NameWindowPixmapRequest {
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            NameWindowPixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -523,7 +523,7 @@ impl GetOverlayWindowRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetOverlayWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -595,7 +595,7 @@ impl ReleaseOverlayWindowRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ReleaseOverlayWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -104,36 +105,57 @@ impl TryFrom<u32> for Redirect {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest {
+    pub client_major_version: u32,
+    pub client_minor_version: u32,
+}
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let client_major_version_bytes = self.client_major_version.serialize();
+        let client_minor_version_bytes = self.client_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+            client_major_version_bytes[0],
+            client_major_version_bytes[1],
+            client_major_version_bytes[2],
+            client_major_version_bytes[3],
+            client_minor_version_bytes[0],
+            client_minor_version_bytes[1],
+            client_minor_version_bytes[2],
+            client_minor_version_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u32, client_minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let client_major_version_bytes = client_major_version.serialize();
-    let client_minor_version_bytes = client_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-        client_major_version_bytes[0],
-        client_major_version_bytes[1],
-        client_major_version_bytes[2],
-        client_major_version_bytes[3],
-        client_minor_version_bytes[0],
-        client_minor_version_bytes[1],
-        client_minor_version_bytes[2],
-        client_minor_version_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest {
+        client_major_version: client_major_version,
+        client_minor_version: client_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -164,223 +186,368 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the RedirectWindow request
-pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RedirectWindowRequest {
+    pub window: xproto::Window,
+    pub update: Redirect,
+}
+impl RedirectWindowRequest {
+    /// Opcode for the RedirectWindow request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let update_bytes = u8::from(self.update).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            RedirectWindowRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            update_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn redirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let update_bytes = u8::from(update).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        REDIRECT_WINDOW_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        update_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = RedirectWindowRequest {
+        window: window,
+        update: update,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the RedirectSubwindows request
-pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RedirectSubwindowsRequest {
+    pub window: xproto::Window,
+    pub update: Redirect,
+}
+impl RedirectSubwindowsRequest {
+    /// Opcode for the RedirectSubwindows request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let update_bytes = u8::from(self.update).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            RedirectSubwindowsRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            update_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn redirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let update_bytes = u8::from(update).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        REDIRECT_SUBWINDOWS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        update_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = RedirectSubwindowsRequest {
+        window: window,
+        update: update,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UnredirectWindow request
-pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnredirectWindowRequest {
+    pub window: xproto::Window,
+    pub update: Redirect,
+}
+impl UnredirectWindowRequest {
+    /// Opcode for the UnredirectWindow request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let update_bytes = u8::from(self.update).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            UnredirectWindowRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            update_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn unredirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let update_bytes = u8::from(update).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        UNREDIRECT_WINDOW_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        update_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UnredirectWindowRequest {
+        window: window,
+        update: update,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UnredirectSubwindows request
-pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnredirectSubwindowsRequest {
+    pub window: xproto::Window,
+    pub update: Redirect,
+}
+impl UnredirectSubwindowsRequest {
+    /// Opcode for the UnredirectSubwindows request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let update_bytes = u8::from(self.update).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            UnredirectSubwindowsRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            update_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn unredirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let update_bytes = u8::from(update).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        UNREDIRECT_SUBWINDOWS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        update_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UnredirectSubwindowsRequest {
+        window: window,
+        update: update,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateRegionFromBorderClip request
-pub const CREATE_REGION_FROM_BORDER_CLIP_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateRegionFromBorderClipRequest {
+    pub region: xfixes::Region,
+    pub window: xproto::Window,
+}
+impl CreateRegionFromBorderClipRequest {
+    /// Opcode for the CreateRegionFromBorderClip request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let region_bytes = self.region.serialize();
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateRegionFromBorderClipRequest::opcode(),
+            0,
+            0,
+            region_bytes[0],
+            region_bytes[1],
+            region_bytes[2],
+            region_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_region_from_border_clip<Conn>(conn: &Conn, region: xfixes::Region, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let region_bytes = region.serialize();
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_REGION_FROM_BORDER_CLIP_REQUEST,
-        0,
-        0,
-        region_bytes[0],
-        region_bytes[1],
-        region_bytes[2],
-        region_bytes[3],
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateRegionFromBorderClipRequest {
+        region: region,
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the NameWindowPixmap request
-pub const NAME_WINDOW_PIXMAP_REQUEST: u8 = 6;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NameWindowPixmapRequest {
+    pub window: xproto::Window,
+    pub pixmap: xproto::Pixmap,
+}
+impl NameWindowPixmapRequest {
+    /// Opcode for the NameWindowPixmap request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let pixmap_bytes = self.pixmap.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            NameWindowPixmapRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            pixmap_bytes[0],
+            pixmap_bytes[1],
+            pixmap_bytes[2],
+            pixmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn name_window_pixmap<Conn>(conn: &Conn, window: xproto::Window, pixmap: xproto::Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let pixmap_bytes = pixmap.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        NAME_WINDOW_PIXMAP_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        pixmap_bytes[0],
-        pixmap_bytes[1],
-        pixmap_bytes[2],
-        pixmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = NameWindowPixmapRequest {
+        window: window,
+        pixmap: pixmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetOverlayWindow request
-pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetOverlayWindowRequest {
+    pub window: xproto::Window,
+}
+impl GetOverlayWindowRequest {
+    /// Opcode for the GetOverlayWindow request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetOverlayWindowRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_overlay_window<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetOverlayWindowReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_OVERLAY_WINDOW_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetOverlayWindowRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -409,31 +576,50 @@ impl TryFrom<&[u8]> for GetOverlayWindowReply {
     }
 }
 
-/// Opcode for the ReleaseOverlayWindow request
-pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReleaseOverlayWindowRequest {
+    pub window: xproto::Window,
+}
+impl ReleaseOverlayWindowRequest {
+    /// Opcode for the ReleaseOverlayWindow request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ReleaseOverlayWindowRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn release_overlay_window<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        RELEASE_OVERLAY_WINDOW_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ReleaseOverlayWindowRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Extension trait defining the requests of this extension.

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -150,8 +150,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -231,8 +231,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RedirectWindowRequest {
-        window: window,
-        update: update,
+        window,
+        update,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -284,8 +284,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RedirectSubwindowsRequest {
-        window: window,
-        update: update,
+        window,
+        update,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -337,8 +337,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UnredirectWindowRequest {
-        window: window,
-        update: update,
+        window,
+        update,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -390,8 +390,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UnredirectSubwindowsRequest {
-        window: window,
-        update: update,
+        window,
+        update,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -443,8 +443,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRegionFromBorderClipRequest {
-        region: region,
-        window: window,
+        region,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -496,8 +496,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = NameWindowPixmapRequest {
-        window: window,
-        pixmap: pixmap,
+        window,
+        pixmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -543,7 +543,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetOverlayWindowRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -615,7 +615,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ReleaseOverlayWindowRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -114,7 +114,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -195,7 +194,6 @@ impl RedirectWindowRequest {
     /// Opcode for the RedirectWindow request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -248,7 +246,6 @@ impl RedirectSubwindowsRequest {
     /// Opcode for the RedirectSubwindows request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -301,7 +298,6 @@ impl UnredirectWindowRequest {
     /// Opcode for the UnredirectWindow request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -354,7 +350,6 @@ impl UnredirectSubwindowsRequest {
     /// Opcode for the UnredirectSubwindows request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -407,7 +402,6 @@ impl CreateRegionFromBorderClipRequest {
     /// Opcode for the CreateRegionFromBorderClip request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -460,7 +454,6 @@ impl NameWindowPixmapRequest {
     /// Opcode for the NameWindowPixmap request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -512,7 +505,6 @@ impl GetOverlayWindowRequest {
     /// Opcode for the GetOverlayWindow request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -584,7 +576,6 @@ impl ReleaseOverlayWindowRequest {
     /// Opcode for the ReleaseOverlayWindow request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -114,7 +113,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -194,7 +193,7 @@ impl RedirectWindowRequest {
     /// Opcode for the RedirectWindow request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -246,7 +245,7 @@ impl RedirectSubwindowsRequest {
     /// Opcode for the RedirectSubwindows request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -298,7 +297,7 @@ impl UnredirectWindowRequest {
     /// Opcode for the UnredirectWindow request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -350,7 +349,7 @@ impl UnredirectSubwindowsRequest {
     /// Opcode for the UnredirectSubwindows request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -402,7 +401,7 @@ impl CreateRegionFromBorderClipRequest {
     /// Opcode for the CreateRegionFromBorderClip request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -454,7 +453,7 @@ impl NameWindowPixmapRequest {
     /// Opcode for the NameWindowPixmap request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -505,7 +504,7 @@ impl GetOverlayWindowRequest {
     /// Opcode for the GetOverlayWindow request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -576,7 +575,7 @@ impl ReleaseOverlayWindowRequest {
     /// Opcode for the ReleaseOverlayWindow request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -104,14 +104,14 @@ impl TryFrom<u32> for Redirect {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -124,7 +124,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -184,14 +184,14 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the RedirectWindow request
+pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RedirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
 impl RedirectWindowRequest {
-    /// Opcode for the RedirectWindow request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -204,7 +204,7 @@ impl RedirectWindowRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            REDIRECT_WINDOW_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -236,14 +236,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the RedirectSubwindows request
+pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RedirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
 impl RedirectSubwindowsRequest {
-    /// Opcode for the RedirectSubwindows request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -256,7 +256,7 @@ impl RedirectSubwindowsRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            REDIRECT_SUBWINDOWS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -288,14 +288,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UnredirectWindow request
+pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnredirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
 impl UnredirectWindowRequest {
-    /// Opcode for the UnredirectWindow request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -308,7 +308,7 @@ impl UnredirectWindowRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNREDIRECT_WINDOW_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -340,14 +340,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UnredirectSubwindows request
+pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnredirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
 impl UnredirectSubwindowsRequest {
-    /// Opcode for the UnredirectSubwindows request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -360,7 +360,7 @@ impl UnredirectSubwindowsRequest {
         let update_bytes = u8::from(self.update).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNREDIRECT_SUBWINDOWS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -392,14 +392,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateRegionFromBorderClip request
+pub const CREATE_REGION_FROM_BORDER_CLIP_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateRegionFromBorderClipRequest {
     pub region: xfixes::Region,
     pub window: xproto::Window,
 }
 impl CreateRegionFromBorderClipRequest {
-    /// Opcode for the CreateRegionFromBorderClip request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -412,7 +412,7 @@ impl CreateRegionFromBorderClipRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_REGION_FROM_BORDER_CLIP_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -444,14 +444,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the NameWindowPixmap request
+pub const NAME_WINDOW_PIXMAP_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NameWindowPixmapRequest {
     pub window: xproto::Window,
     pub pixmap: xproto::Pixmap,
 }
 impl NameWindowPixmapRequest {
-    /// Opcode for the NameWindowPixmap request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -464,7 +464,7 @@ impl NameWindowPixmapRequest {
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            NAME_WINDOW_PIXMAP_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -496,13 +496,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetOverlayWindow request
+pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetOverlayWindowRequest {
     pub window: xproto::Window,
 }
 impl GetOverlayWindowRequest {
-    /// Opcode for the GetOverlayWindow request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -514,7 +514,7 @@ impl GetOverlayWindowRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_OVERLAY_WINDOW_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -567,13 +567,13 @@ impl TryFrom<&[u8]> for GetOverlayWindowReply {
     }
 }
 
+/// Opcode for the ReleaseOverlayWindow request
+pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReleaseOverlayWindowRequest {
     pub window: xproto::Window,
 }
 impl ReleaseOverlayWindowRequest {
-    /// Opcode for the ReleaseOverlayWindow request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -585,7 +585,7 @@ impl ReleaseOverlayWindowRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            RELEASE_OVERLAY_WINDOW_REQUEST,
             0,
             0,
             window_bytes[0],

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -221,8 +221,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -308,9 +308,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRequest {
-        damage: damage,
-        drawable: drawable,
-        level: level,
+        damage,
+        drawable,
+        level,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -356,7 +356,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyRequest {
-        damage: damage,
+        damage,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -418,9 +418,9 @@ where
     let repair: xfixes::Region = repair.into();
     let parts: xfixes::Region = parts.into();
     let request0 = SubtractRequest {
-        damage: damage,
-        repair: repair,
-        parts: parts,
+        damage,
+        repair,
+        parts,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -472,8 +472,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AddRequest {
-        drawable: drawable,
-        region: region,
+        drawable,
+        region,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -175,14 +175,14 @@ impl From<BadDamageError> for [u8; 32] {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -195,7 +195,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -255,6 +255,8 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the Create request
+pub const CREATE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateRequest {
     pub damage: Damage,
@@ -262,8 +264,6 @@ pub struct CreateRequest {
     pub level: ReportLevel,
 }
 impl CreateRequest {
-    /// Opcode for the Create request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -277,7 +277,7 @@ impl CreateRequest {
         let level_bytes = u8::from(self.level).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_REQUEST,
             0,
             0,
             damage_bytes[0],
@@ -314,13 +314,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Destroy request
+pub const DESTROY_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyRequest {
     pub damage: Damage,
 }
 impl DestroyRequest {
-    /// Opcode for the Destroy request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -332,7 +332,7 @@ impl DestroyRequest {
         let damage_bytes = self.damage.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_REQUEST,
             0,
             0,
             damage_bytes[0],
@@ -359,6 +359,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Subtract request
+pub const SUBTRACT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SubtractRequest {
     pub damage: Damage,
@@ -366,8 +368,6 @@ pub struct SubtractRequest {
     pub parts: xfixes::Region,
 }
 impl SubtractRequest {
-    /// Opcode for the Subtract request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -381,7 +381,7 @@ impl SubtractRequest {
         let parts_bytes = self.parts.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SUBTRACT_REQUEST,
             0,
             0,
             damage_bytes[0],
@@ -422,14 +422,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Add request
+pub const ADD_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AddRequest {
     pub drawable: xproto::Drawable,
     pub region: xfixes::Region,
 }
 impl AddRequest {
-    /// Opcode for the Add request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -442,7 +442,7 @@ impl AddRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ADD_REQUEST,
             0,
             0,
             drawable_bytes[0],

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -175,36 +176,57 @@ impl From<BadDamageError> for [u8; 32] {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest {
+    pub client_major_version: u32,
+    pub client_minor_version: u32,
+}
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let client_major_version_bytes = self.client_major_version.serialize();
+        let client_minor_version_bytes = self.client_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+            client_major_version_bytes[0],
+            client_major_version_bytes[1],
+            client_major_version_bytes[2],
+            client_major_version_bytes[3],
+            client_minor_version_bytes[0],
+            client_minor_version_bytes[1],
+            client_minor_version_bytes[2],
+            client_minor_version_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u32, client_minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let client_major_version_bytes = client_major_version.serialize();
-    let client_minor_version_bytes = client_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-        client_major_version_bytes[0],
-        client_major_version_bytes[1],
-        client_major_version_bytes[2],
-        client_major_version_bytes[3],
-        client_minor_version_bytes[0],
-        client_minor_version_bytes[1],
-        client_minor_version_bytes[2],
-        client_minor_version_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest {
+        client_major_version: client_major_version,
+        client_minor_version: client_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -235,141 +257,227 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the Create request
-pub const CREATE_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateRequest {
+    pub damage: Damage,
+    pub drawable: xproto::Drawable,
+    pub level: ReportLevel,
+}
+impl CreateRequest {
+    /// Opcode for the Create request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let damage_bytes = self.damage.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let level_bytes = u8::from(self.level).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateRequest::opcode(),
+            0,
+            0,
+            damage_bytes[0],
+            damage_bytes[1],
+            damage_bytes[2],
+            damage_bytes[3],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            level_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create<Conn>(conn: &Conn, damage: Damage, drawable: xproto::Drawable, level: ReportLevel) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let damage_bytes = damage.serialize();
-    let drawable_bytes = drawable.serialize();
-    let level_bytes = u8::from(level).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_REQUEST,
-        0,
-        0,
-        damage_bytes[0],
-        damage_bytes[1],
-        damage_bytes[2],
-        damage_bytes[3],
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        level_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateRequest {
+        damage: damage,
+        drawable: drawable,
+        level: level,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Destroy request
-pub const DESTROY_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroyRequest {
+    pub damage: Damage,
+}
+impl DestroyRequest {
+    /// Opcode for the Destroy request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let damage_bytes = self.damage.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroyRequest::opcode(),
+            0,
+            0,
+            damage_bytes[0],
+            damage_bytes[1],
+            damage_bytes[2],
+            damage_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy<Conn>(conn: &Conn, damage: Damage) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let damage_bytes = damage.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_REQUEST,
-        0,
-        0,
-        damage_bytes[0],
-        damage_bytes[1],
-        damage_bytes[2],
-        damage_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroyRequest {
+        damage: damage,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Subtract request
-pub const SUBTRACT_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubtractRequest {
+    pub damage: Damage,
+    pub repair: xfixes::Region,
+    pub parts: xfixes::Region,
+}
+impl SubtractRequest {
+    /// Opcode for the Subtract request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let damage_bytes = self.damage.serialize();
+        let repair_bytes = self.repair.serialize();
+        let parts_bytes = self.parts.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SubtractRequest::opcode(),
+            0,
+            0,
+            damage_bytes[0],
+            damage_bytes[1],
+            damage_bytes[2],
+            damage_bytes[3],
+            repair_bytes[0],
+            repair_bytes[1],
+            repair_bytes[2],
+            repair_bytes[3],
+            parts_bytes[0],
+            parts_bytes[1],
+            parts_bytes[2],
+            parts_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn subtract<Conn, A, B>(conn: &Conn, damage: Damage, repair: A, parts: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xfixes::Region>,
     B: Into<xfixes::Region>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let repair: xfixes::Region = repair.into();
     let parts: xfixes::Region = parts.into();
-    let length_so_far = 0;
-    let damage_bytes = damage.serialize();
-    let repair_bytes = repair.serialize();
-    let parts_bytes = parts.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SUBTRACT_REQUEST,
-        0,
-        0,
-        damage_bytes[0],
-        damage_bytes[1],
-        damage_bytes[2],
-        damage_bytes[3],
-        repair_bytes[0],
-        repair_bytes[1],
-        repair_bytes[2],
-        repair_bytes[3],
-        parts_bytes[0],
-        parts_bytes[1],
-        parts_bytes[2],
-        parts_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SubtractRequest {
+        damage: damage,
+        repair: repair,
+        parts: parts,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Add request
-pub const ADD_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AddRequest {
+    pub drawable: xproto::Drawable,
+    pub region: xfixes::Region,
+}
+impl AddRequest {
+    /// Opcode for the Add request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let region_bytes = self.region.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            AddRequest::opcode(),
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            region_bytes[0],
+            region_bytes[1],
+            region_bytes[2],
+            region_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn add<Conn>(conn: &Conn, drawable: xproto::Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let region_bytes = region.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        ADD_REQUEST,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        region_bytes[0],
-        region_bytes[1],
-        region_bytes[2],
-        region_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = AddRequest {
+        drawable: drawable,
+        region: region,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Opcode for the Notify event

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -197,7 +197,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -280,7 +280,7 @@ impl CreateRequest {
         let level_bytes = u8::from(self.level).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             damage_bytes[0],
@@ -336,7 +336,7 @@ impl DestroyRequest {
         let damage_bytes = self.damage.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             damage_bytes[0],
@@ -386,7 +386,7 @@ impl SubtractRequest {
         let parts_bytes = self.parts.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SubtractRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             damage_bytes[0],
@@ -448,7 +448,7 @@ impl AddRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AddRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -185,7 +185,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -267,7 +266,6 @@ impl CreateRequest {
     /// Opcode for the Create request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -325,7 +323,6 @@ impl DestroyRequest {
     /// Opcode for the Destroy request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -373,7 +370,6 @@ impl SubtractRequest {
     /// Opcode for the Subtract request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -436,7 +432,6 @@ impl AddRequest {
     /// Opcode for the Add request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -185,7 +184,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -266,7 +265,7 @@ impl CreateRequest {
     /// Opcode for the Create request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -323,7 +322,7 @@ impl DestroyRequest {
     /// Opcode for the Destroy request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -370,7 +369,7 @@ impl SubtractRequest {
     /// Opcode for the Subtract request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -432,7 +431,7 @@ impl AddRequest {
     /// Opcode for the Add request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -32,32 +33,53 @@ pub const X11_EXTENSION_NAME: &str = "DPMS";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 
-/// Opcode for the GetVersion request
-pub const GET_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetVersionRequest {
+    pub client_major_version: u16,
+    pub client_minor_version: u16,
+}
+impl GetVersionRequest {
+    /// Opcode for the GetVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let client_major_version_bytes = self.client_major_version.serialize();
+        let client_minor_version_bytes = self.client_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetVersionRequest::opcode(),
+            0,
+            0,
+            client_major_version_bytes[0],
+            client_major_version_bytes[1],
+            client_minor_version_bytes[0],
+            client_minor_version_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_version<Conn>(conn: &Conn, client_major_version: u16, client_minor_version: u16) -> Result<Cookie<'_, Conn, GetVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let client_major_version_bytes = client_major_version.serialize();
-    let client_minor_version_bytes = client_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_VERSION_REQUEST,
-        0,
-        0,
-        client_major_version_bytes[0],
-        client_major_version_bytes[1],
-        client_minor_version_bytes[0],
-        client_minor_version_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetVersionRequest {
+        client_major_version: client_major_version,
+        client_minor_version: client_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -87,26 +109,41 @@ impl TryFrom<&[u8]> for GetVersionReply {
     }
 }
 
-/// Opcode for the Capable request
-pub const CAPABLE_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapableRequest;
+impl CapableRequest {
+    /// Opcode for the Capable request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CapableRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn capable<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, CapableReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        CAPABLE_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CapableRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -135,26 +172,41 @@ impl TryFrom<&[u8]> for CapableReply {
     }
 }
 
-/// Opcode for the GetTimeouts request
-pub const GET_TIMEOUTS_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetTimeoutsRequest;
+impl GetTimeoutsRequest {
+    /// Opcode for the GetTimeouts request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetTimeoutsRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_timeouts<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetTimeoutsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_TIMEOUTS_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetTimeoutsRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -187,81 +239,134 @@ impl TryFrom<&[u8]> for GetTimeoutsReply {
     }
 }
 
-/// Opcode for the SetTimeouts request
-pub const SET_TIMEOUTS_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetTimeoutsRequest {
+    pub standby_timeout: u16,
+    pub suspend_timeout: u16,
+    pub off_timeout: u16,
+}
+impl SetTimeoutsRequest {
+    /// Opcode for the SetTimeouts request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let standby_timeout_bytes = self.standby_timeout.serialize();
+        let suspend_timeout_bytes = self.suspend_timeout.serialize();
+        let off_timeout_bytes = self.off_timeout.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetTimeoutsRequest::opcode(),
+            0,
+            0,
+            standby_timeout_bytes[0],
+            standby_timeout_bytes[1],
+            suspend_timeout_bytes[0],
+            suspend_timeout_bytes[1],
+            off_timeout_bytes[0],
+            off_timeout_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_timeouts<Conn>(conn: &Conn, standby_timeout: u16, suspend_timeout: u16, off_timeout: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let standby_timeout_bytes = standby_timeout.serialize();
-    let suspend_timeout_bytes = suspend_timeout.serialize();
-    let off_timeout_bytes = off_timeout.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_TIMEOUTS_REQUEST,
-        0,
-        0,
-        standby_timeout_bytes[0],
-        standby_timeout_bytes[1],
-        suspend_timeout_bytes[0],
-        suspend_timeout_bytes[1],
-        off_timeout_bytes[0],
-        off_timeout_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetTimeoutsRequest {
+        standby_timeout: standby_timeout,
+        suspend_timeout: suspend_timeout,
+        off_timeout: off_timeout,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Enable request
-pub const ENABLE_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnableRequest;
+impl EnableRequest {
+    /// Opcode for the Enable request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            EnableRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn enable<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        ENABLE_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = EnableRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Disable request
-pub const DISABLE_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DisableRequest;
+impl DisableRequest {
+    /// Opcode for the Disable request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DisableRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn disable<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        DISABLE_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DisableRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -332,53 +437,87 @@ impl TryFrom<u32> for DPMSMode {
     }
 }
 
-/// Opcode for the ForceLevel request
-pub const FORCE_LEVEL_REQUEST: u8 = 6;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ForceLevelRequest {
+    pub power_level: DPMSMode,
+}
+impl ForceLevelRequest {
+    /// Opcode for the ForceLevel request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let power_level_bytes = u16::from(self.power_level).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ForceLevelRequest::opcode(),
+            0,
+            0,
+            power_level_bytes[0],
+            power_level_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn force_level<Conn>(conn: &Conn, power_level: DPMSMode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let power_level_bytes = u16::from(power_level).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        FORCE_LEVEL_REQUEST,
-        0,
-        0,
-        power_level_bytes[0],
-        power_level_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ForceLevelRequest {
+        power_level: power_level,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Info request
-pub const INFO_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InfoRequest;
+impl InfoRequest {
+    /// Opcode for the Info request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            InfoRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn info<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, InfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        INFO_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = InfoRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -42,7 +42,6 @@ impl GetVersionRequest {
     /// Opcode for the GetVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -115,7 +114,6 @@ impl CapableRequest {
     /// Opcode for the Capable request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -178,7 +176,6 @@ impl GetTimeoutsRequest {
     /// Opcode for the GetTimeouts request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -249,7 +246,6 @@ impl SetTimeoutsRequest {
     /// Opcode for the SetTimeouts request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -301,7 +297,6 @@ impl EnableRequest {
     /// Opcode for the Enable request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -338,7 +333,6 @@ impl DisableRequest {
     /// Opcode for the Disable request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -445,7 +439,6 @@ impl ForceLevelRequest {
     /// Opcode for the ForceLevel request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -489,7 +482,6 @@ impl InfoRequest {
     /// Opcode for the Info request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -74,8 +74,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -286,9 +286,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetTimeoutsRequest {
-        standby_timeout: standby_timeout,
-        suspend_timeout: suspend_timeout,
-        off_timeout: off_timeout,
+        standby_timeout,
+        suspend_timeout,
+        off_timeout,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -476,7 +476,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ForceLevelRequest {
-        power_level: power_level,
+        power_level,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -54,7 +54,7 @@ impl GetVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -125,7 +125,7 @@ impl CapableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            CapableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -188,7 +188,7 @@ impl GetTimeoutsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTimeoutsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -262,7 +262,7 @@ impl SetTimeoutsRequest {
         let off_timeout_bytes = self.off_timeout.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetTimeoutsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             standby_timeout_bytes[0],
@@ -311,7 +311,7 @@ impl EnableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            EnableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -348,7 +348,7 @@ impl DisableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            DisableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -456,7 +456,7 @@ impl ForceLevelRequest {
         let power_level_bytes = u16::from(self.power_level).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ForceLevelRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             power_level_bytes[0],
@@ -499,7 +499,7 @@ impl InfoRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            InfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -32,14 +32,14 @@ pub const X11_EXTENSION_NAME: &str = "DPMS";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 
+/// Opcode for the GetVersion request
+pub const GET_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
 impl GetVersionRequest {
-    /// Opcode for the GetVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -52,7 +52,7 @@ impl GetVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -107,11 +107,11 @@ impl TryFrom<&[u8]> for GetVersionReply {
     }
 }
 
+/// Opcode for the Capable request
+pub const CAPABLE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CapableRequest;
 impl CapableRequest {
-    /// Opcode for the Capable request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -122,7 +122,7 @@ impl CapableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CAPABLE_REQUEST,
             0,
             0,
         ];
@@ -169,11 +169,11 @@ impl TryFrom<&[u8]> for CapableReply {
     }
 }
 
+/// Opcode for the GetTimeouts request
+pub const GET_TIMEOUTS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTimeoutsRequest;
 impl GetTimeoutsRequest {
-    /// Opcode for the GetTimeouts request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -184,7 +184,7 @@ impl GetTimeoutsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TIMEOUTS_REQUEST,
             0,
             0,
         ];
@@ -235,6 +235,8 @@ impl TryFrom<&[u8]> for GetTimeoutsReply {
     }
 }
 
+/// Opcode for the SetTimeouts request
+pub const SET_TIMEOUTS_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetTimeoutsRequest {
     pub standby_timeout: u16,
@@ -242,8 +244,6 @@ pub struct SetTimeoutsRequest {
     pub off_timeout: u16,
 }
 impl SetTimeoutsRequest {
-    /// Opcode for the SetTimeouts request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -257,7 +257,7 @@ impl SetTimeoutsRequest {
         let off_timeout_bytes = self.off_timeout.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_TIMEOUTS_REQUEST,
             0,
             0,
             standby_timeout_bytes[0],
@@ -290,11 +290,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Enable request
+pub const ENABLE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnableRequest;
 impl EnableRequest {
-    /// Opcode for the Enable request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -305,7 +305,7 @@ impl EnableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ENABLE_REQUEST,
             0,
             0,
         ];
@@ -326,11 +326,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Disable request
+pub const DISABLE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableRequest;
 impl DisableRequest {
-    /// Opcode for the Disable request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -341,7 +341,7 @@ impl DisableRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DISABLE_REQUEST,
             0,
             0,
         ];
@@ -430,13 +430,13 @@ impl TryFrom<u32> for DPMSMode {
     }
 }
 
+/// Opcode for the ForceLevel request
+pub const FORCE_LEVEL_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ForceLevelRequest {
     pub power_level: DPMSMode,
 }
 impl ForceLevelRequest {
-    /// Opcode for the ForceLevel request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -448,7 +448,7 @@ impl ForceLevelRequest {
         let power_level_bytes = u16::from(self.power_level).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FORCE_LEVEL_REQUEST,
             0,
             0,
             power_level_bytes[0],
@@ -475,11 +475,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Info request
+pub const INFO_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InfoRequest;
 impl InfoRequest {
-    /// Opcode for the Info request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -490,7 +490,7 @@ impl InfoRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            INFO_REQUEST,
             0,
             0,
         ];

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -42,7 +41,7 @@ impl GetVersionRequest {
     /// Opcode for the GetVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -114,7 +113,7 @@ impl CapableRequest {
     /// Opcode for the Capable request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -176,7 +175,7 @@ impl GetTimeoutsRequest {
     /// Opcode for the GetTimeouts request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -246,7 +245,7 @@ impl SetTimeoutsRequest {
     /// Opcode for the SetTimeouts request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -297,7 +296,7 @@ impl EnableRequest {
     /// Opcode for the Enable request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -333,7 +332,7 @@ impl DisableRequest {
     /// Opcode for the Disable request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -439,7 +438,7 @@ impl ForceLevelRequest {
     /// Opcode for the ForceLevel request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -482,7 +481,7 @@ impl InfoRequest {
     /// Opcode for the Info request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -390,7 +390,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -470,7 +470,7 @@ impl ConnectRequest {
         let driver_type_bytes = u32::from(self.driver_type).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ConnectRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -586,7 +586,7 @@ impl AuthenticateRequest {
         let magic_bytes = self.magic.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AuthenticateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -662,7 +662,7 @@ impl CreateDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateDrawableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -708,7 +708,7 @@ impl DestroyDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyDrawableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -757,7 +757,7 @@ impl<'input> GetBuffersRequest<'input> {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetBuffersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -865,7 +865,7 @@ impl CopyRegionRequest {
         let src_bytes = self.src.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CopyRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -952,7 +952,7 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetBuffersWithFormatRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1066,7 +1066,7 @@ impl SwapBuffersRequest {
         let remainder_lo_bytes = self.remainder_lo.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SwapBuffersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1169,7 +1169,7 @@ impl GetMSCRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMSCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1262,7 +1262,7 @@ impl WaitMSCRequest {
         let remainder_lo_bytes = self.remainder_lo.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            WaitMSCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1377,7 +1377,7 @@ impl WaitSBCRequest {
         let target_sbc_lo_bytes = self.target_sbc_lo.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            WaitSBCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1470,7 +1470,7 @@ impl SwapIntervalRequest {
         let interval_bytes = self.interval.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SwapIntervalRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1523,7 +1523,7 @@ impl GetParamRequest {
         let param_bytes = self.param.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetParamRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -378,7 +377,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -457,7 +456,7 @@ impl ConnectRequest {
     /// Opcode for the Connect request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -572,7 +571,7 @@ impl AuthenticateRequest {
     /// Opcode for the Authenticate request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -648,7 +647,7 @@ impl CreateDrawableRequest {
     /// Opcode for the CreateDrawable request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -693,7 +692,7 @@ impl DestroyDrawableRequest {
     /// Opcode for the DestroyDrawable request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -740,7 +739,7 @@ impl<'input> GetBuffersRequest<'input> {
     /// Opcode for the GetBuffers request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -771,7 +770,7 @@ impl<'input> GetBuffersRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), attachments_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), attachments_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn get_buffers<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &'input [u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
@@ -845,7 +844,7 @@ impl CopyRegionRequest {
     /// Opcode for the CopyRegion request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -933,7 +932,7 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
     /// Opcode for the GetBuffersWithFormat request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -964,7 +963,7 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), attachments_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), attachments_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn get_buffers_with_format<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &'input [AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
@@ -1041,7 +1040,7 @@ impl SwapBuffersRequest {
     /// Opcode for the SwapBuffers request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1149,7 +1148,7 @@ impl GetMSCRequest {
     /// Opcode for the GetMSC request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1235,7 +1234,7 @@ impl WaitMSCRequest {
     /// Opcode for the WaitMSC request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1353,7 +1352,7 @@ impl WaitSBCRequest {
     /// Opcode for the WaitSBC request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1446,7 +1445,7 @@ impl SwapIntervalRequest {
     /// Opcode for the SwapInterval request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1498,7 +1497,7 @@ impl GetParamRequest {
     /// Opcode for the GetParam request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -378,7 +378,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -458,7 +457,6 @@ impl ConnectRequest {
     /// Opcode for the Connect request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -574,7 +572,6 @@ impl AuthenticateRequest {
     /// Opcode for the Authenticate request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -651,7 +648,6 @@ impl CreateDrawableRequest {
     /// Opcode for the CreateDrawable request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -697,7 +693,6 @@ impl DestroyDrawableRequest {
     /// Opcode for the DestroyDrawable request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -745,7 +740,6 @@ impl<'input> GetBuffersRequest<'input> {
     /// Opcode for the GetBuffers request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -851,7 +845,6 @@ impl CopyRegionRequest {
     /// Opcode for the CopyRegion request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -940,7 +933,6 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
     /// Opcode for the GetBuffersWithFormat request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1049,7 +1041,6 @@ impl SwapBuffersRequest {
     /// Opcode for the SwapBuffers request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1158,7 +1149,6 @@ impl GetMSCRequest {
     /// Opcode for the GetMSC request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1245,7 +1235,6 @@ impl WaitMSCRequest {
     /// Opcode for the WaitMSC request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1364,7 +1353,6 @@ impl WaitSBCRequest {
     /// Opcode for the WaitSBC request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1458,7 +1446,6 @@ impl SwapIntervalRequest {
     /// Opcode for the SwapInterval request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1511,7 +1498,6 @@ impl GetParamRequest {
     /// Opcode for the GetParam request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -368,14 +368,14 @@ impl Serialize for AttachFormat {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -388,7 +388,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -447,14 +447,14 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the Connect request
+pub const CONNECT_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConnectRequest {
     pub window: xproto::Window,
     pub driver_type: DriverType,
 }
 impl ConnectRequest {
-    /// Opcode for the Connect request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -467,7 +467,7 @@ impl ConnectRequest {
         let driver_type_bytes = u32::from(self.driver_type).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CONNECT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -562,14 +562,14 @@ impl ConnectReply {
     }
 }
 
+/// Opcode for the Authenticate request
+pub const AUTHENTICATE_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuthenticateRequest {
     pub window: xproto::Window,
     pub magic: u32,
 }
 impl AuthenticateRequest {
-    /// Opcode for the Authenticate request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -582,7 +582,7 @@ impl AuthenticateRequest {
         let magic_bytes = self.magic.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            AUTHENTICATE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -639,13 +639,13 @@ impl TryFrom<&[u8]> for AuthenticateReply {
     }
 }
 
+/// Opcode for the CreateDrawable request
+pub const CREATE_DRAWABLE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateDrawableRequest {
     pub drawable: xproto::Drawable,
 }
 impl CreateDrawableRequest {
-    /// Opcode for the CreateDrawable request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -657,7 +657,7 @@ impl CreateDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_DRAWABLE_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -684,13 +684,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyDrawable request
+pub const DESTROY_DRAWABLE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyDrawableRequest {
     pub drawable: xproto::Drawable,
 }
 impl DestroyDrawableRequest {
-    /// Opcode for the DestroyDrawable request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -702,7 +702,7 @@ impl DestroyDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_DRAWABLE_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -729,6 +729,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetBuffers request
+pub const GET_BUFFERS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetBuffersRequest<'input> {
     pub drawable: xproto::Drawable,
@@ -736,8 +738,6 @@ pub struct GetBuffersRequest<'input> {
     pub attachments: &'input [u32],
 }
 impl<'input> GetBuffersRequest<'input> {
-    /// Opcode for the GetBuffers request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -750,7 +750,7 @@ impl<'input> GetBuffersRequest<'input> {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_BUFFERS_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -833,6 +833,8 @@ impl GetBuffersReply {
     }
 }
 
+/// Opcode for the CopyRegion request
+pub const COPY_REGION_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CopyRegionRequest {
     pub drawable: xproto::Drawable,
@@ -841,8 +843,6 @@ pub struct CopyRegionRequest {
     pub src: u32,
 }
 impl CopyRegionRequest {
-    /// Opcode for the CopyRegion request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -857,7 +857,7 @@ impl CopyRegionRequest {
         let src_bytes = self.src.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COPY_REGION_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -922,6 +922,8 @@ impl TryFrom<&[u8]> for CopyRegionReply {
     }
 }
 
+/// Opcode for the GetBuffersWithFormat request
+pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetBuffersWithFormatRequest<'input> {
     pub drawable: xproto::Drawable,
@@ -929,8 +931,6 @@ pub struct GetBuffersWithFormatRequest<'input> {
     pub attachments: &'input [AttachFormat],
 }
 impl<'input> GetBuffersWithFormatRequest<'input> {
-    /// Opcode for the GetBuffersWithFormat request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -943,7 +943,7 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_BUFFERS_WITH_FORMAT_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1026,6 +1026,8 @@ impl GetBuffersWithFormatReply {
     }
 }
 
+/// Opcode for the SwapBuffers request
+pub const SWAP_BUFFERS_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SwapBuffersRequest {
     pub drawable: xproto::Drawable,
@@ -1037,8 +1039,6 @@ pub struct SwapBuffersRequest {
     pub remainder_lo: u32,
 }
 impl SwapBuffersRequest {
-    /// Opcode for the SwapBuffers request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1056,7 +1056,7 @@ impl SwapBuffersRequest {
         let remainder_lo_bytes = self.remainder_lo.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SWAP_BUFFERS_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1140,13 +1140,13 @@ impl TryFrom<&[u8]> for SwapBuffersReply {
     }
 }
 
+/// Opcode for the GetMSC request
+pub const GET_MSC_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMSCRequest {
     pub drawable: xproto::Drawable,
 }
 impl GetMSCRequest {
-    /// Opcode for the GetMSC request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1158,7 +1158,7 @@ impl GetMSCRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MSC_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1220,6 +1220,8 @@ impl TryFrom<&[u8]> for GetMSCReply {
     }
 }
 
+/// Opcode for the WaitMSC request
+pub const WAIT_MSC_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaitMSCRequest {
     pub drawable: xproto::Drawable,
@@ -1231,8 +1233,6 @@ pub struct WaitMSCRequest {
     pub remainder_lo: u32,
 }
 impl WaitMSCRequest {
-    /// Opcode for the WaitMSC request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1250,7 +1250,7 @@ impl WaitMSCRequest {
         let remainder_lo_bytes = self.remainder_lo.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            WAIT_MSC_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1342,6 +1342,8 @@ impl TryFrom<&[u8]> for WaitMSCReply {
     }
 }
 
+/// Opcode for the WaitSBC request
+pub const WAIT_SBC_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaitSBCRequest {
     pub drawable: xproto::Drawable,
@@ -1349,8 +1351,6 @@ pub struct WaitSBCRequest {
     pub target_sbc_lo: u32,
 }
 impl WaitSBCRequest {
-    /// Opcode for the WaitSBC request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1364,7 +1364,7 @@ impl WaitSBCRequest {
         let target_sbc_lo_bytes = self.target_sbc_lo.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            WAIT_SBC_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1436,14 +1436,14 @@ impl TryFrom<&[u8]> for WaitSBCReply {
     }
 }
 
+/// Opcode for the SwapInterval request
+pub const SWAP_INTERVAL_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SwapIntervalRequest {
     pub drawable: xproto::Drawable,
     pub interval: u32,
 }
 impl SwapIntervalRequest {
-    /// Opcode for the SwapInterval request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1456,7 +1456,7 @@ impl SwapIntervalRequest {
         let interval_bytes = self.interval.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SWAP_INTERVAL_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1488,14 +1488,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetParam request
+pub const GET_PARAM_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetParamRequest {
     pub drawable: xproto::Drawable,
     pub param: u32,
 }
 impl GetParamRequest {
-    /// Opcode for the GetParam request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1508,7 +1508,7 @@ impl GetParamRequest {
         let param_bytes = self.param.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PARAM_REQUEST,
             0,
             0,
             drawable_bytes[0],

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -414,8 +414,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -494,8 +494,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ConnectRequest {
-        window: window,
-        driver_type: driver_type,
+        window,
+        driver_type,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -610,8 +610,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AuthenticateRequest {
-        window: window,
-        magic: magic,
+        window,
+        magic,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -682,7 +682,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateDrawableRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -728,7 +728,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyDrawableRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -785,9 +785,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetBuffersRequest {
-        drawable: drawable,
-        count: count,
-        attachments: attachments,
+        drawable,
+        count,
+        attachments,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -897,10 +897,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CopyRegionRequest {
-        drawable: drawable,
-        region: region,
-        dest: dest,
-        src: src,
+        drawable,
+        region,
+        dest,
+        src,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -980,9 +980,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetBuffersWithFormatRequest {
-        drawable: drawable,
-        count: count,
-        attachments: attachments,
+        drawable,
+        count,
+        attachments,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1110,13 +1110,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SwapBuffersRequest {
-        drawable: drawable,
-        target_msc_hi: target_msc_hi,
-        target_msc_lo: target_msc_lo,
-        divisor_hi: divisor_hi,
-        divisor_lo: divisor_lo,
-        remainder_hi: remainder_hi,
-        remainder_lo: remainder_lo,
+        drawable,
+        target_msc_hi,
+        target_msc_lo,
+        divisor_hi,
+        divisor_lo,
+        remainder_hi,
+        remainder_lo,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1189,7 +1189,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMSCRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1306,13 +1306,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = WaitMSCRequest {
-        drawable: drawable,
-        target_msc_hi: target_msc_hi,
-        target_msc_lo: target_msc_lo,
-        divisor_hi: divisor_hi,
-        divisor_lo: divisor_lo,
-        remainder_hi: remainder_hi,
-        remainder_lo: remainder_lo,
+        drawable,
+        target_msc_hi,
+        target_msc_lo,
+        divisor_hi,
+        divisor_lo,
+        remainder_hi,
+        remainder_lo,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1405,9 +1405,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = WaitSBCRequest {
-        drawable: drawable,
-        target_sbc_hi: target_sbc_hi,
-        target_sbc_lo: target_sbc_lo,
+        drawable,
+        target_sbc_hi,
+        target_sbc_lo,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1494,8 +1494,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SwapIntervalRequest {
-        drawable: drawable,
-        interval: interval,
+        drawable,
+        interval,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1547,8 +1547,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetParamRequest {
-        drawable: drawable,
-        param: param,
+        drawable,
+        param,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -635,7 +635,7 @@ where
 
 /// Opcode for the GetBuffers request
 pub const GET_BUFFERS_REQUEST: u8 = 5;
-pub fn get_buffers<'c, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
+pub fn get_buffers<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &'input [u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -782,7 +782,7 @@ impl TryFrom<&[u8]> for CopyRegionReply {
 
 /// Opcode for the GetBuffersWithFormat request
 pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
-pub fn get_buffers_with_format<'c, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
+pub fn get_buffers_with_format<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &'input [AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1449,7 +1449,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         destroy_drawable(self, drawable)
     }
-    fn dri2_get_buffers<'c>(&'c self, drawable: xproto::Drawable, count: u32, attachments: &[u32]) -> Result<Cookie<'c, Self, GetBuffersReply>, ConnectionError>
+    fn dri2_get_buffers<'c, 'input>(&'c self, drawable: xproto::Drawable, count: u32, attachments: &'input [u32]) -> Result<Cookie<'c, Self, GetBuffersReply>, ConnectionError>
     {
         get_buffers(self, drawable, count, attachments)
     }
@@ -1457,7 +1457,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         copy_region(self, drawable, region, dest, src)
     }
-    fn dri2_get_buffers_with_format<'c>(&'c self, drawable: xproto::Drawable, count: u32, attachments: &[AttachFormat]) -> Result<Cookie<'c, Self, GetBuffersWithFormatReply>, ConnectionError>
+    fn dri2_get_buffers_with_format<'c, 'input>(&'c self, drawable: xproto::Drawable, count: u32, attachments: &'input [AttachFormat]) -> Result<Cookie<'c, Self, GetBuffersWithFormatReply>, ConnectionError>
     {
         get_buffers_with_format(self, drawable, count, attachments)
     }

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -43,7 +42,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -122,7 +121,7 @@ impl OpenRequest {
     /// Opcode for the Open request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -210,7 +209,7 @@ impl PixmapFromBufferRequest {
     /// Opcode for the PixmapFromBuffer request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -288,7 +287,7 @@ impl BufferFromPixmapRequest {
     /// Opcode for the BufferFromPixmap request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -377,7 +376,7 @@ impl FenceFromFDRequest {
     /// Opcode for the FenceFromFD request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -438,7 +437,7 @@ impl FDFromFenceRequest {
     /// Opcode for the FDFromFence request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -520,7 +519,7 @@ impl GetSupportedModifiersRequest {
     /// Opcode for the GetSupportedModifiers request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -646,7 +645,7 @@ impl PixmapFromBuffersRequest {
     /// Opcode for the PixmapFromBuffers request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -778,7 +777,7 @@ impl BuffersFromPixmapRequest {
     /// Opcode for the BuffersFromPixmap request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -55,7 +55,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -135,7 +135,7 @@ impl OpenRequest {
         let provider_bytes = self.provider.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            OpenRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -230,7 +230,7 @@ impl PixmapFromBufferRequest {
         let bpp_bytes = self.bpp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PixmapFromBufferRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             pixmap_bytes[0],
@@ -302,7 +302,7 @@ impl BufferFromPixmapRequest {
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            BufferFromPixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             pixmap_bytes[0],
@@ -394,7 +394,7 @@ impl FenceFromFDRequest {
         let initially_triggered_bytes = self.initially_triggered.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FenceFromFDRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -455,7 +455,7 @@ impl FDFromFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FDFromFenceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -539,7 +539,7 @@ impl GetSupportedModifiersRequest {
         let bpp_bytes = self.bpp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetSupportedModifiersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -680,7 +680,7 @@ impl PixmapFromBuffersRequest {
         let modifier_bytes = self.modifier.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PixmapFromBuffersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             pixmap_bytes[0],
@@ -797,7 +797,7 @@ impl BuffersFromPixmapRequest {
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            BuffersFromPixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             pixmap_bytes[0],

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -79,8 +79,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -159,8 +159,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = OpenRequest {
-        drawable: drawable,
-        provider: provider,
+        drawable,
+        provider,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -268,15 +268,15 @@ where
 {
     let pixmap_fd: RawFdContainer = pixmap_fd.into();
     let request0 = PixmapFromBufferRequest {
-        pixmap: pixmap,
-        drawable: drawable,
-        size: size,
-        width: width,
-        height: height,
-        stride: stride,
-        depth: depth,
-        bpp: bpp,
-        pixmap_fd: pixmap_fd,
+        pixmap,
+        drawable,
+        size,
+        width,
+        height,
+        stride,
+        depth,
+        bpp,
+        pixmap_fd,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -322,7 +322,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = BufferFromPixmapRequest {
-        pixmap: pixmap,
+        pixmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -424,10 +424,10 @@ where
 {
     let fence_fd: RawFdContainer = fence_fd.into();
     let request0 = FenceFromFDRequest {
-        drawable: drawable,
-        fence: fence,
-        initially_triggered: initially_triggered,
-        fence_fd: fence_fd,
+        drawable,
+        fence,
+        initially_triggered,
+        fence_fd,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -479,8 +479,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FDFromFenceRequest {
-        drawable: drawable,
-        fence: fence,
+        drawable,
+        fence,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -563,9 +563,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetSupportedModifiersRequest {
-        window: window,
-        depth: depth,
-        bpp: bpp,
+        window,
+        depth,
+        bpp,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -756,22 +756,22 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PixmapFromBuffersRequest {
-        pixmap: pixmap,
-        window: window,
-        width: width,
-        height: height,
-        stride0: stride0,
-        offset0: offset0,
-        stride1: stride1,
-        offset1: offset1,
-        stride2: stride2,
-        offset2: offset2,
-        stride3: stride3,
-        offset3: offset3,
-        depth: depth,
-        bpp: bpp,
-        modifier: modifier,
-        buffers: buffers,
+        pixmap,
+        window,
+        width,
+        height,
+        stride0,
+        offset0,
+        stride1,
+        offset1,
+        stride2,
+        offset2,
+        stride3,
+        offset3,
+        depth,
+        bpp,
+        modifier,
+        buffers,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -817,7 +817,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = BuffersFromPixmapRequest {
-        pixmap: pixmap,
+        pixmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -43,7 +43,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -123,7 +122,6 @@ impl OpenRequest {
     /// Opcode for the Open request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -212,7 +210,6 @@ impl PixmapFromBufferRequest {
     /// Opcode for the PixmapFromBuffer request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -291,7 +288,6 @@ impl BufferFromPixmapRequest {
     /// Opcode for the BufferFromPixmap request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -381,7 +377,6 @@ impl FenceFromFDRequest {
     /// Opcode for the FenceFromFD request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -443,7 +438,6 @@ impl FDFromFenceRequest {
     /// Opcode for the FDFromFence request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -526,7 +520,6 @@ impl GetSupportedModifiersRequest {
     /// Opcode for the GetSupportedModifiers request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -653,7 +646,6 @@ impl PixmapFromBuffersRequest {
     /// Opcode for the PixmapFromBuffers request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -786,7 +778,6 @@ impl BuffersFromPixmapRequest {
     /// Opcode for the BuffersFromPixmap request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -33,14 +33,14 @@ pub const X11_EXTENSION_NAME: &str = "DRI3";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -53,7 +53,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -112,14 +112,14 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the Open request
+pub const OPEN_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OpenRequest {
     pub drawable: xproto::Drawable,
     pub provider: u32,
 }
 impl OpenRequest {
-    /// Opcode for the Open request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -132,7 +132,7 @@ impl OpenRequest {
         let provider_bytes = self.provider.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            OPEN_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -193,6 +193,8 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for OpenReply {
     }
 }
 
+/// Opcode for the PixmapFromBuffer request
+pub const PIXMAP_FROM_BUFFER_REQUEST: u8 = 2;
 #[derive(Debug, PartialEq, Eq)]
 pub struct PixmapFromBufferRequest {
     pub pixmap: xproto::Pixmap,
@@ -206,8 +208,6 @@ pub struct PixmapFromBufferRequest {
     pub pixmap_fd: RawFdContainer,
 }
 impl PixmapFromBufferRequest {
-    /// Opcode for the PixmapFromBuffer request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -226,7 +226,7 @@ impl PixmapFromBufferRequest {
         let bpp_bytes = self.bpp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PIXMAP_FROM_BUFFER_REQUEST,
             0,
             0,
             pixmap_bytes[0],
@@ -279,13 +279,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the BufferFromPixmap request
+pub const BUFFER_FROM_PIXMAP_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BufferFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }
 impl BufferFromPixmapRequest {
-    /// Opcode for the BufferFromPixmap request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -297,7 +297,7 @@ impl BufferFromPixmapRequest {
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            BUFFER_FROM_PIXMAP_REQUEST,
             0,
             0,
             pixmap_bytes[0],
@@ -365,6 +365,8 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for BufferFromPixmapReply {
     }
 }
 
+/// Opcode for the FenceFromFD request
+pub const FENCE_FROM_FD_REQUEST: u8 = 4;
 #[derive(Debug, PartialEq, Eq)]
 pub struct FenceFromFDRequest {
     pub drawable: xproto::Drawable,
@@ -373,8 +375,6 @@ pub struct FenceFromFDRequest {
     pub fence_fd: RawFdContainer,
 }
 impl FenceFromFDRequest {
-    /// Opcode for the FenceFromFD request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -388,7 +388,7 @@ impl FenceFromFDRequest {
         let initially_triggered_bytes = self.initially_triggered.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FENCE_FROM_FD_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -428,14 +428,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FDFromFence request
+pub const FD_FROM_FENCE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FDFromFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: u32,
 }
 impl FDFromFenceRequest {
-    /// Opcode for the FDFromFence request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -448,7 +448,7 @@ impl FDFromFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FD_FROM_FENCE_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -509,6 +509,8 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for FDFromFenceReply {
     }
 }
 
+/// Opcode for the GetSupportedModifiers request
+pub const GET_SUPPORTED_MODIFIERS_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetSupportedModifiersRequest {
     pub window: u32,
@@ -516,8 +518,6 @@ pub struct GetSupportedModifiersRequest {
     pub bpp: u8,
 }
 impl GetSupportedModifiersRequest {
-    /// Opcode for the GetSupportedModifiers request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -531,7 +531,7 @@ impl GetSupportedModifiersRequest {
         let bpp_bytes = self.bpp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SUPPORTED_MODIFIERS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -622,6 +622,8 @@ impl GetSupportedModifiersReply {
     }
 }
 
+/// Opcode for the PixmapFromBuffers request
+pub const PIXMAP_FROM_BUFFERS_REQUEST: u8 = 7;
 #[derive(Debug, PartialEq, Eq)]
 pub struct PixmapFromBuffersRequest {
     pub pixmap: xproto::Pixmap,
@@ -642,8 +644,6 @@ pub struct PixmapFromBuffersRequest {
     pub buffers: Vec<RawFdContainer>,
 }
 impl PixmapFromBuffersRequest {
-    /// Opcode for the PixmapFromBuffers request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -671,7 +671,7 @@ impl PixmapFromBuffersRequest {
         let modifier_bytes = self.modifier.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PIXMAP_FROM_BUFFERS_REQUEST,
             0,
             0,
             pixmap_bytes[0],
@@ -769,13 +769,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the BuffersFromPixmap request
+pub const BUFFERS_FROM_PIXMAP_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BuffersFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }
 impl BuffersFromPixmapRequest {
-    /// Opcode for the BuffersFromPixmap request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -787,7 +787,7 @@ impl BuffersFromPixmapRequest {
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            BUFFERS_FROM_PIXMAP_REQUEST,
             0,
             0,
             pixmap_bytes[0],

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -32,14 +32,14 @@ pub const X11_EXTENSION_NAME: &str = "Generic Event Extension";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -52,7 +52,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -54,7 +54,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -74,8 +74,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -42,7 +42,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -42,7 +41,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -470,7 +470,7 @@ impl TryFrom<u32> for PBCDT {
 
 /// Opcode for the Render request
 pub const RENDER_REQUEST: u8 = 1;
-pub fn render<'c, Conn>(conn: &'c Conn, context_tag: ContextTag, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn render<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -500,7 +500,7 @@ where
 
 /// Opcode for the RenderLarge request
 pub const RENDER_LARGE_REQUEST: u8 = 2;
-pub fn render_large<'c, Conn>(conn: &'c Conn, context_tag: ContextTag, request_num: u16, request_total: u16, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn render_large<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, request_num: u16, request_total: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1195,7 +1195,7 @@ where
 
 /// Opcode for the VendorPrivate request
 pub const VENDOR_PRIVATE_REQUEST: u8 = 16;
-pub fn vendor_private<'c, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn vendor_private<'c, 'input, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1230,7 +1230,7 @@ where
 
 /// Opcode for the VendorPrivateWithReply request
 pub const VENDOR_PRIVATE_WITH_REPLY_REQUEST: u8 = 17;
-pub fn vendor_private_with_reply<'c, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &[u8]) -> Result<Cookie<'c, Conn, VendorPrivateWithReplyReply>, ConnectionError>
+pub fn vendor_private_with_reply<'c, 'input, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<Cookie<'c, Conn, VendorPrivateWithReplyReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1441,7 +1441,7 @@ impl QueryServerStringReply {
 
 /// Opcode for the ClientInfo request
 pub const CLIENT_INFO_REQUEST: u8 = 20;
-pub fn client_info<'c, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, string: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn client_info<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1553,7 +1553,7 @@ impl GetFBConfigsReply {
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 22;
-pub fn create_pixmap<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pixmap: xproto::Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pixmap<'c, 'input, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pixmap: xproto::Pixmap, glx_pixmap: Pixmap, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1823,7 +1823,7 @@ impl TryFrom<&[u8]> for MakeContextCurrentReply {
 
 /// Opcode for the CreatePbuffer request
 pub const CREATE_PBUFFER_REQUEST: u8 = 27;
-pub fn create_pbuffer<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pbuffer: Pbuffer, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pbuffer<'c, 'input, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pbuffer: Pbuffer, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1968,7 +1968,7 @@ impl GetDrawableAttributesReply {
 
 /// Opcode for the ChangeDrawableAttributes request
 pub const CHANGE_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 30;
-pub fn change_drawable_attributes<'c, Conn>(conn: &'c Conn, drawable: Drawable, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_drawable_attributes<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2006,7 +2006,7 @@ where
 
 /// Opcode for the CreateWindow request
 pub const CREATE_WINDOW_REQUEST: u8 = 31;
-pub fn create_window<'c, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, window: xproto::Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_window<'c, 'input, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, window: xproto::Window, glx_window: Window, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2086,7 +2086,7 @@ where
 
 /// Opcode for the SetClientInfoARB request
 pub const SET_CLIENT_INFO_ARB_REQUEST: u8 = 33;
-pub fn set_client_info_arb<'c, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &[u32], gl_extension_string: &[u8], glx_extension_string: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_client_info_arb<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2143,7 +2143,7 @@ where
 
 /// Opcode for the CreateContextAttribsARB request
 pub const CREATE_CONTEXT_ATTRIBS_ARB_REQUEST: u8 = 34;
-pub fn create_context_attribs_arb<'c, Conn>(conn: &'c Conn, context: Context, fbconfig: Fbconfig, screen: u32, share_list: Context, is_direct: bool, attribs: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_context_attribs_arb<'c, 'input, Conn>(conn: &'c Conn, context: Context, fbconfig: Fbconfig, screen: u32, share_list: Context, is_direct: bool, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2201,7 +2201,7 @@ where
 
 /// Opcode for the SetClientInfo2ARB request
 pub const SET_CLIENT_INFO2_ARB_REQUEST: u8 = 35;
-pub fn set_client_info2_arb<'c, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &[u32], gl_extension_string: &[u8], glx_extension_string: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_client_info2_arb<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -5220,7 +5220,7 @@ where
 
 /// Opcode for the AreTexturesResident request
 pub const ARE_TEXTURES_RESIDENT_REQUEST: u8 = 143;
-pub fn are_textures_resident<'c, Conn>(conn: &'c Conn, context_tag: ContextTag, textures: &[u32]) -> Result<Cookie<'c, Conn, AreTexturesResidentReply>, ConnectionError>
+pub fn are_textures_resident<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, textures: &'input [u32]) -> Result<Cookie<'c, Conn, AreTexturesResidentReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -5300,7 +5300,7 @@ impl AreTexturesResidentReply {
 
 /// Opcode for the DeleteTextures request
 pub const DELETE_TEXTURES_REQUEST: u8 = 144;
-pub fn delete_textures<'c, Conn>(conn: &'c Conn, context_tag: ContextTag, textures: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn delete_textures<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, textures: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -6667,7 +6667,7 @@ impl GetCompressedTexImageARBReply {
 
 /// Opcode for the DeleteQueriesARB request
 pub const DELETE_QUERIES_ARB_REQUEST: u8 = 161;
-pub fn delete_queries_arb<'c, Conn>(conn: &'c Conn, context_tag: ContextTag, ids: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn delete_queries_arb<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, ids: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -7079,11 +7079,11 @@ impl GetQueryObjectuivARBReply {
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {
-    fn glx_render<'c>(&'c self, context_tag: ContextTag, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_render<'c, 'input>(&'c self, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         render(self, context_tag, data)
     }
-    fn glx_render_large<'c>(&'c self, context_tag: ContextTag, request_num: u16, request_total: u16, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_render_large<'c, 'input>(&'c self, context_tag: ContextTag, request_num: u16, request_total: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         render_large(self, context_tag, request_num, request_total, data)
     }
@@ -7139,11 +7139,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         destroy_glx_pixmap(self, glx_pixmap)
     }
-    fn glx_vendor_private<'c>(&'c self, vendor_code: u32, context_tag: ContextTag, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_vendor_private<'c, 'input>(&'c self, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         vendor_private(self, vendor_code, context_tag, data)
     }
-    fn glx_vendor_private_with_reply<'c>(&'c self, vendor_code: u32, context_tag: ContextTag, data: &[u8]) -> Result<Cookie<'c, Self, VendorPrivateWithReplyReply>, ConnectionError>
+    fn glx_vendor_private_with_reply<'c, 'input>(&'c self, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<Cookie<'c, Self, VendorPrivateWithReplyReply>, ConnectionError>
     {
         vendor_private_with_reply(self, vendor_code, context_tag, data)
     }
@@ -7155,7 +7155,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_server_string(self, screen, name)
     }
-    fn glx_client_info<'c>(&'c self, major_version: u32, minor_version: u32, string: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_client_info<'c, 'input>(&'c self, major_version: u32, minor_version: u32, string: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         client_info(self, major_version, minor_version, string)
     }
@@ -7163,7 +7163,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_fb_configs(self, screen)
     }
-    fn glx_create_pixmap<'c>(&'c self, screen: u32, fbconfig: Fbconfig, pixmap: xproto::Pixmap, glx_pixmap: Pixmap, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_pixmap<'c, 'input>(&'c self, screen: u32, fbconfig: Fbconfig, pixmap: xproto::Pixmap, glx_pixmap: Pixmap, attribs: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pixmap(self, screen, fbconfig, pixmap, glx_pixmap, attribs)
     }
@@ -7183,7 +7183,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         make_context_current(self, old_context_tag, drawable, read_drawable, context)
     }
-    fn glx_create_pbuffer<'c>(&'c self, screen: u32, fbconfig: Fbconfig, pbuffer: Pbuffer, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_pbuffer<'c, 'input>(&'c self, screen: u32, fbconfig: Fbconfig, pbuffer: Pbuffer, attribs: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pbuffer(self, screen, fbconfig, pbuffer, attribs)
     }
@@ -7195,11 +7195,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_drawable_attributes(self, drawable)
     }
-    fn glx_change_drawable_attributes<'c>(&'c self, drawable: Drawable, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_change_drawable_attributes<'c, 'input>(&'c self, drawable: Drawable, attribs: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_drawable_attributes(self, drawable, attribs)
     }
-    fn glx_create_window<'c>(&'c self, screen: u32, fbconfig: Fbconfig, window: xproto::Window, glx_window: Window, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_window<'c, 'input>(&'c self, screen: u32, fbconfig: Fbconfig, window: xproto::Window, glx_window: Window, attribs: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_window(self, screen, fbconfig, window, glx_window, attribs)
     }
@@ -7207,15 +7207,15 @@ pub trait ConnectionExt: RequestConnection {
     {
         delete_window(self, glxwindow)
     }
-    fn glx_set_client_info_arb<'c>(&'c self, major_version: u32, minor_version: u32, gl_versions: &[u32], gl_extension_string: &[u8], glx_extension_string: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_set_client_info_arb<'c, 'input>(&'c self, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_client_info_arb(self, major_version, minor_version, gl_versions, gl_extension_string, glx_extension_string)
     }
-    fn glx_create_context_attribs_arb<'c>(&'c self, context: Context, fbconfig: Fbconfig, screen: u32, share_list: Context, is_direct: bool, attribs: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_create_context_attribs_arb<'c, 'input>(&'c self, context: Context, fbconfig: Fbconfig, screen: u32, share_list: Context, is_direct: bool, attribs: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_context_attribs_arb(self, context, fbconfig, screen, share_list, is_direct, attribs)
     }
-    fn glx_set_client_info2_arb<'c>(&'c self, major_version: u32, minor_version: u32, gl_versions: &[u32], gl_extension_string: &[u8], glx_extension_string: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_set_client_info2_arb<'c, 'input>(&'c self, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_client_info2_arb(self, major_version, minor_version, gl_versions, gl_extension_string, glx_extension_string)
     }
@@ -7387,11 +7387,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         flush(self, context_tag)
     }
-    fn glx_are_textures_resident<'c>(&'c self, context_tag: ContextTag, textures: &[u32]) -> Result<Cookie<'c, Self, AreTexturesResidentReply>, ConnectionError>
+    fn glx_are_textures_resident<'c, 'input>(&'c self, context_tag: ContextTag, textures: &'input [u32]) -> Result<Cookie<'c, Self, AreTexturesResidentReply>, ConnectionError>
     {
         are_textures_resident(self, context_tag, textures)
     }
-    fn glx_delete_textures<'c>(&'c self, context_tag: ContextTag, textures: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_delete_textures<'c, 'input>(&'c self, context_tag: ContextTag, textures: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         delete_textures(self, context_tag, textures)
     }
@@ -7459,7 +7459,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_compressed_tex_image_arb(self, context_tag, target, level)
     }
-    fn glx_delete_queries_arb<'c>(&'c self, context_tag: ContextTag, ids: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn glx_delete_queries_arb<'c, 'input>(&'c self, context_tag: ContextTag, ids: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         delete_queries_arb(self, context_tag, ids)
     }

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -468,14 +468,14 @@ impl TryFrom<u32> for PBCDT {
     }
 }
 
+/// Opcode for the Render request
+pub const RENDER_REQUEST: u8 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RenderRequest<'input> {
     pub context_tag: ContextTag,
     pub data: &'input [u8],
 }
 impl<'input> RenderRequest<'input> {
-    /// Opcode for the Render request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -487,7 +487,7 @@ impl<'input> RenderRequest<'input> {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            RENDER_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -518,6 +518,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the RenderLarge request
+pub const RENDER_LARGE_REQUEST: u8 = 2;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RenderLargeRequest<'input> {
     pub context_tag: ContextTag,
@@ -526,8 +528,6 @@ pub struct RenderLargeRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> RenderLargeRequest<'input> {
-    /// Opcode for the RenderLarge request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -543,7 +543,7 @@ impl<'input> RenderLargeRequest<'input> {
         let data_len_bytes = data_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            RENDER_LARGE_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -584,6 +584,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateContext request
+pub const CREATE_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateContextRequest {
     pub context: Context,
@@ -593,8 +595,6 @@ pub struct CreateContextRequest {
     pub is_direct: bool,
 }
 impl CreateContextRequest {
-    /// Opcode for the CreateContext request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -610,7 +610,7 @@ impl CreateContextRequest {
         let is_direct_bytes = self.is_direct.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -657,13 +657,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyContext request
+pub const DESTROY_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyContextRequest {
     pub context: Context,
 }
 impl DestroyContextRequest {
-    /// Opcode for the DestroyContext request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -675,7 +675,7 @@ impl DestroyContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -702,6 +702,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the MakeCurrent request
+pub const MAKE_CURRENT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MakeCurrentRequest {
     pub drawable: Drawable,
@@ -709,8 +711,6 @@ pub struct MakeCurrentRequest {
     pub old_context_tag: ContextTag,
 }
 impl MakeCurrentRequest {
-    /// Opcode for the MakeCurrent request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -724,7 +724,7 @@ impl MakeCurrentRequest {
         let old_context_tag_bytes = self.old_context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            MAKE_CURRENT_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -787,13 +787,13 @@ impl TryFrom<&[u8]> for MakeCurrentReply {
     }
 }
 
+/// Opcode for the IsDirect request
+pub const IS_DIRECT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IsDirectRequest {
     pub context: Context,
 }
 impl IsDirectRequest {
-    /// Opcode for the IsDirect request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -805,7 +805,7 @@ impl IsDirectRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            IS_DIRECT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -858,14 +858,14 @@ impl TryFrom<&[u8]> for IsDirectReply {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -878,7 +878,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -938,13 +938,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the WaitGL request
+pub const WAIT_GL_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaitGLRequest {
     pub context_tag: ContextTag,
 }
 impl WaitGLRequest {
-    /// Opcode for the WaitGL request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -956,7 +956,7 @@ impl WaitGLRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            WAIT_GL_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -983,13 +983,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the WaitX request
+pub const WAIT_X_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaitXRequest {
     pub context_tag: ContextTag,
 }
 impl WaitXRequest {
-    /// Opcode for the WaitX request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1001,7 +1001,7 @@ impl WaitXRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            WAIT_X_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -1028,6 +1028,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CopyContext request
+pub const COPY_CONTEXT_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CopyContextRequest {
     pub src: Context,
@@ -1036,8 +1038,6 @@ pub struct CopyContextRequest {
     pub src_context_tag: ContextTag,
 }
 impl CopyContextRequest {
-    /// Opcode for the CopyContext request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1052,7 +1052,7 @@ impl CopyContextRequest {
         let src_context_tag_bytes = self.src_context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COPY_CONTEXT_REQUEST,
             0,
             0,
             src_bytes[0],
@@ -1182,14 +1182,14 @@ impl TryFrom<u32> for GC {
     }
 }
 
+/// Opcode for the SwapBuffers request
+pub const SWAP_BUFFERS_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SwapBuffersRequest {
     pub context_tag: ContextTag,
     pub drawable: Drawable,
 }
 impl SwapBuffersRequest {
-    /// Opcode for the SwapBuffers request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1202,7 +1202,7 @@ impl SwapBuffersRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SWAP_BUFFERS_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -1234,6 +1234,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UseXFont request
+pub const USE_X_FONT_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UseXFontRequest {
     pub context_tag: ContextTag,
@@ -1243,8 +1245,6 @@ pub struct UseXFontRequest {
     pub list_base: u32,
 }
 impl UseXFontRequest {
-    /// Opcode for the UseXFont request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1260,7 +1260,7 @@ impl UseXFontRequest {
         let list_base_bytes = self.list_base.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            USE_X_FONT_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -1307,6 +1307,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateGLXPixmap request
+pub const CREATE_GLX_PIXMAP_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateGLXPixmapRequest {
     pub screen: u32,
@@ -1315,8 +1317,6 @@ pub struct CreateGLXPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
 impl CreateGLXPixmapRequest {
-    /// Opcode for the CreateGLXPixmap request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1331,7 +1331,7 @@ impl CreateGLXPixmapRequest {
         let glx_pixmap_bytes = self.glx_pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_GLX_PIXMAP_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1373,13 +1373,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetVisualConfigs request
+pub const GET_VISUAL_CONFIGS_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetVisualConfigsRequest {
     pub screen: u32,
 }
 impl GetVisualConfigsRequest {
-    /// Opcode for the GetVisualConfigs request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1391,7 +1391,7 @@ impl GetVisualConfigsRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_VISUAL_CONFIGS_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1462,13 +1462,13 @@ impl GetVisualConfigsReply {
     }
 }
 
+/// Opcode for the DestroyGLXPixmap request
+pub const DESTROY_GLX_PIXMAP_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyGLXPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
 impl DestroyGLXPixmapRequest {
-    /// Opcode for the DestroyGLXPixmap request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1480,7 +1480,7 @@ impl DestroyGLXPixmapRequest {
         let glx_pixmap_bytes = self.glx_pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_GLX_PIXMAP_REQUEST,
             0,
             0,
             glx_pixmap_bytes[0],
@@ -1507,6 +1507,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the VendorPrivate request
+pub const VENDOR_PRIVATE_REQUEST: u8 = 16;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VendorPrivateRequest<'input> {
     pub vendor_code: u32,
@@ -1514,8 +1516,6 @@ pub struct VendorPrivateRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> VendorPrivateRequest<'input> {
-    /// Opcode for the VendorPrivate request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1528,7 +1528,7 @@ impl<'input> VendorPrivateRequest<'input> {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            VENDOR_PRIVATE_REQUEST,
             0,
             0,
             vendor_code_bytes[0],
@@ -1564,6 +1564,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the VendorPrivateWithReply request
+pub const VENDOR_PRIVATE_WITH_REPLY_REQUEST: u8 = 17;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VendorPrivateWithReplyRequest<'input> {
     pub vendor_code: u32,
@@ -1571,8 +1573,6 @@ pub struct VendorPrivateWithReplyRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> VendorPrivateWithReplyRequest<'input> {
-    /// Opcode for the VendorPrivateWithReply request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1585,7 +1585,7 @@ impl<'input> VendorPrivateWithReplyRequest<'input> {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            VENDOR_PRIVATE_WITH_REPLY_REQUEST,
             0,
             0,
             vendor_code_bytes[0],
@@ -1667,13 +1667,13 @@ impl VendorPrivateWithReplyReply {
     }
 }
 
+/// Opcode for the QueryExtensionsString request
+pub const QUERY_EXTENSIONS_STRING_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryExtensionsStringRequest {
     pub screen: u32,
 }
 impl QueryExtensionsStringRequest {
-    /// Opcode for the QueryExtensionsString request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1685,7 +1685,7 @@ impl QueryExtensionsStringRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_EXTENSIONS_STRING_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1739,14 +1739,14 @@ impl TryFrom<&[u8]> for QueryExtensionsStringReply {
     }
 }
 
+/// Opcode for the QueryServerString request
+pub const QUERY_SERVER_STRING_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryServerStringRequest {
     pub screen: u32,
     pub name: u32,
 }
 impl QueryServerStringRequest {
-    /// Opcode for the QueryServerString request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1759,7 +1759,7 @@ impl QueryServerStringRequest {
         let name_bytes = self.name.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_SERVER_STRING_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1835,6 +1835,8 @@ impl QueryServerStringReply {
     }
 }
 
+/// Opcode for the ClientInfo request
+pub const CLIENT_INFO_REQUEST: u8 = 20;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientInfoRequest<'input> {
     pub major_version: u32,
@@ -1842,8 +1844,6 @@ pub struct ClientInfoRequest<'input> {
     pub string: &'input [u8],
 }
 impl<'input> ClientInfoRequest<'input> {
-    /// Opcode for the ClientInfo request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1858,7 +1858,7 @@ impl<'input> ClientInfoRequest<'input> {
         let str_len_bytes = str_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CLIENT_INFO_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -1898,13 +1898,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetFBConfigs request
+pub const GET_FB_CONFIGS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetFBConfigsRequest {
     pub screen: u32,
 }
 impl GetFBConfigsRequest {
-    /// Opcode for the GetFBConfigs request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1916,7 +1916,7 @@ impl GetFBConfigsRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_FB_CONFIGS_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1987,6 +1987,8 @@ impl GetFBConfigsReply {
     }
 }
 
+/// Opcode for the CreatePixmap request
+pub const CREATE_PIXMAP_REQUEST: u8 = 22;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreatePixmapRequest<'input> {
     pub screen: u32,
@@ -1996,8 +1998,6 @@ pub struct CreatePixmapRequest<'input> {
     pub attribs: &'input [u32],
 }
 impl<'input> CreatePixmapRequest<'input> {
-    /// Opcode for the CreatePixmap request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2015,7 +2015,7 @@ impl<'input> CreatePixmapRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_PIXMAP_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -2066,13 +2066,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyPixmap request
+pub const DESTROY_PIXMAP_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
 impl DestroyPixmapRequest {
-    /// Opcode for the DestroyPixmap request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2084,7 +2084,7 @@ impl DestroyPixmapRequest {
         let glx_pixmap_bytes = self.glx_pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_PIXMAP_REQUEST,
             0,
             0,
             glx_pixmap_bytes[0],
@@ -2111,6 +2111,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateNewContext request
+pub const CREATE_NEW_CONTEXT_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateNewContextRequest {
     pub context: Context,
@@ -2121,8 +2123,6 @@ pub struct CreateNewContextRequest {
     pub is_direct: bool,
 }
 impl CreateNewContextRequest {
-    /// Opcode for the CreateNewContext request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2139,7 +2139,7 @@ impl CreateNewContextRequest {
         let is_direct_bytes = self.is_direct.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_NEW_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -2191,13 +2191,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryContext request
+pub const QUERY_CONTEXT_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryContextRequest {
     pub context: Context,
 }
 impl QueryContextRequest {
-    /// Opcode for the QueryContext request
-    pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2209,7 +2209,7 @@ impl QueryContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -2279,6 +2279,8 @@ impl QueryContextReply {
     }
 }
 
+/// Opcode for the MakeContextCurrent request
+pub const MAKE_CONTEXT_CURRENT_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MakeContextCurrentRequest {
     pub old_context_tag: ContextTag,
@@ -2287,8 +2289,6 @@ pub struct MakeContextCurrentRequest {
     pub context: Context,
 }
 impl MakeContextCurrentRequest {
-    /// Opcode for the MakeContextCurrent request
-    pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2303,7 +2303,7 @@ impl MakeContextCurrentRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            MAKE_CONTEXT_CURRENT_REQUEST,
             0,
             0,
             old_context_tag_bytes[0],
@@ -2371,6 +2371,8 @@ impl TryFrom<&[u8]> for MakeContextCurrentReply {
     }
 }
 
+/// Opcode for the CreatePbuffer request
+pub const CREATE_PBUFFER_REQUEST: u8 = 27;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreatePbufferRequest<'input> {
     pub screen: u32,
@@ -2379,8 +2381,6 @@ pub struct CreatePbufferRequest<'input> {
     pub attribs: &'input [u32],
 }
 impl<'input> CreatePbufferRequest<'input> {
-    /// Opcode for the CreatePbuffer request
-    pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2397,7 +2397,7 @@ impl<'input> CreatePbufferRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_PBUFFER_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -2443,13 +2443,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyPbuffer request
+pub const DESTROY_PBUFFER_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyPbufferRequest {
     pub pbuffer: Pbuffer,
 }
 impl DestroyPbufferRequest {
-    /// Opcode for the DestroyPbuffer request
-    pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2461,7 +2461,7 @@ impl DestroyPbufferRequest {
         let pbuffer_bytes = self.pbuffer.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_PBUFFER_REQUEST,
             0,
             0,
             pbuffer_bytes[0],
@@ -2488,13 +2488,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDrawableAttributes request
+pub const GET_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDrawableAttributesRequest {
     pub drawable: Drawable,
 }
 impl GetDrawableAttributesRequest {
-    /// Opcode for the GetDrawableAttributes request
-    pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2506,7 +2506,7 @@ impl GetDrawableAttributesRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DRAWABLE_ATTRIBUTES_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -2576,14 +2576,14 @@ impl GetDrawableAttributesReply {
     }
 }
 
+/// Opcode for the ChangeDrawableAttributes request
+pub const CHANGE_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 30;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeDrawableAttributesRequest<'input> {
     pub drawable: Drawable,
     pub attribs: &'input [u32],
 }
 impl<'input> ChangeDrawableAttributesRequest<'input> {
-    /// Opcode for the ChangeDrawableAttributes request
-    pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2598,7 +2598,7 @@ impl<'input> ChangeDrawableAttributesRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_DRAWABLE_ATTRIBUTES_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -2634,6 +2634,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateWindow request
+pub const CREATE_WINDOW_REQUEST: u8 = 31;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateWindowRequest<'input> {
     pub screen: u32,
@@ -2643,8 +2645,6 @@ pub struct CreateWindowRequest<'input> {
     pub attribs: &'input [u32],
 }
 impl<'input> CreateWindowRequest<'input> {
-    /// Opcode for the CreateWindow request
-    pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2662,7 +2662,7 @@ impl<'input> CreateWindowRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_WINDOW_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -2713,13 +2713,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteWindow request
+pub const DELETE_WINDOW_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteWindowRequest {
     pub glxwindow: Window,
 }
 impl DeleteWindowRequest {
-    /// Opcode for the DeleteWindow request
-    pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2731,7 +2731,7 @@ impl DeleteWindowRequest {
         let glxwindow_bytes = self.glxwindow.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_WINDOW_REQUEST,
             0,
             0,
             glxwindow_bytes[0],
@@ -2758,6 +2758,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetClientInfoARB request
+pub const SET_CLIENT_INFO_ARB_REQUEST: u8 = 33;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetClientInfoARBRequest<'input> {
     pub major_version: u32,
@@ -2767,8 +2769,6 @@ pub struct SetClientInfoARBRequest<'input> {
     pub glx_extension_string: &'input [u8],
 }
 impl<'input> SetClientInfoARBRequest<'input> {
-    /// Opcode for the SetClientInfoARB request
-    pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2788,7 +2788,7 @@ impl<'input> SetClientInfoARBRequest<'input> {
         let glx_str_len_bytes = glx_str_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CLIENT_INFO_ARB_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -2841,6 +2841,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateContextAttribsARB request
+pub const CREATE_CONTEXT_ATTRIBS_ARB_REQUEST: u8 = 34;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateContextAttribsARBRequest<'input> {
     pub context: Context,
@@ -2851,8 +2853,6 @@ pub struct CreateContextAttribsARBRequest<'input> {
     pub attribs: &'input [u32],
 }
 impl<'input> CreateContextAttribsARBRequest<'input> {
-    /// Opcode for the CreateContextAttribsARB request
-    pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2871,7 +2871,7 @@ impl<'input> CreateContextAttribsARBRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CONTEXT_ATTRIBS_ARB_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -2927,6 +2927,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetClientInfo2ARB request
+pub const SET_CLIENT_INFO2_ARB_REQUEST: u8 = 35;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetClientInfo2ARBRequest<'input> {
     pub major_version: u32,
@@ -2936,8 +2938,6 @@ pub struct SetClientInfo2ARBRequest<'input> {
     pub glx_extension_string: &'input [u8],
 }
 impl<'input> SetClientInfo2ARBRequest<'input> {
-    /// Opcode for the SetClientInfo2ARB request
-    pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2957,7 +2957,7 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
         let glx_str_len_bytes = glx_str_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CLIENT_INFO2_ARB_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -3010,6 +3010,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the NewList request
+pub const NEW_LIST_REQUEST: u8 = 101;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NewListRequest {
     pub context_tag: ContextTag,
@@ -3017,8 +3019,6 @@ pub struct NewListRequest {
     pub mode: u32,
 }
 impl NewListRequest {
-    /// Opcode for the NewList request
-    pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3032,7 +3032,7 @@ impl NewListRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            NEW_LIST_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3069,13 +3069,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the EndList request
+pub const END_LIST_REQUEST: u8 = 102;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EndListRequest {
     pub context_tag: ContextTag,
 }
 impl EndListRequest {
-    /// Opcode for the EndList request
-    pub const fn opcode() -> u8 { 102 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3087,7 +3087,7 @@ impl EndListRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            END_LIST_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3114,6 +3114,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteLists request
+pub const DELETE_LISTS_REQUEST: u8 = 103;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteListsRequest {
     pub context_tag: ContextTag,
@@ -3121,8 +3123,6 @@ pub struct DeleteListsRequest {
     pub range: i32,
 }
 impl DeleteListsRequest {
-    /// Opcode for the DeleteLists request
-    pub const fn opcode() -> u8 { 103 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3136,7 +3136,7 @@ impl DeleteListsRequest {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_LISTS_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3173,14 +3173,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GenLists request
+pub const GEN_LISTS_REQUEST: u8 = 104;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GenListsRequest {
     pub context_tag: ContextTag,
     pub range: i32,
 }
 impl GenListsRequest {
-    /// Opcode for the GenLists request
-    pub const fn opcode() -> u8 { 104 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3193,7 +3193,7 @@ impl GenListsRequest {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GEN_LISTS_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3250,6 +3250,8 @@ impl TryFrom<&[u8]> for GenListsReply {
     }
 }
 
+/// Opcode for the FeedbackBuffer request
+pub const FEEDBACK_BUFFER_REQUEST: u8 = 105;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FeedbackBufferRequest {
     pub context_tag: ContextTag,
@@ -3257,8 +3259,6 @@ pub struct FeedbackBufferRequest {
     pub type_: i32,
 }
 impl FeedbackBufferRequest {
-    /// Opcode for the FeedbackBuffer request
-    pub const fn opcode() -> u8 { 105 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3272,7 +3272,7 @@ impl FeedbackBufferRequest {
         let type_bytes = self.type_.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FEEDBACK_BUFFER_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3309,14 +3309,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SelectBuffer request
+pub const SELECT_BUFFER_REQUEST: u8 = 106;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
 }
 impl SelectBufferRequest {
-    /// Opcode for the SelectBuffer request
-    pub const fn opcode() -> u8 { 106 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3329,7 +3329,7 @@ impl SelectBufferRequest {
         let size_bytes = self.size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_BUFFER_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3361,14 +3361,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the RenderMode request
+pub const RENDER_MODE_REQUEST: u8 = 107;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RenderModeRequest {
     pub context_tag: ContextTag,
     pub mode: u32,
 }
 impl RenderModeRequest {
-    /// Opcode for the RenderMode request
-    pub const fn opcode() -> u8 { 107 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3381,7 +3381,7 @@ impl RenderModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            RENDER_MODE_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3509,13 +3509,13 @@ impl TryFrom<u32> for RM {
     }
 }
 
+/// Opcode for the Finish request
+pub const FINISH_REQUEST: u8 = 108;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FinishRequest {
     pub context_tag: ContextTag,
 }
 impl FinishRequest {
-    /// Opcode for the Finish request
-    pub const fn opcode() -> u8 { 108 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3527,7 +3527,7 @@ impl FinishRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FINISH_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3577,6 +3577,8 @@ impl TryFrom<&[u8]> for FinishReply {
     }
 }
 
+/// Opcode for the PixelStoref request
+pub const PIXEL_STOREF_REQUEST: u8 = 109;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PixelStorefRequest {
     pub context_tag: ContextTag,
@@ -3584,8 +3586,6 @@ pub struct PixelStorefRequest {
     pub datum: Float32,
 }
 impl PixelStorefRequest {
-    /// Opcode for the PixelStoref request
-    pub const fn opcode() -> u8 { 109 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3599,7 +3599,7 @@ impl PixelStorefRequest {
         let datum_bytes = self.datum.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PIXEL_STOREF_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3636,6 +3636,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PixelStorei request
+pub const PIXEL_STOREI_REQUEST: u8 = 110;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PixelStoreiRequest {
     pub context_tag: ContextTag,
@@ -3643,8 +3645,6 @@ pub struct PixelStoreiRequest {
     pub datum: i32,
 }
 impl PixelStoreiRequest {
-    /// Opcode for the PixelStorei request
-    pub const fn opcode() -> u8 { 110 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3658,7 +3658,7 @@ impl PixelStoreiRequest {
         let datum_bytes = self.datum.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PIXEL_STOREI_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3695,6 +3695,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ReadPixels request
+pub const READ_PIXELS_REQUEST: u8 = 111;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReadPixelsRequest {
     pub context_tag: ContextTag,
@@ -3708,8 +3710,6 @@ pub struct ReadPixelsRequest {
     pub lsb_first: bool,
 }
 impl ReadPixelsRequest {
-    /// Opcode for the ReadPixels request
-    pub const fn opcode() -> u8 { 111 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3729,7 +3729,7 @@ impl ReadPixelsRequest {
         let lsb_first_bytes = self.lsb_first.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            READ_PIXELS_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3834,14 +3834,14 @@ impl ReadPixelsReply {
     }
 }
 
+/// Opcode for the GetBooleanv request
+pub const GET_BOOLEANV_REQUEST: u8 = 112;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetBooleanvRequest {
     pub context_tag: ContextTag,
     pub pname: i32,
 }
 impl GetBooleanvRequest {
-    /// Opcode for the GetBooleanv request
-    pub const fn opcode() -> u8 { 112 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3854,7 +3854,7 @@ impl GetBooleanvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_BOOLEANV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -3931,14 +3931,14 @@ impl GetBooleanvReply {
     }
 }
 
+/// Opcode for the GetClipPlane request
+pub const GET_CLIP_PLANE_REQUEST: u8 = 113;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetClipPlaneRequest {
     pub context_tag: ContextTag,
     pub plane: i32,
 }
 impl GetClipPlaneRequest {
-    /// Opcode for the GetClipPlane request
-    pub const fn opcode() -> u8 { 113 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3951,7 +3951,7 @@ impl GetClipPlaneRequest {
         let plane_bytes = self.plane.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CLIP_PLANE_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4024,14 +4024,14 @@ impl GetClipPlaneReply {
     }
 }
 
+/// Opcode for the GetDoublev request
+pub const GET_DOUBLEV_REQUEST: u8 = 114;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDoublevRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
 }
 impl GetDoublevRequest {
-    /// Opcode for the GetDoublev request
-    pub const fn opcode() -> u8 { 114 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4044,7 +4044,7 @@ impl GetDoublevRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DOUBLEV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4121,13 +4121,13 @@ impl GetDoublevReply {
     }
 }
 
+/// Opcode for the GetError request
+pub const GET_ERROR_REQUEST: u8 = 115;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetErrorRequest {
     pub context_tag: ContextTag,
 }
 impl GetErrorRequest {
-    /// Opcode for the GetError request
-    pub const fn opcode() -> u8 { 115 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4139,7 +4139,7 @@ impl GetErrorRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_ERROR_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4191,14 +4191,14 @@ impl TryFrom<&[u8]> for GetErrorReply {
     }
 }
 
+/// Opcode for the GetFloatv request
+pub const GET_FLOATV_REQUEST: u8 = 116;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetFloatvRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
 }
 impl GetFloatvRequest {
-    /// Opcode for the GetFloatv request
-    pub const fn opcode() -> u8 { 116 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4211,7 +4211,7 @@ impl GetFloatvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_FLOATV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4288,14 +4288,14 @@ impl GetFloatvReply {
     }
 }
 
+/// Opcode for the GetIntegerv request
+pub const GET_INTEGERV_REQUEST: u8 = 117;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetIntegervRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
 }
 impl GetIntegervRequest {
-    /// Opcode for the GetIntegerv request
-    pub const fn opcode() -> u8 { 117 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4308,7 +4308,7 @@ impl GetIntegervRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_INTEGERV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4385,6 +4385,8 @@ impl GetIntegervReply {
     }
 }
 
+/// Opcode for the GetLightfv request
+pub const GET_LIGHTFV_REQUEST: u8 = 118;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetLightfvRequest {
     pub context_tag: ContextTag,
@@ -4392,8 +4394,6 @@ pub struct GetLightfvRequest {
     pub pname: u32,
 }
 impl GetLightfvRequest {
-    /// Opcode for the GetLightfv request
-    pub const fn opcode() -> u8 { 118 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4407,7 +4407,7 @@ impl GetLightfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_LIGHTFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4489,6 +4489,8 @@ impl GetLightfvReply {
     }
 }
 
+/// Opcode for the GetLightiv request
+pub const GET_LIGHTIV_REQUEST: u8 = 119;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetLightivRequest {
     pub context_tag: ContextTag,
@@ -4496,8 +4498,6 @@ pub struct GetLightivRequest {
     pub pname: u32,
 }
 impl GetLightivRequest {
-    /// Opcode for the GetLightiv request
-    pub const fn opcode() -> u8 { 119 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4511,7 +4511,7 @@ impl GetLightivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_LIGHTIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4593,6 +4593,8 @@ impl GetLightivReply {
     }
 }
 
+/// Opcode for the GetMapdv request
+pub const GET_MAPDV_REQUEST: u8 = 120;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMapdvRequest {
     pub context_tag: ContextTag,
@@ -4600,8 +4602,6 @@ pub struct GetMapdvRequest {
     pub query: u32,
 }
 impl GetMapdvRequest {
-    /// Opcode for the GetMapdv request
-    pub const fn opcode() -> u8 { 120 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4615,7 +4615,7 @@ impl GetMapdvRequest {
         let query_bytes = self.query.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MAPDV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4697,6 +4697,8 @@ impl GetMapdvReply {
     }
 }
 
+/// Opcode for the GetMapfv request
+pub const GET_MAPFV_REQUEST: u8 = 121;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMapfvRequest {
     pub context_tag: ContextTag,
@@ -4704,8 +4706,6 @@ pub struct GetMapfvRequest {
     pub query: u32,
 }
 impl GetMapfvRequest {
-    /// Opcode for the GetMapfv request
-    pub const fn opcode() -> u8 { 121 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4719,7 +4719,7 @@ impl GetMapfvRequest {
         let query_bytes = self.query.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MAPFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4801,6 +4801,8 @@ impl GetMapfvReply {
     }
 }
 
+/// Opcode for the GetMapiv request
+pub const GET_MAPIV_REQUEST: u8 = 122;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMapivRequest {
     pub context_tag: ContextTag,
@@ -4808,8 +4810,6 @@ pub struct GetMapivRequest {
     pub query: u32,
 }
 impl GetMapivRequest {
-    /// Opcode for the GetMapiv request
-    pub const fn opcode() -> u8 { 122 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4823,7 +4823,7 @@ impl GetMapivRequest {
         let query_bytes = self.query.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MAPIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -4905,6 +4905,8 @@ impl GetMapivReply {
     }
 }
 
+/// Opcode for the GetMaterialfv request
+pub const GET_MATERIALFV_REQUEST: u8 = 123;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMaterialfvRequest {
     pub context_tag: ContextTag,
@@ -4912,8 +4914,6 @@ pub struct GetMaterialfvRequest {
     pub pname: u32,
 }
 impl GetMaterialfvRequest {
-    /// Opcode for the GetMaterialfv request
-    pub const fn opcode() -> u8 { 123 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4927,7 +4927,7 @@ impl GetMaterialfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MATERIALFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5009,6 +5009,8 @@ impl GetMaterialfvReply {
     }
 }
 
+/// Opcode for the GetMaterialiv request
+pub const GET_MATERIALIV_REQUEST: u8 = 124;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMaterialivRequest {
     pub context_tag: ContextTag,
@@ -5016,8 +5018,6 @@ pub struct GetMaterialivRequest {
     pub pname: u32,
 }
 impl GetMaterialivRequest {
-    /// Opcode for the GetMaterialiv request
-    pub const fn opcode() -> u8 { 124 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5031,7 +5031,7 @@ impl GetMaterialivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MATERIALIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5113,14 +5113,14 @@ impl GetMaterialivReply {
     }
 }
 
+/// Opcode for the GetPixelMapfv request
+pub const GET_PIXEL_MAPFV_REQUEST: u8 = 125;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPixelMapfvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
 }
 impl GetPixelMapfvRequest {
-    /// Opcode for the GetPixelMapfv request
-    pub const fn opcode() -> u8 { 125 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5133,7 +5133,7 @@ impl GetPixelMapfvRequest {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PIXEL_MAPFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5210,14 +5210,14 @@ impl GetPixelMapfvReply {
     }
 }
 
+/// Opcode for the GetPixelMapuiv request
+pub const GET_PIXEL_MAPUIV_REQUEST: u8 = 126;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPixelMapuivRequest {
     pub context_tag: ContextTag,
     pub map: u32,
 }
 impl GetPixelMapuivRequest {
-    /// Opcode for the GetPixelMapuiv request
-    pub const fn opcode() -> u8 { 126 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5230,7 +5230,7 @@ impl GetPixelMapuivRequest {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PIXEL_MAPUIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5307,14 +5307,14 @@ impl GetPixelMapuivReply {
     }
 }
 
+/// Opcode for the GetPixelMapusv request
+pub const GET_PIXEL_MAPUSV_REQUEST: u8 = 127;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPixelMapusvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
 }
 impl GetPixelMapusvRequest {
-    /// Opcode for the GetPixelMapusv request
-    pub const fn opcode() -> u8 { 127 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5327,7 +5327,7 @@ impl GetPixelMapusvRequest {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PIXEL_MAPUSV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5404,14 +5404,14 @@ impl GetPixelMapusvReply {
     }
 }
 
+/// Opcode for the GetPolygonStipple request
+pub const GET_POLYGON_STIPPLE_REQUEST: u8 = 128;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPolygonStippleRequest {
     pub context_tag: ContextTag,
     pub lsb_first: bool,
 }
 impl GetPolygonStippleRequest {
-    /// Opcode for the GetPolygonStipple request
-    pub const fn opcode() -> u8 { 128 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5424,7 +5424,7 @@ impl GetPolygonStippleRequest {
         let lsb_first_bytes = self.lsb_first.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_POLYGON_STIPPLE_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5498,14 +5498,14 @@ impl GetPolygonStippleReply {
     }
 }
 
+/// Opcode for the GetString request
+pub const GET_STRING_REQUEST: u8 = 129;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetStringRequest {
     pub context_tag: ContextTag,
     pub name: u32,
 }
 impl GetStringRequest {
-    /// Opcode for the GetString request
-    pub const fn opcode() -> u8 { 129 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5518,7 +5518,7 @@ impl GetStringRequest {
         let name_bytes = self.name.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_STRING_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5594,6 +5594,8 @@ impl GetStringReply {
     }
 }
 
+/// Opcode for the GetTexEnvfv request
+pub const GET_TEX_ENVFV_REQUEST: u8 = 130;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexEnvfvRequest {
     pub context_tag: ContextTag,
@@ -5601,8 +5603,6 @@ pub struct GetTexEnvfvRequest {
     pub pname: u32,
 }
 impl GetTexEnvfvRequest {
-    /// Opcode for the GetTexEnvfv request
-    pub const fn opcode() -> u8 { 130 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5616,7 +5616,7 @@ impl GetTexEnvfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_ENVFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5698,6 +5698,8 @@ impl GetTexEnvfvReply {
     }
 }
 
+/// Opcode for the GetTexEnviv request
+pub const GET_TEX_ENVIV_REQUEST: u8 = 131;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexEnvivRequest {
     pub context_tag: ContextTag,
@@ -5705,8 +5707,6 @@ pub struct GetTexEnvivRequest {
     pub pname: u32,
 }
 impl GetTexEnvivRequest {
-    /// Opcode for the GetTexEnviv request
-    pub const fn opcode() -> u8 { 131 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5720,7 +5720,7 @@ impl GetTexEnvivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_ENVIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5802,6 +5802,8 @@ impl GetTexEnvivReply {
     }
 }
 
+/// Opcode for the GetTexGendv request
+pub const GET_TEX_GENDV_REQUEST: u8 = 132;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexGendvRequest {
     pub context_tag: ContextTag,
@@ -5809,8 +5811,6 @@ pub struct GetTexGendvRequest {
     pub pname: u32,
 }
 impl GetTexGendvRequest {
-    /// Opcode for the GetTexGendv request
-    pub const fn opcode() -> u8 { 132 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5824,7 +5824,7 @@ impl GetTexGendvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_GENDV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -5906,6 +5906,8 @@ impl GetTexGendvReply {
     }
 }
 
+/// Opcode for the GetTexGenfv request
+pub const GET_TEX_GENFV_REQUEST: u8 = 133;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexGenfvRequest {
     pub context_tag: ContextTag,
@@ -5913,8 +5915,6 @@ pub struct GetTexGenfvRequest {
     pub pname: u32,
 }
 impl GetTexGenfvRequest {
-    /// Opcode for the GetTexGenfv request
-    pub const fn opcode() -> u8 { 133 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5928,7 +5928,7 @@ impl GetTexGenfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_GENFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6010,6 +6010,8 @@ impl GetTexGenfvReply {
     }
 }
 
+/// Opcode for the GetTexGeniv request
+pub const GET_TEX_GENIV_REQUEST: u8 = 134;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexGenivRequest {
     pub context_tag: ContextTag,
@@ -6017,8 +6019,6 @@ pub struct GetTexGenivRequest {
     pub pname: u32,
 }
 impl GetTexGenivRequest {
-    /// Opcode for the GetTexGeniv request
-    pub const fn opcode() -> u8 { 134 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6032,7 +6032,7 @@ impl GetTexGenivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_GENIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6114,6 +6114,8 @@ impl GetTexGenivReply {
     }
 }
 
+/// Opcode for the GetTexImage request
+pub const GET_TEX_IMAGE_REQUEST: u8 = 135;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexImageRequest {
     pub context_tag: ContextTag,
@@ -6124,8 +6126,6 @@ pub struct GetTexImageRequest {
     pub swap_bytes: bool,
 }
 impl GetTexImageRequest {
-    /// Opcode for the GetTexImage request
-    pub const fn opcode() -> u8 { 135 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6142,7 +6142,7 @@ impl GetTexImageRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_IMAGE_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6243,6 +6243,8 @@ impl GetTexImageReply {
     }
 }
 
+/// Opcode for the GetTexParameterfv request
+pub const GET_TEX_PARAMETERFV_REQUEST: u8 = 136;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexParameterfvRequest {
     pub context_tag: ContextTag,
@@ -6250,8 +6252,6 @@ pub struct GetTexParameterfvRequest {
     pub pname: u32,
 }
 impl GetTexParameterfvRequest {
-    /// Opcode for the GetTexParameterfv request
-    pub const fn opcode() -> u8 { 136 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6265,7 +6265,7 @@ impl GetTexParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_PARAMETERFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6347,6 +6347,8 @@ impl GetTexParameterfvReply {
     }
 }
 
+/// Opcode for the GetTexParameteriv request
+pub const GET_TEX_PARAMETERIV_REQUEST: u8 = 137;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexParameterivRequest {
     pub context_tag: ContextTag,
@@ -6354,8 +6356,6 @@ pub struct GetTexParameterivRequest {
     pub pname: u32,
 }
 impl GetTexParameterivRequest {
-    /// Opcode for the GetTexParameteriv request
-    pub const fn opcode() -> u8 { 137 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6369,7 +6369,7 @@ impl GetTexParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_PARAMETERIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6451,6 +6451,8 @@ impl GetTexParameterivReply {
     }
 }
 
+/// Opcode for the GetTexLevelParameterfv request
+pub const GET_TEX_LEVEL_PARAMETERFV_REQUEST: u8 = 138;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexLevelParameterfvRequest {
     pub context_tag: ContextTag,
@@ -6459,8 +6461,6 @@ pub struct GetTexLevelParameterfvRequest {
     pub pname: u32,
 }
 impl GetTexLevelParameterfvRequest {
-    /// Opcode for the GetTexLevelParameterfv request
-    pub const fn opcode() -> u8 { 138 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6475,7 +6475,7 @@ impl GetTexLevelParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_LEVEL_PARAMETERFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6562,6 +6562,8 @@ impl GetTexLevelParameterfvReply {
     }
 }
 
+/// Opcode for the GetTexLevelParameteriv request
+pub const GET_TEX_LEVEL_PARAMETERIV_REQUEST: u8 = 139;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetTexLevelParameterivRequest {
     pub context_tag: ContextTag,
@@ -6570,8 +6572,6 @@ pub struct GetTexLevelParameterivRequest {
     pub pname: u32,
 }
 impl GetTexLevelParameterivRequest {
-    /// Opcode for the GetTexLevelParameteriv request
-    pub const fn opcode() -> u8 { 139 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6586,7 +6586,7 @@ impl GetTexLevelParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_TEX_LEVEL_PARAMETERIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6673,14 +6673,14 @@ impl GetTexLevelParameterivReply {
     }
 }
 
+/// Opcode for the IsEnabled request
+pub const IS_ENABLED_REQUEST: u8 = 140;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IsEnabledRequest {
     pub context_tag: ContextTag,
     pub capability: u32,
 }
 impl IsEnabledRequest {
-    /// Opcode for the IsEnabled request
-    pub const fn opcode() -> u8 { 140 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6693,7 +6693,7 @@ impl IsEnabledRequest {
         let capability_bytes = self.capability.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            IS_ENABLED_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6750,14 +6750,14 @@ impl TryFrom<&[u8]> for IsEnabledReply {
     }
 }
 
+/// Opcode for the IsList request
+pub const IS_LIST_REQUEST: u8 = 141;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IsListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
 }
 impl IsListRequest {
-    /// Opcode for the IsList request
-    pub const fn opcode() -> u8 { 141 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6770,7 +6770,7 @@ impl IsListRequest {
         let list_bytes = self.list.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            IS_LIST_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6827,13 +6827,13 @@ impl TryFrom<&[u8]> for IsListReply {
     }
 }
 
+/// Opcode for the Flush request
+pub const FLUSH_REQUEST: u8 = 142;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FlushRequest {
     pub context_tag: ContextTag,
 }
 impl FlushRequest {
-    /// Opcode for the Flush request
-    pub const fn opcode() -> u8 { 142 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6845,7 +6845,7 @@ impl FlushRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FLUSH_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6872,14 +6872,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the AreTexturesResident request
+pub const ARE_TEXTURES_RESIDENT_REQUEST: u8 = 143;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AreTexturesResidentRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: &'input [u32],
 }
 impl<'input> AreTexturesResidentRequest<'input> {
-    /// Opcode for the AreTexturesResident request
-    pub const fn opcode() -> u8 { 143 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6893,7 +6893,7 @@ impl<'input> AreTexturesResidentRequest<'input> {
         let n_bytes = n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ARE_TEXTURES_RESIDENT_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -6972,14 +6972,14 @@ impl AreTexturesResidentReply {
     }
 }
 
+/// Opcode for the DeleteTextures request
+pub const DELETE_TEXTURES_REQUEST: u8 = 144;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteTexturesRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: &'input [u32],
 }
 impl<'input> DeleteTexturesRequest<'input> {
-    /// Opcode for the DeleteTextures request
-    pub const fn opcode() -> u8 { 144 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6993,7 +6993,7 @@ impl<'input> DeleteTexturesRequest<'input> {
         let n_bytes = n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_TEXTURES_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7029,14 +7029,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GenTextures request
+pub const GEN_TEXTURES_REQUEST: u8 = 145;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GenTexturesRequest {
     pub context_tag: ContextTag,
     pub n: i32,
 }
 impl GenTexturesRequest {
-    /// Opcode for the GenTextures request
-    pub const fn opcode() -> u8 { 145 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7049,7 +7049,7 @@ impl GenTexturesRequest {
         let n_bytes = self.n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GEN_TEXTURES_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7121,14 +7121,14 @@ impl GenTexturesReply {
     }
 }
 
+/// Opcode for the IsTexture request
+pub const IS_TEXTURE_REQUEST: u8 = 146;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IsTextureRequest {
     pub context_tag: ContextTag,
     pub texture: u32,
 }
 impl IsTextureRequest {
-    /// Opcode for the IsTexture request
-    pub const fn opcode() -> u8 { 146 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7141,7 +7141,7 @@ impl IsTextureRequest {
         let texture_bytes = self.texture.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            IS_TEXTURE_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7198,6 +7198,8 @@ impl TryFrom<&[u8]> for IsTextureReply {
     }
 }
 
+/// Opcode for the GetColorTable request
+pub const GET_COLOR_TABLE_REQUEST: u8 = 147;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetColorTableRequest {
     pub context_tag: ContextTag,
@@ -7207,8 +7209,6 @@ pub struct GetColorTableRequest {
     pub swap_bytes: bool,
 }
 impl GetColorTableRequest {
-    /// Opcode for the GetColorTable request
-    pub const fn opcode() -> u8 { 147 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7224,7 +7224,7 @@ impl GetColorTableRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_COLOR_TABLE_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7316,6 +7316,8 @@ impl GetColorTableReply {
     }
 }
 
+/// Opcode for the GetColorTableParameterfv request
+pub const GET_COLOR_TABLE_PARAMETERFV_REQUEST: u8 = 148;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetColorTableParameterfvRequest {
     pub context_tag: ContextTag,
@@ -7323,8 +7325,6 @@ pub struct GetColorTableParameterfvRequest {
     pub pname: u32,
 }
 impl GetColorTableParameterfvRequest {
-    /// Opcode for the GetColorTableParameterfv request
-    pub const fn opcode() -> u8 { 148 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7338,7 +7338,7 @@ impl GetColorTableParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_COLOR_TABLE_PARAMETERFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7420,6 +7420,8 @@ impl GetColorTableParameterfvReply {
     }
 }
 
+/// Opcode for the GetColorTableParameteriv request
+pub const GET_COLOR_TABLE_PARAMETERIV_REQUEST: u8 = 149;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetColorTableParameterivRequest {
     pub context_tag: ContextTag,
@@ -7427,8 +7429,6 @@ pub struct GetColorTableParameterivRequest {
     pub pname: u32,
 }
 impl GetColorTableParameterivRequest {
-    /// Opcode for the GetColorTableParameteriv request
-    pub const fn opcode() -> u8 { 149 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7442,7 +7442,7 @@ impl GetColorTableParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_COLOR_TABLE_PARAMETERIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7524,6 +7524,8 @@ impl GetColorTableParameterivReply {
     }
 }
 
+/// Opcode for the GetConvolutionFilter request
+pub const GET_CONVOLUTION_FILTER_REQUEST: u8 = 150;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetConvolutionFilterRequest {
     pub context_tag: ContextTag,
@@ -7533,8 +7535,6 @@ pub struct GetConvolutionFilterRequest {
     pub swap_bytes: bool,
 }
 impl GetConvolutionFilterRequest {
-    /// Opcode for the GetConvolutionFilter request
-    pub const fn opcode() -> u8 { 150 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7550,7 +7550,7 @@ impl GetConvolutionFilterRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CONVOLUTION_FILTER_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7644,6 +7644,8 @@ impl GetConvolutionFilterReply {
     }
 }
 
+/// Opcode for the GetConvolutionParameterfv request
+pub const GET_CONVOLUTION_PARAMETERFV_REQUEST: u8 = 151;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetConvolutionParameterfvRequest {
     pub context_tag: ContextTag,
@@ -7651,8 +7653,6 @@ pub struct GetConvolutionParameterfvRequest {
     pub pname: u32,
 }
 impl GetConvolutionParameterfvRequest {
-    /// Opcode for the GetConvolutionParameterfv request
-    pub const fn opcode() -> u8 { 151 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7666,7 +7666,7 @@ impl GetConvolutionParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CONVOLUTION_PARAMETERFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7748,6 +7748,8 @@ impl GetConvolutionParameterfvReply {
     }
 }
 
+/// Opcode for the GetConvolutionParameteriv request
+pub const GET_CONVOLUTION_PARAMETERIV_REQUEST: u8 = 152;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetConvolutionParameterivRequest {
     pub context_tag: ContextTag,
@@ -7755,8 +7757,6 @@ pub struct GetConvolutionParameterivRequest {
     pub pname: u32,
 }
 impl GetConvolutionParameterivRequest {
-    /// Opcode for the GetConvolutionParameteriv request
-    pub const fn opcode() -> u8 { 152 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7770,7 +7770,7 @@ impl GetConvolutionParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CONVOLUTION_PARAMETERIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7852,6 +7852,8 @@ impl GetConvolutionParameterivReply {
     }
 }
 
+/// Opcode for the GetSeparableFilter request
+pub const GET_SEPARABLE_FILTER_REQUEST: u8 = 153;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetSeparableFilterRequest {
     pub context_tag: ContextTag,
@@ -7861,8 +7863,6 @@ pub struct GetSeparableFilterRequest {
     pub swap_bytes: bool,
 }
 impl GetSeparableFilterRequest {
-    /// Opcode for the GetSeparableFilter request
-    pub const fn opcode() -> u8 { 153 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7878,7 +7878,7 @@ impl GetSeparableFilterRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SEPARABLE_FILTER_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -7972,6 +7972,8 @@ impl GetSeparableFilterReply {
     }
 }
 
+/// Opcode for the GetHistogram request
+pub const GET_HISTOGRAM_REQUEST: u8 = 154;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetHistogramRequest {
     pub context_tag: ContextTag,
@@ -7982,8 +7984,6 @@ pub struct GetHistogramRequest {
     pub reset: bool,
 }
 impl GetHistogramRequest {
-    /// Opcode for the GetHistogram request
-    pub const fn opcode() -> u8 { 154 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8000,7 +8000,7 @@ impl GetHistogramRequest {
         let reset_bytes = self.reset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_HISTOGRAM_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8093,6 +8093,8 @@ impl GetHistogramReply {
     }
 }
 
+/// Opcode for the GetHistogramParameterfv request
+pub const GET_HISTOGRAM_PARAMETERFV_REQUEST: u8 = 155;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetHistogramParameterfvRequest {
     pub context_tag: ContextTag,
@@ -8100,8 +8102,6 @@ pub struct GetHistogramParameterfvRequest {
     pub pname: u32,
 }
 impl GetHistogramParameterfvRequest {
-    /// Opcode for the GetHistogramParameterfv request
-    pub const fn opcode() -> u8 { 155 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8115,7 +8115,7 @@ impl GetHistogramParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_HISTOGRAM_PARAMETERFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8197,6 +8197,8 @@ impl GetHistogramParameterfvReply {
     }
 }
 
+/// Opcode for the GetHistogramParameteriv request
+pub const GET_HISTOGRAM_PARAMETERIV_REQUEST: u8 = 156;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetHistogramParameterivRequest {
     pub context_tag: ContextTag,
@@ -8204,8 +8206,6 @@ pub struct GetHistogramParameterivRequest {
     pub pname: u32,
 }
 impl GetHistogramParameterivRequest {
-    /// Opcode for the GetHistogramParameteriv request
-    pub const fn opcode() -> u8 { 156 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8219,7 +8219,7 @@ impl GetHistogramParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_HISTOGRAM_PARAMETERIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8301,6 +8301,8 @@ impl GetHistogramParameterivReply {
     }
 }
 
+/// Opcode for the GetMinmax request
+pub const GET_MINMAX_REQUEST: u8 = 157;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMinmaxRequest {
     pub context_tag: ContextTag,
@@ -8311,8 +8313,6 @@ pub struct GetMinmaxRequest {
     pub reset: bool,
 }
 impl GetMinmaxRequest {
-    /// Opcode for the GetMinmax request
-    pub const fn opcode() -> u8 { 157 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8329,7 +8329,7 @@ impl GetMinmaxRequest {
         let reset_bytes = self.reset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MINMAX_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8419,6 +8419,8 @@ impl GetMinmaxReply {
     }
 }
 
+/// Opcode for the GetMinmaxParameterfv request
+pub const GET_MINMAX_PARAMETERFV_REQUEST: u8 = 158;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMinmaxParameterfvRequest {
     pub context_tag: ContextTag,
@@ -8426,8 +8428,6 @@ pub struct GetMinmaxParameterfvRequest {
     pub pname: u32,
 }
 impl GetMinmaxParameterfvRequest {
-    /// Opcode for the GetMinmaxParameterfv request
-    pub const fn opcode() -> u8 { 158 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8441,7 +8441,7 @@ impl GetMinmaxParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MINMAX_PARAMETERFV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8523,6 +8523,8 @@ impl GetMinmaxParameterfvReply {
     }
 }
 
+/// Opcode for the GetMinmaxParameteriv request
+pub const GET_MINMAX_PARAMETERIV_REQUEST: u8 = 159;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMinmaxParameterivRequest {
     pub context_tag: ContextTag,
@@ -8530,8 +8532,6 @@ pub struct GetMinmaxParameterivRequest {
     pub pname: u32,
 }
 impl GetMinmaxParameterivRequest {
-    /// Opcode for the GetMinmaxParameteriv request
-    pub const fn opcode() -> u8 { 159 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8545,7 +8545,7 @@ impl GetMinmaxParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MINMAX_PARAMETERIV_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8627,6 +8627,8 @@ impl GetMinmaxParameterivReply {
     }
 }
 
+/// Opcode for the GetCompressedTexImageARB request
+pub const GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST: u8 = 160;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCompressedTexImageARBRequest {
     pub context_tag: ContextTag,
@@ -8634,8 +8636,6 @@ pub struct GetCompressedTexImageARBRequest {
     pub level: i32,
 }
 impl GetCompressedTexImageARBRequest {
-    /// Opcode for the GetCompressedTexImageARB request
-    pub const fn opcode() -> u8 { 160 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8649,7 +8649,7 @@ impl GetCompressedTexImageARBRequest {
         let level_bytes = self.level.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8731,14 +8731,14 @@ impl GetCompressedTexImageARBReply {
     }
 }
 
+/// Opcode for the DeleteQueriesARB request
+pub const DELETE_QUERIES_ARB_REQUEST: u8 = 161;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteQueriesARBRequest<'input> {
     pub context_tag: ContextTag,
     pub ids: &'input [u32],
 }
 impl<'input> DeleteQueriesARBRequest<'input> {
-    /// Opcode for the DeleteQueriesARB request
-    pub const fn opcode() -> u8 { 161 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8752,7 +8752,7 @@ impl<'input> DeleteQueriesARBRequest<'input> {
         let n_bytes = n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_QUERIES_ARB_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8788,14 +8788,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GenQueriesARB request
+pub const GEN_QUERIES_ARB_REQUEST: u8 = 162;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GenQueriesARBRequest {
     pub context_tag: ContextTag,
     pub n: i32,
 }
 impl GenQueriesARBRequest {
-    /// Opcode for the GenQueriesARB request
-    pub const fn opcode() -> u8 { 162 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8808,7 +8808,7 @@ impl GenQueriesARBRequest {
         let n_bytes = self.n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GEN_QUERIES_ARB_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8880,14 +8880,14 @@ impl GenQueriesARBReply {
     }
 }
 
+/// Opcode for the IsQueryARB request
+pub const IS_QUERY_ARB_REQUEST: u8 = 163;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IsQueryARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
 }
 impl IsQueryARBRequest {
-    /// Opcode for the IsQueryARB request
-    pub const fn opcode() -> u8 { 163 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8900,7 +8900,7 @@ impl IsQueryARBRequest {
         let id_bytes = self.id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            IS_QUERY_ARB_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -8957,6 +8957,8 @@ impl TryFrom<&[u8]> for IsQueryARBReply {
     }
 }
 
+/// Opcode for the GetQueryivARB request
+pub const GET_QUERYIV_ARB_REQUEST: u8 = 164;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetQueryivARBRequest {
     pub context_tag: ContextTag,
@@ -8964,8 +8966,6 @@ pub struct GetQueryivARBRequest {
     pub pname: u32,
 }
 impl GetQueryivARBRequest {
-    /// Opcode for the GetQueryivARB request
-    pub const fn opcode() -> u8 { 164 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8979,7 +8979,7 @@ impl GetQueryivARBRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_QUERYIV_ARB_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -9061,6 +9061,8 @@ impl GetQueryivARBReply {
     }
 }
 
+/// Opcode for the GetQueryObjectivARB request
+pub const GET_QUERY_OBJECTIV_ARB_REQUEST: u8 = 165;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetQueryObjectivARBRequest {
     pub context_tag: ContextTag,
@@ -9068,8 +9070,6 @@ pub struct GetQueryObjectivARBRequest {
     pub pname: u32,
 }
 impl GetQueryObjectivARBRequest {
-    /// Opcode for the GetQueryObjectivARB request
-    pub const fn opcode() -> u8 { 165 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9083,7 +9083,7 @@ impl GetQueryObjectivARBRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_QUERY_OBJECTIV_ARB_REQUEST,
             0,
             0,
             context_tag_bytes[0],
@@ -9165,6 +9165,8 @@ impl GetQueryObjectivARBReply {
     }
 }
 
+/// Opcode for the GetQueryObjectuivARB request
+pub const GET_QUERY_OBJECTUIV_ARB_REQUEST: u8 = 166;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetQueryObjectuivARBRequest {
     pub context_tag: ContextTag,
@@ -9172,8 +9174,6 @@ pub struct GetQueryObjectuivARBRequest {
     pub pname: u32,
 }
 impl GetQueryObjectuivARBRequest {
-    /// Opcode for the GetQueryObjectuivARB request
-    pub const fn opcode() -> u8 { 166 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9187,7 +9187,7 @@ impl GetQueryObjectuivARBRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_QUERY_OBJECTUIV_ARB_REQUEST,
             0,
             0,
             context_tag_bytes[0],

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -478,7 +478,6 @@ impl<'input> RenderRequest<'input> {
     /// Opcode for the Render request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -531,7 +530,6 @@ impl<'input> RenderLargeRequest<'input> {
     /// Opcode for the RenderLarge request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -599,7 +597,6 @@ impl CreateContextRequest {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -669,7 +666,6 @@ impl DestroyContextRequest {
     /// Opcode for the DestroyContext request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -717,7 +713,6 @@ impl MakeCurrentRequest {
     /// Opcode for the MakeCurrent request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -801,7 +796,6 @@ impl IsDirectRequest {
     /// Opcode for the IsDirect request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -874,7 +868,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -954,7 +947,6 @@ impl WaitGLRequest {
     /// Opcode for the WaitGL request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1000,7 +992,6 @@ impl WaitXRequest {
     /// Opcode for the WaitX request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1049,7 +1040,6 @@ impl CopyContextRequest {
     /// Opcode for the CopyContext request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1202,7 +1192,6 @@ impl SwapBuffersRequest {
     /// Opcode for the SwapBuffers request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1258,7 +1247,6 @@ impl UseXFontRequest {
     /// Opcode for the UseXFont request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1331,7 +1319,6 @@ impl CreateGLXPixmapRequest {
     /// Opcode for the CreateGLXPixmap request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1395,7 +1382,6 @@ impl GetVisualConfigsRequest {
     /// Opcode for the GetVisualConfigs request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1485,7 +1471,6 @@ impl DestroyGLXPixmapRequest {
     /// Opcode for the DestroyGLXPixmap request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1533,7 +1518,6 @@ impl<'input> VendorPrivateRequest<'input> {
     /// Opcode for the VendorPrivate request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1591,7 +1575,6 @@ impl<'input> VendorPrivateWithReplyRequest<'input> {
     /// Opcode for the VendorPrivateWithReply request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1693,7 +1676,6 @@ impl QueryExtensionsStringRequest {
     /// Opcode for the QueryExtensionsString request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1767,7 +1749,6 @@ impl QueryServerStringRequest {
     /// Opcode for the QueryServerString request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1865,7 +1846,6 @@ impl<'input> ClientInfoRequest<'input> {
     /// Opcode for the ClientInfo request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1927,7 +1907,6 @@ impl GetFBConfigsRequest {
     /// Opcode for the GetFBConfigs request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2021,7 +2000,6 @@ impl<'input> CreatePixmapRequest<'input> {
     /// Opcode for the CreatePixmap request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2097,7 +2075,6 @@ impl DestroyPixmapRequest {
     /// Opcode for the DestroyPixmap request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2148,7 +2125,6 @@ impl CreateNewContextRequest {
     /// Opcode for the CreateNewContext request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2224,7 +2200,6 @@ impl QueryContextRequest {
     /// Opcode for the QueryContext request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2316,7 +2291,6 @@ impl MakeContextCurrentRequest {
     /// Opcode for the MakeContextCurrent request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2409,7 +2383,6 @@ impl<'input> CreatePbufferRequest<'input> {
     /// Opcode for the CreatePbuffer request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2479,7 +2452,6 @@ impl DestroyPbufferRequest {
     /// Opcode for the DestroyPbuffer request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2525,7 +2497,6 @@ impl GetDrawableAttributesRequest {
     /// Opcode for the GetDrawableAttributes request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2615,7 +2586,6 @@ impl<'input> ChangeDrawableAttributesRequest<'input> {
     /// Opcode for the ChangeDrawableAttributes request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2677,7 +2647,6 @@ impl<'input> CreateWindowRequest<'input> {
     /// Opcode for the CreateWindow request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2753,7 +2722,6 @@ impl DeleteWindowRequest {
     /// Opcode for the DeleteWindow request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2803,7 +2771,6 @@ impl<'input> SetClientInfoARBRequest<'input> {
     /// Opcode for the SetClientInfoARB request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2888,7 +2855,6 @@ impl<'input> CreateContextAttribsARBRequest<'input> {
     /// Opcode for the CreateContextAttribsARB request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2974,7 +2940,6 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
     /// Opcode for the SetClientInfo2ARB request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3056,7 +3021,6 @@ impl NewListRequest {
     /// Opcode for the NewList request
     pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3114,7 +3078,6 @@ impl EndListRequest {
     /// Opcode for the EndList request
     pub const fn opcode() -> u8 { 102 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3162,7 +3125,6 @@ impl DeleteListsRequest {
     /// Opcode for the DeleteLists request
     pub const fn opcode() -> u8 { 103 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3221,7 +3183,6 @@ impl GenListsRequest {
     /// Opcode for the GenLists request
     pub const fn opcode() -> u8 { 104 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3300,7 +3261,6 @@ impl FeedbackBufferRequest {
     /// Opcode for the FeedbackBuffer request
     pub const fn opcode() -> u8 { 105 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3359,7 +3319,6 @@ impl SelectBufferRequest {
     /// Opcode for the SelectBuffer request
     pub const fn opcode() -> u8 { 106 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3412,7 +3371,6 @@ impl RenderModeRequest {
     /// Opcode for the RenderMode request
     pub const fn opcode() -> u8 { 107 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3560,7 +3518,6 @@ impl FinishRequest {
     /// Opcode for the Finish request
     pub const fn opcode() -> u8 { 108 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3631,7 +3588,6 @@ impl PixelStorefRequest {
     /// Opcode for the PixelStoref request
     pub const fn opcode() -> u8 { 109 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3691,7 +3647,6 @@ impl PixelStoreiRequest {
     /// Opcode for the PixelStorei request
     pub const fn opcode() -> u8 { 110 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3757,7 +3712,6 @@ impl ReadPixelsRequest {
     /// Opcode for the ReadPixels request
     pub const fn opcode() -> u8 { 111 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3890,7 +3844,6 @@ impl GetBooleanvRequest {
     /// Opcode for the GetBooleanv request
     pub const fn opcode() -> u8 { 112 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3988,7 +3941,6 @@ impl GetClipPlaneRequest {
     /// Opcode for the GetClipPlane request
     pub const fn opcode() -> u8 { 113 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4082,7 +4034,6 @@ impl GetDoublevRequest {
     /// Opcode for the GetDoublev request
     pub const fn opcode() -> u8 { 114 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4179,7 +4130,6 @@ impl GetErrorRequest {
     /// Opcode for the GetError request
     pub const fn opcode() -> u8 { 115 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4251,7 +4201,6 @@ impl GetFloatvRequest {
     /// Opcode for the GetFloatv request
     pub const fn opcode() -> u8 { 116 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4349,7 +4298,6 @@ impl GetIntegervRequest {
     /// Opcode for the GetIntegerv request
     pub const fn opcode() -> u8 { 117 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4448,7 +4396,6 @@ impl GetLightfvRequest {
     /// Opcode for the GetLightfv request
     pub const fn opcode() -> u8 { 118 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4553,7 +4500,6 @@ impl GetLightivRequest {
     /// Opcode for the GetLightiv request
     pub const fn opcode() -> u8 { 119 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4658,7 +4604,6 @@ impl GetMapdvRequest {
     /// Opcode for the GetMapdv request
     pub const fn opcode() -> u8 { 120 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4763,7 +4708,6 @@ impl GetMapfvRequest {
     /// Opcode for the GetMapfv request
     pub const fn opcode() -> u8 { 121 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4868,7 +4812,6 @@ impl GetMapivRequest {
     /// Opcode for the GetMapiv request
     pub const fn opcode() -> u8 { 122 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4973,7 +4916,6 @@ impl GetMaterialfvRequest {
     /// Opcode for the GetMaterialfv request
     pub const fn opcode() -> u8 { 123 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5078,7 +5020,6 @@ impl GetMaterialivRequest {
     /// Opcode for the GetMaterialiv request
     pub const fn opcode() -> u8 { 124 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5182,7 +5123,6 @@ impl GetPixelMapfvRequest {
     /// Opcode for the GetPixelMapfv request
     pub const fn opcode() -> u8 { 125 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5280,7 +5220,6 @@ impl GetPixelMapuivRequest {
     /// Opcode for the GetPixelMapuiv request
     pub const fn opcode() -> u8 { 126 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5378,7 +5317,6 @@ impl GetPixelMapusvRequest {
     /// Opcode for the GetPixelMapusv request
     pub const fn opcode() -> u8 { 127 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5476,7 +5414,6 @@ impl GetPolygonStippleRequest {
     /// Opcode for the GetPolygonStipple request
     pub const fn opcode() -> u8 { 128 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5571,7 +5508,6 @@ impl GetStringRequest {
     /// Opcode for the GetString request
     pub const fn opcode() -> u8 { 129 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5669,7 +5605,6 @@ impl GetTexEnvfvRequest {
     /// Opcode for the GetTexEnvfv request
     pub const fn opcode() -> u8 { 130 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5774,7 +5709,6 @@ impl GetTexEnvivRequest {
     /// Opcode for the GetTexEnviv request
     pub const fn opcode() -> u8 { 131 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5879,7 +5813,6 @@ impl GetTexGendvRequest {
     /// Opcode for the GetTexGendv request
     pub const fn opcode() -> u8 { 132 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5984,7 +5917,6 @@ impl GetTexGenfvRequest {
     /// Opcode for the GetTexGenfv request
     pub const fn opcode() -> u8 { 133 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6089,7 +6021,6 @@ impl GetTexGenivRequest {
     /// Opcode for the GetTexGeniv request
     pub const fn opcode() -> u8 { 134 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6197,7 +6128,6 @@ impl GetTexImageRequest {
     /// Opcode for the GetTexImage request
     pub const fn opcode() -> u8 { 135 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6324,7 +6254,6 @@ impl GetTexParameterfvRequest {
     /// Opcode for the GetTexParameterfv request
     pub const fn opcode() -> u8 { 136 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6429,7 +6358,6 @@ impl GetTexParameterivRequest {
     /// Opcode for the GetTexParameteriv request
     pub const fn opcode() -> u8 { 137 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6535,7 +6463,6 @@ impl GetTexLevelParameterfvRequest {
     /// Opcode for the GetTexLevelParameterfv request
     pub const fn opcode() -> u8 { 138 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6647,7 +6574,6 @@ impl GetTexLevelParameterivRequest {
     /// Opcode for the GetTexLevelParameteriv request
     pub const fn opcode() -> u8 { 139 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6757,7 +6683,6 @@ impl IsEnabledRequest {
     /// Opcode for the IsEnabled request
     pub const fn opcode() -> u8 { 140 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6835,7 +6760,6 @@ impl IsListRequest {
     /// Opcode for the IsList request
     pub const fn opcode() -> u8 { 141 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6912,7 +6836,6 @@ impl FlushRequest {
     /// Opcode for the Flush request
     pub const fn opcode() -> u8 { 142 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6959,7 +6882,6 @@ impl<'input> AreTexturesResidentRequest<'input> {
     /// Opcode for the AreTexturesResident request
     pub const fn opcode() -> u8 { 143 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7060,7 +6982,6 @@ impl<'input> DeleteTexturesRequest<'input> {
     /// Opcode for the DeleteTextures request
     pub const fn opcode() -> u8 { 144 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7118,7 +7039,6 @@ impl GenTexturesRequest {
     /// Opcode for the GenTextures request
     pub const fn opcode() -> u8 { 145 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7211,7 +7131,6 @@ impl IsTextureRequest {
     /// Opcode for the IsTexture request
     pub const fn opcode() -> u8 { 146 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7292,7 +7211,6 @@ impl GetColorTableRequest {
     /// Opcode for the GetColorTable request
     pub const fn opcode() -> u8 { 147 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7409,7 +7327,6 @@ impl GetColorTableParameterfvRequest {
     /// Opcode for the GetColorTableParameterfv request
     pub const fn opcode() -> u8 { 148 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7514,7 +7431,6 @@ impl GetColorTableParameterivRequest {
     /// Opcode for the GetColorTableParameteriv request
     pub const fn opcode() -> u8 { 149 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7621,7 +7537,6 @@ impl GetConvolutionFilterRequest {
     /// Opcode for the GetConvolutionFilter request
     pub const fn opcode() -> u8 { 150 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7740,7 +7655,6 @@ impl GetConvolutionParameterfvRequest {
     /// Opcode for the GetConvolutionParameterfv request
     pub const fn opcode() -> u8 { 151 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7845,7 +7759,6 @@ impl GetConvolutionParameterivRequest {
     /// Opcode for the GetConvolutionParameteriv request
     pub const fn opcode() -> u8 { 152 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7952,7 +7865,6 @@ impl GetSeparableFilterRequest {
     /// Opcode for the GetSeparableFilter request
     pub const fn opcode() -> u8 { 153 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8074,7 +7986,6 @@ impl GetHistogramRequest {
     /// Opcode for the GetHistogram request
     pub const fn opcode() -> u8 { 154 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8193,7 +8104,6 @@ impl GetHistogramParameterfvRequest {
     /// Opcode for the GetHistogramParameterfv request
     pub const fn opcode() -> u8 { 155 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8298,7 +8208,6 @@ impl GetHistogramParameterivRequest {
     /// Opcode for the GetHistogramParameteriv request
     pub const fn opcode() -> u8 { 156 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8406,7 +8315,6 @@ impl GetMinmaxRequest {
     /// Opcode for the GetMinmax request
     pub const fn opcode() -> u8 { 157 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8522,7 +8430,6 @@ impl GetMinmaxParameterfvRequest {
     /// Opcode for the GetMinmaxParameterfv request
     pub const fn opcode() -> u8 { 158 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8627,7 +8534,6 @@ impl GetMinmaxParameterivRequest {
     /// Opcode for the GetMinmaxParameteriv request
     pub const fn opcode() -> u8 { 159 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8732,7 +8638,6 @@ impl GetCompressedTexImageARBRequest {
     /// Opcode for the GetCompressedTexImageARB request
     pub const fn opcode() -> u8 { 160 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8836,7 +8741,6 @@ impl<'input> DeleteQueriesARBRequest<'input> {
     /// Opcode for the DeleteQueriesARB request
     pub const fn opcode() -> u8 { 161 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8894,7 +8798,6 @@ impl GenQueriesARBRequest {
     /// Opcode for the GenQueriesARB request
     pub const fn opcode() -> u8 { 162 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8987,7 +8890,6 @@ impl IsQueryARBRequest {
     /// Opcode for the IsQueryARB request
     pub const fn opcode() -> u8 { 163 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9066,7 +8968,6 @@ impl GetQueryivARBRequest {
     /// Opcode for the GetQueryivARB request
     pub const fn opcode() -> u8 { 164 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9171,7 +9072,6 @@ impl GetQueryObjectivARBRequest {
     /// Opcode for the GetQueryObjectivARB request
     pub const fn opcode() -> u8 { 165 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9276,7 +9176,6 @@ impl GetQueryObjectuivARBRequest {
     /// Opcode for the GetQueryObjectuivARB request
     pub const fn opcode() -> u8 { 166 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -512,8 +512,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RenderRequest {
-        context_tag: context_tag,
-        data: data,
+        context_tag,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -577,10 +577,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RenderLargeRequest {
-        context_tag: context_tag,
-        request_num: request_num,
-        request_total: request_total,
-        data: data,
+        context_tag,
+        request_num,
+        request_total,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -650,11 +650,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateContextRequest {
-        context: context,
-        visual: visual,
-        screen: screen,
-        share_list: share_list,
-        is_direct: is_direct,
+        context,
+        visual,
+        screen,
+        share_list,
+        is_direct,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -700,7 +700,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -758,9 +758,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = MakeCurrentRequest {
-        drawable: drawable,
-        context: context,
-        old_context_tag: old_context_tag,
+        drawable,
+        context,
+        old_context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -832,7 +832,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = IsDirectRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -910,8 +910,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -985,7 +985,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = WaitGLRequest {
-        context_tag: context_tag,
+        context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1031,7 +1031,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = WaitXRequest {
-        context_tag: context_tag,
+        context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1095,10 +1095,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CopyContextRequest {
-        src: src,
-        dest: dest,
-        mask: mask,
-        src_context_tag: src_context_tag,
+        src,
+        dest,
+        mask,
+        src_context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1238,8 +1238,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SwapBuffersRequest {
-        context_tag: context_tag,
-        drawable: drawable,
+        context_tag,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1309,11 +1309,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UseXFontRequest {
-        context_tag: context_tag,
-        font: font,
-        first: first,
-        count: count,
-        list_base: list_base,
+        context_tag,
+        font,
+        first,
+        count,
+        list_base,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1377,10 +1377,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateGLXPixmapRequest {
-        screen: screen,
-        visual: visual,
-        pixmap: pixmap,
-        glx_pixmap: glx_pixmap,
+        screen,
+        visual,
+        pixmap,
+        glx_pixmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1426,7 +1426,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetVisualConfigsRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1516,7 +1516,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyGLXPixmapRequest {
-        glx_pixmap: glx_pixmap,
+        glx_pixmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1572,9 +1572,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = VendorPrivateRequest {
-        vendor_code: vendor_code,
-        context_tag: context_tag,
-        data: data,
+        vendor_code,
+        context_tag,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1630,9 +1630,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = VendorPrivateWithReplyRequest {
-        vendor_code: vendor_code,
-        context_tag: context_tag,
-        data: data,
+        vendor_code,
+        context_tag,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1724,7 +1724,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryExtensionsStringRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1803,8 +1803,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryServerStringRequest {
-        screen: screen,
-        name: name,
+        screen,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1910,9 +1910,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ClientInfoRequest {
-        major_version: major_version,
-        minor_version: minor_version,
-        string: string,
+        major_version,
+        minor_version,
+        string,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1958,7 +1958,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetFBConfigsRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2078,11 +2078,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreatePixmapRequest {
-        screen: screen,
-        fbconfig: fbconfig,
-        pixmap: pixmap,
-        glx_pixmap: glx_pixmap,
-        attribs: attribs,
+        screen,
+        fbconfig,
+        pixmap,
+        glx_pixmap,
+        attribs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2128,7 +2128,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyPixmapRequest {
-        glx_pixmap: glx_pixmap,
+        glx_pixmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2204,12 +2204,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateNewContextRequest {
-        context: context,
-        fbconfig: fbconfig,
-        screen: screen,
-        render_type: render_type,
-        share_list: share_list,
-        is_direct: is_direct,
+        context,
+        fbconfig,
+        screen,
+        render_type,
+        share_list,
+        is_direct,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2255,7 +2255,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2362,10 +2362,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = MakeContextCurrentRequest {
-        old_context_tag: old_context_tag,
-        drawable: drawable,
-        read_drawable: read_drawable,
-        context: context,
+        old_context_tag,
+        drawable,
+        read_drawable,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2461,10 +2461,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreatePbufferRequest {
-        screen: screen,
-        fbconfig: fbconfig,
-        pbuffer: pbuffer,
-        attribs: attribs,
+        screen,
+        fbconfig,
+        pbuffer,
+        attribs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2510,7 +2510,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyPbufferRequest {
-        pbuffer: pbuffer,
+        pbuffer,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2556,7 +2556,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDrawableAttributesRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2657,8 +2657,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeDrawableAttributesRequest {
-        drawable: drawable,
-        attribs: attribs,
+        drawable,
+        attribs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2734,11 +2734,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateWindowRequest {
-        screen: screen,
-        fbconfig: fbconfig,
-        window: window,
-        glx_window: glx_window,
-        attribs: attribs,
+        screen,
+        fbconfig,
+        window,
+        glx_window,
+        attribs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2784,7 +2784,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteWindowRequest {
-        glxwindow: glxwindow,
+        glxwindow,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2864,11 +2864,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetClientInfoARBRequest {
-        major_version: major_version,
-        minor_version: minor_version,
-        gl_versions: gl_versions,
-        gl_extension_string: gl_extension_string,
-        glx_extension_string: glx_extension_string,
+        major_version,
+        minor_version,
+        gl_versions,
+        gl_extension_string,
+        glx_extension_string,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2950,12 +2950,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateContextAttribsARBRequest {
-        context: context,
-        fbconfig: fbconfig,
-        screen: screen,
-        share_list: share_list,
-        is_direct: is_direct,
-        attribs: attribs,
+        context,
+        fbconfig,
+        screen,
+        share_list,
+        is_direct,
+        attribs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3035,11 +3035,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetClientInfo2ARBRequest {
-        major_version: major_version,
-        minor_version: minor_version,
-        gl_versions: gl_versions,
-        gl_extension_string: gl_extension_string,
-        glx_extension_string: glx_extension_string,
+        major_version,
+        minor_version,
+        gl_versions,
+        gl_extension_string,
+        glx_extension_string,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3097,9 +3097,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = NewListRequest {
-        context_tag: context_tag,
-        list: list,
-        mode: mode,
+        context_tag,
+        list,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3145,7 +3145,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = EndListRequest {
-        context_tag: context_tag,
+        context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3203,9 +3203,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteListsRequest {
-        context_tag: context_tag,
-        list: list,
-        range: range,
+        context_tag,
+        list,
+        range,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3257,8 +3257,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GenListsRequest {
-        context_tag: context_tag,
-        range: range,
+        context_tag,
+        range,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3341,9 +3341,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FeedbackBufferRequest {
-        context_tag: context_tag,
-        size: size,
-        type_: type_,
+        context_tag,
+        size,
+        type_,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3395,8 +3395,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SelectBufferRequest {
-        context_tag: context_tag,
-        size: size,
+        context_tag,
+        size,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3448,8 +3448,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RenderModeRequest {
-        context_tag: context_tag,
-        mode: mode,
+        context_tag,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3591,7 +3591,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FinishRequest {
-        context_tag: context_tag,
+        context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3672,9 +3672,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PixelStorefRequest {
-        context_tag: context_tag,
-        pname: pname,
-        datum: datum,
+        context_tag,
+        pname,
+        datum,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3732,9 +3732,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PixelStoreiRequest {
-        context_tag: context_tag,
-        pname: pname,
-        datum: datum,
+        context_tag,
+        pname,
+        datum,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3824,15 +3824,15 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ReadPixelsRequest {
-        context_tag: context_tag,
-        x: x,
-        y: y,
-        width: width,
-        height: height,
-        format: format,
-        type_: type_,
-        swap_bytes: swap_bytes,
-        lsb_first: lsb_first,
+        context_tag,
+        x,
+        y,
+        width,
+        height,
+        format,
+        type_,
+        swap_bytes,
+        lsb_first,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3926,8 +3926,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetBooleanvRequest {
-        context_tag: context_tag,
-        pname: pname,
+        context_tag,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4024,8 +4024,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetClipPlaneRequest {
-        context_tag: context_tag,
-        plane: plane,
+        context_tag,
+        plane,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4118,8 +4118,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDoublevRequest {
-        context_tag: context_tag,
-        pname: pname,
+        context_tag,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4210,7 +4210,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetErrorRequest {
-        context_tag: context_tag,
+        context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4287,8 +4287,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetFloatvRequest {
-        context_tag: context_tag,
-        pname: pname,
+        context_tag,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4385,8 +4385,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetIntegervRequest {
-        context_tag: context_tag,
-        pname: pname,
+        context_tag,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4489,9 +4489,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetLightfvRequest {
-        context_tag: context_tag,
-        light: light,
-        pname: pname,
+        context_tag,
+        light,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4594,9 +4594,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetLightivRequest {
-        context_tag: context_tag,
-        light: light,
-        pname: pname,
+        context_tag,
+        light,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4699,9 +4699,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMapdvRequest {
-        context_tag: context_tag,
-        target: target,
-        query: query,
+        context_tag,
+        target,
+        query,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4804,9 +4804,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMapfvRequest {
-        context_tag: context_tag,
-        target: target,
-        query: query,
+        context_tag,
+        target,
+        query,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4909,9 +4909,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMapivRequest {
-        context_tag: context_tag,
-        target: target,
-        query: query,
+        context_tag,
+        target,
+        query,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5014,9 +5014,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMaterialfvRequest {
-        context_tag: context_tag,
-        face: face,
-        pname: pname,
+        context_tag,
+        face,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5119,9 +5119,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMaterialivRequest {
-        context_tag: context_tag,
-        face: face,
-        pname: pname,
+        context_tag,
+        face,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5218,8 +5218,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPixelMapfvRequest {
-        context_tag: context_tag,
-        map: map,
+        context_tag,
+        map,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5316,8 +5316,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPixelMapuivRequest {
-        context_tag: context_tag,
-        map: map,
+        context_tag,
+        map,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5414,8 +5414,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPixelMapusvRequest {
-        context_tag: context_tag,
-        map: map,
+        context_tag,
+        map,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5512,8 +5512,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPolygonStippleRequest {
-        context_tag: context_tag,
-        lsb_first: lsb_first,
+        context_tag,
+        lsb_first,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5607,8 +5607,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetStringRequest {
-        context_tag: context_tag,
-        name: name,
+        context_tag,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5710,9 +5710,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexEnvfvRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5815,9 +5815,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexEnvivRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5920,9 +5920,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexGendvRequest {
-        context_tag: context_tag,
-        coord: coord,
-        pname: pname,
+        context_tag,
+        coord,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6025,9 +6025,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexGenfvRequest {
-        context_tag: context_tag,
-        coord: coord,
-        pname: pname,
+        context_tag,
+        coord,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6130,9 +6130,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexGenivRequest {
-        context_tag: context_tag,
-        coord: coord,
-        pname: pname,
+        context_tag,
+        coord,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6253,12 +6253,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexImageRequest {
-        context_tag: context_tag,
-        target: target,
-        level: level,
-        format: format,
-        type_: type_,
-        swap_bytes: swap_bytes,
+        context_tag,
+        target,
+        level,
+        format,
+        type_,
+        swap_bytes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6365,9 +6365,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexParameterfvRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6470,9 +6470,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexParameterivRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6581,10 +6581,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexLevelParameterfvRequest {
-        context_tag: context_tag,
-        target: target,
-        level: level,
-        pname: pname,
+        context_tag,
+        target,
+        level,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6693,10 +6693,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetTexLevelParameterivRequest {
-        context_tag: context_tag,
-        target: target,
-        level: level,
-        pname: pname,
+        context_tag,
+        target,
+        level,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6793,8 +6793,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = IsEnabledRequest {
-        context_tag: context_tag,
-        capability: capability,
+        context_tag,
+        capability,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6871,8 +6871,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = IsListRequest {
-        context_tag: context_tag,
-        list: list,
+        context_tag,
+        list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6943,7 +6943,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FlushRequest {
-        context_tag: context_tag,
+        context_tag,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7000,8 +7000,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AreTexturesResidentRequest {
-        context_tag: context_tag,
-        textures: textures,
+        context_tag,
+        textures,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7101,8 +7101,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteTexturesRequest {
-        context_tag: context_tag,
-        textures: textures,
+        context_tag,
+        textures,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7154,8 +7154,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GenTexturesRequest {
-        context_tag: context_tag,
-        n: n,
+        context_tag,
+        n,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7247,8 +7247,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = IsTextureRequest {
-        context_tag: context_tag,
-        texture: texture,
+        context_tag,
+        texture,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7343,11 +7343,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetColorTableRequest {
-        context_tag: context_tag,
-        target: target,
-        format: format,
-        type_: type_,
-        swap_bytes: swap_bytes,
+        context_tag,
+        target,
+        format,
+        type_,
+        swap_bytes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7450,9 +7450,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetColorTableParameterfvRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7555,9 +7555,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetColorTableParameterivRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7672,11 +7672,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetConvolutionFilterRequest {
-        context_tag: context_tag,
-        target: target,
-        format: format,
-        type_: type_,
-        swap_bytes: swap_bytes,
+        context_tag,
+        target,
+        format,
+        type_,
+        swap_bytes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7781,9 +7781,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetConvolutionParameterfvRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7886,9 +7886,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetConvolutionParameterivRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8003,11 +8003,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetSeparableFilterRequest {
-        context_tag: context_tag,
-        target: target,
-        format: format,
-        type_: type_,
-        swap_bytes: swap_bytes,
+        context_tag,
+        target,
+        format,
+        type_,
+        swap_bytes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8126,12 +8126,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetHistogramRequest {
-        context_tag: context_tag,
-        target: target,
-        format: format,
-        type_: type_,
-        swap_bytes: swap_bytes,
-        reset: reset,
+        context_tag,
+        target,
+        format,
+        type_,
+        swap_bytes,
+        reset,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8234,9 +8234,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetHistogramParameterfvRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8339,9 +8339,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetHistogramParameterivRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8458,12 +8458,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMinmaxRequest {
-        context_tag: context_tag,
-        target: target,
-        format: format,
-        type_: type_,
-        swap_bytes: swap_bytes,
-        reset: reset,
+        context_tag,
+        target,
+        format,
+        type_,
+        swap_bytes,
+        reset,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8563,9 +8563,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMinmaxParameterfvRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8668,9 +8668,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMinmaxParameterivRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8773,9 +8773,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetCompressedTexImageARBRequest {
-        context_tag: context_tag,
-        target: target,
-        level: level,
+        context_tag,
+        target,
+        level,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8877,8 +8877,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteQueriesARBRequest {
-        context_tag: context_tag,
-        ids: ids,
+        context_tag,
+        ids,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8930,8 +8930,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GenQueriesARBRequest {
-        context_tag: context_tag,
-        n: n,
+        context_tag,
+        n,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9023,8 +9023,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = IsQueryARBRequest {
-        context_tag: context_tag,
-        id: id,
+        context_tag,
+        id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9107,9 +9107,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetQueryivARBRequest {
-        context_tag: context_tag,
-        target: target,
-        pname: pname,
+        context_tag,
+        target,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9212,9 +9212,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetQueryObjectivARBRequest {
-        context_tag: context_tag,
-        id: id,
-        pname: pname,
+        context_tag,
+        id,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9317,9 +9317,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetQueryObjectuivARBRequest {
-        context_tag: context_tag,
-        id: id,
-        pname: pname,
+        context_tag,
+        id,
+        pname,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -489,7 +489,7 @@ impl<'input> RenderRequest<'input> {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RenderRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -546,7 +546,7 @@ impl<'input> RenderLargeRequest<'input> {
         let data_len_bytes = data_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RenderLargeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -614,7 +614,7 @@ impl CreateContextRequest {
         let is_direct_bytes = self.is_direct.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -680,7 +680,7 @@ impl DestroyContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -730,7 +730,7 @@ impl MakeCurrentRequest {
         let old_context_tag_bytes = self.old_context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            MakeCurrentRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -812,7 +812,7 @@ impl IsDirectRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            IsDirectRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -886,7 +886,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -965,7 +965,7 @@ impl WaitGLRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            WaitGLRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -1011,7 +1011,7 @@ impl WaitXRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            WaitXRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -1063,7 +1063,7 @@ impl CopyContextRequest {
         let src_context_tag_bytes = self.src_context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CopyContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             src_bytes[0],
@@ -1214,7 +1214,7 @@ impl SwapBuffersRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SwapBuffersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -1273,7 +1273,7 @@ impl UseXFontRequest {
         let list_base_bytes = self.list_base.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UseXFontRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -1345,7 +1345,7 @@ impl CreateGLXPixmapRequest {
         let glx_pixmap_bytes = self.glx_pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateGLXPixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1406,7 +1406,7 @@ impl GetVisualConfigsRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetVisualConfigsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1496,7 +1496,7 @@ impl DestroyGLXPixmapRequest {
         let glx_pixmap_bytes = self.glx_pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyGLXPixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             glx_pixmap_bytes[0],
@@ -1545,7 +1545,7 @@ impl<'input> VendorPrivateRequest<'input> {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            VendorPrivateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             vendor_code_bytes[0],
@@ -1603,7 +1603,7 @@ impl<'input> VendorPrivateWithReplyRequest<'input> {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            VendorPrivateWithReplyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             vendor_code_bytes[0],
@@ -1704,7 +1704,7 @@ impl QueryExtensionsStringRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryExtensionsStringRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1779,7 +1779,7 @@ impl QueryServerStringRequest {
         let name_bytes = self.name.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryServerStringRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1879,7 +1879,7 @@ impl<'input> ClientInfoRequest<'input> {
         let str_len_bytes = str_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ClientInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -1938,7 +1938,7 @@ impl GetFBConfigsRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetFBConfigsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2038,7 +2038,7 @@ impl<'input> CreatePixmapRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreatePixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2108,7 +2108,7 @@ impl DestroyPixmapRequest {
         let glx_pixmap_bytes = self.glx_pixmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyPixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             glx_pixmap_bytes[0],
@@ -2164,7 +2164,7 @@ impl CreateNewContextRequest {
         let is_direct_bytes = self.is_direct.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateNewContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -2235,7 +2235,7 @@ impl QueryContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -2330,7 +2330,7 @@ impl MakeContextCurrentRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            MakeContextCurrentRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             old_context_tag_bytes[0],
@@ -2425,7 +2425,7 @@ impl<'input> CreatePbufferRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreatePbufferRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2490,7 +2490,7 @@ impl DestroyPbufferRequest {
         let pbuffer_bytes = self.pbuffer.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyPbufferRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             pbuffer_bytes[0],
@@ -2536,7 +2536,7 @@ impl GetDrawableAttributesRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDrawableAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -2629,7 +2629,7 @@ impl<'input> ChangeDrawableAttributesRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeDrawableAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -2694,7 +2694,7 @@ impl<'input> CreateWindowRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2764,7 +2764,7 @@ impl DeleteWindowRequest {
         let glxwindow_bytes = self.glxwindow.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             glxwindow_bytes[0],
@@ -2822,7 +2822,7 @@ impl<'input> SetClientInfoARBRequest<'input> {
         let glx_str_len_bytes = glx_str_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetClientInfoARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -2906,7 +2906,7 @@ impl<'input> CreateContextAttribsARBRequest<'input> {
         let num_attribs_bytes = num_attribs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateContextAttribsARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -2993,7 +2993,7 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
         let glx_str_len_bytes = glx_str_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetClientInfo2ARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -3069,7 +3069,7 @@ impl NewListRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            NewListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3125,7 +3125,7 @@ impl EndListRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            EndListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3175,7 +3175,7 @@ impl DeleteListsRequest {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteListsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3233,7 +3233,7 @@ impl GenListsRequest {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GenListsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3313,7 +3313,7 @@ impl FeedbackBufferRequest {
         let type_bytes = self.type_.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FeedbackBufferRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3371,7 +3371,7 @@ impl SelectBufferRequest {
         let size_bytes = self.size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectBufferRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3424,7 +3424,7 @@ impl RenderModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RenderModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3571,7 +3571,7 @@ impl FinishRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FinishRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3644,7 +3644,7 @@ impl PixelStorefRequest {
         let datum_bytes = self.datum.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PixelStorefRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3704,7 +3704,7 @@ impl PixelStoreiRequest {
         let datum_bytes = self.datum.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PixelStoreiRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3776,7 +3776,7 @@ impl ReadPixelsRequest {
         let lsb_first_bytes = self.lsb_first.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ReadPixelsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -3902,7 +3902,7 @@ impl GetBooleanvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetBooleanvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4000,7 +4000,7 @@ impl GetClipPlaneRequest {
         let plane_bytes = self.plane.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetClipPlaneRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4094,7 +4094,7 @@ impl GetDoublevRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDoublevRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4190,7 +4190,7 @@ impl GetErrorRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetErrorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4263,7 +4263,7 @@ impl GetFloatvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetFloatvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4361,7 +4361,7 @@ impl GetIntegervRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetIntegervRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4461,7 +4461,7 @@ impl GetLightfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetLightfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4566,7 +4566,7 @@ impl GetLightivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetLightivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4671,7 +4671,7 @@ impl GetMapdvRequest {
         let query_bytes = self.query.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMapdvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4776,7 +4776,7 @@ impl GetMapfvRequest {
         let query_bytes = self.query.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMapfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4881,7 +4881,7 @@ impl GetMapivRequest {
         let query_bytes = self.query.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMapivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -4986,7 +4986,7 @@ impl GetMaterialfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMaterialfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5091,7 +5091,7 @@ impl GetMaterialivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMaterialivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5194,7 +5194,7 @@ impl GetPixelMapfvRequest {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPixelMapfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5292,7 +5292,7 @@ impl GetPixelMapuivRequest {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPixelMapuivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5390,7 +5390,7 @@ impl GetPixelMapusvRequest {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPixelMapusvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5488,7 +5488,7 @@ impl GetPolygonStippleRequest {
         let lsb_first_bytes = self.lsb_first.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPolygonStippleRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5583,7 +5583,7 @@ impl GetStringRequest {
         let name_bytes = self.name.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetStringRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5682,7 +5682,7 @@ impl GetTexEnvfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexEnvfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5787,7 +5787,7 @@ impl GetTexEnvivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexEnvivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5892,7 +5892,7 @@ impl GetTexGendvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexGendvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -5997,7 +5997,7 @@ impl GetTexGenfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexGenfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6102,7 +6102,7 @@ impl GetTexGenivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexGenivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6213,7 +6213,7 @@ impl GetTexImageRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexImageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6337,7 +6337,7 @@ impl GetTexParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexParameterfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6442,7 +6442,7 @@ impl GetTexParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexParameterivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6549,7 +6549,7 @@ impl GetTexLevelParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexLevelParameterfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6661,7 +6661,7 @@ impl GetTexLevelParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetTexLevelParameterivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6769,7 +6769,7 @@ impl IsEnabledRequest {
         let capability_bytes = self.capability.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            IsEnabledRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6847,7 +6847,7 @@ impl IsListRequest {
         let list_bytes = self.list.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            IsListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6923,7 +6923,7 @@ impl FlushRequest {
         let context_tag_bytes = self.context_tag.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FlushRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -6972,7 +6972,7 @@ impl<'input> AreTexturesResidentRequest<'input> {
         let n_bytes = n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AreTexturesResidentRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7073,7 +7073,7 @@ impl<'input> DeleteTexturesRequest<'input> {
         let n_bytes = n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteTexturesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7130,7 +7130,7 @@ impl GenTexturesRequest {
         let n_bytes = self.n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GenTexturesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7223,7 +7223,7 @@ impl IsTextureRequest {
         let texture_bytes = self.texture.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            IsTextureRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7307,7 +7307,7 @@ impl GetColorTableRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetColorTableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7422,7 +7422,7 @@ impl GetColorTableParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetColorTableParameterfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7527,7 +7527,7 @@ impl GetColorTableParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetColorTableParameterivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7636,7 +7636,7 @@ impl GetConvolutionFilterRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetConvolutionFilterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7753,7 +7753,7 @@ impl GetConvolutionParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetConvolutionParameterfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7858,7 +7858,7 @@ impl GetConvolutionParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetConvolutionParameterivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -7967,7 +7967,7 @@ impl GetSeparableFilterRequest {
         let swap_bytes_bytes = self.swap_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetSeparableFilterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8090,7 +8090,7 @@ impl GetHistogramRequest {
         let reset_bytes = self.reset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetHistogramRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8206,7 +8206,7 @@ impl GetHistogramParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetHistogramParameterfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8311,7 +8311,7 @@ impl GetHistogramParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetHistogramParameterivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8422,7 +8422,7 @@ impl GetMinmaxRequest {
         let reset_bytes = self.reset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMinmaxRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8535,7 +8535,7 @@ impl GetMinmaxParameterfvRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMinmaxParameterfvRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8640,7 +8640,7 @@ impl GetMinmaxParameterivRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMinmaxParameterivRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8745,7 +8745,7 @@ impl GetCompressedTexImageARBRequest {
         let level_bytes = self.level.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCompressedTexImageARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8849,7 +8849,7 @@ impl<'input> DeleteQueriesARBRequest<'input> {
         let n_bytes = n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteQueriesARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8906,7 +8906,7 @@ impl GenQueriesARBRequest {
         let n_bytes = self.n.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GenQueriesARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -8999,7 +8999,7 @@ impl IsQueryARBRequest {
         let id_bytes = self.id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            IsQueryARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -9079,7 +9079,7 @@ impl GetQueryivARBRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetQueryivARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -9184,7 +9184,7 @@ impl GetQueryObjectivARBRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetQueryObjectivARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],
@@ -9289,7 +9289,7 @@ impl GetQueryObjectuivARBRequest {
         let pname_bytes = self.pname.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetQueryObjectuivARBRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_tag_bytes[0],

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -509,7 +508,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -601,7 +600,7 @@ impl<'input> PixmapRequest<'input> {
     /// Opcode for the Pixmap request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -704,7 +703,7 @@ impl<'input> PixmapRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), notifies_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), notifies_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn pixmap<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &'input [Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -745,7 +744,7 @@ impl NotifyMSCRequest {
     /// Opcode for the NotifyMSC request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -834,7 +833,7 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -893,7 +892,7 @@ impl QueryCapabilitiesRequest {
     /// Opcode for the QueryCapabilities request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -521,7 +521,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -626,7 +626,7 @@ impl<'input> PixmapRequest<'input> {
         let remainder_bytes = self.remainder.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -762,7 +762,7 @@ impl NotifyMSCRequest {
         let remainder_bytes = self.remainder.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            NotifyMSCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -850,7 +850,7 @@ impl SelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             eid_bytes[0],
@@ -908,7 +908,7 @@ impl QueryCapabilitiesRequest {
         let target_bytes = self.target.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryCapabilitiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             target_bytes[0],

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -560,7 +560,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Pixmap request
 pub const PIXMAP_REQUEST: u8 = 1;
-pub fn pixmap<'c, Conn>(conn: &'c Conn, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn pixmap<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &'input [Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1120,7 +1120,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_version(self, major_version, minor_version)
     }
-    fn present_pixmap<'c>(&'c self, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &[Notify]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn present_pixmap<'c, 'input>(&'c self, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &'input [Notify]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         self::pixmap(self, window, pixmap, serial, valid, update, x_off, y_off, target_crtc, wait_fence, idle_fence, options, target_msc, divisor, remainder, notifies)
     }

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -545,8 +545,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -714,21 +714,21 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PixmapRequest {
-        window: window,
-        pixmap: pixmap,
-        serial: serial,
-        valid: valid,
-        update: update,
-        x_off: x_off,
-        y_off: y_off,
-        target_crtc: target_crtc,
-        wait_fence: wait_fence,
-        idle_fence: idle_fence,
-        options: options,
-        target_msc: target_msc,
-        divisor: divisor,
-        remainder: remainder,
-        notifies: notifies,
+        window,
+        pixmap,
+        serial,
+        valid,
+        update,
+        x_off,
+        y_off,
+        target_crtc,
+        wait_fence,
+        idle_fence,
+        options,
+        target_msc,
+        divisor,
+        remainder,
+        notifies,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -814,11 +814,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = NotifyMSCRequest {
-        window: window,
-        serial: serial,
-        target_msc: target_msc,
-        divisor: divisor,
-        remainder: remainder,
+        window,
+        serial,
+        target_msc,
+        divisor,
+        remainder,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -880,9 +880,9 @@ where
 {
     let event_mask: u32 = event_mask.into();
     let request0 = SelectInputRequest {
-        eid: eid,
-        window: window,
-        event_mask: event_mask,
+        eid,
+        window,
+        event_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -928,7 +928,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryCapabilitiesRequest {
-        target: target,
+        target,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -499,14 +499,14 @@ impl Serialize for Notify {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -519,7 +519,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -578,6 +578,8 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the Pixmap request
+pub const PIXMAP_REQUEST: u8 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PixmapRequest<'input> {
     pub window: xproto::Window,
@@ -597,8 +599,6 @@ pub struct PixmapRequest<'input> {
     pub notifies: &'input [Notify],
 }
 impl<'input> PixmapRequest<'input> {
-    /// Opcode for the Pixmap request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -623,7 +623,7 @@ impl<'input> PixmapRequest<'input> {
         let remainder_bytes = self.remainder.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PIXMAP_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -732,6 +732,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the NotifyMSC request
+pub const NOTIFY_MSC_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NotifyMSCRequest {
     pub window: xproto::Window,
@@ -741,8 +743,6 @@ pub struct NotifyMSCRequest {
     pub remainder: u64,
 }
 impl NotifyMSCRequest {
-    /// Opcode for the NotifyMSC request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -758,7 +758,7 @@ impl NotifyMSCRequest {
         let remainder_bytes = self.remainder.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            NOTIFY_MSC_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -823,6 +823,8 @@ where
 
 pub type Event = u32;
 
+/// Opcode for the SelectInput request
+pub const SELECT_INPUT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectInputRequest {
     pub eid: Event,
@@ -830,8 +832,6 @@ pub struct SelectInputRequest {
     pub event_mask: u32,
 }
 impl SelectInputRequest {
-    /// Opcode for the SelectInput request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -845,7 +845,7 @@ impl SelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_INPUT_REQUEST,
             0,
             0,
             eid_bytes[0],
@@ -884,13 +884,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryCapabilities request
+pub const QUERY_CAPABILITIES_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryCapabilitiesRequest {
     pub target: u32,
 }
 impl QueryCapabilitiesRequest {
-    /// Opcode for the QueryCapabilities request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -902,7 +902,7 @@ impl QueryCapabilitiesRequest {
         let target_bytes = self.target.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_CAPABILITIES_REQUEST,
             0,
             0,
             target_bytes[0],

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -509,7 +509,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -602,7 +601,6 @@ impl<'input> PixmapRequest<'input> {
     /// Opcode for the Pixmap request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -747,7 +745,6 @@ impl NotifyMSCRequest {
     /// Opcode for the NotifyMSC request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -837,7 +834,6 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -897,7 +893,6 @@ impl QueryCapabilitiesRequest {
     /// Opcode for the QueryCapabilities request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -510,7 +510,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -663,7 +662,6 @@ impl SetScreenConfigRequest {
     /// Opcode for the SetScreenConfig request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -854,7 +852,6 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -908,7 +905,6 @@ impl GetScreenInfoRequest {
     /// Opcode for the GetScreenInfo request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1013,7 +1009,6 @@ impl GetScreenSizeRangeRequest {
     /// Opcode for the GetScreenSizeRange request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1095,7 +1090,6 @@ impl SetScreenSizeRequest {
     /// Opcode for the SetScreenSize request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1354,7 +1348,6 @@ impl GetScreenResourcesRequest {
     /// Opcode for the GetScreenResources request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1561,7 +1554,6 @@ impl GetOutputInfoRequest {
     /// Opcode for the GetOutputInfo request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1721,7 +1713,6 @@ impl ListOutputPropertiesRequest {
     /// Opcode for the ListOutputProperties request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1810,7 +1801,6 @@ impl QueryOutputPropertyRequest {
     /// Opcode for the QueryOutputProperty request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1912,7 +1902,6 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
     /// Opcode for the ConfigureOutputProperty request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1983,7 +1972,6 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
     /// Opcode for the ChangeOutputProperty request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2061,7 +2049,6 @@ impl DeleteOutputPropertyRequest {
     /// Opcode for the DeleteOutputProperty request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2119,7 +2106,6 @@ impl GetOutputPropertyRequest {
     /// Opcode for the GetOutputProperty request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2235,7 +2221,6 @@ impl<'input> CreateModeRequest<'input> {
     /// Opcode for the CreateMode request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2345,7 +2330,6 @@ impl DestroyModeRequest {
     /// Opcode for the DestroyMode request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2392,7 +2376,6 @@ impl AddOutputModeRequest {
     /// Opcode for the AddOutputMode request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2445,7 +2428,6 @@ impl DeleteOutputModeRequest {
     /// Opcode for the DeleteOutputMode request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2498,7 +2480,6 @@ impl GetCrtcInfoRequest {
     /// Opcode for the GetCrtcInfo request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2632,7 +2613,6 @@ impl<'input> SetCrtcConfigRequest<'input> {
     /// Opcode for the SetCrtcConfig request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2745,7 +2725,6 @@ impl GetCrtcGammaSizeRequest {
     /// Opcode for the GetCrtcGammaSize request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2817,7 +2796,6 @@ impl GetCrtcGammaRequest {
     /// Opcode for the GetCrtcGamma request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2912,7 +2890,6 @@ impl<'input> SetCrtcGammaRequest<'input> {
     /// Opcode for the SetCrtcGamma request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2977,7 +2954,6 @@ impl GetScreenResourcesCurrentRequest {
     /// Opcode for the GetScreenResourcesCurrent request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3190,7 +3166,6 @@ impl<'input> SetCrtcTransformRequest<'input> {
     /// Opcode for the SetCrtcTransform request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3289,7 +3264,6 @@ impl GetCrtcTransformRequest {
     /// Opcode for the GetCrtcTransform request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3443,7 +3417,6 @@ impl GetPanningRequest {
     /// Opcode for the GetPanning request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3553,7 +3526,6 @@ impl SetPanningRequest {
     /// Opcode for the SetPanning request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3681,7 +3653,6 @@ impl SetOutputPrimaryRequest {
     /// Opcode for the SetOutputPrimary request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3733,7 +3704,6 @@ impl GetOutputPrimaryRequest {
     /// Opcode for the GetOutputPrimary request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3804,7 +3774,6 @@ impl GetProvidersRequest {
     /// Opcode for the GetProviders request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3964,7 +3933,6 @@ impl GetProviderInfoRequest {
     /// Opcode for the GetProviderInfo request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4116,7 +4084,6 @@ impl SetProviderOffloadSinkRequest {
     /// Opcode for the SetProviderOffloadSink request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4176,7 +4143,6 @@ impl SetProviderOutputSourceRequest {
     /// Opcode for the SetProviderOutputSource request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4234,7 +4200,6 @@ impl ListProviderPropertiesRequest {
     /// Opcode for the ListProviderProperties request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4323,7 +4288,6 @@ impl QueryProviderPropertyRequest {
     /// Opcode for the QueryProviderProperty request
     pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4425,7 +4389,6 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
     /// Opcode for the ConfigureProviderProperty request
     pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4496,7 +4459,6 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
     /// Opcode for the ChangeProviderProperty request
     pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4574,7 +4536,6 @@ impl DeleteProviderPropertyRequest {
     /// Opcode for the DeleteProviderProperty request
     pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4632,7 +4593,6 @@ impl GetProviderPropertyRequest {
     /// Opcode for the GetProviderProperty request
     pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5467,7 +5427,6 @@ impl GetMonitorsRequest {
     /// Opcode for the GetMonitors request
     pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5566,7 +5525,6 @@ impl SetMonitorRequest {
     /// Opcode for the SetMonitor request
     pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5618,7 +5576,6 @@ impl DeleteMonitorRequest {
     /// Opcode for the DeleteMonitor request
     pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5673,7 +5630,6 @@ impl<'input> CreateLeaseRequest<'input> {
     /// Opcode for the CreateLease request
     pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5771,7 +5727,6 @@ impl FreeLeaseRequest {
     /// Opcode for the FreeLease request
     pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -546,8 +546,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -717,12 +717,12 @@ where
 {
     let rotation: u16 = rotation.into();
     let request0 = SetScreenConfigRequest {
-        window: window,
-        timestamp: timestamp,
-        config_timestamp: config_timestamp,
-        size_id: size_id,
-        rotation: rotation,
-        rate: rate,
+        window,
+        timestamp,
+        config_timestamp,
+        size_id,
+        rotation,
+        rate,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -892,8 +892,8 @@ where
 {
     let enable: u16 = enable.into();
     let request0 = SelectInputRequest {
-        window: window,
-        enable: enable,
+        window,
+        enable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -939,7 +939,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetScreenInfoRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1044,7 +1044,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetScreenSizeRangeRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1142,11 +1142,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetScreenSizeRequest {
-        window: window,
-        width: width,
-        height: height,
-        mm_width: mm_width,
-        mm_height: mm_height,
+        window,
+        width,
+        height,
+        mm_width,
+        mm_height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1385,7 +1385,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetScreenResourcesRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1597,8 +1597,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetOutputInfoRequest {
-        output: output,
-        config_timestamp: config_timestamp,
+        output,
+        config_timestamp,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1752,7 +1752,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListOutputPropertiesRequest {
-        output: output,
+        output,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1846,8 +1846,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryOutputPropertyRequest {
-        output: output,
-        property: property,
+        output,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1958,11 +1958,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ConfigureOutputPropertyRequest {
-        output: output,
-        property: property,
-        pending: pending,
-        range: range,
-        values: values,
+        output,
+        property,
+        pending,
+        range,
+        values,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2039,13 +2039,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeOutputPropertyRequest {
-        output: output,
-        property: property,
-        type_: type_,
-        format: format,
-        mode: mode,
-        num_units: num_units,
-        data: data,
+        output,
+        property,
+        type_,
+        format,
+        mode,
+        num_units,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2097,8 +2097,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteOutputPropertyRequest {
-        output: output,
-        property: property,
+        output,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2178,13 +2178,13 @@ where
 {
     let type_: xproto::Atom = type_.into();
     let request0 = GetOutputPropertyRequest {
-        output: output,
-        property: property,
-        type_: type_,
-        long_offset: long_offset,
-        long_length: long_length,
-        delete: delete,
-        pending: pending,
+        output,
+        property,
+        type_,
+        long_offset,
+        long_length,
+        delete,
+        pending,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2302,9 +2302,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateModeRequest {
-        window: window,
-        mode_info: mode_info,
-        name: name,
+        window,
+        mode_info,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2376,7 +2376,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyModeRequest {
-        mode: mode,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2428,8 +2428,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AddOutputModeRequest {
-        output: output,
-        mode: mode,
+        output,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2481,8 +2481,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteOutputModeRequest {
-        output: output,
-        mode: mode,
+        output,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2534,8 +2534,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetCrtcInfoRequest {
-        crtc: crtc,
-        config_timestamp: config_timestamp,
+        crtc,
+        config_timestamp,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2695,14 +2695,14 @@ where
 {
     let rotation: u16 = rotation.into();
     let request0 = SetCrtcConfigRequest {
-        crtc: crtc,
-        timestamp: timestamp,
-        config_timestamp: config_timestamp,
-        x: x,
-        y: y,
-        mode: mode,
-        rotation: rotation,
-        outputs: outputs,
+        crtc,
+        timestamp,
+        config_timestamp,
+        x,
+        y,
+        mode,
+        rotation,
+        outputs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2776,7 +2776,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetCrtcGammaSizeRequest {
-        crtc: crtc,
+        crtc,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2848,7 +2848,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetCrtcGammaRequest {
-        crtc: crtc,
+        crtc,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2959,10 +2959,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetCrtcGammaRequest {
-        crtc: crtc,
-        red: red,
-        green: green,
-        blue: blue,
+        crtc,
+        red,
+        green,
+        blue,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3008,7 +3008,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetScreenResourcesCurrentRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3271,10 +3271,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetCrtcTransformRequest {
-        crtc: crtc,
-        transform: transform,
-        filter_name: filter_name,
-        filter_params: filter_params,
+        crtc,
+        transform,
+        filter_name,
+        filter_params,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3320,7 +3320,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetCrtcTransformRequest {
-        crtc: crtc,
+        crtc,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3474,7 +3474,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPanningRequest {
-        crtc: crtc,
+        crtc,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3625,20 +3625,20 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPanningRequest {
-        crtc: crtc,
-        timestamp: timestamp,
-        left: left,
-        top: top,
-        width: width,
-        height: height,
-        track_left: track_left,
-        track_top: track_top,
-        track_width: track_width,
-        track_height: track_height,
-        border_left: border_left,
-        border_top: border_top,
-        border_right: border_right,
-        border_bottom: border_bottom,
+        crtc,
+        timestamp,
+        left,
+        top,
+        width,
+        height,
+        track_left,
+        track_top,
+        track_width,
+        track_height,
+        border_left,
+        border_top,
+        border_right,
+        border_bottom,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3717,8 +3717,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetOutputPrimaryRequest {
-        window: window,
-        output: output,
+        window,
+        output,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3764,7 +3764,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetOutputPrimaryRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3835,7 +3835,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetProvidersRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4000,8 +4000,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetProviderInfoRequest {
-        provider: provider,
-        config_timestamp: config_timestamp,
+        provider,
+        config_timestamp,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4157,9 +4157,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetProviderOffloadSinkRequest {
-        provider: provider,
-        sink_provider: sink_provider,
-        config_timestamp: config_timestamp,
+        provider,
+        sink_provider,
+        config_timestamp,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4217,9 +4217,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetProviderOutputSourceRequest {
-        provider: provider,
-        source_provider: source_provider,
-        config_timestamp: config_timestamp,
+        provider,
+        source_provider,
+        config_timestamp,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4265,7 +4265,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListProviderPropertiesRequest {
-        provider: provider,
+        provider,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4359,8 +4359,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryProviderPropertyRequest {
-        provider: provider,
-        property: property,
+        provider,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4471,11 +4471,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ConfigureProviderPropertyRequest {
-        provider: provider,
-        property: property,
-        pending: pending,
-        range: range,
-        values: values,
+        provider,
+        property,
+        pending,
+        range,
+        values,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4552,13 +4552,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeProviderPropertyRequest {
-        provider: provider,
-        property: property,
-        type_: type_,
-        format: format,
-        mode: mode,
-        num_items: num_items,
-        data: data,
+        provider,
+        property,
+        type_,
+        format,
+        mode,
+        num_items,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4610,8 +4610,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteProviderPropertyRequest {
-        provider: provider,
-        property: property,
+        provider,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4689,13 +4689,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetProviderPropertyRequest {
-        provider: provider,
-        property: property,
-        type_: type_,
-        long_offset: long_offset,
-        long_length: long_length,
-        delete: delete,
-        pending: pending,
+        provider,
+        property,
+        type_,
+        long_offset,
+        long_length,
+        delete,
+        pending,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5503,8 +5503,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMonitorsRequest {
-        window: window,
-        get_active: get_active,
+        window,
+        get_active,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5601,8 +5601,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetMonitorRequest {
-        window: window,
-        monitorinfo: monitorinfo,
+        window,
+        monitorinfo,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5654,8 +5654,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteMonitorRequest {
-        window: window,
-        name: name,
+        window,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5723,10 +5723,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateLeaseRequest {
-        window: window,
-        lid: lid,
-        crtcs: crtcs,
-        outputs: outputs,
+        window,
+        lid,
+        crtcs,
+        outputs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5807,8 +5807,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeLeaseRequest {
-        lid: lid,
-        terminate: terminate,
+        lid,
+        terminate,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -1685,7 +1685,7 @@ impl QueryOutputPropertyReply {
 
 /// Opcode for the ConfigureOutputProperty request
 pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
-pub fn configure_output_property<'c, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1727,7 +1727,7 @@ where
 
 /// Opcode for the ChangeOutputProperty request
 pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
-pub fn change_output_property<'c, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1900,7 +1900,7 @@ impl TryFrom<&[u8]> for GetOutputPropertyReply {
 
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
-pub fn create_mode<'c, Conn>(conn: &'c Conn, window: xproto::Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
+pub fn create_mode<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode_info: ModeInfo, name: &'input [u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2187,7 +2187,7 @@ impl GetCrtcInfoReply {
 
 /// Opcode for the SetCrtcConfig request
 pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
-pub fn set_crtc_config<'c, Conn, A>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &[Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
+pub fn set_crtc_config<'c, 'input, Conn, A>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &'input [Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
@@ -2400,7 +2400,7 @@ impl GetCrtcGammaReply {
 
 /// Opcode for the SetCrtcGamma request
 pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
-pub fn set_crtc_gamma<'c, Conn>(conn: &'c Conn, crtc: Crtc, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_crtc_gamma<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2634,7 +2634,7 @@ bitmask_binop!(Transform, u8);
 
 /// Opcode for the SetCrtcTransform request
 pub const SET_CRTC_TRANSFORM_REQUEST: u8 = 26;
-pub fn set_crtc_transform<'c, Conn>(conn: &'c Conn, crtc: Crtc, transform: render::Transform, filter_name: &[u8], filter_params: &[render::Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_crtc_transform<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, transform: render::Transform, filter_name: &'input [u8], filter_params: &'input [render::Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3594,7 +3594,7 @@ impl QueryProviderPropertyReply {
 
 /// Opcode for the ConfigureProviderProperty request
 pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
-pub fn configure_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3636,7 +3636,7 @@ where
 
 /// Opcode for the ChangeProviderProperty request
 pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
-pub fn change_provider_property<'c, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -4670,7 +4670,7 @@ where
 
 /// Opcode for the CreateLease request
 pub const CREATE_LEASE_REQUEST: u8 = 45;
-pub fn create_lease<'c, Conn>(conn: &'c Conn, window: xproto::Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
+pub fn create_lease<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, lid: Lease, crtcs: &'input [Crtc], outputs: &'input [Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -5089,11 +5089,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_output_property(self, output, property)
     }
-    fn randr_configure_output_property<'c>(&'c self, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_configure_output_property<'c, 'input>(&'c self, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_output_property(self, output, property, pending, range, values)
     }
-    fn randr_change_output_property<'c>(&'c self, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_change_output_property<'c, 'input>(&'c self, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_output_property(self, output, property, type_, format, mode, num_units, data)
     }
@@ -5107,7 +5107,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_output_property(self, output, property, type_, long_offset, long_length, delete, pending)
     }
-    fn randr_create_mode<'c>(&'c self, window: xproto::Window, mode_info: ModeInfo, name: &[u8]) -> Result<Cookie<'c, Self, CreateModeReply>, ConnectionError>
+    fn randr_create_mode<'c, 'input>(&'c self, window: xproto::Window, mode_info: ModeInfo, name: &'input [u8]) -> Result<Cookie<'c, Self, CreateModeReply>, ConnectionError>
     {
         create_mode(self, window, mode_info, name)
     }
@@ -5127,7 +5127,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_crtc_info(self, crtc, config_timestamp)
     }
-    fn randr_set_crtc_config<'c, A>(&'c self, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &[Output]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
+    fn randr_set_crtc_config<'c, 'input, A>(&'c self, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &'input [Output]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
     where
         A: Into<u16>,
     {
@@ -5141,7 +5141,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_crtc_gamma(self, crtc)
     }
-    fn randr_set_crtc_gamma<'c>(&'c self, crtc: Crtc, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_set_crtc_gamma<'c, 'input>(&'c self, crtc: Crtc, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_crtc_gamma(self, crtc, red, green, blue)
     }
@@ -5149,7 +5149,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_screen_resources_current(self, window)
     }
-    fn randr_set_crtc_transform<'c>(&'c self, crtc: Crtc, transform: render::Transform, filter_name: &[u8], filter_params: &[render::Fixed]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_set_crtc_transform<'c, 'input>(&'c self, crtc: Crtc, transform: render::Transform, filter_name: &'input [u8], filter_params: &'input [render::Fixed]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_crtc_transform(self, crtc, transform, filter_name, filter_params)
     }
@@ -5197,11 +5197,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_provider_property(self, provider, property)
     }
-    fn randr_configure_provider_property<'c>(&'c self, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &[i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_configure_provider_property<'c, 'input>(&'c self, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_provider_property(self, provider, property, pending, range, values)
     }
-    fn randr_change_provider_property<'c>(&'c self, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn randr_change_provider_property<'c, 'input>(&'c self, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_provider_property(self, provider, property, type_, format, mode, num_items, data)
     }
@@ -5225,7 +5225,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         delete_monitor(self, window, name)
     }
-    fn randr_create_lease<'c>(&'c self, window: xproto::Window, lid: Lease, crtcs: &[Crtc], outputs: &[Output]) -> Result<CookieWithFds<'c, Self, CreateLeaseReply>, ConnectionError>
+    fn randr_create_lease<'c, 'input>(&'c self, window: xproto::Window, lid: Lease, crtcs: &'input [Crtc], outputs: &'input [Output]) -> Result<CookieWithFds<'c, Self, CreateLeaseReply>, ConnectionError>
     {
         create_lease(self, window, lid, crtcs, outputs)
     }

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -500,14 +500,14 @@ impl RefreshRates {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -520,7 +520,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -648,6 +648,8 @@ impl TryFrom<u32> for SetConfig {
     }
 }
 
+/// Opcode for the SetScreenConfig request
+pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetScreenConfigRequest {
     pub window: xproto::Window,
@@ -658,8 +660,6 @@ pub struct SetScreenConfigRequest {
     pub rate: u16,
 }
 impl SetScreenConfigRequest {
-    /// Opcode for the SetScreenConfig request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -676,7 +676,7 @@ impl SetScreenConfigRequest {
         let rate_bytes = self.rate.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_SCREEN_CONFIG_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -842,14 +842,14 @@ impl TryFrom<u32> for NotifyMask {
 }
 bitmask_binop!(NotifyMask, u8);
 
+/// Opcode for the SelectInput request
+pub const SELECT_INPUT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectInputRequest {
     pub window: xproto::Window,
     pub enable: u16,
 }
 impl SelectInputRequest {
-    /// Opcode for the SelectInput request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -862,7 +862,7 @@ impl SelectInputRequest {
         let enable_bytes = self.enable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_INPUT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -896,13 +896,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetScreenInfo request
+pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetScreenInfoRequest {
     pub window: xproto::Window,
 }
 impl GetScreenInfoRequest {
-    /// Opcode for the GetScreenInfo request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -914,7 +914,7 @@ impl GetScreenInfoRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SCREEN_INFO_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1000,13 +1000,13 @@ impl GetScreenInfoReply {
     }
 }
 
+/// Opcode for the GetScreenSizeRange request
+pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetScreenSizeRangeRequest {
     pub window: xproto::Window,
 }
 impl GetScreenSizeRangeRequest {
-    /// Opcode for the GetScreenSizeRange request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1018,7 +1018,7 @@ impl GetScreenSizeRangeRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SCREEN_SIZE_RANGE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1077,6 +1077,8 @@ impl TryFrom<&[u8]> for GetScreenSizeRangeReply {
     }
 }
 
+/// Opcode for the SetScreenSize request
+pub const SET_SCREEN_SIZE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetScreenSizeRequest {
     pub window: xproto::Window,
@@ -1086,8 +1088,6 @@ pub struct SetScreenSizeRequest {
     pub mm_height: u32,
 }
 impl SetScreenSizeRequest {
-    /// Opcode for the SetScreenSize request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1103,7 +1103,7 @@ impl SetScreenSizeRequest {
         let mm_height_bytes = self.mm_height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_SCREEN_SIZE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1339,13 +1339,13 @@ impl Serialize for ModeInfo {
     }
 }
 
+/// Opcode for the GetScreenResources request
+pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetScreenResourcesRequest {
     pub window: xproto::Window,
 }
 impl GetScreenResourcesRequest {
-    /// Opcode for the GetScreenResources request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1357,7 +1357,7 @@ impl GetScreenResourcesRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SCREEN_RESOURCES_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1544,14 +1544,14 @@ impl TryFrom<u32> for Connection {
     }
 }
 
+/// Opcode for the GetOutputInfo request
+pub const GET_OUTPUT_INFO_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetOutputInfoRequest {
     pub output: Output,
     pub config_timestamp: xproto::Timestamp,
 }
 impl GetOutputInfoRequest {
-    /// Opcode for the GetOutputInfo request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1564,7 +1564,7 @@ impl GetOutputInfoRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_OUTPUT_INFO_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -1704,13 +1704,13 @@ impl GetOutputInfoReply {
     }
 }
 
+/// Opcode for the ListOutputProperties request
+pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListOutputPropertiesRequest {
     pub output: Output,
 }
 impl ListOutputPropertiesRequest {
-    /// Opcode for the ListOutputProperties request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1722,7 +1722,7 @@ impl ListOutputPropertiesRequest {
         let output_bytes = self.output.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_OUTPUT_PROPERTIES_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -1791,14 +1791,14 @@ impl ListOutputPropertiesReply {
     }
 }
 
+/// Opcode for the QueryOutputProperty request
+pub const QUERY_OUTPUT_PROPERTY_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
 }
 impl QueryOutputPropertyRequest {
-    /// Opcode for the QueryOutputProperty request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1811,7 +1811,7 @@ impl QueryOutputPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_OUTPUT_PROPERTY_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -1889,6 +1889,8 @@ impl QueryOutputPropertyReply {
     }
 }
 
+/// Opcode for the ConfigureOutputProperty request
+pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConfigureOutputPropertyRequest<'input> {
     pub output: Output,
@@ -1898,8 +1900,6 @@ pub struct ConfigureOutputPropertyRequest<'input> {
     pub values: &'input [i32],
 }
 impl<'input> ConfigureOutputPropertyRequest<'input> {
-    /// Opcode for the ConfigureOutputProperty request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1914,7 +1914,7 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CONFIGURE_OUTPUT_PROPERTY_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -1957,6 +1957,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ChangeOutputProperty request
+pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeOutputPropertyRequest<'input> {
     pub output: Output,
@@ -1968,8 +1970,6 @@ pub struct ChangeOutputPropertyRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> ChangeOutputPropertyRequest<'input> {
-    /// Opcode for the ChangeOutputProperty request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1986,7 +1986,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         let num_units_bytes = self.num_units.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_OUTPUT_PROPERTY_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -2039,14 +2039,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteOutputProperty request
+pub const DELETE_OUTPUT_PROPERTY_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
 }
 impl DeleteOutputPropertyRequest {
-    /// Opcode for the DeleteOutputProperty request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2059,7 +2059,7 @@ impl DeleteOutputPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_OUTPUT_PROPERTY_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -2091,6 +2091,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetOutputProperty request
+pub const GET_OUTPUT_PROPERTY_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetOutputPropertyRequest {
     pub output: Output,
@@ -2102,8 +2104,6 @@ pub struct GetOutputPropertyRequest {
     pub pending: bool,
 }
 impl GetOutputPropertyRequest {
-    /// Opcode for the GetOutputProperty request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2121,7 +2121,7 @@ impl GetOutputPropertyRequest {
         let pending_bytes = self.pending.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_OUTPUT_PROPERTY_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -2210,6 +2210,8 @@ impl TryFrom<&[u8]> for GetOutputPropertyReply {
     }
 }
 
+/// Opcode for the CreateMode request
+pub const CREATE_MODE_REQUEST: u8 = 16;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateModeRequest<'input> {
     pub window: xproto::Window,
@@ -2217,8 +2219,6 @@ pub struct CreateModeRequest<'input> {
     pub name: &'input [u8],
 }
 impl<'input> CreateModeRequest<'input> {
-    /// Opcode for the CreateMode request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2231,7 +2231,7 @@ impl<'input> CreateModeRequest<'input> {
         let mode_info_bytes = self.mode_info.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_MODE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -2321,13 +2321,13 @@ impl TryFrom<&[u8]> for CreateModeReply {
     }
 }
 
+/// Opcode for the DestroyMode request
+pub const DESTROY_MODE_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyModeRequest {
     pub mode: Mode,
 }
 impl DestroyModeRequest {
-    /// Opcode for the DestroyMode request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2339,7 +2339,7 @@ impl DestroyModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_MODE_REQUEST,
             0,
             0,
             mode_bytes[0],
@@ -2366,14 +2366,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the AddOutputMode request
+pub const ADD_OUTPUT_MODE_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AddOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
 }
 impl AddOutputModeRequest {
-    /// Opcode for the AddOutputMode request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2386,7 +2386,7 @@ impl AddOutputModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ADD_OUTPUT_MODE_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -2418,14 +2418,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteOutputMode request
+pub const DELETE_OUTPUT_MODE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
 }
 impl DeleteOutputModeRequest {
-    /// Opcode for the DeleteOutputMode request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2438,7 +2438,7 @@ impl DeleteOutputModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_OUTPUT_MODE_REQUEST,
             0,
             0,
             output_bytes[0],
@@ -2470,14 +2470,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetCrtcInfo request
+pub const GET_CRTC_INFO_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCrtcInfoRequest {
     pub crtc: Crtc,
     pub config_timestamp: xproto::Timestamp,
 }
 impl GetCrtcInfoRequest {
-    /// Opcode for the GetCrtcInfo request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2490,7 +2490,7 @@ impl GetCrtcInfoRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CRTC_INFO_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -2597,6 +2597,8 @@ impl GetCrtcInfoReply {
     }
 }
 
+/// Opcode for the SetCrtcConfig request
+pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetCrtcConfigRequest<'input> {
     pub crtc: Crtc,
@@ -2609,8 +2611,6 @@ pub struct SetCrtcConfigRequest<'input> {
     pub outputs: &'input [Output],
 }
 impl<'input> SetCrtcConfigRequest<'input> {
-    /// Opcode for the SetCrtcConfig request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2628,7 +2628,7 @@ impl<'input> SetCrtcConfigRequest<'input> {
         let rotation_bytes = self.rotation.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CRTC_CONFIG_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -2716,13 +2716,13 @@ impl TryFrom<&[u8]> for SetCrtcConfigReply {
     }
 }
 
+/// Opcode for the GetCrtcGammaSize request
+pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCrtcGammaSizeRequest {
     pub crtc: Crtc,
 }
 impl GetCrtcGammaSizeRequest {
-    /// Opcode for the GetCrtcGammaSize request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2734,7 +2734,7 @@ impl GetCrtcGammaSizeRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CRTC_GAMMA_SIZE_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -2787,13 +2787,13 @@ impl TryFrom<&[u8]> for GetCrtcGammaSizeReply {
     }
 }
 
+/// Opcode for the GetCrtcGamma request
+pub const GET_CRTC_GAMMA_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCrtcGammaRequest {
     pub crtc: Crtc,
 }
 impl GetCrtcGammaRequest {
-    /// Opcode for the GetCrtcGamma request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2805,7 +2805,7 @@ impl GetCrtcGammaRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CRTC_GAMMA_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -2878,6 +2878,8 @@ impl GetCrtcGammaReply {
     }
 }
 
+/// Opcode for the SetCrtcGamma request
+pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetCrtcGammaRequest<'input> {
     pub crtc: Crtc,
@@ -2886,8 +2888,6 @@ pub struct SetCrtcGammaRequest<'input> {
     pub blue: &'input [u16],
 }
 impl<'input> SetCrtcGammaRequest<'input> {
-    /// Opcode for the SetCrtcGamma request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2901,7 +2901,7 @@ impl<'input> SetCrtcGammaRequest<'input> {
         let size_bytes = size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CRTC_GAMMA_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -2945,13 +2945,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetScreenResourcesCurrent request
+pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetScreenResourcesCurrentRequest {
     pub window: xproto::Window,
 }
 impl GetScreenResourcesCurrentRequest {
-    /// Opcode for the GetScreenResourcesCurrent request
-    pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2963,7 +2963,7 @@ impl GetScreenResourcesCurrentRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SCREEN_RESOURCES_CURRENT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -3154,6 +3154,8 @@ impl TryFrom<u32> for Transform {
 }
 bitmask_binop!(Transform, u8);
 
+/// Opcode for the SetCrtcTransform request
+pub const SET_CRTC_TRANSFORM_REQUEST: u8 = 26;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetCrtcTransformRequest<'input> {
     pub crtc: Crtc,
@@ -3162,8 +3164,6 @@ pub struct SetCrtcTransformRequest<'input> {
     pub filter_params: &'input [render::Fixed],
 }
 impl<'input> SetCrtcTransformRequest<'input> {
-    /// Opcode for the SetCrtcTransform request
-    pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3178,7 +3178,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
         let filter_len_bytes = filter_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CRTC_TRANSFORM_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -3255,13 +3255,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetCrtcTransform request
+pub const GET_CRTC_TRANSFORM_REQUEST: u8 = 27;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCrtcTransformRequest {
     pub crtc: Crtc,
 }
 impl GetCrtcTransformRequest {
-    /// Opcode for the GetCrtcTransform request
-    pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3273,7 +3273,7 @@ impl GetCrtcTransformRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CRTC_TRANSFORM_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -3408,13 +3408,13 @@ impl GetCrtcTransformReply {
     }
 }
 
+/// Opcode for the GetPanning request
+pub const GET_PANNING_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPanningRequest {
     pub crtc: Crtc,
 }
 impl GetPanningRequest {
-    /// Opcode for the GetPanning request
-    pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3426,7 +3426,7 @@ impl GetPanningRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PANNING_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -3504,6 +3504,8 @@ impl TryFrom<&[u8]> for GetPanningReply {
     }
 }
 
+/// Opcode for the SetPanning request
+pub const SET_PANNING_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetPanningRequest {
     pub crtc: Crtc,
@@ -3522,8 +3524,6 @@ pub struct SetPanningRequest {
     pub border_bottom: i16,
 }
 impl SetPanningRequest {
-    /// Opcode for the SetPanning request
-    pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3548,7 +3548,7 @@ impl SetPanningRequest {
         let border_bottom_bytes = self.border_bottom.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PANNING_REQUEST,
             0,
             0,
             crtc_bytes[0],
@@ -3643,14 +3643,14 @@ impl TryFrom<&[u8]> for SetPanningReply {
     }
 }
 
+/// Opcode for the SetOutputPrimary request
+pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetOutputPrimaryRequest {
     pub window: xproto::Window,
     pub output: Output,
 }
 impl SetOutputPrimaryRequest {
-    /// Opcode for the SetOutputPrimary request
-    pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3663,7 +3663,7 @@ impl SetOutputPrimaryRequest {
         let output_bytes = self.output.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_OUTPUT_PRIMARY_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -3695,13 +3695,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetOutputPrimary request
+pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetOutputPrimaryRequest {
     pub window: xproto::Window,
 }
 impl GetOutputPrimaryRequest {
-    /// Opcode for the GetOutputPrimary request
-    pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3713,7 +3713,7 @@ impl GetOutputPrimaryRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_OUTPUT_PRIMARY_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -3765,13 +3765,13 @@ impl TryFrom<&[u8]> for GetOutputPrimaryReply {
     }
 }
 
+/// Opcode for the GetProviders request
+pub const GET_PROVIDERS_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetProvidersRequest {
     pub window: xproto::Window,
 }
 impl GetProvidersRequest {
-    /// Opcode for the GetProviders request
-    pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3783,7 +3783,7 @@ impl GetProvidersRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PROVIDERS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -3923,14 +3923,14 @@ impl TryFrom<u32> for ProviderCapability {
 }
 bitmask_binop!(ProviderCapability, u8);
 
+/// Opcode for the GetProviderInfo request
+pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetProviderInfoRequest {
     pub provider: Provider,
     pub config_timestamp: xproto::Timestamp,
 }
 impl GetProviderInfoRequest {
-    /// Opcode for the GetProviderInfo request
-    pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3943,7 +3943,7 @@ impl GetProviderInfoRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PROVIDER_INFO_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4073,6 +4073,8 @@ impl GetProviderInfoReply {
     }
 }
 
+/// Opcode for the SetProviderOffloadSink request
+pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetProviderOffloadSinkRequest {
     pub provider: Provider,
@@ -4080,8 +4082,6 @@ pub struct SetProviderOffloadSinkRequest {
     pub config_timestamp: xproto::Timestamp,
 }
 impl SetProviderOffloadSinkRequest {
-    /// Opcode for the SetProviderOffloadSink request
-    pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4095,7 +4095,7 @@ impl SetProviderOffloadSinkRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PROVIDER_OFFLOAD_SINK_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4132,6 +4132,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetProviderOutputSource request
+pub const SET_PROVIDER_OUTPUT_SOURCE_REQUEST: u8 = 35;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetProviderOutputSourceRequest {
     pub provider: Provider,
@@ -4139,8 +4141,6 @@ pub struct SetProviderOutputSourceRequest {
     pub config_timestamp: xproto::Timestamp,
 }
 impl SetProviderOutputSourceRequest {
-    /// Opcode for the SetProviderOutputSource request
-    pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4154,7 +4154,7 @@ impl SetProviderOutputSourceRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PROVIDER_OUTPUT_SOURCE_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4191,13 +4191,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ListProviderProperties request
+pub const LIST_PROVIDER_PROPERTIES_REQUEST: u8 = 36;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListProviderPropertiesRequest {
     pub provider: Provider,
 }
 impl ListProviderPropertiesRequest {
-    /// Opcode for the ListProviderProperties request
-    pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4209,7 +4209,7 @@ impl ListProviderPropertiesRequest {
         let provider_bytes = self.provider.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_PROVIDER_PROPERTIES_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4278,14 +4278,14 @@ impl ListProviderPropertiesReply {
     }
 }
 
+/// Opcode for the QueryProviderProperty request
+pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
 }
 impl QueryProviderPropertyRequest {
-    /// Opcode for the QueryProviderProperty request
-    pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4298,7 +4298,7 @@ impl QueryProviderPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_PROVIDER_PROPERTY_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4376,6 +4376,8 @@ impl QueryProviderPropertyReply {
     }
 }
 
+/// Opcode for the ConfigureProviderProperty request
+pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConfigureProviderPropertyRequest<'input> {
     pub provider: Provider,
@@ -4385,8 +4387,6 @@ pub struct ConfigureProviderPropertyRequest<'input> {
     pub values: &'input [i32],
 }
 impl<'input> ConfigureProviderPropertyRequest<'input> {
-    /// Opcode for the ConfigureProviderProperty request
-    pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4401,7 +4401,7 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CONFIGURE_PROVIDER_PROPERTY_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4444,6 +4444,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ChangeProviderProperty request
+pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeProviderPropertyRequest<'input> {
     pub provider: Provider,
@@ -4455,8 +4457,6 @@ pub struct ChangeProviderPropertyRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> ChangeProviderPropertyRequest<'input> {
-    /// Opcode for the ChangeProviderProperty request
-    pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4473,7 +4473,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         let num_items_bytes = self.num_items.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_PROVIDER_PROPERTY_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4526,14 +4526,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteProviderProperty request
+pub const DELETE_PROVIDER_PROPERTY_REQUEST: u8 = 40;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
 }
 impl DeleteProviderPropertyRequest {
-    /// Opcode for the DeleteProviderProperty request
-    pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4546,7 +4546,7 @@ impl DeleteProviderPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_PROVIDER_PROPERTY_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -4578,6 +4578,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetProviderProperty request
+pub const GET_PROVIDER_PROPERTY_REQUEST: u8 = 41;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetProviderPropertyRequest {
     pub provider: Provider,
@@ -4589,8 +4591,6 @@ pub struct GetProviderPropertyRequest {
     pub pending: bool,
 }
 impl GetProviderPropertyRequest {
-    /// Opcode for the GetProviderProperty request
-    pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4608,7 +4608,7 @@ impl GetProviderPropertyRequest {
         let pending_bytes = self.pending.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PROVIDER_PROPERTY_REQUEST,
             0,
             0,
             provider_bytes[0],
@@ -5417,14 +5417,14 @@ impl MonitorInfo {
     }
 }
 
+/// Opcode for the GetMonitors request
+pub const GET_MONITORS_REQUEST: u8 = 42;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMonitorsRequest {
     pub window: xproto::Window,
     pub get_active: bool,
 }
 impl GetMonitorsRequest {
-    /// Opcode for the GetMonitors request
-    pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5437,7 +5437,7 @@ impl GetMonitorsRequest {
         let get_active_bytes = self.get_active.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MONITORS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -5515,14 +5515,14 @@ impl GetMonitorsReply {
     }
 }
 
+/// Opcode for the SetMonitor request
+pub const SET_MONITOR_REQUEST: u8 = 43;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetMonitorRequest {
     pub window: xproto::Window,
     pub monitorinfo: MonitorInfo,
 }
 impl SetMonitorRequest {
-    /// Opcode for the SetMonitor request
-    pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5534,7 +5534,7 @@ impl SetMonitorRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_MONITOR_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -5566,14 +5566,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteMonitor request
+pub const DELETE_MONITOR_REQUEST: u8 = 44;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteMonitorRequest {
     pub window: xproto::Window,
     pub name: xproto::Atom,
 }
 impl DeleteMonitorRequest {
-    /// Opcode for the DeleteMonitor request
-    pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5586,7 +5586,7 @@ impl DeleteMonitorRequest {
         let name_bytes = self.name.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_MONITOR_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -5618,6 +5618,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateLease request
+pub const CREATE_LEASE_REQUEST: u8 = 45;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateLeaseRequest<'input> {
     pub window: xproto::Window,
@@ -5626,8 +5628,6 @@ pub struct CreateLeaseRequest<'input> {
     pub outputs: &'input [Output],
 }
 impl<'input> CreateLeaseRequest<'input> {
-    /// Opcode for the CreateLease request
-    pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5644,7 +5644,7 @@ impl<'input> CreateLeaseRequest<'input> {
         let num_outputs_bytes = num_outputs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_LEASE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -5717,14 +5717,14 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for CreateLeaseReply {
     }
 }
 
+/// Opcode for the FreeLease request
+pub const FREE_LEASE_REQUEST: u8 = 46;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FreeLeaseRequest {
     pub lid: Lease,
     pub terminate: u8,
 }
 impl FreeLeaseRequest {
-    /// Opcode for the FreeLease request
-    pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5737,7 +5737,7 @@ impl FreeLeaseRequest {
         let terminate_bytes = self.terminate.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FREE_LEASE_REQUEST,
             0,
             0,
             lid_bytes[0],

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -510,7 +509,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -662,7 +661,7 @@ impl SetScreenConfigRequest {
     /// Opcode for the SetScreenConfig request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -852,7 +851,7 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -905,7 +904,7 @@ impl GetScreenInfoRequest {
     /// Opcode for the GetScreenInfo request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1009,7 +1008,7 @@ impl GetScreenSizeRangeRequest {
     /// Opcode for the GetScreenSizeRange request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1090,7 +1089,7 @@ impl SetScreenSizeRequest {
     /// Opcode for the SetScreenSize request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1348,7 +1347,7 @@ impl GetScreenResourcesRequest {
     /// Opcode for the GetScreenResources request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1554,7 +1553,7 @@ impl GetOutputInfoRequest {
     /// Opcode for the GetOutputInfo request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1713,7 +1712,7 @@ impl ListOutputPropertiesRequest {
     /// Opcode for the ListOutputProperties request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1801,7 +1800,7 @@ impl QueryOutputPropertyRequest {
     /// Opcode for the QueryOutputProperty request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1902,7 +1901,7 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
     /// Opcode for the ConfigureOutputProperty request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1939,7 +1938,7 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), values_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn configure_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1972,7 +1971,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
     /// Opcode for the ChangeOutputProperty request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2019,7 +2018,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn change_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2049,7 +2048,7 @@ impl DeleteOutputPropertyRequest {
     /// Opcode for the DeleteOutputProperty request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2106,7 +2105,7 @@ impl GetOutputPropertyRequest {
     /// Opcode for the GetOutputProperty request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2221,7 +2220,7 @@ impl<'input> CreateModeRequest<'input> {
     /// Opcode for the CreateMode request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2279,7 +2278,7 @@ impl<'input> CreateModeRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn create_mode<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode_info: ModeInfo, name: &'input [u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
@@ -2330,7 +2329,7 @@ impl DestroyModeRequest {
     /// Opcode for the DestroyMode request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2376,7 +2375,7 @@ impl AddOutputModeRequest {
     /// Opcode for the AddOutputMode request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2428,7 +2427,7 @@ impl DeleteOutputModeRequest {
     /// Opcode for the DeleteOutputMode request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2480,7 +2479,7 @@ impl GetCrtcInfoRequest {
     /// Opcode for the GetCrtcInfo request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2613,7 +2612,7 @@ impl<'input> SetCrtcConfigRequest<'input> {
     /// Opcode for the SetCrtcConfig request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2665,7 +2664,7 @@ impl<'input> SetCrtcConfigRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), outputs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), outputs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_crtc_config<'c, 'input, Conn, A>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &'input [Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
@@ -2725,7 +2724,7 @@ impl GetCrtcGammaSizeRequest {
     /// Opcode for the GetCrtcGammaSize request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2796,7 +2795,7 @@ impl GetCrtcGammaRequest {
     /// Opcode for the GetCrtcGamma request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2890,7 +2889,7 @@ impl<'input> SetCrtcGammaRequest<'input> {
     /// Opcode for the SetCrtcGamma request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2928,7 +2927,7 @@ impl<'input> SetCrtcGammaRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), red_bytes.into(), green_bytes.into(), blue_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), red_bytes.into(), green_bytes.into(), blue_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_crtc_gamma<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2954,7 +2953,7 @@ impl GetScreenResourcesCurrentRequest {
     /// Opcode for the GetScreenResourcesCurrent request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3166,7 +3165,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
     /// Opcode for the SetCrtcTransform request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3238,7 +3237,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.filter_name[..]).into(), padding0.into(), filter_params_bytes.into(), Cow::Borrowed(&padding1)], vec![]))
+        Ok((vec![request0.into(), (&self.filter_name[..]).into(), padding0.into(), filter_params_bytes.into(), padding1.into()], vec![]))
     }
 }
 pub fn set_crtc_transform<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, transform: render::Transform, filter_name: &'input [u8], filter_params: &'input [render::Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3264,7 +3263,7 @@ impl GetCrtcTransformRequest {
     /// Opcode for the GetCrtcTransform request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3417,7 +3416,7 @@ impl GetPanningRequest {
     /// Opcode for the GetPanning request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3526,7 +3525,7 @@ impl SetPanningRequest {
     /// Opcode for the SetPanning request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3653,7 +3652,7 @@ impl SetOutputPrimaryRequest {
     /// Opcode for the SetOutputPrimary request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3704,7 +3703,7 @@ impl GetOutputPrimaryRequest {
     /// Opcode for the GetOutputPrimary request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3774,7 +3773,7 @@ impl GetProvidersRequest {
     /// Opcode for the GetProviders request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3933,7 +3932,7 @@ impl GetProviderInfoRequest {
     /// Opcode for the GetProviderInfo request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4084,7 +4083,7 @@ impl SetProviderOffloadSinkRequest {
     /// Opcode for the SetProviderOffloadSink request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4143,7 +4142,7 @@ impl SetProviderOutputSourceRequest {
     /// Opcode for the SetProviderOutputSource request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4200,7 +4199,7 @@ impl ListProviderPropertiesRequest {
     /// Opcode for the ListProviderProperties request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4288,7 +4287,7 @@ impl QueryProviderPropertyRequest {
     /// Opcode for the QueryProviderProperty request
     pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4389,7 +4388,7 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
     /// Opcode for the ConfigureProviderProperty request
     pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4426,7 +4425,7 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), values_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn configure_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4459,7 +4458,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
     /// Opcode for the ChangeProviderProperty request
     pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4506,7 +4505,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn change_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4536,7 +4535,7 @@ impl DeleteProviderPropertyRequest {
     /// Opcode for the DeleteProviderProperty request
     pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4593,7 +4592,7 @@ impl GetProviderPropertyRequest {
     /// Opcode for the GetProviderProperty request
     pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5427,7 +5426,7 @@ impl GetMonitorsRequest {
     /// Opcode for the GetMonitors request
     pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5525,7 +5524,7 @@ impl SetMonitorRequest {
     /// Opcode for the SetMonitor request
     pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5551,7 +5550,7 @@ impl SetMonitorRequest {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), monitorinfo_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), monitorinfo_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_monitor<Conn>(conn: &Conn, window: xproto::Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Conn>, ConnectionError>
@@ -5576,7 +5575,7 @@ impl DeleteMonitorRequest {
     /// Opcode for the DeleteMonitor request
     pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5630,7 +5629,7 @@ impl<'input> CreateLeaseRequest<'input> {
     /// Opcode for the CreateLease request
     pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5671,7 +5670,7 @@ impl<'input> CreateLeaseRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), crtcs_bytes.into(), outputs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), crtcs_bytes.into(), outputs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_lease<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, lid: Lease, crtcs: &'input [Crtc], outputs: &'input [Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
@@ -5727,7 +5726,7 @@ impl FreeLeaseRequest {
     /// Opcode for the FreeLease request
     pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -500,36 +501,57 @@ impl RefreshRates {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest {
+    pub major_version: u32,
+    pub minor_version: u32,
+}
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn, major_version: u32, minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let major_version_bytes = major_version.serialize();
-    let minor_version_bytes = minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-        major_version_bytes[0],
-        major_version_bytes[1],
-        major_version_bytes[2],
-        major_version_bytes[3],
-        minor_version_bytes[0],
-        minor_version_bytes[1],
-        minor_version_bytes[2],
-        minor_version_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest {
+        major_version: major_version,
+        minor_version: minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -628,54 +650,83 @@ impl TryFrom<u32> for SetConfig {
     }
 }
 
-/// Opcode for the SetScreenConfig request
-pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetScreenConfigRequest {
+    pub window: xproto::Window,
+    pub timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
+    pub size_id: u16,
+    pub rotation: u16,
+    pub rate: u16,
+}
+impl SetScreenConfigRequest {
+    /// Opcode for the SetScreenConfig request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let size_id_bytes = self.size_id.serialize();
+        let rotation_bytes = self.rotation.serialize();
+        let rate_bytes = self.rate.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetScreenConfigRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+            size_id_bytes[0],
+            size_id_bytes[1],
+            rotation_bytes[0],
+            rotation_bytes[1],
+            rate_bytes[0],
+            rate_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_screen_config<Conn, A>(conn: &Conn, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: A, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let rotation: u16 = rotation.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let timestamp_bytes = timestamp.serialize();
-    let config_timestamp_bytes = config_timestamp.serialize();
-    let size_id_bytes = size_id.serialize();
-    let rotation_bytes = rotation.serialize();
-    let rate_bytes = rate.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_SCREEN_CONFIG_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        timestamp_bytes[0],
-        timestamp_bytes[1],
-        timestamp_bytes[2],
-        timestamp_bytes[3],
-        config_timestamp_bytes[0],
-        config_timestamp_bytes[1],
-        config_timestamp_bytes[2],
-        config_timestamp_bytes[3],
-        size_id_bytes[0],
-        size_id_bytes[1],
-        rotation_bytes[0],
-        rotation_bytes[1],
-        rate_bytes[0],
-        rate_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetScreenConfigRequest {
+        window: window,
+        timestamp: timestamp,
+        config_timestamp: config_timestamp,
+        size_id: size_id,
+        rotation: rotation,
+        rate: rate,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -794,65 +845,105 @@ impl TryFrom<u32> for NotifyMask {
 }
 bitmask_binop!(NotifyMask, u8);
 
-/// Opcode for the SelectInput request
-pub const SELECT_INPUT_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectInputRequest {
+    pub window: xproto::Window,
+    pub enable: u16,
+}
+impl SelectInputRequest {
+    /// Opcode for the SelectInput request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let enable_bytes = self.enable.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SelectInputRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            enable_bytes[0],
+            enable_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn select_input<Conn, A>(conn: &Conn, window: xproto::Window, enable: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let enable: u16 = enable.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let enable_bytes = enable.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SELECT_INPUT_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        enable_bytes[0],
-        enable_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SelectInputRequest {
+        window: window,
+        enable: enable,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetScreenInfo request
-pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetScreenInfoRequest {
+    pub window: xproto::Window,
+}
+impl GetScreenInfoRequest {
+    /// Opcode for the GetScreenInfo request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetScreenInfoRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_screen_info<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_SCREEN_INFO_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetScreenInfoRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -914,31 +1005,50 @@ impl GetScreenInfoReply {
     }
 }
 
-/// Opcode for the GetScreenSizeRange request
-pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetScreenSizeRangeRequest {
+    pub window: xproto::Window,
+}
+impl GetScreenSizeRangeRequest {
+    /// Opcode for the GetScreenSizeRange request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetScreenSizeRangeRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_screen_size_range<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenSizeRangeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_SCREEN_SIZE_RANGE_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetScreenSizeRangeRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -973,47 +1083,74 @@ impl TryFrom<&[u8]> for GetScreenSizeRangeReply {
     }
 }
 
-/// Opcode for the SetScreenSize request
-pub const SET_SCREEN_SIZE_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetScreenSizeRequest {
+    pub window: xproto::Window,
+    pub width: u16,
+    pub height: u16,
+    pub mm_width: u32,
+    pub mm_height: u32,
+}
+impl SetScreenSizeRequest {
+    /// Opcode for the SetScreenSize request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mm_width_bytes = self.mm_width.serialize();
+        let mm_height_bytes = self.mm_height.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetScreenSizeRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            mm_width_bytes[0],
+            mm_width_bytes[1],
+            mm_width_bytes[2],
+            mm_width_bytes[3],
+            mm_height_bytes[0],
+            mm_height_bytes[1],
+            mm_height_bytes[2],
+            mm_height_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_screen_size<Conn>(conn: &Conn, window: xproto::Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let mm_width_bytes = mm_width.serialize();
-    let mm_height_bytes = mm_height.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_SCREEN_SIZE_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        mm_width_bytes[0],
-        mm_width_bytes[1],
-        mm_width_bytes[2],
-        mm_width_bytes[3],
-        mm_height_bytes[0],
-        mm_height_bytes[1],
-        mm_height_bytes[2],
-        mm_height_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetScreenSizeRequest {
+        window: window,
+        width: width,
+        height: height,
+        mm_width: mm_width,
+        mm_height: mm_height,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1209,31 +1346,50 @@ impl Serialize for ModeInfo {
     }
 }
 
-/// Opcode for the GetScreenResources request
-pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetScreenResourcesRequest {
+    pub window: xproto::Window,
+}
+impl GetScreenResourcesRequest {
+    /// Opcode for the GetScreenResources request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetScreenResourcesRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_screen_resources<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenResourcesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_SCREEN_RESOURCES_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetScreenResourcesRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1396,36 +1552,57 @@ impl TryFrom<u32> for Connection {
     }
 }
 
-/// Opcode for the GetOutputInfo request
-pub const GET_OUTPUT_INFO_REQUEST: u8 = 9;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetOutputInfoRequest {
+    pub output: Output,
+    pub config_timestamp: xproto::Timestamp,
+}
+impl GetOutputInfoRequest {
+    /// Opcode for the GetOutputInfo request
+    pub const fn opcode() -> u8 { 9 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetOutputInfoRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_output_info<Conn>(conn: &Conn, output: Output, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetOutputInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let config_timestamp_bytes = config_timestamp.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_OUTPUT_INFO_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        config_timestamp_bytes[0],
-        config_timestamp_bytes[1],
-        config_timestamp_bytes[2],
-        config_timestamp_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetOutputInfoRequest {
+        output: output,
+        config_timestamp: config_timestamp,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1536,31 +1713,50 @@ impl GetOutputInfoReply {
     }
 }
 
-/// Opcode for the ListOutputProperties request
-pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListOutputPropertiesRequest {
+    pub output: Output,
+}
+impl ListOutputPropertiesRequest {
+    /// Opcode for the ListOutputProperties request
+    pub const fn opcode() -> u8 { 10 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListOutputPropertiesRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_output_properties<Conn>(conn: &Conn, output: Output) -> Result<Cookie<'_, Conn, ListOutputPropertiesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_OUTPUT_PROPERTIES_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListOutputPropertiesRequest {
+        output: output,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1605,36 +1801,57 @@ impl ListOutputPropertiesReply {
     }
 }
 
-/// Opcode for the QueryOutputProperty request
-pub const QUERY_OUTPUT_PROPERTY_REQUEST: u8 = 11;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryOutputPropertyRequest {
+    pub output: Output,
+    pub property: xproto::Atom,
+}
+impl QueryOutputPropertyRequest {
+    /// Opcode for the QueryOutputProperty request
+    pub const fn opcode() -> u8 { 11 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let property_bytes = self.property.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryOutputPropertyRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_output_property<Conn>(conn: &Conn, output: Output, property: xproto::Atom) -> Result<Cookie<'_, Conn, QueryOutputPropertyReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let property_bytes = property.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_OUTPUT_PROPERTY_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryOutputPropertyRequest {
+        output: output,
+        property: property,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1683,185 +1900,295 @@ impl QueryOutputPropertyReply {
     }
 }
 
-/// Opcode for the ConfigureOutputProperty request
-pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigureOutputPropertyRequest<'input> {
+    pub output: Output,
+    pub property: xproto::Atom,
+    pub pending: bool,
+    pub range: bool,
+    pub values: &'input [i32],
+}
+impl<'input> ConfigureOutputPropertyRequest<'input> {
+    /// Opcode for the ConfigureOutputProperty request
+    pub const fn opcode() -> u8 { 12 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let property_bytes = self.property.serialize();
+        let pending_bytes = self.pending.serialize();
+        let range_bytes = self.range.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ConfigureOutputPropertyRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            pending_bytes[0],
+            range_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let values_bytes = self.values.serialize();
+        let length_so_far = length_so_far + values_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn configure_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let property_bytes = property.serialize();
-    let pending_bytes = pending.serialize();
-    let range_bytes = range.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CONFIGURE_OUTPUT_PROPERTY_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        pending_bytes[0],
-        range_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let values_bytes = values.serialize();
-    let length_so_far = length_so_far + values_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&values_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ConfigureOutputPropertyRequest {
+        output: output,
+        property: property,
+        pending: pending,
+        range: range,
+        values: values,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangeOutputProperty request
-pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeOutputPropertyRequest<'input> {
+    pub output: Output,
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub format: u8,
+    pub mode: xproto::PropMode,
+    pub num_units: u32,
+    pub data: &'input [u8],
+}
+impl<'input> ChangeOutputPropertyRequest<'input> {
+    /// Opcode for the ChangeOutputProperty request
+    pub const fn opcode() -> u8 { 13 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let format_bytes = self.format.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let num_units_bytes = self.num_units.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeOutputPropertyRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            format_bytes[0],
+            mode_bytes[0],
+            0,
+            0,
+            num_units_bytes[0],
+            num_units_bytes[1],
+            num_units_bytes[2],
+            num_units_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(self.data.len(), usize::try_from(self.num_units.checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
+        let length_so_far = length_so_far + (&self.data[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let format_bytes = format.serialize();
-    let mode_bytes = u8::from(mode).serialize();
-    let num_units_bytes = num_units.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_OUTPUT_PROPERTY_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        format_bytes[0],
-        mode_bytes[0],
-        0,
-        0,
-        num_units_bytes[0],
-        num_units_bytes[1],
-        num_units_bytes[2],
-        num_units_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(data.len(), usize::try_from(num_units.checked_mul(u32::from(format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
-    let length_so_far = length_so_far + data.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(data), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeOutputPropertyRequest {
+        output: output,
+        property: property,
+        type_: type_,
+        format: format,
+        mode: mode,
+        num_units: num_units,
+        data: data,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DeleteOutputProperty request
-pub const DELETE_OUTPUT_PROPERTY_REQUEST: u8 = 14;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeleteOutputPropertyRequest {
+    pub output: Output,
+    pub property: xproto::Atom,
+}
+impl DeleteOutputPropertyRequest {
+    /// Opcode for the DeleteOutputProperty request
+    pub const fn opcode() -> u8 { 14 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let property_bytes = self.property.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DeleteOutputPropertyRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn delete_output_property<Conn>(conn: &Conn, output: Output, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let property_bytes = property.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DELETE_OUTPUT_PROPERTY_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DeleteOutputPropertyRequest {
+        output: output,
+        property: property,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetOutputProperty request
-pub const GET_OUTPUT_PROPERTY_REQUEST: u8 = 15;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetOutputPropertyRequest {
+    pub output: Output,
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub long_offset: u32,
+    pub long_length: u32,
+    pub delete: bool,
+    pub pending: bool,
+}
+impl GetOutputPropertyRequest {
+    /// Opcode for the GetOutputProperty request
+    pub const fn opcode() -> u8 { 15 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let long_offset_bytes = self.long_offset.serialize();
+        let long_length_bytes = self.long_length.serialize();
+        let delete_bytes = self.delete.serialize();
+        let pending_bytes = self.pending.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetOutputPropertyRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            long_offset_bytes[0],
+            long_offset_bytes[1],
+            long_offset_bytes[2],
+            long_offset_bytes[3],
+            long_length_bytes[0],
+            long_length_bytes[1],
+            long_length_bytes[2],
+            long_length_bytes[3],
+            delete_bytes[0],
+            pending_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_output_property<Conn, A>(conn: &Conn, output: Output, property: xproto::Atom, type_: A, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetOutputPropertyReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Atom>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let type_: xproto::Atom = type_.into();
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let long_offset_bytes = long_offset.serialize();
-    let long_length_bytes = long_length.serialize();
-    let delete_bytes = delete.serialize();
-    let pending_bytes = pending.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_OUTPUT_PROPERTY_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        long_offset_bytes[0],
-        long_offset_bytes[1],
-        long_offset_bytes[2],
-        long_offset_bytes[3],
-        long_length_bytes[0],
-        long_length_bytes[1],
-        long_length_bytes[2],
-        long_length_bytes[3],
-        delete_bytes[0],
-        pending_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetOutputPropertyRequest {
+        output: output,
+        property: property,
+        type_: type_,
+        long_offset: long_offset,
+        long_length: long_length,
+        delete: delete,
+        pending: pending,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1898,67 +2225,90 @@ impl TryFrom<&[u8]> for GetOutputPropertyReply {
     }
 }
 
-/// Opcode for the CreateMode request
-pub const CREATE_MODE_REQUEST: u8 = 16;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateModeRequest<'input> {
+    pub window: xproto::Window,
+    pub mode_info: ModeInfo,
+    pub name: &'input [u8],
+}
+impl<'input> CreateModeRequest<'input> {
+    /// Opcode for the CreateMode request
+    pub const fn opcode() -> u8 { 16 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mode_info_bytes = self.mode_info.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateModeRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            mode_info_bytes[0],
+            mode_info_bytes[1],
+            mode_info_bytes[2],
+            mode_info_bytes[3],
+            mode_info_bytes[4],
+            mode_info_bytes[5],
+            mode_info_bytes[6],
+            mode_info_bytes[7],
+            mode_info_bytes[8],
+            mode_info_bytes[9],
+            mode_info_bytes[10],
+            mode_info_bytes[11],
+            mode_info_bytes[12],
+            mode_info_bytes[13],
+            mode_info_bytes[14],
+            mode_info_bytes[15],
+            mode_info_bytes[16],
+            mode_info_bytes[17],
+            mode_info_bytes[18],
+            mode_info_bytes[19],
+            mode_info_bytes[20],
+            mode_info_bytes[21],
+            mode_info_bytes[22],
+            mode_info_bytes[23],
+            mode_info_bytes[24],
+            mode_info_bytes[25],
+            mode_info_bytes[26],
+            mode_info_bytes[27],
+            mode_info_bytes[28],
+            mode_info_bytes[29],
+            mode_info_bytes[30],
+            mode_info_bytes[31],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_mode<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode_info: ModeInfo, name: &'input [u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mode_info_bytes = mode_info.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_MODE_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        mode_info_bytes[0],
-        mode_info_bytes[1],
-        mode_info_bytes[2],
-        mode_info_bytes[3],
-        mode_info_bytes[4],
-        mode_info_bytes[5],
-        mode_info_bytes[6],
-        mode_info_bytes[7],
-        mode_info_bytes[8],
-        mode_info_bytes[9],
-        mode_info_bytes[10],
-        mode_info_bytes[11],
-        mode_info_bytes[12],
-        mode_info_bytes[13],
-        mode_info_bytes[14],
-        mode_info_bytes[15],
-        mode_info_bytes[16],
-        mode_info_bytes[17],
-        mode_info_bytes[18],
-        mode_info_bytes[19],
-        mode_info_bytes[20],
-        mode_info_bytes[21],
-        mode_info_bytes[22],
-        mode_info_bytes[23],
-        mode_info_bytes[24],
-        mode_info_bytes[25],
-        mode_info_bytes[26],
-        mode_info_bytes[27],
-        mode_info_bytes[28],
-        mode_info_bytes[29],
-        mode_info_bytes[30],
-        mode_info_bytes[31],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateModeRequest {
+        window: window,
+        mode_info: mode_info,
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1987,127 +2337,209 @@ impl TryFrom<&[u8]> for CreateModeReply {
     }
 }
 
-/// Opcode for the DestroyMode request
-pub const DESTROY_MODE_REQUEST: u8 = 17;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroyModeRequest {
+    pub mode: Mode,
+}
+impl DestroyModeRequest {
+    /// Opcode for the DestroyMode request
+    pub const fn opcode() -> u8 { 17 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mode_bytes = self.mode.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroyModeRequest::opcode(),
+            0,
+            0,
+            mode_bytes[0],
+            mode_bytes[1],
+            mode_bytes[2],
+            mode_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_mode<Conn>(conn: &Conn, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mode_bytes = mode.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_MODE_REQUEST,
-        0,
-        0,
-        mode_bytes[0],
-        mode_bytes[1],
-        mode_bytes[2],
-        mode_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroyModeRequest {
+        mode: mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the AddOutputMode request
-pub const ADD_OUTPUT_MODE_REQUEST: u8 = 18;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AddOutputModeRequest {
+    pub output: Output,
+    pub mode: Mode,
+}
+impl AddOutputModeRequest {
+    /// Opcode for the AddOutputMode request
+    pub const fn opcode() -> u8 { 18 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let mode_bytes = self.mode.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            AddOutputModeRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            mode_bytes[0],
+            mode_bytes[1],
+            mode_bytes[2],
+            mode_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn add_output_mode<Conn>(conn: &Conn, output: Output, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let mode_bytes = mode.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        ADD_OUTPUT_MODE_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        mode_bytes[0],
-        mode_bytes[1],
-        mode_bytes[2],
-        mode_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = AddOutputModeRequest {
+        output: output,
+        mode: mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DeleteOutputMode request
-pub const DELETE_OUTPUT_MODE_REQUEST: u8 = 19;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeleteOutputModeRequest {
+    pub output: Output,
+    pub mode: Mode,
+}
+impl DeleteOutputModeRequest {
+    /// Opcode for the DeleteOutputMode request
+    pub const fn opcode() -> u8 { 19 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let output_bytes = self.output.serialize();
+        let mode_bytes = self.mode.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DeleteOutputModeRequest::opcode(),
+            0,
+            0,
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+            mode_bytes[0],
+            mode_bytes[1],
+            mode_bytes[2],
+            mode_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn delete_output_mode<Conn>(conn: &Conn, output: Output, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let output_bytes = output.serialize();
-    let mode_bytes = mode.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DELETE_OUTPUT_MODE_REQUEST,
-        0,
-        0,
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-        mode_bytes[0],
-        mode_bytes[1],
-        mode_bytes[2],
-        mode_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DeleteOutputModeRequest {
+        output: output,
+        mode: mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetCrtcInfo request
-pub const GET_CRTC_INFO_REQUEST: u8 = 20;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetCrtcInfoRequest {
+    pub crtc: Crtc,
+    pub config_timestamp: xproto::Timestamp,
+}
+impl GetCrtcInfoRequest {
+    /// Opcode for the GetCrtcInfo request
+    pub const fn opcode() -> u8 { 20 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetCrtcInfoRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_crtc_info<Conn>(conn: &Conn, crtc: Crtc, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetCrtcInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let config_timestamp_bytes = config_timestamp.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_CRTC_INFO_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-        config_timestamp_bytes[0],
-        config_timestamp_bytes[1],
-        config_timestamp_bytes[2],
-        config_timestamp_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetCrtcInfoRequest {
+        crtc: crtc,
+        config_timestamp: config_timestamp,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2185,63 +2617,96 @@ impl GetCrtcInfoReply {
     }
 }
 
-/// Opcode for the SetCrtcConfig request
-pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetCrtcConfigRequest<'input> {
+    pub crtc: Crtc,
+    pub timestamp: xproto::Timestamp,
+    pub config_timestamp: xproto::Timestamp,
+    pub x: i16,
+    pub y: i16,
+    pub mode: Mode,
+    pub rotation: u16,
+    pub outputs: &'input [Output],
+}
+impl<'input> SetCrtcConfigRequest<'input> {
+    /// Opcode for the SetCrtcConfig request
+    pub const fn opcode() -> u8 { 21 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mode_bytes = self.mode.serialize();
+        let rotation_bytes = self.rotation.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetCrtcConfigRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            mode_bytes[0],
+            mode_bytes[1],
+            mode_bytes[2],
+            mode_bytes[3],
+            rotation_bytes[0],
+            rotation_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let outputs_bytes = self.outputs.serialize();
+        let length_so_far = length_so_far + outputs_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), outputs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_crtc_config<'c, 'input, Conn, A>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &'input [Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let rotation: u16 = rotation.into();
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let timestamp_bytes = timestamp.serialize();
-    let config_timestamp_bytes = config_timestamp.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mode_bytes = mode.serialize();
-    let rotation_bytes = rotation.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_CRTC_CONFIG_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-        timestamp_bytes[0],
-        timestamp_bytes[1],
-        timestamp_bytes[2],
-        timestamp_bytes[3],
-        config_timestamp_bytes[0],
-        config_timestamp_bytes[1],
-        config_timestamp_bytes[2],
-        config_timestamp_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-        mode_bytes[0],
-        mode_bytes[1],
-        mode_bytes[2],
-        mode_bytes[3],
-        rotation_bytes[0],
-        rotation_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let outputs_bytes = outputs.serialize();
-    let length_so_far = length_so_far + outputs_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&outputs_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetCrtcConfigRequest {
+        crtc: crtc,
+        timestamp: timestamp,
+        config_timestamp: config_timestamp,
+        x: x,
+        y: y,
+        mode: mode,
+        rotation: rotation,
+        outputs: outputs,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2272,31 +2737,50 @@ impl TryFrom<&[u8]> for SetCrtcConfigReply {
     }
 }
 
-/// Opcode for the GetCrtcGammaSize request
-pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetCrtcGammaSizeRequest {
+    pub crtc: Crtc,
+}
+impl GetCrtcGammaSizeRequest {
+    /// Opcode for the GetCrtcGammaSize request
+    pub const fn opcode() -> u8 { 22 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetCrtcGammaSizeRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_crtc_gamma_size<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcGammaSizeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_CRTC_GAMMA_SIZE_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetCrtcGammaSizeRequest {
+        crtc: crtc,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2325,31 +2809,50 @@ impl TryFrom<&[u8]> for GetCrtcGammaSizeReply {
     }
 }
 
-/// Opcode for the GetCrtcGamma request
-pub const GET_CRTC_GAMMA_REQUEST: u8 = 23;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetCrtcGammaRequest {
+    pub crtc: Crtc,
+}
+impl GetCrtcGammaRequest {
+    /// Opcode for the GetCrtcGamma request
+    pub const fn opcode() -> u8 { 23 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetCrtcGammaRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_crtc_gamma<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcGammaReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_CRTC_GAMMA_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetCrtcGammaRequest {
+        crtc: crtc,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2398,74 +2901,118 @@ impl GetCrtcGammaReply {
     }
 }
 
-/// Opcode for the SetCrtcGamma request
-pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetCrtcGammaRequest<'input> {
+    pub crtc: Crtc,
+    pub red: &'input [u16],
+    pub green: &'input [u16],
+    pub blue: &'input [u16],
+}
+impl<'input> SetCrtcGammaRequest<'input> {
+    /// Opcode for the SetCrtcGamma request
+    pub const fn opcode() -> u8 { 24 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let size = u16::try_from(self.red.len()).expect("`red` has too many elements");
+        let size_bytes = size.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetCrtcGammaRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+            size_bytes[0],
+            size_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let red_bytes = self.red.serialize();
+        let length_so_far = length_so_far + red_bytes.len();
+        assert_eq!(self.green.len(), usize::try_from(size).unwrap(), "`green` has an incorrect length");
+        let green_bytes = self.green.serialize();
+        let length_so_far = length_so_far + green_bytes.len();
+        assert_eq!(self.blue.len(), usize::try_from(size).unwrap(), "`blue` has an incorrect length");
+        let blue_bytes = self.blue.serialize();
+        let length_so_far = length_so_far + blue_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), red_bytes.into(), green_bytes.into(), blue_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_crtc_gamma<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let size = u16::try_from(red.len()).expect("`red` has too many elements");
-    let size_bytes = size.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_CRTC_GAMMA_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-        size_bytes[0],
-        size_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let red_bytes = red.serialize();
-    let length_so_far = length_so_far + red_bytes.len();
-    assert_eq!(green.len(), usize::try_from(size).unwrap(), "`green` has an incorrect length");
-    let green_bytes = green.serialize();
-    let length_so_far = length_so_far + green_bytes.len();
-    assert_eq!(blue.len(), usize::try_from(size).unwrap(), "`blue` has an incorrect length");
-    let blue_bytes = blue.serialize();
-    let length_so_far = length_so_far + blue_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&red_bytes), IoSlice::new(&green_bytes), IoSlice::new(&blue_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetCrtcGammaRequest {
+        crtc: crtc,
+        red: red,
+        green: green,
+        blue: blue,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetScreenResourcesCurrent request
-pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetScreenResourcesCurrentRequest {
+    pub window: xproto::Window,
+}
+impl GetScreenResourcesCurrentRequest {
+    /// Opcode for the GetScreenResourcesCurrent request
+    pub const fn opcode() -> u8 { 25 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetScreenResourcesCurrentRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_screen_resources_current<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenResourcesCurrentReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_SCREEN_RESOURCES_CURRENT_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetScreenResourcesCurrentRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2632,108 +3179,152 @@ impl TryFrom<u32> for Transform {
 }
 bitmask_binop!(Transform, u8);
 
-/// Opcode for the SetCrtcTransform request
-pub const SET_CRTC_TRANSFORM_REQUEST: u8 = 26;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetCrtcTransformRequest<'input> {
+    pub crtc: Crtc,
+    pub transform: render::Transform,
+    pub filter_name: &'input [u8],
+    pub filter_params: &'input [render::Fixed],
+}
+impl<'input> SetCrtcTransformRequest<'input> {
+    /// Opcode for the SetCrtcTransform request
+    pub const fn opcode() -> u8 { 26 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let transform_bytes = self.transform.serialize();
+        let filter_len = u16::try_from(self.filter_name.len()).expect("`filter_name` has too many elements");
+        let filter_len_bytes = filter_len.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetCrtcTransformRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+            transform_bytes[0],
+            transform_bytes[1],
+            transform_bytes[2],
+            transform_bytes[3],
+            transform_bytes[4],
+            transform_bytes[5],
+            transform_bytes[6],
+            transform_bytes[7],
+            transform_bytes[8],
+            transform_bytes[9],
+            transform_bytes[10],
+            transform_bytes[11],
+            transform_bytes[12],
+            transform_bytes[13],
+            transform_bytes[14],
+            transform_bytes[15],
+            transform_bytes[16],
+            transform_bytes[17],
+            transform_bytes[18],
+            transform_bytes[19],
+            transform_bytes[20],
+            transform_bytes[21],
+            transform_bytes[22],
+            transform_bytes[23],
+            transform_bytes[24],
+            transform_bytes[25],
+            transform_bytes[26],
+            transform_bytes[27],
+            transform_bytes[28],
+            transform_bytes[29],
+            transform_bytes[30],
+            transform_bytes[31],
+            transform_bytes[32],
+            transform_bytes[33],
+            transform_bytes[34],
+            transform_bytes[35],
+            filter_len_bytes[0],
+            filter_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.filter_name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        let filter_params_bytes = self.filter_params.serialize();
+        let length_so_far = length_so_far + filter_params_bytes.len();
+        let padding1 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding1.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.filter_name[..]).into(), padding0.into(), filter_params_bytes.into(), Cow::Borrowed(&padding1)], vec![]))
+    }
+}
 pub fn set_crtc_transform<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, transform: render::Transform, filter_name: &'input [u8], filter_params: &'input [render::Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let transform_bytes = transform.serialize();
-    let filter_len = u16::try_from(filter_name.len()).expect("`filter_name` has too many elements");
-    let filter_len_bytes = filter_len.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_CRTC_TRANSFORM_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-        transform_bytes[0],
-        transform_bytes[1],
-        transform_bytes[2],
-        transform_bytes[3],
-        transform_bytes[4],
-        transform_bytes[5],
-        transform_bytes[6],
-        transform_bytes[7],
-        transform_bytes[8],
-        transform_bytes[9],
-        transform_bytes[10],
-        transform_bytes[11],
-        transform_bytes[12],
-        transform_bytes[13],
-        transform_bytes[14],
-        transform_bytes[15],
-        transform_bytes[16],
-        transform_bytes[17],
-        transform_bytes[18],
-        transform_bytes[19],
-        transform_bytes[20],
-        transform_bytes[21],
-        transform_bytes[22],
-        transform_bytes[23],
-        transform_bytes[24],
-        transform_bytes[25],
-        transform_bytes[26],
-        transform_bytes[27],
-        transform_bytes[28],
-        transform_bytes[29],
-        transform_bytes[30],
-        transform_bytes[31],
-        transform_bytes[32],
-        transform_bytes[33],
-        transform_bytes[34],
-        transform_bytes[35],
-        filter_len_bytes[0],
-        filter_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + filter_name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    let filter_params_bytes = filter_params.serialize();
-    let length_so_far = length_so_far + filter_params_bytes.len();
-    let padding1 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding1.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(filter_name), IoSlice::new(&padding0), IoSlice::new(&filter_params_bytes), IoSlice::new(&padding1)], vec![])?)
+    let request0 = SetCrtcTransformRequest {
+        crtc: crtc,
+        transform: transform,
+        filter_name: filter_name,
+        filter_params: filter_params,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetCrtcTransform request
-pub const GET_CRTC_TRANSFORM_REQUEST: u8 = 27;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetCrtcTransformRequest {
+    pub crtc: Crtc,
+}
+impl GetCrtcTransformRequest {
+    /// Opcode for the GetCrtcTransform request
+    pub const fn opcode() -> u8 { 27 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetCrtcTransformRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_crtc_transform<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcTransformReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_CRTC_TRANSFORM_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetCrtcTransformRequest {
+        crtc: crtc,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2844,31 +3435,50 @@ impl GetCrtcTransformReply {
     }
 }
 
-/// Opcode for the GetPanning request
-pub const GET_PANNING_REQUEST: u8 = 28;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetPanningRequest {
+    pub crtc: Crtc,
+}
+impl GetPanningRequest {
+    /// Opcode for the GetPanning request
+    pub const fn opcode() -> u8 { 28 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetPanningRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_panning<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetPanningReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_PANNING_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetPanningRequest {
+        crtc: crtc,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2922,72 +3532,117 @@ impl TryFrom<&[u8]> for GetPanningReply {
     }
 }
 
-/// Opcode for the SetPanning request
-pub const SET_PANNING_REQUEST: u8 = 29;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetPanningRequest {
+    pub crtc: Crtc,
+    pub timestamp: xproto::Timestamp,
+    pub left: u16,
+    pub top: u16,
+    pub width: u16,
+    pub height: u16,
+    pub track_left: u16,
+    pub track_top: u16,
+    pub track_width: u16,
+    pub track_height: u16,
+    pub border_left: i16,
+    pub border_top: i16,
+    pub border_right: i16,
+    pub border_bottom: i16,
+}
+impl SetPanningRequest {
+    /// Opcode for the SetPanning request
+    pub const fn opcode() -> u8 { 29 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let crtc_bytes = self.crtc.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let left_bytes = self.left.serialize();
+        let top_bytes = self.top.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let track_left_bytes = self.track_left.serialize();
+        let track_top_bytes = self.track_top.serialize();
+        let track_width_bytes = self.track_width.serialize();
+        let track_height_bytes = self.track_height.serialize();
+        let border_left_bytes = self.border_left.serialize();
+        let border_top_bytes = self.border_top.serialize();
+        let border_right_bytes = self.border_right.serialize();
+        let border_bottom_bytes = self.border_bottom.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetPanningRequest::opcode(),
+            0,
+            0,
+            crtc_bytes[0],
+            crtc_bytes[1],
+            crtc_bytes[2],
+            crtc_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            left_bytes[0],
+            left_bytes[1],
+            top_bytes[0],
+            top_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            track_left_bytes[0],
+            track_left_bytes[1],
+            track_top_bytes[0],
+            track_top_bytes[1],
+            track_width_bytes[0],
+            track_width_bytes[1],
+            track_height_bytes[0],
+            track_height_bytes[1],
+            border_left_bytes[0],
+            border_left_bytes[1],
+            border_top_bytes[0],
+            border_top_bytes[1],
+            border_right_bytes[0],
+            border_right_bytes[1],
+            border_bottom_bytes[0],
+            border_bottom_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_panning<Conn>(conn: &Conn, crtc: Crtc, timestamp: xproto::Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Conn, SetPanningReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let crtc_bytes = crtc.serialize();
-    let timestamp_bytes = timestamp.serialize();
-    let left_bytes = left.serialize();
-    let top_bytes = top.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let track_left_bytes = track_left.serialize();
-    let track_top_bytes = track_top.serialize();
-    let track_width_bytes = track_width.serialize();
-    let track_height_bytes = track_height.serialize();
-    let border_left_bytes = border_left.serialize();
-    let border_top_bytes = border_top.serialize();
-    let border_right_bytes = border_right.serialize();
-    let border_bottom_bytes = border_bottom.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_PANNING_REQUEST,
-        0,
-        0,
-        crtc_bytes[0],
-        crtc_bytes[1],
-        crtc_bytes[2],
-        crtc_bytes[3],
-        timestamp_bytes[0],
-        timestamp_bytes[1],
-        timestamp_bytes[2],
-        timestamp_bytes[3],
-        left_bytes[0],
-        left_bytes[1],
-        top_bytes[0],
-        top_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        track_left_bytes[0],
-        track_left_bytes[1],
-        track_top_bytes[0],
-        track_top_bytes[1],
-        track_width_bytes[0],
-        track_width_bytes[1],
-        track_height_bytes[0],
-        track_height_bytes[1],
-        border_left_bytes[0],
-        border_left_bytes[1],
-        border_top_bytes[0],
-        border_top_bytes[1],
-        border_right_bytes[0],
-        border_right_bytes[1],
-        border_bottom_bytes[0],
-        border_bottom_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetPanningRequest {
+        crtc: crtc,
+        timestamp: timestamp,
+        left: left,
+        top: top,
+        width: width,
+        height: height,
+        track_left: track_left,
+        track_top: track_top,
+        track_width: track_width,
+        track_height: track_height,
+        border_left: border_left,
+        border_top: border_top,
+        border_right: border_right,
+        border_bottom: border_bottom,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3017,63 +3672,103 @@ impl TryFrom<&[u8]> for SetPanningReply {
     }
 }
 
-/// Opcode for the SetOutputPrimary request
-pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetOutputPrimaryRequest {
+    pub window: xproto::Window,
+    pub output: Output,
+}
+impl SetOutputPrimaryRequest {
+    /// Opcode for the SetOutputPrimary request
+    pub const fn opcode() -> u8 { 30 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let output_bytes = self.output.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetOutputPrimaryRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_output_primary<Conn>(conn: &Conn, window: xproto::Window, output: Output) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let output_bytes = output.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_OUTPUT_PRIMARY_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        output_bytes[0],
-        output_bytes[1],
-        output_bytes[2],
-        output_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetOutputPrimaryRequest {
+        window: window,
+        output: output,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetOutputPrimary request
-pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetOutputPrimaryRequest {
+    pub window: xproto::Window,
+}
+impl GetOutputPrimaryRequest {
+    /// Opcode for the GetOutputPrimary request
+    pub const fn opcode() -> u8 { 31 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetOutputPrimaryRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_output_primary<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetOutputPrimaryReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_OUTPUT_PRIMARY_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetOutputPrimaryRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3101,31 +3796,50 @@ impl TryFrom<&[u8]> for GetOutputPrimaryReply {
     }
 }
 
-/// Opcode for the GetProviders request
-pub const GET_PROVIDERS_REQUEST: u8 = 32;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetProvidersRequest {
+    pub window: xproto::Window,
+}
+impl GetProvidersRequest {
+    /// Opcode for the GetProviders request
+    pub const fn opcode() -> u8 { 32 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetProvidersRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_providers<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetProvidersReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_PROVIDERS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetProvidersRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3241,36 +3955,57 @@ impl TryFrom<u32> for ProviderCapability {
 }
 bitmask_binop!(ProviderCapability, u8);
 
-/// Opcode for the GetProviderInfo request
-pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetProviderInfoRequest {
+    pub provider: Provider,
+    pub config_timestamp: xproto::Timestamp,
+}
+impl GetProviderInfoRequest {
+    /// Opcode for the GetProviderInfo request
+    pub const fn opcode() -> u8 { 33 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetProviderInfoRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_provider_info<Conn>(conn: &Conn, provider: Provider, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetProviderInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let config_timestamp_bytes = config_timestamp.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_PROVIDER_INFO_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        config_timestamp_bytes[0],
-        config_timestamp_bytes[1],
-        config_timestamp_bytes[2],
-        config_timestamp_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetProviderInfoRequest {
+        provider: provider,
+        config_timestamp: config_timestamp,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3371,105 +4106,170 @@ impl GetProviderInfoReply {
     }
 }
 
-/// Opcode for the SetProviderOffloadSink request
-pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetProviderOffloadSinkRequest {
+    pub provider: Provider,
+    pub sink_provider: Provider,
+    pub config_timestamp: xproto::Timestamp,
+}
+impl SetProviderOffloadSinkRequest {
+    /// Opcode for the SetProviderOffloadSink request
+    pub const fn opcode() -> u8 { 34 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let sink_provider_bytes = self.sink_provider.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetProviderOffloadSinkRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            sink_provider_bytes[0],
+            sink_provider_bytes[1],
+            sink_provider_bytes[2],
+            sink_provider_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_provider_offload_sink<Conn>(conn: &Conn, provider: Provider, sink_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let sink_provider_bytes = sink_provider.serialize();
-    let config_timestamp_bytes = config_timestamp.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_PROVIDER_OFFLOAD_SINK_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        sink_provider_bytes[0],
-        sink_provider_bytes[1],
-        sink_provider_bytes[2],
-        sink_provider_bytes[3],
-        config_timestamp_bytes[0],
-        config_timestamp_bytes[1],
-        config_timestamp_bytes[2],
-        config_timestamp_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetProviderOffloadSinkRequest {
+        provider: provider,
+        sink_provider: sink_provider,
+        config_timestamp: config_timestamp,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetProviderOutputSource request
-pub const SET_PROVIDER_OUTPUT_SOURCE_REQUEST: u8 = 35;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetProviderOutputSourceRequest {
+    pub provider: Provider,
+    pub source_provider: Provider,
+    pub config_timestamp: xproto::Timestamp,
+}
+impl SetProviderOutputSourceRequest {
+    /// Opcode for the SetProviderOutputSource request
+    pub const fn opcode() -> u8 { 35 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let source_provider_bytes = self.source_provider.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetProviderOutputSourceRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            source_provider_bytes[0],
+            source_provider_bytes[1],
+            source_provider_bytes[2],
+            source_provider_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_provider_output_source<Conn>(conn: &Conn, provider: Provider, source_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let source_provider_bytes = source_provider.serialize();
-    let config_timestamp_bytes = config_timestamp.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_PROVIDER_OUTPUT_SOURCE_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        source_provider_bytes[0],
-        source_provider_bytes[1],
-        source_provider_bytes[2],
-        source_provider_bytes[3],
-        config_timestamp_bytes[0],
-        config_timestamp_bytes[1],
-        config_timestamp_bytes[2],
-        config_timestamp_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetProviderOutputSourceRequest {
+        provider: provider,
+        source_provider: source_provider,
+        config_timestamp: config_timestamp,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ListProviderProperties request
-pub const LIST_PROVIDER_PROPERTIES_REQUEST: u8 = 36;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListProviderPropertiesRequest {
+    pub provider: Provider,
+}
+impl ListProviderPropertiesRequest {
+    /// Opcode for the ListProviderProperties request
+    pub const fn opcode() -> u8 { 36 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListProviderPropertiesRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_provider_properties<Conn>(conn: &Conn, provider: Provider) -> Result<Cookie<'_, Conn, ListProviderPropertiesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_PROVIDER_PROPERTIES_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListProviderPropertiesRequest {
+        provider: provider,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3514,36 +4314,57 @@ impl ListProviderPropertiesReply {
     }
 }
 
-/// Opcode for the QueryProviderProperty request
-pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryProviderPropertyRequest {
+    pub provider: Provider,
+    pub property: xproto::Atom,
+}
+impl QueryProviderPropertyRequest {
+    /// Opcode for the QueryProviderProperty request
+    pub const fn opcode() -> u8 { 37 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let property_bytes = self.property.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryProviderPropertyRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom) -> Result<Cookie<'_, Conn, QueryProviderPropertyReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let property_bytes = property.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_PROVIDER_PROPERTY_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryProviderPropertyRequest {
+        provider: provider,
+        property: property,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3592,183 +4413,293 @@ impl QueryProviderPropertyReply {
     }
 }
 
-/// Opcode for the ConfigureProviderProperty request
-pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigureProviderPropertyRequest<'input> {
+    pub provider: Provider,
+    pub property: xproto::Atom,
+    pub pending: bool,
+    pub range: bool,
+    pub values: &'input [i32],
+}
+impl<'input> ConfigureProviderPropertyRequest<'input> {
+    /// Opcode for the ConfigureProviderProperty request
+    pub const fn opcode() -> u8 { 38 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let property_bytes = self.property.serialize();
+        let pending_bytes = self.pending.serialize();
+        let range_bytes = self.range.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ConfigureProviderPropertyRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            pending_bytes[0],
+            range_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let values_bytes = self.values.serialize();
+        let length_so_far = length_so_far + values_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn configure_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let property_bytes = property.serialize();
-    let pending_bytes = pending.serialize();
-    let range_bytes = range.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CONFIGURE_PROVIDER_PROPERTY_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        pending_bytes[0],
-        range_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let values_bytes = values.serialize();
-    let length_so_far = length_so_far + values_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&values_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ConfigureProviderPropertyRequest {
+        provider: provider,
+        property: property,
+        pending: pending,
+        range: range,
+        values: values,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangeProviderProperty request
-pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeProviderPropertyRequest<'input> {
+    pub provider: Provider,
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub format: u8,
+    pub mode: u8,
+    pub num_items: u32,
+    pub data: &'input [u8],
+}
+impl<'input> ChangeProviderPropertyRequest<'input> {
+    /// Opcode for the ChangeProviderProperty request
+    pub const fn opcode() -> u8 { 39 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let format_bytes = self.format.serialize();
+        let mode_bytes = self.mode.serialize();
+        let num_items_bytes = self.num_items.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeProviderPropertyRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            format_bytes[0],
+            mode_bytes[0],
+            0,
+            0,
+            num_items_bytes[0],
+            num_items_bytes[1],
+            num_items_bytes[2],
+            num_items_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(self.data.len(), usize::try_from(self.num_items.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
+        let length_so_far = length_so_far + (&self.data[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let format_bytes = format.serialize();
-    let mode_bytes = mode.serialize();
-    let num_items_bytes = num_items.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_PROVIDER_PROPERTY_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        format_bytes[0],
-        mode_bytes[0],
-        0,
-        0,
-        num_items_bytes[0],
-        num_items_bytes[1],
-        num_items_bytes[2],
-        num_items_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(data.len(), usize::try_from(num_items.checked_mul(u32::from(format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
-    let length_so_far = length_so_far + data.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(data), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeProviderPropertyRequest {
+        provider: provider,
+        property: property,
+        type_: type_,
+        format: format,
+        mode: mode,
+        num_items: num_items,
+        data: data,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DeleteProviderProperty request
-pub const DELETE_PROVIDER_PROPERTY_REQUEST: u8 = 40;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeleteProviderPropertyRequest {
+    pub provider: Provider,
+    pub property: xproto::Atom,
+}
+impl DeleteProviderPropertyRequest {
+    /// Opcode for the DeleteProviderProperty request
+    pub const fn opcode() -> u8 { 40 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let property_bytes = self.property.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DeleteProviderPropertyRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn delete_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let property_bytes = property.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DELETE_PROVIDER_PROPERTY_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DeleteProviderPropertyRequest {
+        provider: provider,
+        property: property,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetProviderProperty request
-pub const GET_PROVIDER_PROPERTY_REQUEST: u8 = 41;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetProviderPropertyRequest {
+    pub provider: Provider,
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub long_offset: u32,
+    pub long_length: u32,
+    pub delete: bool,
+    pub pending: bool,
+}
+impl GetProviderPropertyRequest {
+    /// Opcode for the GetProviderProperty request
+    pub const fn opcode() -> u8 { 41 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let provider_bytes = self.provider.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let long_offset_bytes = self.long_offset.serialize();
+        let long_length_bytes = self.long_length.serialize();
+        let delete_bytes = self.delete.serialize();
+        let pending_bytes = self.pending.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetProviderPropertyRequest::opcode(),
+            0,
+            0,
+            provider_bytes[0],
+            provider_bytes[1],
+            provider_bytes[2],
+            provider_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            long_offset_bytes[0],
+            long_offset_bytes[1],
+            long_offset_bytes[2],
+            long_offset_bytes[3],
+            long_length_bytes[0],
+            long_length_bytes[1],
+            long_length_bytes[2],
+            long_length_bytes[3],
+            delete_bytes[0],
+            pending_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetProviderPropertyReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let provider_bytes = provider.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let long_offset_bytes = long_offset.serialize();
-    let long_length_bytes = long_length.serialize();
-    let delete_bytes = delete.serialize();
-    let pending_bytes = pending.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_PROVIDER_PROPERTY_REQUEST,
-        0,
-        0,
-        provider_bytes[0],
-        provider_bytes[1],
-        provider_bytes[2],
-        provider_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        long_offset_bytes[0],
-        long_offset_bytes[1],
-        long_offset_bytes[2],
-        long_offset_bytes[3],
-        long_length_bytes[0],
-        long_length_bytes[1],
-        long_length_bytes[2],
-        long_length_bytes[3],
-        delete_bytes[0],
-        pending_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetProviderPropertyRequest {
+        provider: provider,
+        property: property,
+        type_: type_,
+        long_offset: long_offset,
+        long_length: long_length,
+        delete: delete,
+        pending: pending,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4527,36 +5458,57 @@ impl MonitorInfo {
     }
 }
 
-/// Opcode for the GetMonitors request
-pub const GET_MONITORS_REQUEST: u8 = 42;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetMonitorsRequest {
+    pub window: xproto::Window,
+    pub get_active: bool,
+}
+impl GetMonitorsRequest {
+    /// Opcode for the GetMonitors request
+    pub const fn opcode() -> u8 { 42 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let get_active_bytes = self.get_active.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetMonitorsRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            get_active_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_monitors<Conn>(conn: &Conn, window: xproto::Window, get_active: bool) -> Result<Cookie<'_, Conn, GetMonitorsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let get_active_bytes = get_active.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_MONITORS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        get_active_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetMonitorsRequest {
+        window: window,
+        get_active: get_active,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4605,113 +5557,180 @@ impl GetMonitorsReply {
     }
 }
 
-/// Opcode for the SetMonitor request
-pub const SET_MONITOR_REQUEST: u8 = 43;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetMonitorRequest {
+    pub window: xproto::Window,
+    pub monitorinfo: MonitorInfo,
+}
+impl SetMonitorRequest {
+    /// Opcode for the SetMonitor request
+    pub const fn opcode() -> u8 { 43 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetMonitorRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let monitorinfo_bytes = self.monitorinfo.serialize();
+        let length_so_far = length_so_far + monitorinfo_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), monitorinfo_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_monitor<Conn>(conn: &Conn, window: xproto::Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_MONITOR_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let monitorinfo_bytes = monitorinfo.serialize();
-    let length_so_far = length_so_far + monitorinfo_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&monitorinfo_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetMonitorRequest {
+        window: window,
+        monitorinfo: monitorinfo,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DeleteMonitor request
-pub const DELETE_MONITOR_REQUEST: u8 = 44;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeleteMonitorRequest {
+    pub window: xproto::Window,
+    pub name: xproto::Atom,
+}
+impl DeleteMonitorRequest {
+    /// Opcode for the DeleteMonitor request
+    pub const fn opcode() -> u8 { 44 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let name_bytes = self.name.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DeleteMonitorRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            name_bytes[0],
+            name_bytes[1],
+            name_bytes[2],
+            name_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn delete_monitor<Conn>(conn: &Conn, window: xproto::Window, name: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let name_bytes = name.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DELETE_MONITOR_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        name_bytes[0],
-        name_bytes[1],
-        name_bytes[2],
-        name_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DeleteMonitorRequest {
+        window: window,
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateLease request
-pub const CREATE_LEASE_REQUEST: u8 = 45;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateLeaseRequest<'input> {
+    pub window: xproto::Window,
+    pub lid: Lease,
+    pub crtcs: &'input [Crtc],
+    pub outputs: &'input [Output],
+}
+impl<'input> CreateLeaseRequest<'input> {
+    /// Opcode for the CreateLease request
+    pub const fn opcode() -> u8 { 45 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let lid_bytes = self.lid.serialize();
+        let num_crtcs = u16::try_from(self.crtcs.len()).expect("`crtcs` has too many elements");
+        let num_crtcs_bytes = num_crtcs.serialize();
+        let num_outputs = u16::try_from(self.outputs.len()).expect("`outputs` has too many elements");
+        let num_outputs_bytes = num_outputs.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateLeaseRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            lid_bytes[0],
+            lid_bytes[1],
+            lid_bytes[2],
+            lid_bytes[3],
+            num_crtcs_bytes[0],
+            num_crtcs_bytes[1],
+            num_outputs_bytes[0],
+            num_outputs_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let crtcs_bytes = self.crtcs.serialize();
+        let length_so_far = length_so_far + crtcs_bytes.len();
+        let outputs_bytes = self.outputs.serialize();
+        let length_so_far = length_so_far + outputs_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), crtcs_bytes.into(), outputs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_lease<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, lid: Lease, crtcs: &'input [Crtc], outputs: &'input [Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let lid_bytes = lid.serialize();
-    let num_crtcs = u16::try_from(crtcs.len()).expect("`crtcs` has too many elements");
-    let num_crtcs_bytes = num_crtcs.serialize();
-    let num_outputs = u16::try_from(outputs.len()).expect("`outputs` has too many elements");
-    let num_outputs_bytes = num_outputs.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_LEASE_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        lid_bytes[0],
-        lid_bytes[1],
-        lid_bytes[2],
-        lid_bytes[3],
-        num_crtcs_bytes[0],
-        num_crtcs_bytes[1],
-        num_outputs_bytes[0],
-        num_outputs_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let crtcs_bytes = crtcs.serialize();
-    let length_so_far = length_so_far + crtcs_bytes.len();
-    let outputs_bytes = outputs.serialize();
-    let length_so_far = length_so_far + outputs_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply_with_fds(&[IoSlice::new(&request0), IoSlice::new(&crtcs_bytes), IoSlice::new(&outputs_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateLeaseRequest {
+        window: window,
+        lid: lid,
+        crtcs: crtcs,
+        outputs: outputs,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply_with_fds(&slices, fds)?)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -4743,36 +5762,57 @@ impl TryFrom<(&[u8], Vec<RawFdContainer>)> for CreateLeaseReply {
     }
 }
 
-/// Opcode for the FreeLease request
-pub const FREE_LEASE_REQUEST: u8 = 46;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FreeLeaseRequest {
+    pub lid: Lease,
+    pub terminate: u8,
+}
+impl FreeLeaseRequest {
+    /// Opcode for the FreeLease request
+    pub const fn opcode() -> u8 { 46 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let lid_bytes = self.lid.serialize();
+        let terminate_bytes = self.terminate.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            FreeLeaseRequest::opcode(),
+            0,
+            0,
+            lid_bytes[0],
+            lid_bytes[1],
+            lid_bytes[2],
+            lid_bytes[3],
+            terminate_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn free_lease<Conn>(conn: &Conn, lid: Lease, terminate: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let lid_bytes = lid.serialize();
-    let terminate_bytes = terminate.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        FREE_LEASE_REQUEST,
-        0,
-        0,
-        lid_bytes[0],
-        lid_bytes[1],
-        lid_bytes[2],
-        lid_bytes[3],
-        terminate_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FreeLeaseRequest {
+        lid: lid,
+        terminate: terminate,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -522,7 +522,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -679,7 +679,7 @@ impl SetScreenConfigRequest {
         let rate_bytes = self.rate.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetScreenConfigRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -866,7 +866,7 @@ impl SelectInputRequest {
         let enable_bytes = self.enable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -919,7 +919,7 @@ impl GetScreenInfoRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetScreenInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1024,7 +1024,7 @@ impl GetScreenSizeRangeRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetScreenSizeRangeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1110,7 +1110,7 @@ impl SetScreenSizeRequest {
         let mm_height_bytes = self.mm_height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetScreenSizeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1365,7 +1365,7 @@ impl GetScreenResourcesRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetScreenResourcesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1573,7 +1573,7 @@ impl GetOutputInfoRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetOutputInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -1732,7 +1732,7 @@ impl ListOutputPropertiesRequest {
         let output_bytes = self.output.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListOutputPropertiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -1822,7 +1822,7 @@ impl QueryOutputPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryOutputPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -1926,7 +1926,7 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ConfigureOutputPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -1999,7 +1999,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         let num_units_bytes = self.num_units.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeOutputPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -2073,7 +2073,7 @@ impl DeleteOutputPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteOutputPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -2136,7 +2136,7 @@ impl GetOutputPropertyRequest {
         let pending_bytes = self.pending.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetOutputPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -2247,7 +2247,7 @@ impl<'input> CreateModeRequest<'input> {
         let mode_info_bytes = self.mode_info.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -2356,7 +2356,7 @@ impl DestroyModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             mode_bytes[0],
@@ -2404,7 +2404,7 @@ impl AddOutputModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AddOutputModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -2457,7 +2457,7 @@ impl DeleteOutputModeRequest {
         let mode_bytes = self.mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteOutputModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_bytes[0],
@@ -2510,7 +2510,7 @@ impl GetCrtcInfoRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCrtcInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -2649,7 +2649,7 @@ impl<'input> SetCrtcConfigRequest<'input> {
         let rotation_bytes = self.rotation.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetCrtcConfigRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -2756,7 +2756,7 @@ impl GetCrtcGammaSizeRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCrtcGammaSizeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -2828,7 +2828,7 @@ impl GetCrtcGammaRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCrtcGammaRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -2925,7 +2925,7 @@ impl<'input> SetCrtcGammaRequest<'input> {
         let size_bytes = size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetCrtcGammaRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -2988,7 +2988,7 @@ impl GetScreenResourcesCurrentRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetScreenResourcesCurrentRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -3204,7 +3204,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
         let filter_len_bytes = filter_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetCrtcTransformRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -3300,7 +3300,7 @@ impl GetCrtcTransformRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCrtcTransformRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -3454,7 +3454,7 @@ impl GetPanningRequest {
         let crtc_bytes = self.crtc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPanningRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -3577,7 +3577,7 @@ impl SetPanningRequest {
         let border_bottom_bytes = self.border_bottom.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPanningRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             crtc_bytes[0],
@@ -3693,7 +3693,7 @@ impl SetOutputPrimaryRequest {
         let output_bytes = self.output.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetOutputPrimaryRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -3744,7 +3744,7 @@ impl GetOutputPrimaryRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetOutputPrimaryRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -3815,7 +3815,7 @@ impl GetProvidersRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetProvidersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -3976,7 +3976,7 @@ impl GetProviderInfoRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetProviderInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4129,7 +4129,7 @@ impl SetProviderOffloadSinkRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetProviderOffloadSinkRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4189,7 +4189,7 @@ impl SetProviderOutputSourceRequest {
         let config_timestamp_bytes = self.config_timestamp.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetProviderOutputSourceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4245,7 +4245,7 @@ impl ListProviderPropertiesRequest {
         let provider_bytes = self.provider.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListProviderPropertiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4335,7 +4335,7 @@ impl QueryProviderPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryProviderPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4439,7 +4439,7 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
         let range_bytes = self.range.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ConfigureProviderPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4512,7 +4512,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         let num_items_bytes = self.num_items.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeProviderPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4586,7 +4586,7 @@ impl DeleteProviderPropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteProviderPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -4649,7 +4649,7 @@ impl GetProviderPropertyRequest {
         let pending_bytes = self.pending.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetProviderPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             provider_bytes[0],
@@ -5479,7 +5479,7 @@ impl GetMonitorsRequest {
         let get_active_bytes = self.get_active.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMonitorsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -5577,7 +5577,7 @@ impl SetMonitorRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetMonitorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -5630,7 +5630,7 @@ impl DeleteMonitorRequest {
         let name_bytes = self.name.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteMonitorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -5689,7 +5689,7 @@ impl<'input> CreateLeaseRequest<'input> {
         let num_outputs_bytes = num_outputs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateLeaseRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -5783,7 +5783,7 @@ impl FreeLeaseRequest {
         let terminate_bytes = self.terminate.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FreeLeaseRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             lid_bytes[0],

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -551,7 +551,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 1;
-pub fn create_context<'c, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_context<'c, 'input, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -601,7 +601,7 @@ where
 
 /// Opcode for the RegisterClients request
 pub const REGISTER_CLIENTS_REQUEST: u8 = 2;
-pub fn register_clients<'c, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn register_clients<'c, 'input, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -651,7 +651,7 @@ where
 
 /// Opcode for the UnregisterClients request
 pub const UNREGISTER_CLIENTS_REQUEST: u8 = 3;
-pub fn unregister_clients<'c, Conn>(conn: &'c Conn, context: Context, client_specs: &[ClientSpec]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn unregister_clients<'c, 'input, Conn>(conn: &'c Conn, context: Context, client_specs: &'input [ClientSpec]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -900,15 +900,15 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_version(self, major_version, minor_version)
     }
-    fn record_create_context<'c>(&'c self, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn record_create_context<'c, 'input>(&'c self, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_context(self, context, element_header, client_specs, ranges)
     }
-    fn record_register_clients<'c>(&'c self, context: Context, element_header: ElementHeader, client_specs: &[ClientSpec], ranges: &[Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn record_register_clients<'c, 'input>(&'c self, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         register_clients(self, context, element_header, client_specs, ranges)
     }
-    fn record_unregister_clients<'c>(&'c self, context: Context, client_specs: &[ClientSpec]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn record_unregister_clients<'c, 'input>(&'c self, context: Context, client_specs: &'input [ClientSpec]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         unregister_clients(self, context, client_specs)
     }

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -504,7 +503,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -581,7 +580,7 @@ impl<'input> CreateContextRequest<'input> {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -626,7 +625,7 @@ impl<'input> CreateContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), client_specs_bytes.into(), ranges_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), client_specs_bytes.into(), ranges_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_context<'c, 'input, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -655,7 +654,7 @@ impl<'input> RegisterClientsRequest<'input> {
     /// Opcode for the RegisterClients request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -700,7 +699,7 @@ impl<'input> RegisterClientsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), client_specs_bytes.into(), ranges_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), client_specs_bytes.into(), ranges_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn register_clients<'c, 'input, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -727,7 +726,7 @@ impl<'input> UnregisterClientsRequest<'input> {
     /// Opcode for the UnregisterClients request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -759,7 +758,7 @@ impl<'input> UnregisterClientsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), client_specs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), client_specs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn unregister_clients<'c, 'input, Conn>(conn: &'c Conn, context: Context, client_specs: &'input [ClientSpec]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -783,7 +782,7 @@ impl GetContextRequest {
     /// Opcode for the GetContext request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -874,7 +873,7 @@ impl EnableContextRequest {
     /// Opcode for the EnableContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -973,7 +972,7 @@ impl DisableContextRequest {
     /// Opcode for the DisableContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1018,7 +1017,7 @@ impl FreeContextRequest {
     /// Opcode for the FreeContext request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -494,14 +494,14 @@ impl From<BadContextError> for [u8; 32] {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -514,7 +514,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -569,6 +569,8 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the CreateContext request
+pub const CREATE_CONTEXT_REQUEST: u8 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateContextRequest<'input> {
     pub context: Context,
@@ -577,8 +579,6 @@ pub struct CreateContextRequest<'input> {
     pub ranges: &'input [Range],
 }
 impl<'input> CreateContextRequest<'input> {
-    /// Opcode for the CreateContext request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -595,7 +595,7 @@ impl<'input> CreateContextRequest<'input> {
         let num_ranges_bytes = num_ranges.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -643,6 +643,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the RegisterClients request
+pub const REGISTER_CLIENTS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegisterClientsRequest<'input> {
     pub context: Context,
@@ -651,8 +653,6 @@ pub struct RegisterClientsRequest<'input> {
     pub ranges: &'input [Range],
 }
 impl<'input> RegisterClientsRequest<'input> {
-    /// Opcode for the RegisterClients request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -669,7 +669,7 @@ impl<'input> RegisterClientsRequest<'input> {
         let num_ranges_bytes = num_ranges.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            REGISTER_CLIENTS_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -717,14 +717,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UnregisterClients request
+pub const UNREGISTER_CLIENTS_REQUEST: u8 = 3;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnregisterClientsRequest<'input> {
     pub context: Context,
     pub client_specs: &'input [ClientSpec],
 }
 impl<'input> UnregisterClientsRequest<'input> {
-    /// Opcode for the UnregisterClients request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -738,7 +738,7 @@ impl<'input> UnregisterClientsRequest<'input> {
         let num_client_specs_bytes = num_client_specs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNREGISTER_CLIENTS_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -774,13 +774,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetContext request
+pub const GET_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetContextRequest {
     pub context: Context,
 }
 impl GetContextRequest {
-    /// Opcode for the GetContext request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -792,7 +792,7 @@ impl GetContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -865,13 +865,13 @@ impl GetContextReply {
     }
 }
 
+/// Opcode for the EnableContext request
+pub const ENABLE_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnableContextRequest {
     pub context: Context,
 }
 impl EnableContextRequest {
-    /// Opcode for the EnableContext request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -883,7 +883,7 @@ impl EnableContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ENABLE_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -964,13 +964,13 @@ impl EnableContextReply {
     }
 }
 
+/// Opcode for the DisableContext request
+pub const DISABLE_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableContextRequest {
     pub context: Context,
 }
 impl DisableContextRequest {
-    /// Opcode for the DisableContext request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -982,7 +982,7 @@ impl DisableContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DISABLE_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1009,13 +1009,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreeContext request
+pub const FREE_CONTEXT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FreeContextRequest {
     pub context: Context,
 }
 impl FreeContextRequest {
-    /// Opcode for the FreeContext request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1027,7 +1027,7 @@ impl FreeContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FREE_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -536,8 +536,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -636,10 +636,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateContextRequest {
-        context: context,
-        element_header: element_header,
-        client_specs: client_specs,
-        ranges: ranges,
+        context,
+        element_header,
+        client_specs,
+        ranges,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -711,10 +711,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RegisterClientsRequest {
-        context: context,
-        element_header: element_header,
-        client_specs: client_specs,
-        ranges: ranges,
+        context,
+        element_header,
+        client_specs,
+        ranges,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -771,8 +771,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UnregisterClientsRequest {
-        context: context,
-        client_specs: client_specs,
+        context,
+        client_specs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -818,7 +818,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -910,7 +910,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = EnableContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1010,7 +1010,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DisableContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1056,7 +1056,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -516,7 +516,7 @@ impl QueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -598,7 +598,7 @@ impl<'input> CreateContextRequest<'input> {
         let num_ranges_bytes = num_ranges.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -673,7 +673,7 @@ impl<'input> RegisterClientsRequest<'input> {
         let num_ranges_bytes = num_ranges.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RegisterClientsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -743,7 +743,7 @@ impl<'input> UnregisterClientsRequest<'input> {
         let num_client_specs_bytes = num_client_specs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UnregisterClientsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -798,7 +798,7 @@ impl GetContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -890,7 +890,7 @@ impl EnableContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            EnableContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -990,7 +990,7 @@ impl DisableContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DisableContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1036,7 +1036,7 @@ impl FreeContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FreeContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -504,7 +504,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -582,7 +581,6 @@ impl<'input> CreateContextRequest<'input> {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -657,7 +655,6 @@ impl<'input> RegisterClientsRequest<'input> {
     /// Opcode for the RegisterClients request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -730,7 +727,6 @@ impl<'input> UnregisterClientsRequest<'input> {
     /// Opcode for the UnregisterClients request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -787,7 +783,6 @@ impl GetContextRequest {
     /// Opcode for the GetContext request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -879,7 +874,6 @@ impl EnableContextRequest {
     /// Opcode for the EnableContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -979,7 +973,6 @@ impl DisableContextRequest {
     /// Opcode for the DisableContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1025,7 +1018,6 @@ impl FreeContextRequest {
     /// Opcode for the FreeContext request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1855,8 +1855,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2053,7 +2053,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryPictIndexValuesRequest {
-        format: format,
+        format,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2347,10 +2347,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreatePictureRequest {
-        pid: pid,
-        drawable: drawable,
-        format: format,
-        value_list: value_list,
+        pid,
+        drawable,
+        format,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2590,8 +2590,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangePictureRequest {
-        picture: picture,
-        value_list: value_list,
+        picture,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2650,10 +2650,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPictureClipRectanglesRequest {
-        picture: picture,
-        clip_x_origin: clip_x_origin,
-        clip_y_origin: clip_y_origin,
-        rectangles: rectangles,
+        picture,
+        clip_x_origin,
+        clip_y_origin,
+        rectangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2699,7 +2699,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreePictureRequest {
-        picture: picture,
+        picture,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2797,18 +2797,18 @@ where
 {
     let mask: Picture = mask.into();
     let request0 = CompositeRequest {
-        op: op,
-        src: src,
-        mask: mask,
-        dst: dst,
-        src_x: src_x,
-        src_y: src_y,
-        mask_x: mask_x,
-        mask_y: mask_y,
-        dst_x: dst_x,
-        dst_y: dst_y,
-        width: width,
-        height: height,
+        op,
+        src,
+        mask,
+        dst,
+        src_x,
+        src_y,
+        mask_x,
+        mask_y,
+        dst_x,
+        dst_y,
+        width,
+        height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2885,13 +2885,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = TrapezoidsRequest {
-        op: op,
-        src: src,
-        dst: dst,
-        mask_format: mask_format,
-        src_x: src_x,
-        src_y: src_y,
-        traps: traps,
+        op,
+        src,
+        dst,
+        mask_format,
+        src_x,
+        src_y,
+        traps,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2968,13 +2968,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = TrianglesRequest {
-        op: op,
-        src: src,
-        dst: dst,
-        mask_format: mask_format,
-        src_x: src_x,
-        src_y: src_y,
-        triangles: triangles,
+        op,
+        src,
+        dst,
+        mask_format,
+        src_x,
+        src_y,
+        triangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3051,13 +3051,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = TriStripRequest {
-        op: op,
-        src: src,
-        dst: dst,
-        mask_format: mask_format,
-        src_x: src_x,
-        src_y: src_y,
-        points: points,
+        op,
+        src,
+        dst,
+        mask_format,
+        src_x,
+        src_y,
+        points,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3134,13 +3134,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = TriFanRequest {
-        op: op,
-        src: src,
-        dst: dst,
-        mask_format: mask_format,
-        src_x: src_x,
-        src_y: src_y,
-        points: points,
+        op,
+        src,
+        dst,
+        mask_format,
+        src_x,
+        src_y,
+        points,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3192,8 +3192,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateGlyphSetRequest {
-        gsid: gsid,
-        format: format,
+        gsid,
+        format,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3245,8 +3245,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ReferenceGlyphSetRequest {
-        gsid: gsid,
-        existing: existing,
+        gsid,
+        existing,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3292,7 +3292,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeGlyphSetRequest {
-        glyphset: glyphset,
+        glyphset,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3355,10 +3355,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AddGlyphsRequest {
-        glyphset: glyphset,
-        glyphids: glyphids,
-        glyphs: glyphs,
-        data: data,
+        glyphset,
+        glyphids,
+        glyphs,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3409,8 +3409,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeGlyphsRequest {
-        glyphset: glyphset,
-        glyphs: glyphs,
+        glyphset,
+        glyphs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3492,14 +3492,14 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CompositeGlyphs8Request {
-        op: op,
-        src: src,
-        dst: dst,
-        mask_format: mask_format,
-        glyphset: glyphset,
-        src_x: src_x,
-        src_y: src_y,
-        glyphcmds: glyphcmds,
+        op,
+        src,
+        dst,
+        mask_format,
+        glyphset,
+        src_x,
+        src_y,
+        glyphcmds,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3581,14 +3581,14 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CompositeGlyphs16Request {
-        op: op,
-        src: src,
-        dst: dst,
-        mask_format: mask_format,
-        glyphset: glyphset,
-        src_x: src_x,
-        src_y: src_y,
-        glyphcmds: glyphcmds,
+        op,
+        src,
+        dst,
+        mask_format,
+        glyphset,
+        src_x,
+        src_y,
+        glyphcmds,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3670,14 +3670,14 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CompositeGlyphs32Request {
-        op: op,
-        src: src,
-        dst: dst,
-        mask_format: mask_format,
-        glyphset: glyphset,
-        src_x: src_x,
-        src_y: src_y,
-        glyphcmds: glyphcmds,
+        op,
+        src,
+        dst,
+        mask_format,
+        glyphset,
+        src_x,
+        src_y,
+        glyphcmds,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3744,10 +3744,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FillRectanglesRequest {
-        op: op,
-        dst: dst,
-        color: color,
-        rects: rects,
+        op,
+        dst,
+        color,
+        rects,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3807,10 +3807,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateCursorRequest {
-        cid: cid,
-        source: source,
-        x: x,
-        y: y,
+        cid,
+        source,
+        x,
+        y,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3992,8 +3992,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPictureTransformRequest {
-        picture: picture,
-        transform: transform,
+        picture,
+        transform,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4039,7 +4039,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryFiltersRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4158,9 +4158,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPictureFilterRequest {
-        picture: picture,
-        filter: filter,
-        values: values,
+        picture,
+        filter,
+        values,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4253,8 +4253,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateAnimCursorRequest {
-        cid: cid,
-        cursors: cursors,
+        cid,
+        cursors,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4421,10 +4421,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AddTrapsRequest {
-        picture: picture,
-        x_off: x_off,
-        y_off: y_off,
-        traps: traps,
+        picture,
+        x_off,
+        y_off,
+        traps,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4480,8 +4480,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateSolidFillRequest {
-        picture: picture,
-        color: color,
+        picture,
+        color,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4562,11 +4562,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateLinearGradientRequest {
-        picture: picture,
-        p1: p1,
-        p2: p2,
-        stops: stops,
-        colors: colors,
+        picture,
+        p1,
+        p2,
+        stops,
+        colors,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4659,13 +4659,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRadialGradientRequest {
-        picture: picture,
-        inner: inner,
-        outer: outer,
-        inner_radius: inner_radius,
-        outer_radius: outer_radius,
-        stops: stops,
-        colors: colors,
+        picture,
+        inner,
+        outer,
+        inner_radius,
+        outer_radius,
+        stops,
+        colors,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4742,11 +4742,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateConicalGradientRequest {
-        picture: picture,
-        center: center,
-        angle: angle,
-        stops: stops,
-        colors: colors,
+        picture,
+        center,
+        angle,
+        stops,
+        colors,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -2231,7 +2231,7 @@ impl CreatePictureAux {
     }
 }
 
-pub fn create_picture<'c, Conn>(conn: &'c Conn, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_picture<'c, 'input, Conn>(conn: &'c Conn, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &'input CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2461,7 +2461,7 @@ impl ChangePictureAux {
     }
 }
 
-pub fn change_picture<'c, Conn>(conn: &'c Conn, picture: Picture, value_list: &ChangePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_picture<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, value_list: &'input ChangePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2498,7 +2498,7 @@ where
 
 /// Opcode for the SetPictureClipRectangles request
 pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
-pub fn set_picture_clip_rectangles<'c, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_picture_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2630,7 +2630,7 @@ where
 
 /// Opcode for the Trapezoids request
 pub const TRAPEZOIDS_REQUEST: u8 = 10;
-pub fn trapezoids<'c, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &[Trapezoid]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn trapezoids<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &'input [Trapezoid]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2682,7 +2682,7 @@ where
 
 /// Opcode for the Triangles request
 pub const TRIANGLES_REQUEST: u8 = 11;
-pub fn triangles<'c, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &[Triangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn triangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &'input [Triangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2734,7 +2734,7 @@ where
 
 /// Opcode for the TriStrip request
 pub const TRI_STRIP_REQUEST: u8 = 12;
-pub fn tri_strip<'c, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn tri_strip<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2786,7 +2786,7 @@ where
 
 /// Opcode for the TriFan request
 pub const TRI_FAN_REQUEST: u8 = 13;
-pub fn tri_fan<'c, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn tri_fan<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2929,7 +2929,7 @@ where
 
 /// Opcode for the AddGlyphs request
 pub const ADD_GLYPHS_REQUEST: u8 = 20;
-pub fn add_glyphs<'c, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphids: &[u32], glyphs: &[Glyphinfo], data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn add_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphids: &'input [u32], glyphs: &'input [Glyphinfo], data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2970,7 +2970,7 @@ where
 
 /// Opcode for the FreeGlyphs request
 pub const FREE_GLYPHS_REQUEST: u8 = 22;
-pub fn free_glyphs<'c, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphs: &[Glyph]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn free_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphs: &'input [Glyph]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3001,7 +3001,7 @@ where
 
 /// Opcode for the CompositeGlyphs8 request
 pub const COMPOSITE_GLYPHS8_REQUEST: u8 = 23;
-pub fn composite_glyphs8<'c, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn composite_glyphs8<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3057,7 +3057,7 @@ where
 
 /// Opcode for the CompositeGlyphs16 request
 pub const COMPOSITE_GLYPHS16_REQUEST: u8 = 24;
-pub fn composite_glyphs16<'c, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn composite_glyphs16<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3113,7 +3113,7 @@ where
 
 /// Opcode for the CompositeGlyphs32 request
 pub const COMPOSITE_GLYPHS32_REQUEST: u8 = 25;
-pub fn composite_glyphs32<'c, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn composite_glyphs32<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3169,7 +3169,7 @@ where
 
 /// Opcode for the FillRectangles request
 pub const FILL_RECTANGLES_REQUEST: u8 = 26;
-pub fn fill_rectangles<'c, Conn>(conn: &'c Conn, op: PictOp, dst: Picture, color: Color, rects: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn fill_rectangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, dst: Picture, color: Color, rects: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3499,7 +3499,7 @@ impl QueryFiltersReply {
 
 /// Opcode for the SetPictureFilter request
 pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
-pub fn set_picture_filter<'c, Conn>(conn: &'c Conn, picture: Picture, filter: &[u8], values: &[Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_picture_filter<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, filter: &'input [u8], values: &'input [Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3581,7 +3581,7 @@ impl Serialize for Animcursorelt {
 
 /// Opcode for the CreateAnimCursor request
 pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
-pub fn create_anim_cursor<'c, Conn>(conn: &'c Conn, cid: xproto::Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_anim_cursor<'c, 'input, Conn>(conn: &'c Conn, cid: xproto::Cursor, cursors: &'input [Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3720,7 +3720,7 @@ impl Serialize for Trap {
 
 /// Opcode for the AddTraps request
 pub const ADD_TRAPS_REQUEST: u8 = 32;
-pub fn add_traps<'c, Conn>(conn: &'c Conn, picture: Picture, x_off: i16, y_off: i16, traps: &[Trap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn add_traps<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, x_off: i16, y_off: i16, traps: &'input [Trap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3793,7 +3793,7 @@ where
 
 /// Opcode for the CreateLinearGradient request
 pub const CREATE_LINEAR_GRADIENT_REQUEST: u8 = 34;
-pub fn create_linear_gradient<'c, Conn>(conn: &'c Conn, picture: Picture, p1: Pointfix, p2: Pointfix, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_linear_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, p1: Pointfix, p2: Pointfix, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3851,7 +3851,7 @@ where
 
 /// Opcode for the CreateRadialGradient request
 pub const CREATE_RADIAL_GRADIENT_REQUEST: u8 = 35;
-pub fn create_radial_gradient<'c, Conn>(conn: &'c Conn, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_radial_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3919,7 +3919,7 @@ where
 
 /// Opcode for the CreateConicalGradient request
 pub const CREATE_CONICAL_GRADIENT_REQUEST: u8 = 36;
-pub fn create_conical_gradient<'c, Conn>(conn: &'c Conn, picture: Picture, center: Pointfix, angle: Fixed, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_conical_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, center: Pointfix, angle: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -3985,15 +3985,15 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_pict_index_values(self, format)
     }
-    fn render_create_picture<'c>(&'c self, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &CreatePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_picture<'c, 'input>(&'c self, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &'input CreatePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_picture(self, pid, drawable, format, value_list)
     }
-    fn render_change_picture<'c>(&'c self, picture: Picture, value_list: &ChangePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_change_picture<'c, 'input>(&'c self, picture: Picture, value_list: &'input ChangePictureAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_picture(self, picture, value_list)
     }
-    fn render_set_picture_clip_rectangles<'c>(&'c self, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_set_picture_clip_rectangles<'c, 'input>(&'c self, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_picture_clip_rectangles(self, picture, clip_x_origin, clip_y_origin, rectangles)
     }
@@ -4007,19 +4007,19 @@ pub trait ConnectionExt: RequestConnection {
     {
         composite(self, op, src, mask, dst, src_x, src_y, mask_x, mask_y, dst_x, dst_y, width, height)
     }
-    fn render_trapezoids<'c>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &[Trapezoid]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_trapezoids<'c, 'input>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &'input [Trapezoid]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         trapezoids(self, op, src, dst, mask_format, src_x, src_y, traps)
     }
-    fn render_triangles<'c>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &[Triangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_triangles<'c, 'input>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &'input [Triangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         self::triangles(self, op, src, dst, mask_format, src_x, src_y, triangles)
     }
-    fn render_tri_strip<'c>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_tri_strip<'c, 'input>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         tri_strip(self, op, src, dst, mask_format, src_x, src_y, points)
     }
-    fn render_tri_fan<'c>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &[Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_tri_fan<'c, 'input>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         tri_fan(self, op, src, dst, mask_format, src_x, src_y, points)
     }
@@ -4035,27 +4035,27 @@ pub trait ConnectionExt: RequestConnection {
     {
         free_glyph_set(self, glyphset)
     }
-    fn render_add_glyphs<'c>(&'c self, glyphset: Glyphset, glyphids: &[u32], glyphs: &[Glyphinfo], data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_add_glyphs<'c, 'input>(&'c self, glyphset: Glyphset, glyphids: &'input [u32], glyphs: &'input [Glyphinfo], data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         add_glyphs(self, glyphset, glyphids, glyphs, data)
     }
-    fn render_free_glyphs<'c>(&'c self, glyphset: Glyphset, glyphs: &[Glyph]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_free_glyphs<'c, 'input>(&'c self, glyphset: Glyphset, glyphs: &'input [Glyph]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         free_glyphs(self, glyphset, glyphs)
     }
-    fn render_composite_glyphs8<'c>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_composite_glyphs8<'c, 'input>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         composite_glyphs8(self, op, src, dst, mask_format, glyphset, src_x, src_y, glyphcmds)
     }
-    fn render_composite_glyphs16<'c>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_composite_glyphs16<'c, 'input>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         composite_glyphs16(self, op, src, dst, mask_format, glyphset, src_x, src_y, glyphcmds)
     }
-    fn render_composite_glyphs32<'c>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_composite_glyphs32<'c, 'input>(&'c self, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         composite_glyphs32(self, op, src, dst, mask_format, glyphset, src_x, src_y, glyphcmds)
     }
-    fn render_fill_rectangles<'c>(&'c self, op: PictOp, dst: Picture, color: Color, rects: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_fill_rectangles<'c, 'input>(&'c self, op: PictOp, dst: Picture, color: Color, rects: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         fill_rectangles(self, op, dst, color, rects)
     }
@@ -4071,15 +4071,15 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_filters(self, drawable)
     }
-    fn render_set_picture_filter<'c>(&'c self, picture: Picture, filter: &[u8], values: &[Fixed]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_set_picture_filter<'c, 'input>(&'c self, picture: Picture, filter: &'input [u8], values: &'input [Fixed]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_picture_filter(self, picture, filter, values)
     }
-    fn render_create_anim_cursor<'c>(&'c self, cid: xproto::Cursor, cursors: &[Animcursorelt]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_anim_cursor<'c, 'input>(&'c self, cid: xproto::Cursor, cursors: &'input [Animcursorelt]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_anim_cursor(self, cid, cursors)
     }
-    fn render_add_traps<'c>(&'c self, picture: Picture, x_off: i16, y_off: i16, traps: &[Trap]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_add_traps<'c, 'input>(&'c self, picture: Picture, x_off: i16, y_off: i16, traps: &'input [Trap]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         add_traps(self, picture, x_off, y_off, traps)
     }
@@ -4087,15 +4087,15 @@ pub trait ConnectionExt: RequestConnection {
     {
         create_solid_fill(self, picture, color)
     }
-    fn render_create_linear_gradient<'c>(&'c self, picture: Picture, p1: Pointfix, p2: Pointfix, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_linear_gradient<'c, 'input>(&'c self, picture: Picture, p1: Pointfix, p2: Pointfix, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_linear_gradient(self, picture, p1, p2, stops, colors)
     }
-    fn render_create_radial_gradient<'c>(&'c self, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_radial_gradient<'c, 'input>(&'c self, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_radial_gradient(self, picture, inner, outer, inner_radius, outer_radius, stops, colors)
     }
-    fn render_create_conical_gradient<'c>(&'c self, picture: Picture, center: Pointfix, angle: Fixed, stops: &[Fixed], colors: &[Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn render_create_conical_gradient<'c, 'input>(&'c self, picture: Picture, center: Pointfix, angle: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_conical_gradient(self, picture, center, angle, stops, colors)
     }

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1831,7 +1831,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -1907,7 +1907,7 @@ impl QueryPictFormatsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryPictFormatsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -2033,7 +2033,7 @@ impl QueryPictIndexValuesRequest {
         let format_bytes = self.format.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryPictIndexValuesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             format_bytes[0],
@@ -2311,7 +2311,7 @@ impl<'input> CreatePictureRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreatePictureRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             pid_bytes[0],
@@ -2562,7 +2562,7 @@ impl<'input> ChangePictureRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangePictureRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -2622,7 +2622,7 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
         let clip_y_origin_bytes = self.clip_y_origin.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPictureClipRectanglesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -2679,7 +2679,7 @@ impl FreePictureRequest {
         let picture_bytes = self.picture.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FreePictureRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -2747,7 +2747,7 @@ impl CompositeRequest {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CompositeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -2845,7 +2845,7 @@ impl<'input> TrapezoidsRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            TrapezoidsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -2928,7 +2928,7 @@ impl<'input> TrianglesRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            TrianglesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -3011,7 +3011,7 @@ impl<'input> TriStripRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            TriStripRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -3094,7 +3094,7 @@ impl<'input> TriFanRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            TriFanRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -3168,7 +3168,7 @@ impl CreateGlyphSetRequest {
         let format_bytes = self.format.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateGlyphSetRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             gsid_bytes[0],
@@ -3221,7 +3221,7 @@ impl ReferenceGlyphSetRequest {
         let existing_bytes = self.existing.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ReferenceGlyphSetRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             gsid_bytes[0],
@@ -3272,7 +3272,7 @@ impl FreeGlyphSetRequest {
         let glyphset_bytes = self.glyphset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FreeGlyphSetRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             glyphset_bytes[0],
@@ -3323,7 +3323,7 @@ impl<'input> AddGlyphsRequest<'input> {
         let glyphs_len_bytes = glyphs_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AddGlyphsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             glyphset_bytes[0],
@@ -3385,7 +3385,7 @@ impl<'input> FreeGlyphsRequest<'input> {
         let glyphset_bytes = self.glyphset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FreeGlyphsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             glyphset_bytes[0],
@@ -3449,7 +3449,7 @@ impl<'input> CompositeGlyphs8Request<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CompositeGlyphs8Request::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -3538,7 +3538,7 @@ impl<'input> CompositeGlyphs16Request<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CompositeGlyphs16Request::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -3627,7 +3627,7 @@ impl<'input> CompositeGlyphs32Request<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CompositeGlyphs32Request::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -3708,7 +3708,7 @@ impl<'input> FillRectanglesRequest<'input> {
         let color_bytes = self.color.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FillRectanglesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             op_bytes[0],
@@ -3779,7 +3779,7 @@ impl CreateCursorRequest {
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cid_bytes[0],
@@ -3936,7 +3936,7 @@ impl SetPictureTransformRequest {
         let transform_bytes = self.transform.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPictureTransformRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -4019,7 +4019,7 @@ impl QueryFiltersRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryFiltersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -4127,7 +4127,7 @@ impl<'input> SetPictureFilterRequest<'input> {
         let filter_len_bytes = filter_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPictureFilterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -4229,7 +4229,7 @@ impl<'input> CreateAnimCursorRequest<'input> {
         let cid_bytes = self.cid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateAnimCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cid_bytes[0],
@@ -4393,7 +4393,7 @@ impl<'input> AddTrapsRequest<'input> {
         let y_off_bytes = self.y_off.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AddTrapsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -4452,7 +4452,7 @@ impl CreateSolidFillRequest {
         let color_bytes = self.color.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateSolidFillRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -4515,7 +4515,7 @@ impl<'input> CreateLinearGradientRequest<'input> {
         let num_stops_bytes = num_stops.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateLinearGradientRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -4604,7 +4604,7 @@ impl<'input> CreateRadialGradientRequest<'input> {
         let num_stops_bytes = num_stops.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRadialGradientRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -4699,7 +4699,7 @@ impl<'input> CreateConicalGradientRequest<'input> {
         let num_stops_bytes = num_stops.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateConicalGradientRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1809,14 +1809,14 @@ impl Serialize for Glyphinfo {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1829,7 +1829,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -1889,11 +1889,11 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the QueryPictFormats request
+pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryPictFormatsRequest;
 impl QueryPictFormatsRequest {
-    /// Opcode for the QueryPictFormats request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1904,7 +1904,7 @@ impl QueryPictFormatsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_PICT_FORMATS_REQUEST,
             0,
             0,
         ];
@@ -2011,13 +2011,13 @@ impl QueryPictFormatsReply {
     }
 }
 
+/// Opcode for the QueryPictIndexValues request
+pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryPictIndexValuesRequest {
     pub format: Pictformat,
 }
 impl QueryPictIndexValuesRequest {
-    /// Opcode for the QueryPictIndexValues request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2029,7 +2029,7 @@ impl QueryPictIndexValuesRequest {
         let format_bytes = self.format.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_PICT_INDEX_VALUES_REQUEST,
             0,
             0,
             format_bytes[0],
@@ -2281,6 +2281,8 @@ impl CreatePictureAux {
     }
 }
 
+/// Opcode for the CreatePicture request
+pub const CREATE_PICTURE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreatePictureRequest<'input> {
     pub pid: Picture,
@@ -2289,8 +2291,6 @@ pub struct CreatePictureRequest<'input> {
     pub value_list: &'input CreatePictureAux,
 }
 impl<'input> CreatePictureRequest<'input> {
-    /// Opcode for the CreatePicture request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2306,7 +2306,7 @@ impl<'input> CreatePictureRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_PICTURE_REQUEST,
             0,
             0,
             pid_bytes[0],
@@ -2535,14 +2535,14 @@ impl ChangePictureAux {
     }
 }
 
+/// Opcode for the ChangePicture request
+pub const CHANGE_PICTURE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangePictureRequest<'input> {
     pub picture: Picture,
     pub value_list: &'input ChangePictureAux,
 }
 impl<'input> ChangePictureRequest<'input> {
-    /// Opcode for the ChangePicture request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2556,7 +2556,7 @@ impl<'input> ChangePictureRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_PICTURE_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -2592,6 +2592,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetPictureClipRectangles request
+pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetPictureClipRectanglesRequest<'input> {
     pub picture: Picture,
@@ -2600,8 +2602,6 @@ pub struct SetPictureClipRectanglesRequest<'input> {
     pub rectangles: &'input [xproto::Rectangle],
 }
 impl<'input> SetPictureClipRectanglesRequest<'input> {
-    /// Opcode for the SetPictureClipRectangles request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2615,7 +2615,7 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
         let clip_y_origin_bytes = self.clip_y_origin.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PICTURE_CLIP_RECTANGLES_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -2653,13 +2653,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreePicture request
+pub const FREE_PICTURE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FreePictureRequest {
     pub picture: Picture,
 }
 impl FreePictureRequest {
-    /// Opcode for the FreePicture request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2671,7 +2671,7 @@ impl FreePictureRequest {
         let picture_bytes = self.picture.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FREE_PICTURE_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -2698,6 +2698,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Composite request
+pub const COMPOSITE_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompositeRequest {
     pub op: PictOp,
@@ -2714,8 +2716,6 @@ pub struct CompositeRequest {
     pub height: u16,
 }
 impl CompositeRequest {
-    /// Opcode for the Composite request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2738,7 +2738,7 @@ impl CompositeRequest {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COMPOSITE_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -2806,6 +2806,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Trapezoids request
+pub const TRAPEZOIDS_REQUEST: u8 = 10;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrapezoidsRequest<'input> {
     pub op: PictOp,
@@ -2817,8 +2819,6 @@ pub struct TrapezoidsRequest<'input> {
     pub traps: &'input [Trapezoid],
 }
 impl<'input> TrapezoidsRequest<'input> {
-    /// Opcode for the Trapezoids request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2835,7 +2835,7 @@ impl<'input> TrapezoidsRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            TRAPEZOIDS_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -2888,6 +2888,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Triangles request
+pub const TRIANGLES_REQUEST: u8 = 11;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrianglesRequest<'input> {
     pub op: PictOp,
@@ -2899,8 +2901,6 @@ pub struct TrianglesRequest<'input> {
     pub triangles: &'input [Triangle],
 }
 impl<'input> TrianglesRequest<'input> {
-    /// Opcode for the Triangles request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2917,7 +2917,7 @@ impl<'input> TrianglesRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            TRIANGLES_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -2970,6 +2970,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the TriStrip request
+pub const TRI_STRIP_REQUEST: u8 = 12;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TriStripRequest<'input> {
     pub op: PictOp,
@@ -2981,8 +2983,6 @@ pub struct TriStripRequest<'input> {
     pub points: &'input [Pointfix],
 }
 impl<'input> TriStripRequest<'input> {
-    /// Opcode for the TriStrip request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2999,7 +2999,7 @@ impl<'input> TriStripRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            TRI_STRIP_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -3052,6 +3052,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the TriFan request
+pub const TRI_FAN_REQUEST: u8 = 13;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TriFanRequest<'input> {
     pub op: PictOp,
@@ -3063,8 +3065,6 @@ pub struct TriFanRequest<'input> {
     pub points: &'input [Pointfix],
 }
 impl<'input> TriFanRequest<'input> {
-    /// Opcode for the TriFan request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3081,7 +3081,7 @@ impl<'input> TriFanRequest<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            TRI_FAN_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -3134,14 +3134,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateGlyphSet request
+pub const CREATE_GLYPH_SET_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateGlyphSetRequest {
     pub gsid: Glyphset,
     pub format: Pictformat,
 }
 impl CreateGlyphSetRequest {
-    /// Opcode for the CreateGlyphSet request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3154,7 +3154,7 @@ impl CreateGlyphSetRequest {
         let format_bytes = self.format.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_GLYPH_SET_REQUEST,
             0,
             0,
             gsid_bytes[0],
@@ -3186,14 +3186,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ReferenceGlyphSet request
+pub const REFERENCE_GLYPH_SET_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReferenceGlyphSetRequest {
     pub gsid: Glyphset,
     pub existing: Glyphset,
 }
 impl ReferenceGlyphSetRequest {
-    /// Opcode for the ReferenceGlyphSet request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3206,7 +3206,7 @@ impl ReferenceGlyphSetRequest {
         let existing_bytes = self.existing.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            REFERENCE_GLYPH_SET_REQUEST,
             0,
             0,
             gsid_bytes[0],
@@ -3238,13 +3238,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreeGlyphSet request
+pub const FREE_GLYPH_SET_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FreeGlyphSetRequest {
     pub glyphset: Glyphset,
 }
 impl FreeGlyphSetRequest {
-    /// Opcode for the FreeGlyphSet request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3256,7 +3256,7 @@ impl FreeGlyphSetRequest {
         let glyphset_bytes = self.glyphset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FREE_GLYPH_SET_REQUEST,
             0,
             0,
             glyphset_bytes[0],
@@ -3283,6 +3283,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the AddGlyphs request
+pub const ADD_GLYPHS_REQUEST: u8 = 20;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddGlyphsRequest<'input> {
     pub glyphset: Glyphset,
@@ -3291,8 +3293,6 @@ pub struct AddGlyphsRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> AddGlyphsRequest<'input> {
-    /// Opcode for the AddGlyphs request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3306,7 +3306,7 @@ impl<'input> AddGlyphsRequest<'input> {
         let glyphs_len_bytes = glyphs_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ADD_GLYPHS_REQUEST,
             0,
             0,
             glyphset_bytes[0],
@@ -3348,14 +3348,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreeGlyphs request
+pub const FREE_GLYPHS_REQUEST: u8 = 22;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FreeGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphs: &'input [Glyph],
 }
 impl<'input> FreeGlyphsRequest<'input> {
-    /// Opcode for the FreeGlyphs request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3367,7 +3367,7 @@ impl<'input> FreeGlyphsRequest<'input> {
         let glyphset_bytes = self.glyphset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FREE_GLYPHS_REQUEST,
             0,
             0,
             glyphset_bytes[0],
@@ -3399,6 +3399,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CompositeGlyphs8 request
+pub const COMPOSITE_GLYPHS8_REQUEST: u8 = 23;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompositeGlyphs8Request<'input> {
     pub op: PictOp,
@@ -3411,8 +3413,6 @@ pub struct CompositeGlyphs8Request<'input> {
     pub glyphcmds: &'input [u8],
 }
 impl<'input> CompositeGlyphs8Request<'input> {
-    /// Opcode for the CompositeGlyphs8 request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3430,7 +3430,7 @@ impl<'input> CompositeGlyphs8Request<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COMPOSITE_GLYPHS8_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -3487,6 +3487,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CompositeGlyphs16 request
+pub const COMPOSITE_GLYPHS16_REQUEST: u8 = 24;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompositeGlyphs16Request<'input> {
     pub op: PictOp,
@@ -3499,8 +3501,6 @@ pub struct CompositeGlyphs16Request<'input> {
     pub glyphcmds: &'input [u8],
 }
 impl<'input> CompositeGlyphs16Request<'input> {
-    /// Opcode for the CompositeGlyphs16 request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3518,7 +3518,7 @@ impl<'input> CompositeGlyphs16Request<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COMPOSITE_GLYPHS16_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -3575,6 +3575,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CompositeGlyphs32 request
+pub const COMPOSITE_GLYPHS32_REQUEST: u8 = 25;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompositeGlyphs32Request<'input> {
     pub op: PictOp,
@@ -3587,8 +3589,6 @@ pub struct CompositeGlyphs32Request<'input> {
     pub glyphcmds: &'input [u8],
 }
 impl<'input> CompositeGlyphs32Request<'input> {
-    /// Opcode for the CompositeGlyphs32 request
-    pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3606,7 +3606,7 @@ impl<'input> CompositeGlyphs32Request<'input> {
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COMPOSITE_GLYPHS32_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -3663,6 +3663,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FillRectangles request
+pub const FILL_RECTANGLES_REQUEST: u8 = 26;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FillRectanglesRequest<'input> {
     pub op: PictOp,
@@ -3671,8 +3673,6 @@ pub struct FillRectanglesRequest<'input> {
     pub rects: &'input [xproto::Rectangle],
 }
 impl<'input> FillRectanglesRequest<'input> {
-    /// Opcode for the FillRectangles request
-    pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3686,7 +3686,7 @@ impl<'input> FillRectanglesRequest<'input> {
         let color_bytes = self.color.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FILL_RECTANGLES_REQUEST,
             0,
             0,
             op_bytes[0],
@@ -3732,6 +3732,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateCursor request
+pub const CREATE_CURSOR_REQUEST: u8 = 27;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateCursorRequest {
     pub cid: xproto::Cursor,
@@ -3740,8 +3742,6 @@ pub struct CreateCursorRequest {
     pub y: u16,
 }
 impl CreateCursorRequest {
-    /// Opcode for the CreateCursor request
-    pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3756,7 +3756,7 @@ impl CreateCursorRequest {
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CURSOR_REQUEST,
             0,
             0,
             cid_bytes[0],
@@ -3892,14 +3892,14 @@ impl Serialize for Transform {
     }
 }
 
+/// Opcode for the SetPictureTransform request
+pub const SET_PICTURE_TRANSFORM_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetPictureTransformRequest {
     pub picture: Picture,
     pub transform: Transform,
 }
 impl SetPictureTransformRequest {
-    /// Opcode for the SetPictureTransform request
-    pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3912,7 +3912,7 @@ impl SetPictureTransformRequest {
         let transform_bytes = self.transform.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PICTURE_TRANSFORM_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -3976,13 +3976,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryFilters request
+pub const QUERY_FILTERS_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryFiltersRequest {
     pub drawable: xproto::Drawable,
 }
 impl QueryFiltersRequest {
-    /// Opcode for the QueryFilters request
-    pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3994,7 +3994,7 @@ impl QueryFiltersRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_FILTERS_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -4079,6 +4079,8 @@ impl QueryFiltersReply {
     }
 }
 
+/// Opcode for the SetPictureFilter request
+pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetPictureFilterRequest<'input> {
     pub picture: Picture,
@@ -4086,8 +4088,6 @@ pub struct SetPictureFilterRequest<'input> {
     pub values: &'input [Fixed],
 }
 impl<'input> SetPictureFilterRequest<'input> {
-    /// Opcode for the SetPictureFilter request
-    pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4101,7 +4101,7 @@ impl<'input> SetPictureFilterRequest<'input> {
         let filter_len_bytes = filter_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PICTURE_FILTER_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -4183,14 +4183,14 @@ impl Serialize for Animcursorelt {
     }
 }
 
+/// Opcode for the CreateAnimCursor request
+pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateAnimCursorRequest<'input> {
     pub cid: xproto::Cursor,
     pub cursors: &'input [Animcursorelt],
 }
 impl<'input> CreateAnimCursorRequest<'input> {
-    /// Opcode for the CreateAnimCursor request
-    pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4202,7 +4202,7 @@ impl<'input> CreateAnimCursorRequest<'input> {
         let cid_bytes = self.cid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_ANIM_CURSOR_REQUEST,
             0,
             0,
             cid_bytes[0],
@@ -4342,6 +4342,8 @@ impl Serialize for Trap {
     }
 }
 
+/// Opcode for the AddTraps request
+pub const ADD_TRAPS_REQUEST: u8 = 32;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddTrapsRequest<'input> {
     pub picture: Picture,
@@ -4350,8 +4352,6 @@ pub struct AddTrapsRequest<'input> {
     pub traps: &'input [Trap],
 }
 impl<'input> AddTrapsRequest<'input> {
-    /// Opcode for the AddTraps request
-    pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4365,7 +4365,7 @@ impl<'input> AddTrapsRequest<'input> {
         let y_off_bytes = self.y_off.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ADD_TRAPS_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -4403,14 +4403,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateSolidFill request
+pub const CREATE_SOLID_FILL_REQUEST: u8 = 33;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateSolidFillRequest {
     pub picture: Picture,
     pub color: Color,
 }
 impl CreateSolidFillRequest {
-    /// Opcode for the CreateSolidFill request
-    pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4423,7 +4423,7 @@ impl CreateSolidFillRequest {
         let color_bytes = self.color.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_SOLID_FILL_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -4459,6 +4459,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateLinearGradient request
+pub const CREATE_LINEAR_GRADIENT_REQUEST: u8 = 34;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateLinearGradientRequest<'input> {
     pub picture: Picture,
@@ -4468,8 +4470,6 @@ pub struct CreateLinearGradientRequest<'input> {
     pub colors: &'input [Color],
 }
 impl<'input> CreateLinearGradientRequest<'input> {
-    /// Opcode for the CreateLinearGradient request
-    pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4485,7 +4485,7 @@ impl<'input> CreateLinearGradientRequest<'input> {
         let num_stops_bytes = num_stops.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_LINEAR_GRADIENT_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -4543,6 +4543,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateRadialGradient request
+pub const CREATE_RADIAL_GRADIENT_REQUEST: u8 = 35;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateRadialGradientRequest<'input> {
     pub picture: Picture,
@@ -4554,8 +4556,6 @@ pub struct CreateRadialGradientRequest<'input> {
     pub colors: &'input [Color],
 }
 impl<'input> CreateRadialGradientRequest<'input> {
-    /// Opcode for the CreateRadialGradient request
-    pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4573,7 +4573,7 @@ impl<'input> CreateRadialGradientRequest<'input> {
         let num_stops_bytes = num_stops.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_RADIAL_GRADIENT_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -4641,6 +4641,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateConicalGradient request
+pub const CREATE_CONICAL_GRADIENT_REQUEST: u8 = 36;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateConicalGradientRequest<'input> {
     pub picture: Picture,
@@ -4650,8 +4652,6 @@ pub struct CreateConicalGradientRequest<'input> {
     pub colors: &'input [Color],
 }
 impl<'input> CreateConicalGradientRequest<'input> {
-    /// Opcode for the CreateConicalGradient request
-    pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4667,7 +4667,7 @@ impl<'input> CreateConicalGradientRequest<'input> {
         let num_stops_bytes = num_stops.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CONICAL_GRADIENT_REQUEST,
             0,
             0,
             picture_bytes[0],

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1819,7 +1819,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1897,7 +1896,6 @@ impl QueryPictFormatsRequest {
     /// Opcode for the QueryPictFormats request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2022,7 +2020,6 @@ impl QueryPictIndexValuesRequest {
     /// Opcode for the QueryPictIndexValues request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2296,7 +2293,6 @@ impl<'input> CreatePictureRequest<'input> {
     /// Opcode for the CreatePicture request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2549,7 +2545,6 @@ impl<'input> ChangePictureRequest<'input> {
     /// Opcode for the ChangePicture request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2609,7 +2604,6 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
     /// Opcode for the SetPictureClipRectangles request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2668,7 +2662,6 @@ impl FreePictureRequest {
     /// Opcode for the FreePicture request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2725,7 +2718,6 @@ impl CompositeRequest {
     /// Opcode for the Composite request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2829,7 +2821,6 @@ impl<'input> TrapezoidsRequest<'input> {
     /// Opcode for the Trapezoids request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2912,7 +2903,6 @@ impl<'input> TrianglesRequest<'input> {
     /// Opcode for the Triangles request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2995,7 +2985,6 @@ impl<'input> TriStripRequest<'input> {
     /// Opcode for the TriStrip request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3078,7 +3067,6 @@ impl<'input> TriFanRequest<'input> {
     /// Opcode for the TriFan request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3156,7 +3144,6 @@ impl CreateGlyphSetRequest {
     /// Opcode for the CreateGlyphSet request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3209,7 +3196,6 @@ impl ReferenceGlyphSetRequest {
     /// Opcode for the ReferenceGlyphSet request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3261,7 +3247,6 @@ impl FreeGlyphSetRequest {
     /// Opcode for the FreeGlyphSet request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3310,7 +3295,6 @@ impl<'input> AddGlyphsRequest<'input> {
     /// Opcode for the AddGlyphs request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3374,7 +3358,6 @@ impl<'input> FreeGlyphsRequest<'input> {
     /// Opcode for the FreeGlyphs request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3432,7 +3415,6 @@ impl<'input> CompositeGlyphs8Request<'input> {
     /// Opcode for the CompositeGlyphs8 request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3521,7 +3503,6 @@ impl<'input> CompositeGlyphs16Request<'input> {
     /// Opcode for the CompositeGlyphs16 request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3610,7 +3591,6 @@ impl<'input> CompositeGlyphs32Request<'input> {
     /// Opcode for the CompositeGlyphs32 request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3695,7 +3675,6 @@ impl<'input> FillRectanglesRequest<'input> {
     /// Opcode for the FillRectangles request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3765,7 +3744,6 @@ impl CreateCursorRequest {
     /// Opcode for the CreateCursor request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3924,7 +3902,6 @@ impl SetPictureTransformRequest {
     /// Opcode for the SetPictureTransform request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4008,7 +3985,6 @@ impl QueryFiltersRequest {
     /// Opcode for the QueryFilters request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4114,7 +4090,6 @@ impl<'input> SetPictureFilterRequest<'input> {
     /// Opcode for the SetPictureFilter request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4218,7 +4193,6 @@ impl<'input> CreateAnimCursorRequest<'input> {
     /// Opcode for the CreateAnimCursor request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4380,7 +4354,6 @@ impl<'input> AddTrapsRequest<'input> {
     /// Opcode for the AddTraps request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4440,7 +4413,6 @@ impl CreateSolidFillRequest {
     /// Opcode for the CreateSolidFill request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4500,7 +4472,6 @@ impl<'input> CreateLinearGradientRequest<'input> {
     /// Opcode for the CreateLinearGradient request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4587,7 +4558,6 @@ impl<'input> CreateRadialGradientRequest<'input> {
     /// Opcode for the CreateRadialGradient request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4684,7 +4654,6 @@ impl<'input> CreateConicalGradientRequest<'input> {
     /// Opcode for the CreateConicalGradient request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -1819,7 +1818,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1896,7 +1895,7 @@ impl QueryPictFormatsRequest {
     /// Opcode for the QueryPictFormats request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2020,7 +2019,7 @@ impl QueryPictIndexValuesRequest {
     /// Opcode for the QueryPictIndexValues request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2293,7 +2292,7 @@ impl<'input> CreatePictureRequest<'input> {
     /// Opcode for the CreatePicture request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2335,7 +2334,7 @@ impl<'input> CreatePictureRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_picture<'c, 'input, Conn>(conn: &'c Conn, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &'input CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2545,7 +2544,7 @@ impl<'input> ChangePictureRequest<'input> {
     /// Opcode for the ChangePicture request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2577,7 +2576,7 @@ impl<'input> ChangePictureRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_picture<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, value_list: &'input ChangePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2604,7 +2603,7 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
     /// Opcode for the SetPictureClipRectangles request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2636,7 +2635,7 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rectangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_picture_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2662,7 +2661,7 @@ impl FreePictureRequest {
     /// Opcode for the FreePicture request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2718,7 +2717,7 @@ impl CompositeRequest {
     /// Opcode for the Composite request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2821,7 +2820,7 @@ impl<'input> TrapezoidsRequest<'input> {
     /// Opcode for the Trapezoids request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2868,7 +2867,7 @@ impl<'input> TrapezoidsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), traps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), traps_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn trapezoids<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &'input [Trapezoid]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2903,7 +2902,7 @@ impl<'input> TrianglesRequest<'input> {
     /// Opcode for the Triangles request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2950,7 +2949,7 @@ impl<'input> TrianglesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), triangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), triangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn triangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &'input [Triangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2985,7 +2984,7 @@ impl<'input> TriStripRequest<'input> {
     /// Opcode for the TriStrip request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3032,7 +3031,7 @@ impl<'input> TriStripRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), points_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn tri_strip<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3067,7 +3066,7 @@ impl<'input> TriFanRequest<'input> {
     /// Opcode for the TriFan request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3114,7 +3113,7 @@ impl<'input> TriFanRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), points_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn tri_fan<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3144,7 +3143,7 @@ impl CreateGlyphSetRequest {
     /// Opcode for the CreateGlyphSet request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3196,7 +3195,7 @@ impl ReferenceGlyphSetRequest {
     /// Opcode for the ReferenceGlyphSet request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3247,7 +3246,7 @@ impl FreeGlyphSetRequest {
     /// Opcode for the FreeGlyphSet request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3295,7 +3294,7 @@ impl<'input> AddGlyphsRequest<'input> {
     /// Opcode for the AddGlyphs request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3331,7 +3330,7 @@ impl<'input> AddGlyphsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), glyphids_bytes.into(), glyphs_bytes.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), glyphids_bytes.into(), glyphs_bytes.into(), (&self.data[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn add_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphids: &'input [u32], glyphs: &'input [Glyphinfo], data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3358,7 +3357,7 @@ impl<'input> FreeGlyphsRequest<'input> {
     /// Opcode for the FreeGlyphs request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3384,7 +3383,7 @@ impl<'input> FreeGlyphsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), glyphs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), glyphs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn free_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphs: &'input [Glyph]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3415,7 +3414,7 @@ impl<'input> CompositeGlyphs8Request<'input> {
     /// Opcode for the CompositeGlyphs8 request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3466,7 +3465,7 @@ impl<'input> CompositeGlyphs8Request<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn composite_glyphs8<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3503,7 +3502,7 @@ impl<'input> CompositeGlyphs16Request<'input> {
     /// Opcode for the CompositeGlyphs16 request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3554,7 +3553,7 @@ impl<'input> CompositeGlyphs16Request<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn composite_glyphs16<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3591,7 +3590,7 @@ impl<'input> CompositeGlyphs32Request<'input> {
     /// Opcode for the CompositeGlyphs32 request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3642,7 +3641,7 @@ impl<'input> CompositeGlyphs32Request<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn composite_glyphs32<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3675,7 +3674,7 @@ impl<'input> FillRectanglesRequest<'input> {
     /// Opcode for the FillRectangles request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3715,7 +3714,7 @@ impl<'input> FillRectanglesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rects_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rects_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn fill_rectangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, dst: Picture, color: Color, rects: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3744,7 +3743,7 @@ impl CreateCursorRequest {
     /// Opcode for the CreateCursor request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3902,7 +3901,7 @@ impl SetPictureTransformRequest {
     /// Opcode for the SetPictureTransform request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3985,7 +3984,7 @@ impl QueryFiltersRequest {
     /// Opcode for the QueryFilters request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4090,7 +4089,7 @@ impl<'input> SetPictureFilterRequest<'input> {
     /// Opcode for the SetPictureFilter request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4125,7 +4124,7 @@ impl<'input> SetPictureFilterRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.filter[..]).into(), padding0.into(), values_bytes.into(), Cow::Borrowed(&padding1)], vec![]))
+        Ok((vec![request0.into(), (&self.filter[..]).into(), padding0.into(), values_bytes.into(), padding1.into()], vec![]))
     }
 }
 pub fn set_picture_filter<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, filter: &'input [u8], values: &'input [Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4193,7 +4192,7 @@ impl<'input> CreateAnimCursorRequest<'input> {
     /// Opcode for the CreateAnimCursor request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4219,7 +4218,7 @@ impl<'input> CreateAnimCursorRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), cursors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), cursors_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_anim_cursor<'c, 'input, Conn>(conn: &'c Conn, cid: xproto::Cursor, cursors: &'input [Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4354,7 +4353,7 @@ impl<'input> AddTrapsRequest<'input> {
     /// Opcode for the AddTraps request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4386,7 +4385,7 @@ impl<'input> AddTrapsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), traps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), traps_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn add_traps<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, x_off: i16, y_off: i16, traps: &'input [Trap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4413,7 +4412,7 @@ impl CreateSolidFillRequest {
     /// Opcode for the CreateSolidFill request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4472,7 +4471,7 @@ impl<'input> CreateLinearGradientRequest<'input> {
     /// Opcode for the CreateLinearGradient request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4525,7 +4524,7 @@ impl<'input> CreateLinearGradientRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_linear_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, p1: Pointfix, p2: Pointfix, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4558,7 +4557,7 @@ impl<'input> CreateRadialGradientRequest<'input> {
     /// Opcode for the CreateRadialGradient request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4621,7 +4620,7 @@ impl<'input> CreateRadialGradientRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_radial_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4654,7 +4653,7 @@ impl<'input> CreateConicalGradientRequest<'input> {
     /// Opcode for the CreateConicalGradient request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4703,7 +4702,7 @@ impl<'input> CreateConicalGradientRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_conical_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, center: Pointfix, angle: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -1809,36 +1810,57 @@ impl Serialize for Glyphinfo {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest {
+    pub client_major_version: u32,
+    pub client_minor_version: u32,
+}
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let client_major_version_bytes = self.client_major_version.serialize();
+        let client_minor_version_bytes = self.client_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+            client_major_version_bytes[0],
+            client_major_version_bytes[1],
+            client_major_version_bytes[2],
+            client_major_version_bytes[3],
+            client_minor_version_bytes[0],
+            client_minor_version_bytes[1],
+            client_minor_version_bytes[2],
+            client_minor_version_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u32, client_minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let client_major_version_bytes = client_major_version.serialize();
-    let client_minor_version_bytes = client_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-        client_major_version_bytes[0],
-        client_major_version_bytes[1],
-        client_major_version_bytes[2],
-        client_major_version_bytes[3],
-        client_minor_version_bytes[0],
-        client_minor_version_bytes[1],
-        client_minor_version_bytes[2],
-        client_minor_version_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest {
+        client_major_version: client_major_version,
+        client_minor_version: client_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1869,26 +1891,41 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the QueryPictFormats request
-pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryPictFormatsRequest;
+impl QueryPictFormatsRequest {
+    /// Opcode for the QueryPictFormats request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryPictFormatsRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_pict_formats<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryPictFormatsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_PICT_FORMATS_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryPictFormatsRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1977,31 +2014,50 @@ impl QueryPictFormatsReply {
     }
 }
 
-/// Opcode for the QueryPictIndexValues request
-pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryPictIndexValuesRequest {
+    pub format: Pictformat,
+}
+impl QueryPictIndexValuesRequest {
+    /// Opcode for the QueryPictIndexValues request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let format_bytes = self.format.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryPictIndexValuesRequest::opcode(),
+            0,
+            0,
+            format_bytes[0],
+            format_bytes[1],
+            format_bytes[2],
+            format_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_pict_index_values<Conn>(conn: &Conn, format: Pictformat) -> Result<Cookie<'_, Conn, QueryPictIndexValuesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let format_bytes = format.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_PICT_INDEX_VALUES_REQUEST,
-        0,
-        0,
-        format_bytes[0],
-        format_bytes[1],
-        format_bytes[2],
-        format_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryPictIndexValuesRequest {
+        format: format,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2046,8 +2102,6 @@ impl QueryPictIndexValuesReply {
     }
 }
 
-/// Opcode for the CreatePicture request
-pub const CREATE_PICTURE_REQUEST: u8 = 4;
 /// Auxiliary and optional information for the `create_picture` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreatePictureAux {
@@ -2231,53 +2285,78 @@ impl CreatePictureAux {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreatePictureRequest<'input> {
+    pub pid: Picture,
+    pub drawable: xproto::Drawable,
+    pub format: Pictformat,
+    pub value_list: &'input CreatePictureAux,
+}
+impl<'input> CreatePictureRequest<'input> {
+    /// Opcode for the CreatePicture request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let pid_bytes = self.pid.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let format_bytes = self.format.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreatePictureRequest::opcode(),
+            0,
+            0,
+            pid_bytes[0],
+            pid_bytes[1],
+            pid_bytes[2],
+            pid_bytes[3],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            format_bytes[0],
+            format_bytes[1],
+            format_bytes[2],
+            format_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_picture<'c, 'input, Conn>(conn: &'c Conn, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &'input CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let pid_bytes = pid.serialize();
-    let drawable_bytes = drawable.serialize();
-    let format_bytes = format.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_PICTURE_REQUEST,
-        0,
-        0,
-        pid_bytes[0],
-        pid_bytes[1],
-        pid_bytes[2],
-        pid_bytes[3],
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        format_bytes[0],
-        format_bytes[1],
-        format_bytes[2],
-        format_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreatePictureRequest {
+        pid: pid,
+        drawable: drawable,
+        format: format,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangePicture request
-pub const CHANGE_PICTURE_REQUEST: u8 = 5;
 /// Auxiliary and optional information for the `change_picture` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangePictureAux {
@@ -2461,793 +2540,1281 @@ impl ChangePictureAux {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangePictureRequest<'input> {
+    pub picture: Picture,
+    pub value_list: &'input ChangePictureAux,
+}
+impl<'input> ChangePictureRequest<'input> {
+    /// Opcode for the ChangePicture request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangePictureRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_picture<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, value_list: &'input ChangePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_PICTURE_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangePictureRequest {
+        picture: picture,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetPictureClipRectangles request
-pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetPictureClipRectanglesRequest<'input> {
+    pub picture: Picture,
+    pub clip_x_origin: i16,
+    pub clip_y_origin: i16,
+    pub rectangles: &'input [xproto::Rectangle],
+}
+impl<'input> SetPictureClipRectanglesRequest<'input> {
+    /// Opcode for the SetPictureClipRectangles request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let clip_x_origin_bytes = self.clip_x_origin.serialize();
+        let clip_y_origin_bytes = self.clip_y_origin.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetPictureClipRectanglesRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            clip_x_origin_bytes[0],
+            clip_x_origin_bytes[1],
+            clip_y_origin_bytes[0],
+            clip_y_origin_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let rectangles_bytes = self.rectangles.serialize();
+        let length_so_far = length_so_far + rectangles_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_picture_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let clip_x_origin_bytes = clip_x_origin.serialize();
-    let clip_y_origin_bytes = clip_y_origin.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_PICTURE_CLIP_RECTANGLES_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        clip_x_origin_bytes[0],
-        clip_x_origin_bytes[1],
-        clip_y_origin_bytes[0],
-        clip_y_origin_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let rectangles_bytes = rectangles.serialize();
-    let length_so_far = length_so_far + rectangles_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&rectangles_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetPictureClipRectanglesRequest {
+        picture: picture,
+        clip_x_origin: clip_x_origin,
+        clip_y_origin: clip_y_origin,
+        rectangles: rectangles,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FreePicture request
-pub const FREE_PICTURE_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FreePictureRequest {
+    pub picture: Picture,
+}
+impl FreePictureRequest {
+    /// Opcode for the FreePicture request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            FreePictureRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn free_picture<Conn>(conn: &Conn, picture: Picture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        FREE_PICTURE_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FreePictureRequest {
+        picture: picture,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Composite request
-pub const COMPOSITE_REQUEST: u8 = 8;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompositeRequest {
+    pub op: PictOp,
+    pub src: Picture,
+    pub mask: Picture,
+    pub dst: Picture,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub mask_x: i16,
+    pub mask_y: i16,
+    pub dst_x: i16,
+    pub dst_y: i16,
+    pub width: u16,
+    pub height: u16,
+}
+impl CompositeRequest {
+    /// Opcode for the Composite request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let mask_bytes = self.mask.serialize();
+        let dst_bytes = self.dst.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mask_x_bytes = self.mask_x.serialize();
+        let mask_y_bytes = self.mask_y.serialize();
+        let dst_x_bytes = self.dst_x.serialize();
+        let dst_y_bytes = self.dst_y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CompositeRequest::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            mask_bytes[0],
+            mask_bytes[1],
+            mask_bytes[2],
+            mask_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+            mask_x_bytes[0],
+            mask_x_bytes[1],
+            mask_y_bytes[0],
+            mask_y_bytes[1],
+            dst_x_bytes[0],
+            dst_x_bytes[1],
+            dst_y_bytes[0],
+            dst_y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn composite<Conn, A>(conn: &Conn, op: PictOp, src: Picture, mask: A, dst: Picture, src_x: i16, src_y: i16, mask_x: i16, mask_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Picture>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let mask: Picture = mask.into();
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let mask_bytes = mask.serialize();
-    let dst_bytes = dst.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mask_x_bytes = mask_x.serialize();
-    let mask_y_bytes = mask_y.serialize();
-    let dst_x_bytes = dst_x.serialize();
-    let dst_y_bytes = dst_y.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        COMPOSITE_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        mask_bytes[0],
-        mask_bytes[1],
-        mask_bytes[2],
-        mask_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-        mask_x_bytes[0],
-        mask_x_bytes[1],
-        mask_y_bytes[0],
-        mask_y_bytes[1],
-        dst_x_bytes[0],
-        dst_x_bytes[1],
-        dst_y_bytes[0],
-        dst_y_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CompositeRequest {
+        op: op,
+        src: src,
+        mask: mask,
+        dst: dst,
+        src_x: src_x,
+        src_y: src_y,
+        mask_x: mask_x,
+        mask_y: mask_y,
+        dst_x: dst_x,
+        dst_y: dst_y,
+        width: width,
+        height: height,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Trapezoids request
-pub const TRAPEZOIDS_REQUEST: u8 = 10;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrapezoidsRequest<'input> {
+    pub op: PictOp,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub traps: &'input [Trapezoid],
+}
+impl<'input> TrapezoidsRequest<'input> {
+    /// Opcode for the Trapezoids request
+    pub const fn opcode() -> u8 { 10 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let dst_bytes = self.dst.serialize();
+        let mask_format_bytes = self.mask_format.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            TrapezoidsRequest::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            mask_format_bytes[0],
+            mask_format_bytes[1],
+            mask_format_bytes[2],
+            mask_format_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let traps_bytes = self.traps.serialize();
+        let length_so_far = length_so_far + traps_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), traps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn trapezoids<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &'input [Trapezoid]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let dst_bytes = dst.serialize();
-    let mask_format_bytes = mask_format.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        TRAPEZOIDS_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        mask_format_bytes[0],
-        mask_format_bytes[1],
-        mask_format_bytes[2],
-        mask_format_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let traps_bytes = traps.serialize();
-    let length_so_far = length_so_far + traps_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&traps_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = TrapezoidsRequest {
+        op: op,
+        src: src,
+        dst: dst,
+        mask_format: mask_format,
+        src_x: src_x,
+        src_y: src_y,
+        traps: traps,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Triangles request
-pub const TRIANGLES_REQUEST: u8 = 11;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrianglesRequest<'input> {
+    pub op: PictOp,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub triangles: &'input [Triangle],
+}
+impl<'input> TrianglesRequest<'input> {
+    /// Opcode for the Triangles request
+    pub const fn opcode() -> u8 { 11 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let dst_bytes = self.dst.serialize();
+        let mask_format_bytes = self.mask_format.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            TrianglesRequest::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            mask_format_bytes[0],
+            mask_format_bytes[1],
+            mask_format_bytes[2],
+            mask_format_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let triangles_bytes = self.triangles.serialize();
+        let length_so_far = length_so_far + triangles_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), triangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn triangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &'input [Triangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let dst_bytes = dst.serialize();
-    let mask_format_bytes = mask_format.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        TRIANGLES_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        mask_format_bytes[0],
-        mask_format_bytes[1],
-        mask_format_bytes[2],
-        mask_format_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let triangles_bytes = triangles.serialize();
-    let length_so_far = length_so_far + triangles_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&triangles_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = TrianglesRequest {
+        op: op,
+        src: src,
+        dst: dst,
+        mask_format: mask_format,
+        src_x: src_x,
+        src_y: src_y,
+        triangles: triangles,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the TriStrip request
-pub const TRI_STRIP_REQUEST: u8 = 12;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriStripRequest<'input> {
+    pub op: PictOp,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub points: &'input [Pointfix],
+}
+impl<'input> TriStripRequest<'input> {
+    /// Opcode for the TriStrip request
+    pub const fn opcode() -> u8 { 12 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let dst_bytes = self.dst.serialize();
+        let mask_format_bytes = self.mask_format.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            TriStripRequest::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            mask_format_bytes[0],
+            mask_format_bytes[1],
+            mask_format_bytes[2],
+            mask_format_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let points_bytes = self.points.serialize();
+        let length_so_far = length_so_far + points_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn tri_strip<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let dst_bytes = dst.serialize();
-    let mask_format_bytes = mask_format.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        TRI_STRIP_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        mask_format_bytes[0],
-        mask_format_bytes[1],
-        mask_format_bytes[2],
-        mask_format_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let points_bytes = points.serialize();
-    let length_so_far = length_so_far + points_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&points_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = TriStripRequest {
+        op: op,
+        src: src,
+        dst: dst,
+        mask_format: mask_format,
+        src_x: src_x,
+        src_y: src_y,
+        points: points,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the TriFan request
-pub const TRI_FAN_REQUEST: u8 = 13;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriFanRequest<'input> {
+    pub op: PictOp,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub points: &'input [Pointfix],
+}
+impl<'input> TriFanRequest<'input> {
+    /// Opcode for the TriFan request
+    pub const fn opcode() -> u8 { 13 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let dst_bytes = self.dst.serialize();
+        let mask_format_bytes = self.mask_format.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            TriFanRequest::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            mask_format_bytes[0],
+            mask_format_bytes[1],
+            mask_format_bytes[2],
+            mask_format_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let points_bytes = self.points.serialize();
+        let length_so_far = length_so_far + points_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn tri_fan<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let dst_bytes = dst.serialize();
-    let mask_format_bytes = mask_format.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        TRI_FAN_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        mask_format_bytes[0],
-        mask_format_bytes[1],
-        mask_format_bytes[2],
-        mask_format_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let points_bytes = points.serialize();
-    let length_so_far = length_so_far + points_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&points_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = TriFanRequest {
+        op: op,
+        src: src,
+        dst: dst,
+        mask_format: mask_format,
+        src_x: src_x,
+        src_y: src_y,
+        points: points,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateGlyphSet request
-pub const CREATE_GLYPH_SET_REQUEST: u8 = 17;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateGlyphSetRequest {
+    pub gsid: Glyphset,
+    pub format: Pictformat,
+}
+impl CreateGlyphSetRequest {
+    /// Opcode for the CreateGlyphSet request
+    pub const fn opcode() -> u8 { 17 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let gsid_bytes = self.gsid.serialize();
+        let format_bytes = self.format.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateGlyphSetRequest::opcode(),
+            0,
+            0,
+            gsid_bytes[0],
+            gsid_bytes[1],
+            gsid_bytes[2],
+            gsid_bytes[3],
+            format_bytes[0],
+            format_bytes[1],
+            format_bytes[2],
+            format_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_glyph_set<Conn>(conn: &Conn, gsid: Glyphset, format: Pictformat) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let gsid_bytes = gsid.serialize();
-    let format_bytes = format.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_GLYPH_SET_REQUEST,
-        0,
-        0,
-        gsid_bytes[0],
-        gsid_bytes[1],
-        gsid_bytes[2],
-        gsid_bytes[3],
-        format_bytes[0],
-        format_bytes[1],
-        format_bytes[2],
-        format_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateGlyphSetRequest {
+        gsid: gsid,
+        format: format,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ReferenceGlyphSet request
-pub const REFERENCE_GLYPH_SET_REQUEST: u8 = 18;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReferenceGlyphSetRequest {
+    pub gsid: Glyphset,
+    pub existing: Glyphset,
+}
+impl ReferenceGlyphSetRequest {
+    /// Opcode for the ReferenceGlyphSet request
+    pub const fn opcode() -> u8 { 18 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let gsid_bytes = self.gsid.serialize();
+        let existing_bytes = self.existing.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ReferenceGlyphSetRequest::opcode(),
+            0,
+            0,
+            gsid_bytes[0],
+            gsid_bytes[1],
+            gsid_bytes[2],
+            gsid_bytes[3],
+            existing_bytes[0],
+            existing_bytes[1],
+            existing_bytes[2],
+            existing_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn reference_glyph_set<Conn>(conn: &Conn, gsid: Glyphset, existing: Glyphset) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let gsid_bytes = gsid.serialize();
-    let existing_bytes = existing.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        REFERENCE_GLYPH_SET_REQUEST,
-        0,
-        0,
-        gsid_bytes[0],
-        gsid_bytes[1],
-        gsid_bytes[2],
-        gsid_bytes[3],
-        existing_bytes[0],
-        existing_bytes[1],
-        existing_bytes[2],
-        existing_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ReferenceGlyphSetRequest {
+        gsid: gsid,
+        existing: existing,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FreeGlyphSet request
-pub const FREE_GLYPH_SET_REQUEST: u8 = 19;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FreeGlyphSetRequest {
+    pub glyphset: Glyphset,
+}
+impl FreeGlyphSetRequest {
+    /// Opcode for the FreeGlyphSet request
+    pub const fn opcode() -> u8 { 19 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let glyphset_bytes = self.glyphset.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            FreeGlyphSetRequest::opcode(),
+            0,
+            0,
+            glyphset_bytes[0],
+            glyphset_bytes[1],
+            glyphset_bytes[2],
+            glyphset_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn free_glyph_set<Conn>(conn: &Conn, glyphset: Glyphset) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let glyphset_bytes = glyphset.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        FREE_GLYPH_SET_REQUEST,
-        0,
-        0,
-        glyphset_bytes[0],
-        glyphset_bytes[1],
-        glyphset_bytes[2],
-        glyphset_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FreeGlyphSetRequest {
+        glyphset: glyphset,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the AddGlyphs request
-pub const ADD_GLYPHS_REQUEST: u8 = 20;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddGlyphsRequest<'input> {
+    pub glyphset: Glyphset,
+    pub glyphids: &'input [u32],
+    pub glyphs: &'input [Glyphinfo],
+    pub data: &'input [u8],
+}
+impl<'input> AddGlyphsRequest<'input> {
+    /// Opcode for the AddGlyphs request
+    pub const fn opcode() -> u8 { 20 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let glyphset_bytes = self.glyphset.serialize();
+        let glyphs_len = u32::try_from(self.glyphids.len()).expect("`glyphids` has too many elements");
+        let glyphs_len_bytes = glyphs_len.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            AddGlyphsRequest::opcode(),
+            0,
+            0,
+            glyphset_bytes[0],
+            glyphset_bytes[1],
+            glyphset_bytes[2],
+            glyphset_bytes[3],
+            glyphs_len_bytes[0],
+            glyphs_len_bytes[1],
+            glyphs_len_bytes[2],
+            glyphs_len_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let glyphids_bytes = self.glyphids.serialize();
+        let length_so_far = length_so_far + glyphids_bytes.len();
+        assert_eq!(self.glyphs.len(), usize::try_from(glyphs_len).unwrap(), "`glyphs` has an incorrect length");
+        let glyphs_bytes = self.glyphs.serialize();
+        let length_so_far = length_so_far + glyphs_bytes.len();
+        let length_so_far = length_so_far + (&self.data[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), glyphids_bytes.into(), glyphs_bytes.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn add_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphids: &'input [u32], glyphs: &'input [Glyphinfo], data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let glyphset_bytes = glyphset.serialize();
-    let glyphs_len = u32::try_from(glyphids.len()).expect("`glyphids` has too many elements");
-    let glyphs_len_bytes = glyphs_len.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        ADD_GLYPHS_REQUEST,
-        0,
-        0,
-        glyphset_bytes[0],
-        glyphset_bytes[1],
-        glyphset_bytes[2],
-        glyphset_bytes[3],
-        glyphs_len_bytes[0],
-        glyphs_len_bytes[1],
-        glyphs_len_bytes[2],
-        glyphs_len_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let glyphids_bytes = glyphids.serialize();
-    let length_so_far = length_so_far + glyphids_bytes.len();
-    assert_eq!(glyphs.len(), usize::try_from(glyphs_len).unwrap(), "`glyphs` has an incorrect length");
-    let glyphs_bytes = glyphs.serialize();
-    let length_so_far = length_so_far + glyphs_bytes.len();
-    let length_so_far = length_so_far + data.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&glyphids_bytes), IoSlice::new(&glyphs_bytes), IoSlice::new(data), IoSlice::new(&padding0)], vec![])?)
+    let request0 = AddGlyphsRequest {
+        glyphset: glyphset,
+        glyphids: glyphids,
+        glyphs: glyphs,
+        data: data,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FreeGlyphs request
-pub const FREE_GLYPHS_REQUEST: u8 = 22;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FreeGlyphsRequest<'input> {
+    pub glyphset: Glyphset,
+    pub glyphs: &'input [Glyph],
+}
+impl<'input> FreeGlyphsRequest<'input> {
+    /// Opcode for the FreeGlyphs request
+    pub const fn opcode() -> u8 { 22 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let glyphset_bytes = self.glyphset.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            FreeGlyphsRequest::opcode(),
+            0,
+            0,
+            glyphset_bytes[0],
+            glyphset_bytes[1],
+            glyphset_bytes[2],
+            glyphset_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let glyphs_bytes = self.glyphs.serialize();
+        let length_so_far = length_so_far + glyphs_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), glyphs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn free_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphs: &'input [Glyph]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let glyphset_bytes = glyphset.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        FREE_GLYPHS_REQUEST,
-        0,
-        0,
-        glyphset_bytes[0],
-        glyphset_bytes[1],
-        glyphset_bytes[2],
-        glyphset_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let glyphs_bytes = glyphs.serialize();
-    let length_so_far = length_so_far + glyphs_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&glyphs_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = FreeGlyphsRequest {
+        glyphset: glyphset,
+        glyphs: glyphs,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CompositeGlyphs8 request
-pub const COMPOSITE_GLYPHS8_REQUEST: u8 = 23;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompositeGlyphs8Request<'input> {
+    pub op: PictOp,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub glyphset: Glyphset,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub glyphcmds: &'input [u8],
+}
+impl<'input> CompositeGlyphs8Request<'input> {
+    /// Opcode for the CompositeGlyphs8 request
+    pub const fn opcode() -> u8 { 23 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let dst_bytes = self.dst.serialize();
+        let mask_format_bytes = self.mask_format.serialize();
+        let glyphset_bytes = self.glyphset.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CompositeGlyphs8Request::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            mask_format_bytes[0],
+            mask_format_bytes[1],
+            mask_format_bytes[2],
+            mask_format_bytes[3],
+            glyphset_bytes[0],
+            glyphset_bytes[1],
+            glyphset_bytes[2],
+            glyphset_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.glyphcmds[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn composite_glyphs8<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let dst_bytes = dst.serialize();
-    let mask_format_bytes = mask_format.serialize();
-    let glyphset_bytes = glyphset.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        COMPOSITE_GLYPHS8_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        mask_format_bytes[0],
-        mask_format_bytes[1],
-        mask_format_bytes[2],
-        mask_format_bytes[3],
-        glyphset_bytes[0],
-        glyphset_bytes[1],
-        glyphset_bytes[2],
-        glyphset_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + glyphcmds.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(glyphcmds), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CompositeGlyphs8Request {
+        op: op,
+        src: src,
+        dst: dst,
+        mask_format: mask_format,
+        glyphset: glyphset,
+        src_x: src_x,
+        src_y: src_y,
+        glyphcmds: glyphcmds,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CompositeGlyphs16 request
-pub const COMPOSITE_GLYPHS16_REQUEST: u8 = 24;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompositeGlyphs16Request<'input> {
+    pub op: PictOp,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub glyphset: Glyphset,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub glyphcmds: &'input [u8],
+}
+impl<'input> CompositeGlyphs16Request<'input> {
+    /// Opcode for the CompositeGlyphs16 request
+    pub const fn opcode() -> u8 { 24 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let dst_bytes = self.dst.serialize();
+        let mask_format_bytes = self.mask_format.serialize();
+        let glyphset_bytes = self.glyphset.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CompositeGlyphs16Request::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            mask_format_bytes[0],
+            mask_format_bytes[1],
+            mask_format_bytes[2],
+            mask_format_bytes[3],
+            glyphset_bytes[0],
+            glyphset_bytes[1],
+            glyphset_bytes[2],
+            glyphset_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.glyphcmds[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn composite_glyphs16<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let dst_bytes = dst.serialize();
-    let mask_format_bytes = mask_format.serialize();
-    let glyphset_bytes = glyphset.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        COMPOSITE_GLYPHS16_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        mask_format_bytes[0],
-        mask_format_bytes[1],
-        mask_format_bytes[2],
-        mask_format_bytes[3],
-        glyphset_bytes[0],
-        glyphset_bytes[1],
-        glyphset_bytes[2],
-        glyphset_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + glyphcmds.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(glyphcmds), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CompositeGlyphs16Request {
+        op: op,
+        src: src,
+        dst: dst,
+        mask_format: mask_format,
+        glyphset: glyphset,
+        src_x: src_x,
+        src_y: src_y,
+        glyphcmds: glyphcmds,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CompositeGlyphs32 request
-pub const COMPOSITE_GLYPHS32_REQUEST: u8 = 25;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompositeGlyphs32Request<'input> {
+    pub op: PictOp,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub glyphset: Glyphset,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub glyphcmds: &'input [u8],
+}
+impl<'input> CompositeGlyphs32Request<'input> {
+    /// Opcode for the CompositeGlyphs32 request
+    pub const fn opcode() -> u8 { 25 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let src_bytes = self.src.serialize();
+        let dst_bytes = self.dst.serialize();
+        let mask_format_bytes = self.mask_format.serialize();
+        let glyphset_bytes = self.glyphset.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CompositeGlyphs32Request::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            src_bytes[0],
+            src_bytes[1],
+            src_bytes[2],
+            src_bytes[3],
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            mask_format_bytes[0],
+            mask_format_bytes[1],
+            mask_format_bytes[2],
+            mask_format_bytes[3],
+            glyphset_bytes[0],
+            glyphset_bytes[1],
+            glyphset_bytes[2],
+            glyphset_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.glyphcmds[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn composite_glyphs32<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let src_bytes = src.serialize();
-    let dst_bytes = dst.serialize();
-    let mask_format_bytes = mask_format.serialize();
-    let glyphset_bytes = glyphset.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        COMPOSITE_GLYPHS32_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        src_bytes[0],
-        src_bytes[1],
-        src_bytes[2],
-        src_bytes[3],
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        mask_format_bytes[0],
-        mask_format_bytes[1],
-        mask_format_bytes[2],
-        mask_format_bytes[3],
-        glyphset_bytes[0],
-        glyphset_bytes[1],
-        glyphset_bytes[2],
-        glyphset_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + glyphcmds.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(glyphcmds), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CompositeGlyphs32Request {
+        op: op,
+        src: src,
+        dst: dst,
+        mask_format: mask_format,
+        glyphset: glyphset,
+        src_x: src_x,
+        src_y: src_y,
+        glyphcmds: glyphcmds,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FillRectangles request
-pub const FILL_RECTANGLES_REQUEST: u8 = 26;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FillRectanglesRequest<'input> {
+    pub op: PictOp,
+    pub dst: Picture,
+    pub color: Color,
+    pub rects: &'input [xproto::Rectangle],
+}
+impl<'input> FillRectanglesRequest<'input> {
+    /// Opcode for the FillRectangles request
+    pub const fn opcode() -> u8 { 26 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let op_bytes = u8::from(self.op).serialize();
+        let dst_bytes = self.dst.serialize();
+        let color_bytes = self.color.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            FillRectanglesRequest::opcode(),
+            0,
+            0,
+            op_bytes[0],
+            0,
+            0,
+            0,
+            dst_bytes[0],
+            dst_bytes[1],
+            dst_bytes[2],
+            dst_bytes[3],
+            color_bytes[0],
+            color_bytes[1],
+            color_bytes[2],
+            color_bytes[3],
+            color_bytes[4],
+            color_bytes[5],
+            color_bytes[6],
+            color_bytes[7],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let rects_bytes = self.rects.serialize();
+        let length_so_far = length_so_far + rects_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), rects_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn fill_rectangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, dst: Picture, color: Color, rects: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let op_bytes = u8::from(op).serialize();
-    let dst_bytes = dst.serialize();
-    let color_bytes = color.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        FILL_RECTANGLES_REQUEST,
-        0,
-        0,
-        op_bytes[0],
-        0,
-        0,
-        0,
-        dst_bytes[0],
-        dst_bytes[1],
-        dst_bytes[2],
-        dst_bytes[3],
-        color_bytes[0],
-        color_bytes[1],
-        color_bytes[2],
-        color_bytes[3],
-        color_bytes[4],
-        color_bytes[5],
-        color_bytes[6],
-        color_bytes[7],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let rects_bytes = rects.serialize();
-    let length_so_far = length_so_far + rects_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&rects_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = FillRectanglesRequest {
+        op: op,
+        dst: dst,
+        color: color,
+        rects: rects,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateCursor request
-pub const CREATE_CURSOR_REQUEST: u8 = 27;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateCursorRequest {
+    pub cid: xproto::Cursor,
+    pub source: Picture,
+    pub x: u16,
+    pub y: u16,
+}
+impl CreateCursorRequest {
+    /// Opcode for the CreateCursor request
+    pub const fn opcode() -> u8 { 27 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let cid_bytes = self.cid.serialize();
+        let source_bytes = self.source.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateCursorRequest::opcode(),
+            0,
+            0,
+            cid_bytes[0],
+            cid_bytes[1],
+            cid_bytes[2],
+            cid_bytes[3],
+            source_bytes[0],
+            source_bytes[1],
+            source_bytes[2],
+            source_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_cursor<Conn>(conn: &Conn, cid: xproto::Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let cid_bytes = cid.serialize();
-    let source_bytes = source.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_CURSOR_REQUEST,
-        0,
-        0,
-        cid_bytes[0],
-        cid_bytes[1],
-        cid_bytes[2],
-        cid_bytes[3],
-        source_bytes[0],
-        source_bytes[1],
-        source_bytes[2],
-        source_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateCursorRequest {
+        cid: cid,
+        source: source,
+        x: x,
+        y: y,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3348,95 +3915,135 @@ impl Serialize for Transform {
     }
 }
 
-/// Opcode for the SetPictureTransform request
-pub const SET_PICTURE_TRANSFORM_REQUEST: u8 = 28;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetPictureTransformRequest {
+    pub picture: Picture,
+    pub transform: Transform,
+}
+impl SetPictureTransformRequest {
+    /// Opcode for the SetPictureTransform request
+    pub const fn opcode() -> u8 { 28 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let transform_bytes = self.transform.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetPictureTransformRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            transform_bytes[0],
+            transform_bytes[1],
+            transform_bytes[2],
+            transform_bytes[3],
+            transform_bytes[4],
+            transform_bytes[5],
+            transform_bytes[6],
+            transform_bytes[7],
+            transform_bytes[8],
+            transform_bytes[9],
+            transform_bytes[10],
+            transform_bytes[11],
+            transform_bytes[12],
+            transform_bytes[13],
+            transform_bytes[14],
+            transform_bytes[15],
+            transform_bytes[16],
+            transform_bytes[17],
+            transform_bytes[18],
+            transform_bytes[19],
+            transform_bytes[20],
+            transform_bytes[21],
+            transform_bytes[22],
+            transform_bytes[23],
+            transform_bytes[24],
+            transform_bytes[25],
+            transform_bytes[26],
+            transform_bytes[27],
+            transform_bytes[28],
+            transform_bytes[29],
+            transform_bytes[30],
+            transform_bytes[31],
+            transform_bytes[32],
+            transform_bytes[33],
+            transform_bytes[34],
+            transform_bytes[35],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_picture_transform<Conn>(conn: &Conn, picture: Picture, transform: Transform) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let transform_bytes = transform.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_PICTURE_TRANSFORM_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        transform_bytes[0],
-        transform_bytes[1],
-        transform_bytes[2],
-        transform_bytes[3],
-        transform_bytes[4],
-        transform_bytes[5],
-        transform_bytes[6],
-        transform_bytes[7],
-        transform_bytes[8],
-        transform_bytes[9],
-        transform_bytes[10],
-        transform_bytes[11],
-        transform_bytes[12],
-        transform_bytes[13],
-        transform_bytes[14],
-        transform_bytes[15],
-        transform_bytes[16],
-        transform_bytes[17],
-        transform_bytes[18],
-        transform_bytes[19],
-        transform_bytes[20],
-        transform_bytes[21],
-        transform_bytes[22],
-        transform_bytes[23],
-        transform_bytes[24],
-        transform_bytes[25],
-        transform_bytes[26],
-        transform_bytes[27],
-        transform_bytes[28],
-        transform_bytes[29],
-        transform_bytes[30],
-        transform_bytes[31],
-        transform_bytes[32],
-        transform_bytes[33],
-        transform_bytes[34],
-        transform_bytes[35],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetPictureTransformRequest {
+        picture: picture,
+        transform: transform,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the QueryFilters request
-pub const QUERY_FILTERS_REQUEST: u8 = 29;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryFiltersRequest {
+    pub drawable: xproto::Drawable,
+}
+impl QueryFiltersRequest {
+    /// Opcode for the QueryFilters request
+    pub const fn opcode() -> u8 { 29 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryFiltersRequest::opcode(),
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_filters<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, QueryFiltersReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_FILTERS_REQUEST,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryFiltersRequest {
+        drawable: drawable,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3497,44 +4104,67 @@ impl QueryFiltersReply {
     }
 }
 
-/// Opcode for the SetPictureFilter request
-pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetPictureFilterRequest<'input> {
+    pub picture: Picture,
+    pub filter: &'input [u8],
+    pub values: &'input [Fixed],
+}
+impl<'input> SetPictureFilterRequest<'input> {
+    /// Opcode for the SetPictureFilter request
+    pub const fn opcode() -> u8 { 30 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let filter_len = u16::try_from(self.filter.len()).expect("`filter` has too many elements");
+        let filter_len_bytes = filter_len.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetPictureFilterRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            filter_len_bytes[0],
+            filter_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.filter[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        let values_bytes = self.values.serialize();
+        let length_so_far = length_so_far + values_bytes.len();
+        let padding1 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding1.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.filter[..]).into(), padding0.into(), values_bytes.into(), Cow::Borrowed(&padding1)], vec![]))
+    }
+}
 pub fn set_picture_filter<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, filter: &'input [u8], values: &'input [Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let filter_len = u16::try_from(filter.len()).expect("`filter` has too many elements");
-    let filter_len_bytes = filter_len.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_PICTURE_FILTER_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        filter_len_bytes[0],
-        filter_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + filter.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    let values_bytes = values.serialize();
-    let length_so_far = length_so_far + values_bytes.len();
-    let padding1 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding1.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(filter), IoSlice::new(&padding0), IoSlice::new(&values_bytes), IoSlice::new(&padding1)], vec![])?)
+    let request0 = SetPictureFilterRequest {
+        picture: picture,
+        filter: filter,
+        values: values,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3579,35 +4209,56 @@ impl Serialize for Animcursorelt {
     }
 }
 
-/// Opcode for the CreateAnimCursor request
-pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateAnimCursorRequest<'input> {
+    pub cid: xproto::Cursor,
+    pub cursors: &'input [Animcursorelt],
+}
+impl<'input> CreateAnimCursorRequest<'input> {
+    /// Opcode for the CreateAnimCursor request
+    pub const fn opcode() -> u8 { 31 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let cid_bytes = self.cid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateAnimCursorRequest::opcode(),
+            0,
+            0,
+            cid_bytes[0],
+            cid_bytes[1],
+            cid_bytes[2],
+            cid_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let cursors_bytes = self.cursors.serialize();
+        let length_so_far = length_so_far + cursors_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), cursors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_anim_cursor<'c, 'input, Conn>(conn: &'c Conn, cid: xproto::Cursor, cursors: &'input [Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let cid_bytes = cid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_ANIM_CURSOR_REQUEST,
-        0,
-        0,
-        cid_bytes[0],
-        cid_bytes[1],
-        cid_bytes[2],
-        cid_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let cursors_bytes = cursors.serialize();
-    let length_so_far = length_so_far + cursors_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&cursors_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateAnimCursorRequest {
+        cid: cid,
+        cursors: cursors,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3718,257 +4369,388 @@ impl Serialize for Trap {
     }
 }
 
-/// Opcode for the AddTraps request
-pub const ADD_TRAPS_REQUEST: u8 = 32;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddTrapsRequest<'input> {
+    pub picture: Picture,
+    pub x_off: i16,
+    pub y_off: i16,
+    pub traps: &'input [Trap],
+}
+impl<'input> AddTrapsRequest<'input> {
+    /// Opcode for the AddTraps request
+    pub const fn opcode() -> u8 { 32 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let x_off_bytes = self.x_off.serialize();
+        let y_off_bytes = self.y_off.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            AddTrapsRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            x_off_bytes[0],
+            x_off_bytes[1],
+            y_off_bytes[0],
+            y_off_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let traps_bytes = self.traps.serialize();
+        let length_so_far = length_so_far + traps_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), traps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn add_traps<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, x_off: i16, y_off: i16, traps: &'input [Trap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let x_off_bytes = x_off.serialize();
-    let y_off_bytes = y_off.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        ADD_TRAPS_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        x_off_bytes[0],
-        x_off_bytes[1],
-        y_off_bytes[0],
-        y_off_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let traps_bytes = traps.serialize();
-    let length_so_far = length_so_far + traps_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&traps_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = AddTrapsRequest {
+        picture: picture,
+        x_off: x_off,
+        y_off: y_off,
+        traps: traps,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateSolidFill request
-pub const CREATE_SOLID_FILL_REQUEST: u8 = 33;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateSolidFillRequest {
+    pub picture: Picture,
+    pub color: Color,
+}
+impl CreateSolidFillRequest {
+    /// Opcode for the CreateSolidFill request
+    pub const fn opcode() -> u8 { 33 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let color_bytes = self.color.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateSolidFillRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            color_bytes[0],
+            color_bytes[1],
+            color_bytes[2],
+            color_bytes[3],
+            color_bytes[4],
+            color_bytes[5],
+            color_bytes[6],
+            color_bytes[7],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_solid_fill<Conn>(conn: &Conn, picture: Picture, color: Color) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let color_bytes = color.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_SOLID_FILL_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        color_bytes[0],
-        color_bytes[1],
-        color_bytes[2],
-        color_bytes[3],
-        color_bytes[4],
-        color_bytes[5],
-        color_bytes[6],
-        color_bytes[7],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateSolidFillRequest {
+        picture: picture,
+        color: color,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateLinearGradient request
-pub const CREATE_LINEAR_GRADIENT_REQUEST: u8 = 34;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateLinearGradientRequest<'input> {
+    pub picture: Picture,
+    pub p1: Pointfix,
+    pub p2: Pointfix,
+    pub stops: &'input [Fixed],
+    pub colors: &'input [Color],
+}
+impl<'input> CreateLinearGradientRequest<'input> {
+    /// Opcode for the CreateLinearGradient request
+    pub const fn opcode() -> u8 { 34 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let p1_bytes = self.p1.serialize();
+        let p2_bytes = self.p2.serialize();
+        let num_stops = u32::try_from(self.stops.len()).expect("`stops` has too many elements");
+        let num_stops_bytes = num_stops.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateLinearGradientRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            p1_bytes[0],
+            p1_bytes[1],
+            p1_bytes[2],
+            p1_bytes[3],
+            p1_bytes[4],
+            p1_bytes[5],
+            p1_bytes[6],
+            p1_bytes[7],
+            p2_bytes[0],
+            p2_bytes[1],
+            p2_bytes[2],
+            p2_bytes[3],
+            p2_bytes[4],
+            p2_bytes[5],
+            p2_bytes[6],
+            p2_bytes[7],
+            num_stops_bytes[0],
+            num_stops_bytes[1],
+            num_stops_bytes[2],
+            num_stops_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let stops_bytes = self.stops.serialize();
+        let length_so_far = length_so_far + stops_bytes.len();
+        assert_eq!(self.colors.len(), usize::try_from(num_stops).unwrap(), "`colors` has an incorrect length");
+        let colors_bytes = self.colors.serialize();
+        let length_so_far = length_so_far + colors_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_linear_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, p1: Pointfix, p2: Pointfix, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let p1_bytes = p1.serialize();
-    let p2_bytes = p2.serialize();
-    let num_stops = u32::try_from(stops.len()).expect("`stops` has too many elements");
-    let num_stops_bytes = num_stops.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_LINEAR_GRADIENT_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        p1_bytes[0],
-        p1_bytes[1],
-        p1_bytes[2],
-        p1_bytes[3],
-        p1_bytes[4],
-        p1_bytes[5],
-        p1_bytes[6],
-        p1_bytes[7],
-        p2_bytes[0],
-        p2_bytes[1],
-        p2_bytes[2],
-        p2_bytes[3],
-        p2_bytes[4],
-        p2_bytes[5],
-        p2_bytes[6],
-        p2_bytes[7],
-        num_stops_bytes[0],
-        num_stops_bytes[1],
-        num_stops_bytes[2],
-        num_stops_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let stops_bytes = stops.serialize();
-    let length_so_far = length_so_far + stops_bytes.len();
-    assert_eq!(colors.len(), usize::try_from(num_stops).unwrap(), "`colors` has an incorrect length");
-    let colors_bytes = colors.serialize();
-    let length_so_far = length_so_far + colors_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&stops_bytes), IoSlice::new(&colors_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateLinearGradientRequest {
+        picture: picture,
+        p1: p1,
+        p2: p2,
+        stops: stops,
+        colors: colors,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateRadialGradient request
-pub const CREATE_RADIAL_GRADIENT_REQUEST: u8 = 35;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateRadialGradientRequest<'input> {
+    pub picture: Picture,
+    pub inner: Pointfix,
+    pub outer: Pointfix,
+    pub inner_radius: Fixed,
+    pub outer_radius: Fixed,
+    pub stops: &'input [Fixed],
+    pub colors: &'input [Color],
+}
+impl<'input> CreateRadialGradientRequest<'input> {
+    /// Opcode for the CreateRadialGradient request
+    pub const fn opcode() -> u8 { 35 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let inner_bytes = self.inner.serialize();
+        let outer_bytes = self.outer.serialize();
+        let inner_radius_bytes = self.inner_radius.serialize();
+        let outer_radius_bytes = self.outer_radius.serialize();
+        let num_stops = u32::try_from(self.stops.len()).expect("`stops` has too many elements");
+        let num_stops_bytes = num_stops.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateRadialGradientRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            inner_bytes[0],
+            inner_bytes[1],
+            inner_bytes[2],
+            inner_bytes[3],
+            inner_bytes[4],
+            inner_bytes[5],
+            inner_bytes[6],
+            inner_bytes[7],
+            outer_bytes[0],
+            outer_bytes[1],
+            outer_bytes[2],
+            outer_bytes[3],
+            outer_bytes[4],
+            outer_bytes[5],
+            outer_bytes[6],
+            outer_bytes[7],
+            inner_radius_bytes[0],
+            inner_radius_bytes[1],
+            inner_radius_bytes[2],
+            inner_radius_bytes[3],
+            outer_radius_bytes[0],
+            outer_radius_bytes[1],
+            outer_radius_bytes[2],
+            outer_radius_bytes[3],
+            num_stops_bytes[0],
+            num_stops_bytes[1],
+            num_stops_bytes[2],
+            num_stops_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let stops_bytes = self.stops.serialize();
+        let length_so_far = length_so_far + stops_bytes.len();
+        assert_eq!(self.colors.len(), usize::try_from(num_stops).unwrap(), "`colors` has an incorrect length");
+        let colors_bytes = self.colors.serialize();
+        let length_so_far = length_so_far + colors_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_radial_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let inner_bytes = inner.serialize();
-    let outer_bytes = outer.serialize();
-    let inner_radius_bytes = inner_radius.serialize();
-    let outer_radius_bytes = outer_radius.serialize();
-    let num_stops = u32::try_from(stops.len()).expect("`stops` has too many elements");
-    let num_stops_bytes = num_stops.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_RADIAL_GRADIENT_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        inner_bytes[0],
-        inner_bytes[1],
-        inner_bytes[2],
-        inner_bytes[3],
-        inner_bytes[4],
-        inner_bytes[5],
-        inner_bytes[6],
-        inner_bytes[7],
-        outer_bytes[0],
-        outer_bytes[1],
-        outer_bytes[2],
-        outer_bytes[3],
-        outer_bytes[4],
-        outer_bytes[5],
-        outer_bytes[6],
-        outer_bytes[7],
-        inner_radius_bytes[0],
-        inner_radius_bytes[1],
-        inner_radius_bytes[2],
-        inner_radius_bytes[3],
-        outer_radius_bytes[0],
-        outer_radius_bytes[1],
-        outer_radius_bytes[2],
-        outer_radius_bytes[3],
-        num_stops_bytes[0],
-        num_stops_bytes[1],
-        num_stops_bytes[2],
-        num_stops_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let stops_bytes = stops.serialize();
-    let length_so_far = length_so_far + stops_bytes.len();
-    assert_eq!(colors.len(), usize::try_from(num_stops).unwrap(), "`colors` has an incorrect length");
-    let colors_bytes = colors.serialize();
-    let length_so_far = length_so_far + colors_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&stops_bytes), IoSlice::new(&colors_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateRadialGradientRequest {
+        picture: picture,
+        inner: inner,
+        outer: outer,
+        inner_radius: inner_radius,
+        outer_radius: outer_radius,
+        stops: stops,
+        colors: colors,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateConicalGradient request
-pub const CREATE_CONICAL_GRADIENT_REQUEST: u8 = 36;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateConicalGradientRequest<'input> {
+    pub picture: Picture,
+    pub center: Pointfix,
+    pub angle: Fixed,
+    pub stops: &'input [Fixed],
+    pub colors: &'input [Color],
+}
+impl<'input> CreateConicalGradientRequest<'input> {
+    /// Opcode for the CreateConicalGradient request
+    pub const fn opcode() -> u8 { 36 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let picture_bytes = self.picture.serialize();
+        let center_bytes = self.center.serialize();
+        let angle_bytes = self.angle.serialize();
+        let num_stops = u32::try_from(self.stops.len()).expect("`stops` has too many elements");
+        let num_stops_bytes = num_stops.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateConicalGradientRequest::opcode(),
+            0,
+            0,
+            picture_bytes[0],
+            picture_bytes[1],
+            picture_bytes[2],
+            picture_bytes[3],
+            center_bytes[0],
+            center_bytes[1],
+            center_bytes[2],
+            center_bytes[3],
+            center_bytes[4],
+            center_bytes[5],
+            center_bytes[6],
+            center_bytes[7],
+            angle_bytes[0],
+            angle_bytes[1],
+            angle_bytes[2],
+            angle_bytes[3],
+            num_stops_bytes[0],
+            num_stops_bytes[1],
+            num_stops_bytes[2],
+            num_stops_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let stops_bytes = self.stops.serialize();
+        let length_so_far = length_so_far + stops_bytes.len();
+        assert_eq!(self.colors.len(), usize::try_from(num_stops).unwrap(), "`colors` has an incorrect length");
+        let colors_bytes = self.colors.serialize();
+        let length_so_far = length_so_far + colors_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), stops_bytes.into(), colors_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_conical_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, center: Pointfix, angle: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let picture_bytes = picture.serialize();
-    let center_bytes = center.serialize();
-    let angle_bytes = angle.serialize();
-    let num_stops = u32::try_from(stops.len()).expect("`stops` has too many elements");
-    let num_stops_bytes = num_stops.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_CONICAL_GRADIENT_REQUEST,
-        0,
-        0,
-        picture_bytes[0],
-        picture_bytes[1],
-        picture_bytes[2],
-        picture_bytes[3],
-        center_bytes[0],
-        center_bytes[1],
-        center_bytes[2],
-        center_bytes[3],
-        center_bytes[4],
-        center_bytes[5],
-        center_bytes[6],
-        center_bytes[7],
-        angle_bytes[0],
-        angle_bytes[1],
-        angle_bytes[2],
-        angle_bytes[3],
-        num_stops_bytes[0],
-        num_stops_bytes[1],
-        num_stops_bytes[2],
-        num_stops_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let stops_bytes = stops.serialize();
-    let length_so_far = length_so_far + stops_bytes.len();
-    assert_eq!(colors.len(), usize::try_from(num_stops).unwrap(), "`colors` has an incorrect length");
-    let colors_bytes = colors.serialize();
-    let length_so_far = length_so_far + colors_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&stops_bytes), IoSlice::new(&colors_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateConicalGradientRequest {
+        picture: picture,
+        center: center,
+        angle: angle,
+        stops: stops,
+        colors: colors,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Extension trait defining the requests of this extension.

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -451,7 +451,7 @@ impl QueryVersionRequest {
         let client_minor_bytes = self.client_minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_bytes[0],
@@ -522,7 +522,7 @@ impl QueryClientsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryClientsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -604,7 +604,7 @@ impl QueryClientResourcesRequest {
         let xid_bytes = self.xid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryClientResourcesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             xid_bytes[0],
@@ -692,7 +692,7 @@ impl QueryClientPixmapBytesRequest {
         let xid_bytes = self.xid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryClientPixmapBytesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             xid_bytes[0],
@@ -766,7 +766,7 @@ impl<'input> QueryClientIdsRequest<'input> {
         let num_specs_bytes = num_specs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryClientIdsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             num_specs_bytes[0],
@@ -861,7 +861,7 @@ impl<'input> QueryResourceBytesRequest<'input> {
         let num_specs_bytes = num_specs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryResourceBytesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_bytes[0],

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -429,14 +429,14 @@ impl ResourceSizeValue {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -449,7 +449,7 @@ impl QueryVersionRequest {
         let client_minor_bytes = self.client_minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_bytes[0],
@@ -504,11 +504,11 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the QueryClients request
+pub const QUERY_CLIENTS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryClientsRequest;
 impl QueryClientsRequest {
-    /// Opcode for the QueryClients request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -519,7 +519,7 @@ impl QueryClientsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_CLIENTS_REQUEST,
             0,
             0,
         ];
@@ -582,13 +582,13 @@ impl QueryClientsReply {
     }
 }
 
+/// Opcode for the QueryClientResources request
+pub const QUERY_CLIENT_RESOURCES_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryClientResourcesRequest {
     pub xid: u32,
 }
 impl QueryClientResourcesRequest {
-    /// Opcode for the QueryClientResources request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -600,7 +600,7 @@ impl QueryClientResourcesRequest {
         let xid_bytes = self.xid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_CLIENT_RESOURCES_REQUEST,
             0,
             0,
             xid_bytes[0],
@@ -669,13 +669,13 @@ impl QueryClientResourcesReply {
     }
 }
 
+/// Opcode for the QueryClientPixmapBytes request
+pub const QUERY_CLIENT_PIXMAP_BYTES_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryClientPixmapBytesRequest {
     pub xid: u32,
 }
 impl QueryClientPixmapBytesRequest {
-    /// Opcode for the QueryClientPixmapBytes request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -687,7 +687,7 @@ impl QueryClientPixmapBytesRequest {
         let xid_bytes = self.xid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_CLIENT_PIXMAP_BYTES_REQUEST,
             0,
             0,
             xid_bytes[0],
@@ -741,13 +741,13 @@ impl TryFrom<&[u8]> for QueryClientPixmapBytesReply {
     }
 }
 
+/// Opcode for the QueryClientIds request
+pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryClientIdsRequest<'input> {
     pub specs: &'input [ClientIdSpec],
 }
 impl<'input> QueryClientIdsRequest<'input> {
-    /// Opcode for the QueryClientIds request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -760,7 +760,7 @@ impl<'input> QueryClientIdsRequest<'input> {
         let num_specs_bytes = num_specs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_CLIENT_IDS_REQUEST,
             0,
             0,
             num_specs_bytes[0],
@@ -833,14 +833,14 @@ impl QueryClientIdsReply {
     }
 }
 
+/// Opcode for the QueryResourceBytes request
+pub const QUERY_RESOURCE_BYTES_REQUEST: u8 = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryResourceBytesRequest<'input> {
     pub client: u32,
     pub specs: &'input [ResourceIdSpec],
 }
 impl<'input> QueryResourceBytesRequest<'input> {
-    /// Opcode for the QueryResourceBytes request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -854,7 +854,7 @@ impl<'input> QueryResourceBytesRequest<'input> {
         let num_specs_bytes = num_specs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_RESOURCE_BYTES_REQUEST,
             0,
             0,
             client_bytes[0],

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -471,8 +471,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major: client_major,
-        client_minor: client_minor,
+        client_major,
+        client_minor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -624,7 +624,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryClientResourcesRequest {
-        xid: xid,
+        xid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -712,7 +712,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryClientPixmapBytesRequest {
-        xid: xid,
+        xid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -790,7 +790,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryClientIdsRequest {
-        specs: specs,
+        specs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -889,8 +889,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryResourceBytesRequest {
-        client: client,
-        specs: specs,
+        client,
+        specs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -439,7 +439,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -512,7 +511,6 @@ impl QueryClientsRequest {
     /// Opcode for the QueryClients request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -593,7 +591,6 @@ impl QueryClientResourcesRequest {
     /// Opcode for the QueryClientResources request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -681,7 +678,6 @@ impl QueryClientPixmapBytesRequest {
     /// Opcode for the QueryClientPixmapBytes request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -754,7 +750,6 @@ impl<'input> QueryClientIdsRequest<'input> {
     /// Opcode for the QueryClientIds request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -848,7 +843,6 @@ impl<'input> QueryResourceBytesRequest<'input> {
     /// Opcode for the QueryResourceBytes request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -439,7 +438,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -511,7 +510,7 @@ impl QueryClientsRequest {
     /// Opcode for the QueryClients request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -591,7 +590,7 @@ impl QueryClientResourcesRequest {
     /// Opcode for the QueryClientResources request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -678,7 +677,7 @@ impl QueryClientPixmapBytesRequest {
     /// Opcode for the QueryClientPixmapBytes request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -750,7 +749,7 @@ impl<'input> QueryClientIdsRequest<'input> {
     /// Opcode for the QueryClientIds request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -777,7 +776,7 @@ impl<'input> QueryClientIdsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), specs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), specs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn query_client_ids<'c, 'input, Conn>(conn: &'c Conn, specs: &'input [ClientIdSpec]) -> Result<Cookie<'c, Conn, QueryClientIdsReply>, ConnectionError>
@@ -843,7 +842,7 @@ impl<'input> QueryResourceBytesRequest<'input> {
     /// Opcode for the QueryResourceBytes request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -875,7 +874,7 @@ impl<'input> QueryResourceBytesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), specs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), specs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn query_resource_bytes<'c, 'input, Conn>(conn: &'c Conn, client: u32, specs: &'input [ResourceIdSpec]) -> Result<Cookie<'c, Conn, QueryResourceBytesReply>, ConnectionError>

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -673,7 +673,7 @@ impl TryFrom<&[u8]> for QueryClientPixmapBytesReply {
 
 /// Opcode for the QueryClientIds request
 pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
-pub fn query_client_ids<'c, Conn>(conn: &'c Conn, specs: &[ClientIdSpec]) -> Result<Cookie<'c, Conn, QueryClientIdsReply>, ConnectionError>
+pub fn query_client_ids<'c, 'input, Conn>(conn: &'c Conn, specs: &'input [ClientIdSpec]) -> Result<Cookie<'c, Conn, QueryClientIdsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -747,7 +747,7 @@ impl QueryClientIdsReply {
 
 /// Opcode for the QueryResourceBytes request
 pub const QUERY_RESOURCE_BYTES_REQUEST: u8 = 5;
-pub fn query_resource_bytes<'c, Conn>(conn: &'c Conn, client: u32, specs: &[ResourceIdSpec]) -> Result<Cookie<'c, Conn, QueryResourceBytesReply>, ConnectionError>
+pub fn query_resource_bytes<'c, 'input, Conn>(conn: &'c Conn, client: u32, specs: &'input [ResourceIdSpec]) -> Result<Cookie<'c, Conn, QueryResourceBytesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -842,11 +842,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_client_pixmap_bytes(self, xid)
     }
-    fn res_query_client_ids<'c>(&'c self, specs: &[ClientIdSpec]) -> Result<Cookie<'c, Self, QueryClientIdsReply>, ConnectionError>
+    fn res_query_client_ids<'c, 'input>(&'c self, specs: &'input [ClientIdSpec]) -> Result<Cookie<'c, Self, QueryClientIdsReply>, ConnectionError>
     {
         query_client_ids(self, specs)
     }
-    fn res_query_resource_bytes<'c>(&'c self, client: u32, specs: &[ResourceIdSpec]) -> Result<Cookie<'c, Self, QueryResourceBytesReply>, ConnectionError>
+    fn res_query_resource_bytes<'c, 'input>(&'c self, client: u32, specs: &'input [ResourceIdSpec]) -> Result<Cookie<'c, Self, QueryResourceBytesReply>, ConnectionError>
     {
         query_resource_bytes(self, client, specs)
     }

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -591,7 +591,7 @@ impl SetAttributesAux {
     }
 }
 
-pub fn set_attributes<'c, Conn>(conn: &'c Conn, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: xproto::WindowClass, depth: u8, visual: xproto::Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_attributes<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: xproto::WindowClass, depth: u8, visual: xproto::Visualid, value_list: &'input SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -808,7 +808,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         select_input(self, drawable, event_mask)
     }
-    fn screensaver_set_attributes<'c>(&'c self, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: xproto::WindowClass, depth: u8, visual: xproto::Visualid, value_list: &SetAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn screensaver_set_attributes<'c, 'input>(&'c self, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: xproto::WindowClass, depth: u8, visual: xproto::Visualid, value_list: &'input SetAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_attributes(self, drawable, x, y, width, height, border_width, class, depth, visual, value_list)
     }

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -271,8 +271,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -346,7 +346,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryInfoRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -436,8 +436,8 @@ where
 {
     let event_mask: u32 = event_mask.into();
     let request0 = SelectInputRequest {
-        drawable: drawable,
-        event_mask: event_mask,
+        drawable,
+        event_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -733,16 +733,16 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetAttributesRequest {
-        drawable: drawable,
-        x: x,
-        y: y,
-        width: width,
-        height: height,
-        border_width: border_width,
-        class: class,
-        depth: depth,
-        visual: visual,
-        value_list: value_list,
+        drawable,
+        x,
+        y,
+        width,
+        height,
+        border_width,
+        class,
+        depth,
+        visual,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -788,7 +788,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UnsetAttributesRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -834,7 +834,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SuspendRequest {
-        suspend: suspend,
+        suspend,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -229,14 +229,14 @@ impl TryFrom<u32> for State {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major_version: u8,
     pub client_minor_version: u8,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -249,7 +249,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -305,13 +305,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the QueryInfo request
+pub const QUERY_INFO_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryInfoRequest {
     pub drawable: xproto::Drawable,
 }
 impl QueryInfoRequest {
-    /// Opcode for the QueryInfo request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -323,7 +323,7 @@ impl QueryInfoRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_INFO_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -386,14 +386,14 @@ impl TryFrom<&[u8]> for QueryInfoReply {
     }
 }
 
+/// Opcode for the SelectInput request
+pub const SELECT_INPUT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectInputRequest {
     pub drawable: xproto::Drawable,
     pub event_mask: u32,
 }
 impl SelectInputRequest {
-    /// Opcode for the SelectInput request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -406,7 +406,7 @@ impl SelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_INPUT_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -647,6 +647,8 @@ impl SetAttributesAux {
     }
 }
 
+/// Opcode for the SetAttributes request
+pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetAttributesRequest<'input> {
     pub drawable: xproto::Drawable,
@@ -661,8 +663,6 @@ pub struct SetAttributesRequest<'input> {
     pub value_list: &'input SetAttributesAux,
 }
 impl<'input> SetAttributesRequest<'input> {
-    /// Opcode for the SetAttributes request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -684,7 +684,7 @@ impl<'input> SetAttributesRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_ATTRIBUTES_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -744,13 +744,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UnsetAttributes request
+pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnsetAttributesRequest {
     pub drawable: xproto::Drawable,
 }
 impl UnsetAttributesRequest {
-    /// Opcode for the UnsetAttributes request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -762,7 +762,7 @@ impl UnsetAttributesRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNSET_ATTRIBUTES_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -789,13 +789,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Suspend request
+pub const SUSPEND_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SuspendRequest {
     pub suspend: u32,
 }
 impl SuspendRequest {
-    /// Opcode for the Suspend request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -807,7 +807,7 @@ impl SuspendRequest {
         let suspend_bytes = self.suspend.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SUSPEND_REQUEST,
             0,
             0,
             suspend_bytes[0],

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -251,7 +251,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -326,7 +326,7 @@ impl QueryInfoRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -410,7 +410,7 @@ impl SelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -689,7 +689,7 @@ impl<'input> SetAttributesRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -768,7 +768,7 @@ impl UnsetAttributesRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UnsetAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -814,7 +814,7 @@ impl SuspendRequest {
         let suspend_bytes = self.suspend.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SuspendRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             suspend_bytes[0],

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -239,7 +239,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -315,7 +314,6 @@ impl QueryInfoRequest {
     /// Opcode for the QueryInfo request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -398,7 +396,6 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -668,7 +665,6 @@ impl<'input> SetAttributesRequest<'input> {
     /// Opcode for the SetAttributes request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -757,7 +753,6 @@ impl UnsetAttributesRequest {
     /// Opcode for the UnsetAttributes request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -803,7 +798,6 @@ impl SuspendRequest {
     /// Opcode for the Suspend request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -239,7 +238,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -314,7 +313,7 @@ impl QueryInfoRequest {
     /// Opcode for the QueryInfo request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -396,7 +395,7 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -665,7 +664,7 @@ impl<'input> SetAttributesRequest<'input> {
     /// Opcode for the SetAttributes request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -721,7 +720,7 @@ impl<'input> SetAttributesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_attributes<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: xproto::WindowClass, depth: u8, visual: xproto::Visualid, value_list: &'input SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -753,7 +752,7 @@ impl UnsetAttributesRequest {
     /// Opcode for the UnsetAttributes request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -798,7 +797,7 @@ impl SuspendRequest {
     /// Opcode for the Suspend request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -229,32 +230,53 @@ impl TryFrom<u32> for State {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest {
+    pub client_major_version: u8,
+    pub client_minor_version: u8,
+}
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let client_major_version_bytes = self.client_major_version.serialize();
+        let client_minor_version_bytes = self.client_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+            client_major_version_bytes[0],
+            client_minor_version_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u8, client_minor_version: u8) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let client_major_version_bytes = client_major_version.serialize();
-    let client_minor_version_bytes = client_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-        client_major_version_bytes[0],
-        client_minor_version_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest {
+        client_major_version: client_major_version,
+        client_minor_version: client_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -285,31 +307,50 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the QueryInfo request
-pub const QUERY_INFO_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryInfoRequest {
+    pub drawable: xproto::Drawable,
+}
+impl QueryInfoRequest {
+    /// Opcode for the QueryInfo request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryInfoRequest::opcode(),
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_info<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, QueryInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_INFO_REQUEST,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryInfoRequest {
+        drawable: drawable,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -348,42 +389,61 @@ impl TryFrom<&[u8]> for QueryInfoReply {
     }
 }
 
-/// Opcode for the SelectInput request
-pub const SELECT_INPUT_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectInputRequest {
+    pub drawable: xproto::Drawable,
+    pub event_mask: u32,
+}
+impl SelectInputRequest {
+    /// Opcode for the SelectInput request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let event_mask_bytes = self.event_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SelectInputRequest::opcode(),
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            event_mask_bytes[2],
+            event_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn select_input<Conn, A>(conn: &Conn, drawable: xproto::Drawable, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let event_mask: u32 = event_mask.into();
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let event_mask_bytes = event_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SELECT_INPUT_REQUEST,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        event_mask_bytes[0],
-        event_mask_bytes[1],
-        event_mask_bytes[2],
-        event_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SelectInputRequest {
+        drawable: drawable,
+        event_mask: event_mask,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetAttributes request
-pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
 /// Auxiliary and optional information for the `set_attributes` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SetAttributesAux {
@@ -591,117 +651,194 @@ impl SetAttributesAux {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetAttributesRequest<'input> {
+    pub drawable: xproto::Drawable,
+    pub x: i16,
+    pub y: i16,
+    pub width: u16,
+    pub height: u16,
+    pub border_width: u16,
+    pub class: xproto::WindowClass,
+    pub depth: u8,
+    pub visual: xproto::Visualid,
+    pub value_list: &'input SetAttributesAux,
+}
+impl<'input> SetAttributesRequest<'input> {
+    /// Opcode for the SetAttributes request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let border_width_bytes = self.border_width.serialize();
+        let class_bytes = u8::from(self.class).serialize();
+        let depth_bytes = self.depth.serialize();
+        let visual_bytes = self.visual.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetAttributesRequest::opcode(),
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            border_width_bytes[0],
+            border_width_bytes[1],
+            class_bytes[0],
+            depth_bytes[0],
+            visual_bytes[0],
+            visual_bytes[1],
+            visual_bytes[2],
+            visual_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_attributes<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: xproto::WindowClass, depth: u8, visual: xproto::Visualid, value_list: &'input SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let border_width_bytes = border_width.serialize();
-    let class_bytes = u8::from(class).serialize();
-    let depth_bytes = depth.serialize();
-    let visual_bytes = visual.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_ATTRIBUTES_REQUEST,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        border_width_bytes[0],
-        border_width_bytes[1],
-        class_bytes[0],
-        depth_bytes[0],
-        visual_bytes[0],
-        visual_bytes[1],
-        visual_bytes[2],
-        visual_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetAttributesRequest {
+        drawable: drawable,
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+        border_width: border_width,
+        class: class,
+        depth: depth,
+        visual: visual,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UnsetAttributes request
-pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnsetAttributesRequest {
+    pub drawable: xproto::Drawable,
+}
+impl UnsetAttributesRequest {
+    /// Opcode for the UnsetAttributes request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            UnsetAttributesRequest::opcode(),
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn unset_attributes<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        UNSET_ATTRIBUTES_REQUEST,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UnsetAttributesRequest {
+        drawable: drawable,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Suspend request
-pub const SUSPEND_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SuspendRequest {
+    pub suspend: u32,
+}
+impl SuspendRequest {
+    /// Opcode for the Suspend request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let suspend_bytes = self.suspend.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SuspendRequest::opcode(),
+            0,
+            0,
+            suspend_bytes[0],
+            suspend_bytes[1],
+            suspend_bytes[2],
+            suspend_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn suspend<Conn>(conn: &Conn, suspend: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let suspend_bytes = suspend.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SUSPEND_REQUEST,
-        0,
-        0,
-        suspend_bytes[0],
-        suspend_bytes[1],
-        suspend_bytes[2],
-        suspend_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SuspendRequest {
+        suspend: suspend,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Opcode for the Notify event

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -283,7 +283,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -361,7 +361,7 @@ impl<'input> RectanglesRequest<'input> {
         let y_offset_bytes = self.y_offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RectanglesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             operation_bytes[0],
@@ -435,7 +435,7 @@ impl MaskRequest {
         let source_bitmap_bytes = self.source_bitmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            MaskRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             operation_bytes[0],
@@ -512,7 +512,7 @@ impl CombineRequest {
         let source_window_bytes = self.source_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CombineRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             operation_bytes[0],
@@ -582,7 +582,7 @@ impl OffsetRequest {
         let y_offset_bytes = self.y_offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            OffsetRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             destination_kind_bytes[0],
@@ -639,7 +639,7 @@ impl QueryExtentsRequest {
         let destination_window_bytes = self.destination_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryExtentsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             destination_window_bytes[0],
@@ -731,7 +731,7 @@ impl SelectInputRequest {
         let enable_bytes = self.enable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             destination_window_bytes[0],
@@ -782,7 +782,7 @@ impl InputSelectedRequest {
         let destination_window_bytes = self.destination_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            InputSelectedRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             destination_window_bytes[0],
@@ -854,7 +854,7 @@ impl GetRectanglesRequest {
         let source_kind_bytes = Kind::from(self.source_kind).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetRectanglesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -273,7 +273,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -345,7 +344,6 @@ impl<'input> RectanglesRequest<'input> {
     /// Opcode for the Rectangles request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -419,7 +417,6 @@ impl MaskRequest {
     /// Opcode for the Mask request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -495,7 +492,6 @@ impl CombineRequest {
     /// Opcode for the Combine request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -568,7 +564,6 @@ impl OffsetRequest {
     /// Opcode for the Offset request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -628,7 +623,6 @@ impl QueryExtentsRequest {
     /// Opcode for the QueryExtents request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -719,7 +713,6 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -771,7 +764,6 @@ impl InputSelectedRequest {
     /// Opcode for the InputSelected request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -842,7 +834,6 @@ impl GetRectanglesRequest {
     /// Opcode for the GetRectangles request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -393,13 +393,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RectanglesRequest {
-        operation: operation,
-        destination_kind: destination_kind,
-        ordering: ordering,
-        destination_window: destination_window,
-        x_offset: x_offset,
-        y_offset: y_offset,
-        rectangles: rectangles,
+        operation,
+        destination_kind,
+        ordering,
+        destination_window,
+        x_offset,
+        y_offset,
+        rectangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -469,12 +469,12 @@ where
 {
     let source_bitmap: xproto::Pixmap = source_bitmap.into();
     let request0 = MaskRequest {
-        operation: operation,
-        destination_kind: destination_kind,
-        destination_window: destination_window,
-        x_offset: x_offset,
-        y_offset: y_offset,
-        source_bitmap: source_bitmap,
+        operation,
+        destination_kind,
+        destination_window,
+        x_offset,
+        y_offset,
+        source_bitmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -544,13 +544,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CombineRequest {
-        operation: operation,
-        destination_kind: destination_kind,
-        source_kind: source_kind,
-        destination_window: destination_window,
-        x_offset: x_offset,
-        y_offset: y_offset,
-        source_window: source_window,
+        operation,
+        destination_kind,
+        source_kind,
+        destination_window,
+        x_offset,
+        y_offset,
+        source_window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -610,10 +610,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = OffsetRequest {
-        destination_kind: destination_kind,
-        destination_window: destination_window,
-        x_offset: x_offset,
-        y_offset: y_offset,
+        destination_kind,
+        destination_window,
+        x_offset,
+        y_offset,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -659,7 +659,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryExtentsRequest {
-        destination_window: destination_window,
+        destination_window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -755,8 +755,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SelectInputRequest {
-        destination_window: destination_window,
-        enable: enable,
+        destination_window,
+        enable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -802,7 +802,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = InputSelectedRequest {
-        destination_window: destination_window,
+        destination_window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -878,8 +878,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetRectanglesRequest {
-        window: window,
-        source_kind: source_kind,
+        window,
+        source_kind,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -273,7 +272,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -344,7 +343,7 @@ impl<'input> RectanglesRequest<'input> {
     /// Opcode for the Rectangles request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -383,7 +382,7 @@ impl<'input> RectanglesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rectangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn rectangles<'c, 'input, Conn>(conn: &'c Conn, operation: SO, destination_kind: SK, ordering: xproto::ClipOrdering, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -417,7 +416,7 @@ impl MaskRequest {
     /// Opcode for the Mask request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -492,7 +491,7 @@ impl CombineRequest {
     /// Opcode for the Combine request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -564,7 +563,7 @@ impl OffsetRequest {
     /// Opcode for the Offset request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -623,7 +622,7 @@ impl QueryExtentsRequest {
     /// Opcode for the QueryExtents request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -713,7 +712,7 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -764,7 +763,7 @@ impl InputSelectedRequest {
     /// Opcode for the InputSelected request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -834,7 +833,7 @@ impl GetRectanglesRequest {
     /// Opcode for the GetRectangles request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -266,11 +266,11 @@ impl From<NotifyEvent> for [u8; 32] {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -281,7 +281,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
         ];
@@ -329,6 +329,8 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the Rectangles request
+pub const RECTANGLES_REQUEST: u8 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RectanglesRequest<'input> {
     pub operation: SO,
@@ -340,8 +342,6 @@ pub struct RectanglesRequest<'input> {
     pub rectangles: &'input [xproto::Rectangle],
 }
 impl<'input> RectanglesRequest<'input> {
-    /// Opcode for the Rectangles request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -358,7 +358,7 @@ impl<'input> RectanglesRequest<'input> {
         let y_offset_bytes = self.y_offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            RECTANGLES_REQUEST,
             0,
             0,
             operation_bytes[0],
@@ -403,6 +403,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Mask request
+pub const MASK_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MaskRequest {
     pub operation: SO,
@@ -413,8 +415,6 @@ pub struct MaskRequest {
     pub source_bitmap: xproto::Pixmap,
 }
 impl MaskRequest {
-    /// Opcode for the Mask request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -431,7 +431,7 @@ impl MaskRequest {
         let source_bitmap_bytes = self.source_bitmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            MASK_REQUEST,
             0,
             0,
             operation_bytes[0],
@@ -477,6 +477,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Combine request
+pub const COMBINE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CombineRequest {
     pub operation: SO,
@@ -488,8 +490,6 @@ pub struct CombineRequest {
     pub source_window: xproto::Window,
 }
 impl CombineRequest {
-    /// Opcode for the Combine request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -507,7 +507,7 @@ impl CombineRequest {
         let source_window_bytes = self.source_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COMBINE_REQUEST,
             0,
             0,
             operation_bytes[0],
@@ -552,6 +552,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Offset request
+pub const OFFSET_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OffsetRequest {
     pub destination_kind: SK,
@@ -560,8 +562,6 @@ pub struct OffsetRequest {
     pub y_offset: i16,
 }
 impl OffsetRequest {
-    /// Opcode for the Offset request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -576,7 +576,7 @@ impl OffsetRequest {
         let y_offset_bytes = self.y_offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            OFFSET_REQUEST,
             0,
             0,
             destination_kind_bytes[0],
@@ -614,13 +614,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryExtents request
+pub const QUERY_EXTENTS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryExtentsRequest {
     pub destination_window: xproto::Window,
 }
 impl QueryExtentsRequest {
-    /// Opcode for the QueryExtents request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -632,7 +632,7 @@ impl QueryExtentsRequest {
         let destination_window_bytes = self.destination_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_EXTENTS_REQUEST,
             0,
             0,
             destination_window_bytes[0],
@@ -703,14 +703,14 @@ impl TryFrom<&[u8]> for QueryExtentsReply {
     }
 }
 
+/// Opcode for the SelectInput request
+pub const SELECT_INPUT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectInputRequest {
     pub destination_window: xproto::Window,
     pub enable: bool,
 }
 impl SelectInputRequest {
-    /// Opcode for the SelectInput request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -723,7 +723,7 @@ impl SelectInputRequest {
         let enable_bytes = self.enable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_INPUT_REQUEST,
             0,
             0,
             destination_window_bytes[0],
@@ -755,13 +755,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the InputSelected request
+pub const INPUT_SELECTED_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InputSelectedRequest {
     pub destination_window: xproto::Window,
 }
 impl InputSelectedRequest {
-    /// Opcode for the InputSelected request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -773,7 +773,7 @@ impl InputSelectedRequest {
         let destination_window_bytes = self.destination_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            INPUT_SELECTED_REQUEST,
             0,
             0,
             destination_window_bytes[0],
@@ -824,14 +824,14 @@ impl TryFrom<&[u8]> for InputSelectedReply {
     }
 }
 
+/// Opcode for the GetRectangles request
+pub const GET_RECTANGLES_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetRectanglesRequest {
     pub window: xproto::Window,
     pub source_kind: SK,
 }
 impl GetRectanglesRequest {
-    /// Opcode for the GetRectangles request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -844,7 +844,7 @@ impl GetRectanglesRequest {
         let source_kind_bytes = Kind::from(self.source_kind).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_RECTANGLES_REQUEST,
             0,
             0,
             window_bytes[0],

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -317,7 +317,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the Rectangles request
 pub const RECTANGLES_REQUEST: u8 = 1;
-pub fn rectangles<'c, Conn>(conn: &'c Conn, operation: SO, destination_kind: SK, ordering: xproto::ClipOrdering, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn rectangles<'c, 'input, Conn>(conn: &'c Conn, operation: SO, destination_kind: SK, ordering: xproto::ClipOrdering, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -724,7 +724,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_version(self)
     }
-    fn shape_rectangles<'c>(&'c self, operation: SO, destination_kind: SK, ordering: xproto::ClipOrdering, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn shape_rectangles<'c, 'input>(&'c self, operation: SO, destination_kind: SK, ordering: xproto::ClipOrdering, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         self::rectangles(self, operation, destination_kind, ordering, destination_window, x_offset, y_offset, rectangles)
     }

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -266,26 +267,41 @@ impl From<NotifyEvent> for [u8; 32] {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest;
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -315,204 +331,339 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the Rectangles request
-pub const RECTANGLES_REQUEST: u8 = 1;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RectanglesRequest<'input> {
+    pub operation: SO,
+    pub destination_kind: SK,
+    pub ordering: xproto::ClipOrdering,
+    pub destination_window: xproto::Window,
+    pub x_offset: i16,
+    pub y_offset: i16,
+    pub rectangles: &'input [xproto::Rectangle],
+}
+impl<'input> RectanglesRequest<'input> {
+    /// Opcode for the Rectangles request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let operation_bytes = Op::from(self.operation).serialize();
+        let destination_kind_bytes = Kind::from(self.destination_kind).serialize();
+        let ordering_bytes = u8::from(self.ordering).serialize();
+        let destination_window_bytes = self.destination_window.serialize();
+        let x_offset_bytes = self.x_offset.serialize();
+        let y_offset_bytes = self.y_offset.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            RectanglesRequest::opcode(),
+            0,
+            0,
+            operation_bytes[0],
+            destination_kind_bytes[0],
+            ordering_bytes[0],
+            0,
+            destination_window_bytes[0],
+            destination_window_bytes[1],
+            destination_window_bytes[2],
+            destination_window_bytes[3],
+            x_offset_bytes[0],
+            x_offset_bytes[1],
+            y_offset_bytes[0],
+            y_offset_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let rectangles_bytes = self.rectangles.serialize();
+        let length_so_far = length_so_far + rectangles_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn rectangles<'c, 'input, Conn>(conn: &'c Conn, operation: SO, destination_kind: SK, ordering: xproto::ClipOrdering, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let operation_bytes = Op::from(operation).serialize();
-    let destination_kind_bytes = Kind::from(destination_kind).serialize();
-    let ordering_bytes = u8::from(ordering).serialize();
-    let destination_window_bytes = destination_window.serialize();
-    let x_offset_bytes = x_offset.serialize();
-    let y_offset_bytes = y_offset.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        RECTANGLES_REQUEST,
-        0,
-        0,
-        operation_bytes[0],
-        destination_kind_bytes[0],
-        ordering_bytes[0],
-        0,
-        destination_window_bytes[0],
-        destination_window_bytes[1],
-        destination_window_bytes[2],
-        destination_window_bytes[3],
-        x_offset_bytes[0],
-        x_offset_bytes[1],
-        y_offset_bytes[0],
-        y_offset_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let rectangles_bytes = rectangles.serialize();
-    let length_so_far = length_so_far + rectangles_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&rectangles_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = RectanglesRequest {
+        operation: operation,
+        destination_kind: destination_kind,
+        ordering: ordering,
+        destination_window: destination_window,
+        x_offset: x_offset,
+        y_offset: y_offset,
+        rectangles: rectangles,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Mask request
-pub const MASK_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaskRequest {
+    pub operation: SO,
+    pub destination_kind: SK,
+    pub destination_window: xproto::Window,
+    pub x_offset: i16,
+    pub y_offset: i16,
+    pub source_bitmap: xproto::Pixmap,
+}
+impl MaskRequest {
+    /// Opcode for the Mask request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let operation_bytes = Op::from(self.operation).serialize();
+        let destination_kind_bytes = Kind::from(self.destination_kind).serialize();
+        let destination_window_bytes = self.destination_window.serialize();
+        let x_offset_bytes = self.x_offset.serialize();
+        let y_offset_bytes = self.y_offset.serialize();
+        let source_bitmap_bytes = self.source_bitmap.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            MaskRequest::opcode(),
+            0,
+            0,
+            operation_bytes[0],
+            destination_kind_bytes[0],
+            0,
+            0,
+            destination_window_bytes[0],
+            destination_window_bytes[1],
+            destination_window_bytes[2],
+            destination_window_bytes[3],
+            x_offset_bytes[0],
+            x_offset_bytes[1],
+            y_offset_bytes[0],
+            y_offset_bytes[1],
+            source_bitmap_bytes[0],
+            source_bitmap_bytes[1],
+            source_bitmap_bytes[2],
+            source_bitmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn mask<Conn, A>(conn: &Conn, operation: SO, destination_kind: SK, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_bitmap: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Pixmap>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let source_bitmap: xproto::Pixmap = source_bitmap.into();
-    let length_so_far = 0;
-    let operation_bytes = Op::from(operation).serialize();
-    let destination_kind_bytes = Kind::from(destination_kind).serialize();
-    let destination_window_bytes = destination_window.serialize();
-    let x_offset_bytes = x_offset.serialize();
-    let y_offset_bytes = y_offset.serialize();
-    let source_bitmap_bytes = source_bitmap.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        MASK_REQUEST,
-        0,
-        0,
-        operation_bytes[0],
-        destination_kind_bytes[0],
-        0,
-        0,
-        destination_window_bytes[0],
-        destination_window_bytes[1],
-        destination_window_bytes[2],
-        destination_window_bytes[3],
-        x_offset_bytes[0],
-        x_offset_bytes[1],
-        y_offset_bytes[0],
-        y_offset_bytes[1],
-        source_bitmap_bytes[0],
-        source_bitmap_bytes[1],
-        source_bitmap_bytes[2],
-        source_bitmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = MaskRequest {
+        operation: operation,
+        destination_kind: destination_kind,
+        destination_window: destination_window,
+        x_offset: x_offset,
+        y_offset: y_offset,
+        source_bitmap: source_bitmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Combine request
-pub const COMBINE_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CombineRequest {
+    pub operation: SO,
+    pub destination_kind: SK,
+    pub source_kind: SK,
+    pub destination_window: xproto::Window,
+    pub x_offset: i16,
+    pub y_offset: i16,
+    pub source_window: xproto::Window,
+}
+impl CombineRequest {
+    /// Opcode for the Combine request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let operation_bytes = Op::from(self.operation).serialize();
+        let destination_kind_bytes = Kind::from(self.destination_kind).serialize();
+        let source_kind_bytes = Kind::from(self.source_kind).serialize();
+        let destination_window_bytes = self.destination_window.serialize();
+        let x_offset_bytes = self.x_offset.serialize();
+        let y_offset_bytes = self.y_offset.serialize();
+        let source_window_bytes = self.source_window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CombineRequest::opcode(),
+            0,
+            0,
+            operation_bytes[0],
+            destination_kind_bytes[0],
+            source_kind_bytes[0],
+            0,
+            destination_window_bytes[0],
+            destination_window_bytes[1],
+            destination_window_bytes[2],
+            destination_window_bytes[3],
+            x_offset_bytes[0],
+            x_offset_bytes[1],
+            y_offset_bytes[0],
+            y_offset_bytes[1],
+            source_window_bytes[0],
+            source_window_bytes[1],
+            source_window_bytes[2],
+            source_window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn combine<Conn>(conn: &Conn, operation: SO, destination_kind: SK, source_kind: SK, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let operation_bytes = Op::from(operation).serialize();
-    let destination_kind_bytes = Kind::from(destination_kind).serialize();
-    let source_kind_bytes = Kind::from(source_kind).serialize();
-    let destination_window_bytes = destination_window.serialize();
-    let x_offset_bytes = x_offset.serialize();
-    let y_offset_bytes = y_offset.serialize();
-    let source_window_bytes = source_window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        COMBINE_REQUEST,
-        0,
-        0,
-        operation_bytes[0],
-        destination_kind_bytes[0],
-        source_kind_bytes[0],
-        0,
-        destination_window_bytes[0],
-        destination_window_bytes[1],
-        destination_window_bytes[2],
-        destination_window_bytes[3],
-        x_offset_bytes[0],
-        x_offset_bytes[1],
-        y_offset_bytes[0],
-        y_offset_bytes[1],
-        source_window_bytes[0],
-        source_window_bytes[1],
-        source_window_bytes[2],
-        source_window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CombineRequest {
+        operation: operation,
+        destination_kind: destination_kind,
+        source_kind: source_kind,
+        destination_window: destination_window,
+        x_offset: x_offset,
+        y_offset: y_offset,
+        source_window: source_window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Offset request
-pub const OFFSET_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OffsetRequest {
+    pub destination_kind: SK,
+    pub destination_window: xproto::Window,
+    pub x_offset: i16,
+    pub y_offset: i16,
+}
+impl OffsetRequest {
+    /// Opcode for the Offset request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let destination_kind_bytes = Kind::from(self.destination_kind).serialize();
+        let destination_window_bytes = self.destination_window.serialize();
+        let x_offset_bytes = self.x_offset.serialize();
+        let y_offset_bytes = self.y_offset.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            OffsetRequest::opcode(),
+            0,
+            0,
+            destination_kind_bytes[0],
+            0,
+            0,
+            0,
+            destination_window_bytes[0],
+            destination_window_bytes[1],
+            destination_window_bytes[2],
+            destination_window_bytes[3],
+            x_offset_bytes[0],
+            x_offset_bytes[1],
+            y_offset_bytes[0],
+            y_offset_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn offset<Conn>(conn: &Conn, destination_kind: SK, destination_window: xproto::Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let destination_kind_bytes = Kind::from(destination_kind).serialize();
-    let destination_window_bytes = destination_window.serialize();
-    let x_offset_bytes = x_offset.serialize();
-    let y_offset_bytes = y_offset.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        OFFSET_REQUEST,
-        0,
-        0,
-        destination_kind_bytes[0],
-        0,
-        0,
-        0,
-        destination_window_bytes[0],
-        destination_window_bytes[1],
-        destination_window_bytes[2],
-        destination_window_bytes[3],
-        x_offset_bytes[0],
-        x_offset_bytes[1],
-        y_offset_bytes[0],
-        y_offset_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = OffsetRequest {
+        destination_kind: destination_kind,
+        destination_window: destination_window,
+        x_offset: x_offset,
+        y_offset: y_offset,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the QueryExtents request
-pub const QUERY_EXTENTS_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryExtentsRequest {
+    pub destination_window: xproto::Window,
+}
+impl QueryExtentsRequest {
+    /// Opcode for the QueryExtents request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let destination_window_bytes = self.destination_window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryExtentsRequest::opcode(),
+            0,
+            0,
+            destination_window_bytes[0],
+            destination_window_bytes[1],
+            destination_window_bytes[2],
+            destination_window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_extents<Conn>(conn: &Conn, destination_window: xproto::Window) -> Result<Cookie<'_, Conn, QueryExtentsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let destination_window_bytes = destination_window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_EXTENTS_REQUEST,
-        0,
-        0,
-        destination_window_bytes[0],
-        destination_window_bytes[1],
-        destination_window_bytes[2],
-        destination_window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryExtentsRequest {
+        destination_window: destination_window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -559,63 +710,103 @@ impl TryFrom<&[u8]> for QueryExtentsReply {
     }
 }
 
-/// Opcode for the SelectInput request
-pub const SELECT_INPUT_REQUEST: u8 = 6;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectInputRequest {
+    pub destination_window: xproto::Window,
+    pub enable: bool,
+}
+impl SelectInputRequest {
+    /// Opcode for the SelectInput request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let destination_window_bytes = self.destination_window.serialize();
+        let enable_bytes = self.enable.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SelectInputRequest::opcode(),
+            0,
+            0,
+            destination_window_bytes[0],
+            destination_window_bytes[1],
+            destination_window_bytes[2],
+            destination_window_bytes[3],
+            enable_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn select_input<Conn>(conn: &Conn, destination_window: xproto::Window, enable: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let destination_window_bytes = destination_window.serialize();
-    let enable_bytes = enable.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SELECT_INPUT_REQUEST,
-        0,
-        0,
-        destination_window_bytes[0],
-        destination_window_bytes[1],
-        destination_window_bytes[2],
-        destination_window_bytes[3],
-        enable_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SelectInputRequest {
+        destination_window: destination_window,
+        enable: enable,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the InputSelected request
-pub const INPUT_SELECTED_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InputSelectedRequest {
+    pub destination_window: xproto::Window,
+}
+impl InputSelectedRequest {
+    /// Opcode for the InputSelected request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let destination_window_bytes = self.destination_window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            InputSelectedRequest::opcode(),
+            0,
+            0,
+            destination_window_bytes[0],
+            destination_window_bytes[1],
+            destination_window_bytes[2],
+            destination_window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn input_selected<Conn>(conn: &Conn, destination_window: xproto::Window) -> Result<Cookie<'_, Conn, InputSelectedReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let destination_window_bytes = destination_window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        INPUT_SELECTED_REQUEST,
-        0,
-        0,
-        destination_window_bytes[0],
-        destination_window_bytes[1],
-        destination_window_bytes[2],
-        destination_window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = InputSelectedRequest {
+        destination_window: destination_window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -642,36 +833,57 @@ impl TryFrom<&[u8]> for InputSelectedReply {
     }
 }
 
-/// Opcode for the GetRectangles request
-pub const GET_RECTANGLES_REQUEST: u8 = 8;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetRectanglesRequest {
+    pub window: xproto::Window,
+    pub source_kind: SK,
+}
+impl GetRectanglesRequest {
+    /// Opcode for the GetRectangles request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let source_kind_bytes = Kind::from(self.source_kind).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetRectanglesRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            source_kind_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_rectangles<Conn>(conn: &Conn, window: xproto::Window, source_kind: SK) -> Result<Cookie<'_, Conn, GetRectanglesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let source_kind_bytes = Kind::from(source_kind).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_RECTANGLES_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        source_kind_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetRectanglesRequest {
+        window: window,
+        source_kind: source_kind,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -131,7 +131,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -207,7 +206,6 @@ impl AttachRequest {
     /// Opcode for the Attach request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -265,7 +263,6 @@ impl DetachRequest {
     /// Opcode for the Detach request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -325,7 +322,6 @@ impl PutImageRequest {
     /// Opcode for the PutImage request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -439,7 +435,6 @@ impl GetImageRequest {
     /// Opcode for the GetImage request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -559,7 +554,6 @@ impl CreatePixmapRequest {
     /// Opcode for the CreatePixmap request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -639,7 +633,6 @@ impl AttachFdRequest {
     /// Opcode for the AttachFd request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -696,7 +689,6 @@ impl CreateSegmentRequest {
     /// Opcode for the CreateSegment request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -124,11 +124,11 @@ impl From<CompletionEvent> for [u8; 32] {
 pub const BAD_SEG_ERROR: u8 = 0;
 pub type BadSegError = xproto::ValueError;
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -139,7 +139,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
         ];
@@ -195,6 +195,8 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the Attach request
+pub const ATTACH_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AttachRequest {
     pub shmseg: Seg,
@@ -202,8 +204,6 @@ pub struct AttachRequest {
     pub read_only: bool,
 }
 impl AttachRequest {
-    /// Opcode for the Attach request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -217,7 +217,7 @@ impl AttachRequest {
         let read_only_bytes = self.read_only.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ATTACH_REQUEST,
             0,
             0,
             shmseg_bytes[0],
@@ -254,13 +254,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Detach request
+pub const DETACH_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DetachRequest {
     pub shmseg: Seg,
 }
 impl DetachRequest {
-    /// Opcode for the Detach request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -272,7 +272,7 @@ impl DetachRequest {
         let shmseg_bytes = self.shmseg.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DETACH_REQUEST,
             0,
             0,
             shmseg_bytes[0],
@@ -299,6 +299,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PutImage request
+pub const PUT_IMAGE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PutImageRequest {
     pub drawable: xproto::Drawable,
@@ -318,8 +320,6 @@ pub struct PutImageRequest {
     pub offset: u32,
 }
 impl PutImageRequest {
-    /// Opcode for the PutImage request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -345,7 +345,7 @@ impl PutImageRequest {
         let offset_bytes = self.offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PUT_IMAGE_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -418,6 +418,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetImage request
+pub const GET_IMAGE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetImageRequest {
     pub drawable: xproto::Drawable,
@@ -431,8 +433,6 @@ pub struct GetImageRequest {
     pub offset: u32,
 }
 impl GetImageRequest {
-    /// Opcode for the GetImage request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -452,7 +452,7 @@ impl GetImageRequest {
         let offset_bytes = self.offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_IMAGE_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -539,6 +539,8 @@ impl TryFrom<&[u8]> for GetImageReply {
     }
 }
 
+/// Opcode for the CreatePixmap request
+pub const CREATE_PIXMAP_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreatePixmapRequest {
     pub pid: xproto::Pixmap,
@@ -550,8 +552,6 @@ pub struct CreatePixmapRequest {
     pub offset: u32,
 }
 impl CreatePixmapRequest {
-    /// Opcode for the CreatePixmap request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -569,7 +569,7 @@ impl CreatePixmapRequest {
         let offset_bytes = self.offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_PIXMAP_REQUEST,
             0,
             0,
             pid_bytes[0],
@@ -622,6 +622,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the AttachFd request
+pub const ATTACH_FD_REQUEST: u8 = 6;
 #[derive(Debug, PartialEq, Eq)]
 pub struct AttachFdRequest {
     pub shmseg: Seg,
@@ -629,8 +631,6 @@ pub struct AttachFdRequest {
     pub read_only: bool,
 }
 impl AttachFdRequest {
-    /// Opcode for the AttachFd request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -643,7 +643,7 @@ impl AttachFdRequest {
         let read_only_bytes = self.read_only.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ATTACH_FD_REQUEST,
             0,
             0,
             shmseg_bytes[0],
@@ -678,6 +678,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateSegment request
+pub const CREATE_SEGMENT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateSegmentRequest {
     pub shmseg: Seg,
@@ -685,8 +687,6 @@ pub struct CreateSegmentRequest {
     pub read_only: bool,
 }
 impl CreateSegmentRequest {
-    /// Opcode for the CreateSegment request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -700,7 +700,7 @@ impl CreateSegmentRequest {
         let read_only_bytes = self.read_only.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_SEGMENT_REQUEST,
             0,
             0,
             shmseg_bytes[0],

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -248,9 +248,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AttachRequest {
-        shmseg: shmseg,
-        shmid: shmid,
-        read_only: read_only,
+        shmseg,
+        shmid,
+        read_only,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -296,7 +296,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DetachRequest {
-        shmseg: shmseg,
+        shmseg,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -402,21 +402,21 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PutImageRequest {
-        drawable: drawable,
-        gc: gc,
-        total_width: total_width,
-        total_height: total_height,
-        src_x: src_x,
-        src_y: src_y,
-        src_width: src_width,
-        src_height: src_height,
-        dst_x: dst_x,
-        dst_y: dst_y,
-        depth: depth,
-        format: format,
-        send_event: send_event,
-        shmseg: shmseg,
-        offset: offset,
+        drawable,
+        gc,
+        total_width,
+        total_height,
+        src_x,
+        src_y,
+        src_width,
+        src_height,
+        dst_x,
+        dst_y,
+        depth,
+        format,
+        send_event,
+        shmseg,
+        offset,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -502,15 +502,15 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetImageRequest {
-        drawable: drawable,
-        x: x,
-        y: y,
-        width: width,
-        height: height,
-        plane_mask: plane_mask,
-        format: format,
-        shmseg: shmseg,
-        offset: offset,
+        drawable,
+        x,
+        y,
+        width,
+        height,
+        plane_mask,
+        format,
+        shmseg,
+        offset,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -616,13 +616,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreatePixmapRequest {
-        pid: pid,
-        drawable: drawable,
-        width: width,
-        height: height,
-        depth: depth,
-        shmseg: shmseg,
-        offset: offset,
+        pid,
+        drawable,
+        width,
+        height,
+        depth,
+        shmseg,
+        offset,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -677,9 +677,9 @@ where
 {
     let shm_fd: RawFdContainer = shm_fd.into();
     let request0 = AttachFdRequest {
-        shmseg: shmseg,
-        shm_fd: shm_fd,
-        read_only: read_only,
+        shmseg,
+        shm_fd,
+        read_only,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -737,9 +737,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateSegmentRequest {
-        shmseg: shmseg,
-        size: size,
-        read_only: read_only,
+        shmseg,
+        size,
+        read_only,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -141,7 +141,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -220,7 +220,7 @@ impl AttachRequest {
         let read_only_bytes = self.read_only.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AttachRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             shmseg_bytes[0],
@@ -276,7 +276,7 @@ impl DetachRequest {
         let shmseg_bytes = self.shmseg.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DetachRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             shmseg_bytes[0],
@@ -350,7 +350,7 @@ impl PutImageRequest {
         let offset_bytes = self.offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PutImageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -458,7 +458,7 @@ impl GetImageRequest {
         let offset_bytes = self.offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetImageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -576,7 +576,7 @@ impl CreatePixmapRequest {
         let offset_bytes = self.offset.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreatePixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             pid_bytes[0],
@@ -651,7 +651,7 @@ impl AttachFdRequest {
         let read_only_bytes = self.read_only.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AttachFdRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             shmseg_bytes[0],
@@ -709,7 +709,7 @@ impl CreateSegmentRequest {
         let read_only_bytes = self.read_only.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateSegmentRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             shmseg_bytes[0],

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -131,7 +130,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -206,7 +205,7 @@ impl AttachRequest {
     /// Opcode for the Attach request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -263,7 +262,7 @@ impl DetachRequest {
     /// Opcode for the Detach request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -322,7 +321,7 @@ impl PutImageRequest {
     /// Opcode for the PutImage request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -435,7 +434,7 @@ impl GetImageRequest {
     /// Opcode for the GetImage request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -554,7 +553,7 @@ impl CreatePixmapRequest {
     /// Opcode for the CreatePixmap request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -633,7 +632,7 @@ impl AttachFdRequest {
     /// Opcode for the AttachFd request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -689,7 +688,7 @@ impl CreateSegmentRequest {
     /// Opcode for the CreateSegment request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -748,8 +748,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = InitializeRequest {
-        desired_major_version: desired_major_version,
-        desired_minor_version: desired_minor_version,
+        desired_major_version,
+        desired_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -912,8 +912,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateCounterRequest {
-        id: id,
-        initial_value: initial_value,
+        id,
+        initial_value,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -959,7 +959,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyCounterRequest {
-        counter: counter,
+        counter,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1005,7 +1005,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryCounterRequest {
-        counter: counter,
+        counter,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1075,7 +1075,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AwaitRequest {
-        wait_list: wait_list,
+        wait_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1131,8 +1131,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeCounterRequest {
-        counter: counter,
-        amount: amount,
+        counter,
+        amount,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1188,8 +1188,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetCounterRequest {
-        counter: counter,
-        value: value,
+        counter,
+        value,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1345,8 +1345,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateAlarmRequest {
-        id: id,
-        value_list: value_list,
+        id,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1502,8 +1502,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeAlarmRequest {
-        id: id,
-        value_list: value_list,
+        id,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1549,7 +1549,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyAlarmRequest {
-        alarm: alarm,
+        alarm,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1595,7 +1595,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryAlarmRequest {
-        alarm: alarm,
+        alarm,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1680,8 +1680,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPriorityRequest {
-        id: id,
-        priority: priority,
+        id,
+        priority,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1727,7 +1727,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPriorityRequest {
-        id: id,
+        id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1810,9 +1810,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateFenceRequest {
-        drawable: drawable,
-        fence: fence,
-        initially_triggered: initially_triggered,
+        drawable,
+        fence,
+        initially_triggered,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1858,7 +1858,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = TriggerFenceRequest {
-        fence: fence,
+        fence,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1904,7 +1904,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ResetFenceRequest {
-        fence: fence,
+        fence,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1950,7 +1950,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyFenceRequest {
-        fence: fence,
+        fence,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1996,7 +1996,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryFenceRequest {
-        fence: fence,
+        fence,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2067,7 +2067,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AwaitFenceRequest {
-        fence_list: fence_list,
+        fence_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -716,7 +715,7 @@ impl InitializeRequest {
     /// Opcode for the Initialize request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -789,7 +788,7 @@ impl ListSystemCountersRequest {
     /// Opcode for the ListSystemCounters request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -870,7 +869,7 @@ impl CreateCounterRequest {
     /// Opcode for the CreateCounter request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -925,7 +924,7 @@ impl DestroyCounterRequest {
     /// Opcode for the DestroyCounter request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -970,7 +969,7 @@ impl QueryCounterRequest {
     /// Opcode for the QueryCounter request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1040,7 +1039,7 @@ impl<'input> AwaitRequest<'input> {
     /// Opcode for the Await request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1061,7 +1060,7 @@ impl<'input> AwaitRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), wait_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), wait_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn await_<'c, 'input, Conn>(conn: &'c Conn, wait_list: &'input [Waitcondition]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1085,7 +1084,7 @@ impl ChangeCounterRequest {
     /// Opcode for the ChangeCounter request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1141,7 +1140,7 @@ impl SetCounterRequest {
     /// Opcode for the SetCounter request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1296,7 +1295,7 @@ impl<'input> CreateAlarmRequest<'input> {
     /// Opcode for the CreateAlarm request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1328,7 +1327,7 @@ impl<'input> CreateAlarmRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input CreateAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1452,7 +1451,7 @@ impl<'input> ChangeAlarmRequest<'input> {
     /// Opcode for the ChangeAlarm request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1484,7 +1483,7 @@ impl<'input> ChangeAlarmRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input ChangeAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1508,7 +1507,7 @@ impl DestroyAlarmRequest {
     /// Opcode for the DestroyAlarm request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1553,7 +1552,7 @@ impl QueryAlarmRequest {
     /// Opcode for the QueryAlarm request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1632,7 +1631,7 @@ impl SetPriorityRequest {
     /// Opcode for the SetPriority request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1683,7 +1682,7 @@ impl GetPriorityRequest {
     /// Opcode for the GetPriority request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1755,7 +1754,7 @@ impl CreateFenceRequest {
     /// Opcode for the CreateFence request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1812,7 +1811,7 @@ impl TriggerFenceRequest {
     /// Opcode for the TriggerFence request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1857,7 +1856,7 @@ impl ResetFenceRequest {
     /// Opcode for the ResetFence request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1902,7 +1901,7 @@ impl DestroyFenceRequest {
     /// Opcode for the DestroyFence request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1947,7 +1946,7 @@ impl QueryFenceRequest {
     /// Opcode for the QueryFence request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2018,7 +2017,7 @@ impl<'input> AwaitFenceRequest<'input> {
     /// Opcode for the AwaitFence request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2039,7 +2038,7 @@ impl<'input> AwaitFenceRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), fence_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), fence_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn await_fence<'c, 'input, Conn>(conn: &'c Conn, fence_list: &'input [Fence]) -> Result<VoidCookie<'c, Conn>, ConnectionError>

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -728,7 +728,7 @@ impl InitializeRequest {
         let desired_minor_version_bytes = self.desired_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            InitializeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             desired_major_version_bytes[0],
@@ -800,7 +800,7 @@ impl ListSystemCountersRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListSystemCountersRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -884,7 +884,7 @@ impl CreateCounterRequest {
         let initial_value_bytes = self.initial_value.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateCounterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             id_bytes[0],
@@ -939,7 +939,7 @@ impl DestroyCounterRequest {
         let counter_bytes = self.counter.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyCounterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             counter_bytes[0],
@@ -985,7 +985,7 @@ impl QueryCounterRequest {
         let counter_bytes = self.counter.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryCounterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             counter_bytes[0],
@@ -1055,7 +1055,7 @@ impl<'input> AwaitRequest<'input> {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            AwaitRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1103,7 +1103,7 @@ impl ChangeCounterRequest {
         let amount_bytes = self.amount.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeCounterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             counter_bytes[0],
@@ -1160,7 +1160,7 @@ impl SetCounterRequest {
         let value_bytes = self.value.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetCounterRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             counter_bytes[0],
@@ -1317,7 +1317,7 @@ impl<'input> CreateAlarmRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateAlarmRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             id_bytes[0],
@@ -1474,7 +1474,7 @@ impl<'input> ChangeAlarmRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeAlarmRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             id_bytes[0],
@@ -1529,7 +1529,7 @@ impl DestroyAlarmRequest {
         let alarm_bytes = self.alarm.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyAlarmRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             alarm_bytes[0],
@@ -1575,7 +1575,7 @@ impl QueryAlarmRequest {
         let alarm_bytes = self.alarm.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryAlarmRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             alarm_bytes[0],
@@ -1656,7 +1656,7 @@ impl SetPriorityRequest {
         let priority_bytes = self.priority.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPriorityRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             id_bytes[0],
@@ -1707,7 +1707,7 @@ impl GetPriorityRequest {
         let id_bytes = self.id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPriorityRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             id_bytes[0],
@@ -1782,7 +1782,7 @@ impl CreateFenceRequest {
         let initially_triggered_bytes = self.initially_triggered.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateFenceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1838,7 +1838,7 @@ impl TriggerFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            TriggerFenceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             fence_bytes[0],
@@ -1884,7 +1884,7 @@ impl ResetFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ResetFenceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             fence_bytes[0],
@@ -1930,7 +1930,7 @@ impl DestroyFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyFenceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             fence_bytes[0],
@@ -1976,7 +1976,7 @@ impl QueryFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryFenceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             fence_bytes[0],
@@ -2047,7 +2047,7 @@ impl<'input> AwaitFenceRequest<'input> {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            AwaitFenceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -716,7 +716,6 @@ impl InitializeRequest {
     /// Opcode for the Initialize request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -790,7 +789,6 @@ impl ListSystemCountersRequest {
     /// Opcode for the ListSystemCounters request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -872,7 +870,6 @@ impl CreateCounterRequest {
     /// Opcode for the CreateCounter request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -928,7 +925,6 @@ impl DestroyCounterRequest {
     /// Opcode for the DestroyCounter request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -974,7 +970,6 @@ impl QueryCounterRequest {
     /// Opcode for the QueryCounter request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1045,7 +1040,6 @@ impl<'input> AwaitRequest<'input> {
     /// Opcode for the Await request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1091,7 +1085,6 @@ impl ChangeCounterRequest {
     /// Opcode for the ChangeCounter request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1148,7 +1141,6 @@ impl SetCounterRequest {
     /// Opcode for the SetCounter request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1304,7 +1296,6 @@ impl<'input> CreateAlarmRequest<'input> {
     /// Opcode for the CreateAlarm request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1461,7 +1452,6 @@ impl<'input> ChangeAlarmRequest<'input> {
     /// Opcode for the ChangeAlarm request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1518,7 +1508,6 @@ impl DestroyAlarmRequest {
     /// Opcode for the DestroyAlarm request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1564,7 +1553,6 @@ impl QueryAlarmRequest {
     /// Opcode for the QueryAlarm request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1644,7 +1632,6 @@ impl SetPriorityRequest {
     /// Opcode for the SetPriority request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1696,7 +1683,6 @@ impl GetPriorityRequest {
     /// Opcode for the GetPriority request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1769,7 +1755,6 @@ impl CreateFenceRequest {
     /// Opcode for the CreateFence request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1827,7 +1812,6 @@ impl TriggerFenceRequest {
     /// Opcode for the TriggerFence request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1873,7 +1857,6 @@ impl ResetFenceRequest {
     /// Opcode for the ResetFence request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1919,7 +1902,6 @@ impl DestroyFenceRequest {
     /// Opcode for the DestroyFence request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1965,7 +1947,6 @@ impl QueryFenceRequest {
     /// Opcode for the QueryFence request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2037,7 +2018,6 @@ impl<'input> AwaitFenceRequest<'input> {
     /// Opcode for the AwaitFence request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -706,14 +706,14 @@ impl From<AlarmError> for [u8; 32] {
     }
 }
 
+/// Opcode for the Initialize request
+pub const INITIALIZE_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InitializeRequest {
     pub desired_major_version: u8,
     pub desired_minor_version: u8,
 }
 impl InitializeRequest {
-    /// Opcode for the Initialize request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -726,7 +726,7 @@ impl InitializeRequest {
         let desired_minor_version_bytes = self.desired_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            INITIALIZE_REQUEST,
             0,
             0,
             desired_major_version_bytes[0],
@@ -782,11 +782,11 @@ impl TryFrom<&[u8]> for InitializeReply {
     }
 }
 
+/// Opcode for the ListSystemCounters request
+pub const LIST_SYSTEM_COUNTERS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListSystemCountersRequest;
 impl ListSystemCountersRequest {
-    /// Opcode for the ListSystemCounters request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -797,7 +797,7 @@ impl ListSystemCountersRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_SYSTEM_COUNTERS_REQUEST,
             0,
             0,
         ];
@@ -860,14 +860,14 @@ impl ListSystemCountersReply {
     }
 }
 
+/// Opcode for the CreateCounter request
+pub const CREATE_COUNTER_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateCounterRequest {
     pub id: Counter,
     pub initial_value: Int64,
 }
 impl CreateCounterRequest {
-    /// Opcode for the CreateCounter request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -880,7 +880,7 @@ impl CreateCounterRequest {
         let initial_value_bytes = self.initial_value.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_COUNTER_REQUEST,
             0,
             0,
             id_bytes[0],
@@ -916,13 +916,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyCounter request
+pub const DESTROY_COUNTER_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyCounterRequest {
     pub counter: Counter,
 }
 impl DestroyCounterRequest {
-    /// Opcode for the DestroyCounter request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -934,7 +934,7 @@ impl DestroyCounterRequest {
         let counter_bytes = self.counter.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_COUNTER_REQUEST,
             0,
             0,
             counter_bytes[0],
@@ -961,13 +961,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryCounter request
+pub const QUERY_COUNTER_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryCounterRequest {
     pub counter: Counter,
 }
 impl QueryCounterRequest {
-    /// Opcode for the QueryCounter request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -979,7 +979,7 @@ impl QueryCounterRequest {
         let counter_bytes = self.counter.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_COUNTER_REQUEST,
             0,
             0,
             counter_bytes[0],
@@ -1031,13 +1031,13 @@ impl TryFrom<&[u8]> for QueryCounterReply {
     }
 }
 
+/// Opcode for the Await request
+pub const AWAIT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AwaitRequest<'input> {
     pub wait_list: &'input [Waitcondition],
 }
 impl<'input> AwaitRequest<'input> {
-    /// Opcode for the Await request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1048,7 +1048,7 @@ impl<'input> AwaitRequest<'input> {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            AWAIT_REQUEST,
             0,
             0,
         ];
@@ -1075,14 +1075,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ChangeCounter request
+pub const CHANGE_COUNTER_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeCounterRequest {
     pub counter: Counter,
     pub amount: Int64,
 }
 impl ChangeCounterRequest {
-    /// Opcode for the ChangeCounter request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1095,7 +1095,7 @@ impl ChangeCounterRequest {
         let amount_bytes = self.amount.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_COUNTER_REQUEST,
             0,
             0,
             counter_bytes[0],
@@ -1131,14 +1131,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetCounter request
+pub const SET_COUNTER_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetCounterRequest {
     pub counter: Counter,
     pub value: Int64,
 }
 impl SetCounterRequest {
-    /// Opcode for the SetCounter request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1151,7 +1151,7 @@ impl SetCounterRequest {
         let value_bytes = self.value.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_COUNTER_REQUEST,
             0,
             0,
             counter_bytes[0],
@@ -1286,14 +1286,14 @@ impl CreateAlarmAux {
     }
 }
 
+/// Opcode for the CreateAlarm request
+pub const CREATE_ALARM_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: &'input CreateAlarmAux,
 }
 impl<'input> CreateAlarmRequest<'input> {
-    /// Opcode for the CreateAlarm request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1307,7 +1307,7 @@ impl<'input> CreateAlarmRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_ALARM_REQUEST,
             0,
             0,
             id_bytes[0],
@@ -1442,14 +1442,14 @@ impl ChangeAlarmAux {
     }
 }
 
+/// Opcode for the ChangeAlarm request
+pub const CHANGE_ALARM_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: &'input ChangeAlarmAux,
 }
 impl<'input> ChangeAlarmRequest<'input> {
-    /// Opcode for the ChangeAlarm request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1463,7 +1463,7 @@ impl<'input> ChangeAlarmRequest<'input> {
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_ALARM_REQUEST,
             0,
             0,
             id_bytes[0],
@@ -1499,13 +1499,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyAlarm request
+pub const DESTROY_ALARM_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyAlarmRequest {
     pub alarm: Alarm,
 }
 impl DestroyAlarmRequest {
-    /// Opcode for the DestroyAlarm request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1517,7 +1517,7 @@ impl DestroyAlarmRequest {
         let alarm_bytes = self.alarm.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_ALARM_REQUEST,
             0,
             0,
             alarm_bytes[0],
@@ -1544,13 +1544,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryAlarm request
+pub const QUERY_ALARM_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryAlarmRequest {
     pub alarm: Alarm,
 }
 impl QueryAlarmRequest {
-    /// Opcode for the QueryAlarm request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1562,7 +1562,7 @@ impl QueryAlarmRequest {
         let alarm_bytes = self.alarm.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_ALARM_REQUEST,
             0,
             0,
             alarm_bytes[0],
@@ -1622,14 +1622,14 @@ impl TryFrom<&[u8]> for QueryAlarmReply {
     }
 }
 
+/// Opcode for the SetPriority request
+pub const SET_PRIORITY_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetPriorityRequest {
     pub id: u32,
     pub priority: i32,
 }
 impl SetPriorityRequest {
-    /// Opcode for the SetPriority request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1642,7 +1642,7 @@ impl SetPriorityRequest {
         let priority_bytes = self.priority.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PRIORITY_REQUEST,
             0,
             0,
             id_bytes[0],
@@ -1674,13 +1674,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetPriority request
+pub const GET_PRIORITY_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPriorityRequest {
     pub id: u32,
 }
 impl GetPriorityRequest {
-    /// Opcode for the GetPriority request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1692,7 +1692,7 @@ impl GetPriorityRequest {
         let id_bytes = self.id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PRIORITY_REQUEST,
             0,
             0,
             id_bytes[0],
@@ -1744,6 +1744,8 @@ impl TryFrom<&[u8]> for GetPriorityReply {
     }
 }
 
+/// Opcode for the CreateFence request
+pub const CREATE_FENCE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateFenceRequest {
     pub drawable: xproto::Drawable,
@@ -1751,8 +1753,6 @@ pub struct CreateFenceRequest {
     pub initially_triggered: bool,
 }
 impl CreateFenceRequest {
-    /// Opcode for the CreateFence request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1766,7 +1766,7 @@ impl CreateFenceRequest {
         let initially_triggered_bytes = self.initially_triggered.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_FENCE_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1803,13 +1803,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the TriggerFence request
+pub const TRIGGER_FENCE_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TriggerFenceRequest {
     pub fence: Fence,
 }
 impl TriggerFenceRequest {
-    /// Opcode for the TriggerFence request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1821,7 +1821,7 @@ impl TriggerFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            TRIGGER_FENCE_REQUEST,
             0,
             0,
             fence_bytes[0],
@@ -1848,13 +1848,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ResetFence request
+pub const RESET_FENCE_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResetFenceRequest {
     pub fence: Fence,
 }
 impl ResetFenceRequest {
-    /// Opcode for the ResetFence request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1866,7 +1866,7 @@ impl ResetFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            RESET_FENCE_REQUEST,
             0,
             0,
             fence_bytes[0],
@@ -1893,13 +1893,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyFence request
+pub const DESTROY_FENCE_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyFenceRequest {
     pub fence: Fence,
 }
 impl DestroyFenceRequest {
-    /// Opcode for the DestroyFence request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1911,7 +1911,7 @@ impl DestroyFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_FENCE_REQUEST,
             0,
             0,
             fence_bytes[0],
@@ -1938,13 +1938,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryFence request
+pub const QUERY_FENCE_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryFenceRequest {
     pub fence: Fence,
 }
 impl QueryFenceRequest {
-    /// Opcode for the QueryFence request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1956,7 +1956,7 @@ impl QueryFenceRequest {
         let fence_bytes = self.fence.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_FENCE_REQUEST,
             0,
             0,
             fence_bytes[0],
@@ -2009,13 +2009,13 @@ impl TryFrom<&[u8]> for QueryFenceReply {
     }
 }
 
+/// Opcode for the AwaitFence request
+pub const AWAIT_FENCE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AwaitFenceRequest<'input> {
     pub fence_list: &'input [Fence],
 }
 impl<'input> AwaitFenceRequest<'input> {
-    /// Opcode for the AwaitFence request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2026,7 +2026,7 @@ impl<'input> AwaitFenceRequest<'input> {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            AWAIT_FENCE_REQUEST,
             0,
             0,
         ];

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -943,7 +943,7 @@ impl TryFrom<&[u8]> for QueryCounterReply {
 
 /// Opcode for the Await request
 pub const AWAIT_REQUEST: u8 = 7;
-pub fn await_<'c, Conn>(conn: &'c Conn, wait_list: &[Waitcondition]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn await_<'c, 'input, Conn>(conn: &'c Conn, wait_list: &'input [Waitcondition]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1140,7 +1140,7 @@ impl CreateAlarmAux {
     }
 }
 
-pub fn create_alarm<'c, Conn>(conn: &'c Conn, id: Alarm, value_list: &CreateAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input CreateAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1276,7 +1276,7 @@ impl ChangeAlarmAux {
     }
 }
 
-pub fn change_alarm<'c, Conn>(conn: &'c Conn, id: Alarm, value_list: &ChangeAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input ChangeAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1655,7 +1655,7 @@ impl TryFrom<&[u8]> for QueryFenceReply {
 
 /// Opcode for the AwaitFence request
 pub const AWAIT_FENCE_REQUEST: u8 = 19;
-pub fn await_fence<'c, Conn>(conn: &'c Conn, fence_list: &[Fence]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn await_fence<'c, 'input, Conn>(conn: &'c Conn, fence_list: &'input [Fence]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1877,7 +1877,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_counter(self, counter)
     }
-    fn sync_await_<'c>(&'c self, wait_list: &[Waitcondition]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn sync_await_<'c, 'input>(&'c self, wait_list: &'input [Waitcondition]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         await_(self, wait_list)
     }
@@ -1889,11 +1889,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         set_counter(self, counter, value)
     }
-    fn sync_create_alarm<'c>(&'c self, id: Alarm, value_list: &CreateAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn sync_create_alarm<'c, 'input>(&'c self, id: Alarm, value_list: &'input CreateAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_alarm(self, id, value_list)
     }
-    fn sync_change_alarm<'c>(&'c self, id: Alarm, value_list: &ChangeAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn sync_change_alarm<'c, 'input>(&'c self, id: Alarm, value_list: &'input ChangeAlarmAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_alarm(self, id, value_list)
     }
@@ -1933,7 +1933,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_fence(self, fence)
     }
-    fn sync_await_fence<'c>(&'c self, fence_list: &[Fence]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn sync_await_fence<'c, 'input>(&'c self, fence_list: &'input [Fence]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         await_fence(self, fence_list)
     }

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -706,32 +707,53 @@ impl From<AlarmError> for [u8; 32] {
     }
 }
 
-/// Opcode for the Initialize request
-pub const INITIALIZE_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InitializeRequest {
+    pub desired_major_version: u8,
+    pub desired_minor_version: u8,
+}
+impl InitializeRequest {
+    /// Opcode for the Initialize request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let desired_major_version_bytes = self.desired_major_version.serialize();
+        let desired_minor_version_bytes = self.desired_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            InitializeRequest::opcode(),
+            0,
+            0,
+            desired_major_version_bytes[0],
+            desired_minor_version_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn initialize<Conn>(conn: &Conn, desired_major_version: u8, desired_minor_version: u8) -> Result<Cookie<'_, Conn, InitializeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let desired_major_version_bytes = desired_major_version.serialize();
-    let desired_minor_version_bytes = desired_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        INITIALIZE_REQUEST,
-        0,
-        0,
-        desired_major_version_bytes[0],
-        desired_minor_version_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = InitializeRequest {
+        desired_major_version: desired_major_version,
+        desired_minor_version: desired_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -762,26 +784,41 @@ impl TryFrom<&[u8]> for InitializeReply {
     }
 }
 
-/// Opcode for the ListSystemCounters request
-pub const LIST_SYSTEM_COUNTERS_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListSystemCountersRequest;
+impl ListSystemCountersRequest {
+    /// Opcode for the ListSystemCounters request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListSystemCountersRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_system_counters<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListSystemCountersReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_SYSTEM_COUNTERS_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListSystemCountersRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -826,94 +863,153 @@ impl ListSystemCountersReply {
     }
 }
 
-/// Opcode for the CreateCounter request
-pub const CREATE_COUNTER_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateCounterRequest {
+    pub id: Counter,
+    pub initial_value: Int64,
+}
+impl CreateCounterRequest {
+    /// Opcode for the CreateCounter request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let id_bytes = self.id.serialize();
+        let initial_value_bytes = self.initial_value.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateCounterRequest::opcode(),
+            0,
+            0,
+            id_bytes[0],
+            id_bytes[1],
+            id_bytes[2],
+            id_bytes[3],
+            initial_value_bytes[0],
+            initial_value_bytes[1],
+            initial_value_bytes[2],
+            initial_value_bytes[3],
+            initial_value_bytes[4],
+            initial_value_bytes[5],
+            initial_value_bytes[6],
+            initial_value_bytes[7],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_counter<Conn>(conn: &Conn, id: Counter, initial_value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let id_bytes = id.serialize();
-    let initial_value_bytes = initial_value.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_COUNTER_REQUEST,
-        0,
-        0,
-        id_bytes[0],
-        id_bytes[1],
-        id_bytes[2],
-        id_bytes[3],
-        initial_value_bytes[0],
-        initial_value_bytes[1],
-        initial_value_bytes[2],
-        initial_value_bytes[3],
-        initial_value_bytes[4],
-        initial_value_bytes[5],
-        initial_value_bytes[6],
-        initial_value_bytes[7],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateCounterRequest {
+        id: id,
+        initial_value: initial_value,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DestroyCounter request
-pub const DESTROY_COUNTER_REQUEST: u8 = 6;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroyCounterRequest {
+    pub counter: Counter,
+}
+impl DestroyCounterRequest {
+    /// Opcode for the DestroyCounter request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let counter_bytes = self.counter.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroyCounterRequest::opcode(),
+            0,
+            0,
+            counter_bytes[0],
+            counter_bytes[1],
+            counter_bytes[2],
+            counter_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_counter<Conn>(conn: &Conn, counter: Counter) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let counter_bytes = counter.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_COUNTER_REQUEST,
-        0,
-        0,
-        counter_bytes[0],
-        counter_bytes[1],
-        counter_bytes[2],
-        counter_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroyCounterRequest {
+        counter: counter,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the QueryCounter request
-pub const QUERY_COUNTER_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryCounterRequest {
+    pub counter: Counter,
+}
+impl QueryCounterRequest {
+    /// Opcode for the QueryCounter request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let counter_bytes = self.counter.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryCounterRequest::opcode(),
+            0,
+            0,
+            counter_bytes[0],
+            counter_bytes[1],
+            counter_bytes[2],
+            counter_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_counter<Conn>(conn: &Conn, counter: Counter) -> Result<Cookie<'_, Conn, QueryCounterReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let counter_bytes = counter.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_COUNTER_REQUEST,
-        0,
-        0,
-        counter_bytes[0],
-        counter_bytes[1],
-        counter_bytes[2],
-        counter_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryCounterRequest {
+        counter: counter,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -941,106 +1037,165 @@ impl TryFrom<&[u8]> for QueryCounterReply {
     }
 }
 
-/// Opcode for the Await request
-pub const AWAIT_REQUEST: u8 = 7;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwaitRequest<'input> {
+    pub wait_list: &'input [Waitcondition],
+}
+impl<'input> AwaitRequest<'input> {
+    /// Opcode for the Await request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            AwaitRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let wait_list_bytes = self.wait_list.serialize();
+        let length_so_far = length_so_far + wait_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), wait_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn await_<'c, 'input, Conn>(conn: &'c Conn, wait_list: &'input [Waitcondition]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        AWAIT_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let wait_list_bytes = wait_list.serialize();
-    let length_so_far = length_so_far + wait_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&wait_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = AwaitRequest {
+        wait_list: wait_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangeCounter request
-pub const CHANGE_COUNTER_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeCounterRequest {
+    pub counter: Counter,
+    pub amount: Int64,
+}
+impl ChangeCounterRequest {
+    /// Opcode for the ChangeCounter request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let counter_bytes = self.counter.serialize();
+        let amount_bytes = self.amount.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeCounterRequest::opcode(),
+            0,
+            0,
+            counter_bytes[0],
+            counter_bytes[1],
+            counter_bytes[2],
+            counter_bytes[3],
+            amount_bytes[0],
+            amount_bytes[1],
+            amount_bytes[2],
+            amount_bytes[3],
+            amount_bytes[4],
+            amount_bytes[5],
+            amount_bytes[6],
+            amount_bytes[7],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn change_counter<Conn>(conn: &Conn, counter: Counter, amount: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let counter_bytes = counter.serialize();
-    let amount_bytes = amount.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_COUNTER_REQUEST,
-        0,
-        0,
-        counter_bytes[0],
-        counter_bytes[1],
-        counter_bytes[2],
-        counter_bytes[3],
-        amount_bytes[0],
-        amount_bytes[1],
-        amount_bytes[2],
-        amount_bytes[3],
-        amount_bytes[4],
-        amount_bytes[5],
-        amount_bytes[6],
-        amount_bytes[7],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ChangeCounterRequest {
+        counter: counter,
+        amount: amount,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetCounter request
-pub const SET_COUNTER_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetCounterRequest {
+    pub counter: Counter,
+    pub value: Int64,
+}
+impl SetCounterRequest {
+    /// Opcode for the SetCounter request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let counter_bytes = self.counter.serialize();
+        let value_bytes = self.value.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetCounterRequest::opcode(),
+            0,
+            0,
+            counter_bytes[0],
+            counter_bytes[1],
+            counter_bytes[2],
+            counter_bytes[3],
+            value_bytes[0],
+            value_bytes[1],
+            value_bytes[2],
+            value_bytes[3],
+            value_bytes[4],
+            value_bytes[5],
+            value_bytes[6],
+            value_bytes[7],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_counter<Conn>(conn: &Conn, counter: Counter, value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let counter_bytes = counter.serialize();
-    let value_bytes = value.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_COUNTER_REQUEST,
-        0,
-        0,
-        counter_bytes[0],
-        counter_bytes[1],
-        counter_bytes[2],
-        counter_bytes[3],
-        value_bytes[0],
-        value_bytes[1],
-        value_bytes[2],
-        value_bytes[3],
-        value_bytes[4],
-        value_bytes[5],
-        value_bytes[6],
-        value_bytes[7],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetCounterRequest {
+        counter: counter,
+        value: value,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateAlarm request
-pub const CREATE_ALARM_REQUEST: u8 = 8;
 /// Auxiliary and optional information for the `create_alarm` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreateAlarmAux {
@@ -1140,43 +1295,64 @@ impl CreateAlarmAux {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateAlarmRequest<'input> {
+    pub id: Alarm,
+    pub value_list: &'input CreateAlarmAux,
+}
+impl<'input> CreateAlarmRequest<'input> {
+    /// Opcode for the CreateAlarm request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let id_bytes = self.id.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateAlarmRequest::opcode(),
+            0,
+            0,
+            id_bytes[0],
+            id_bytes[1],
+            id_bytes[2],
+            id_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn create_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input CreateAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let id_bytes = id.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_ALARM_REQUEST,
-        0,
-        0,
-        id_bytes[0],
-        id_bytes[1],
-        id_bytes[2],
-        id_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateAlarmRequest {
+        id: id,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangeAlarm request
-pub const CHANGE_ALARM_REQUEST: u8 = 9;
 /// Auxiliary and optional information for the `change_alarm` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangeAlarmAux {
@@ -1276,93 +1452,154 @@ impl ChangeAlarmAux {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeAlarmRequest<'input> {
+    pub id: Alarm,
+    pub value_list: &'input ChangeAlarmAux,
+}
+impl<'input> ChangeAlarmRequest<'input> {
+    /// Opcode for the ChangeAlarm request
+    pub const fn opcode() -> u8 { 9 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let id_bytes = self.id.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeAlarmRequest::opcode(),
+            0,
+            0,
+            id_bytes[0],
+            id_bytes[1],
+            id_bytes[2],
+            id_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input ChangeAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let id_bytes = id.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_ALARM_REQUEST,
-        0,
-        0,
-        id_bytes[0],
-        id_bytes[1],
-        id_bytes[2],
-        id_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeAlarmRequest {
+        id: id,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DestroyAlarm request
-pub const DESTROY_ALARM_REQUEST: u8 = 11;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroyAlarmRequest {
+    pub alarm: Alarm,
+}
+impl DestroyAlarmRequest {
+    /// Opcode for the DestroyAlarm request
+    pub const fn opcode() -> u8 { 11 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let alarm_bytes = self.alarm.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroyAlarmRequest::opcode(),
+            0,
+            0,
+            alarm_bytes[0],
+            alarm_bytes[1],
+            alarm_bytes[2],
+            alarm_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_alarm<Conn>(conn: &Conn, alarm: Alarm) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let alarm_bytes = alarm.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_ALARM_REQUEST,
-        0,
-        0,
-        alarm_bytes[0],
-        alarm_bytes[1],
-        alarm_bytes[2],
-        alarm_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroyAlarmRequest {
+        alarm: alarm,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the QueryAlarm request
-pub const QUERY_ALARM_REQUEST: u8 = 10;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryAlarmRequest {
+    pub alarm: Alarm,
+}
+impl QueryAlarmRequest {
+    /// Opcode for the QueryAlarm request
+    pub const fn opcode() -> u8 { 10 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let alarm_bytes = self.alarm.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryAlarmRequest::opcode(),
+            0,
+            0,
+            alarm_bytes[0],
+            alarm_bytes[1],
+            alarm_bytes[2],
+            alarm_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_alarm<Conn>(conn: &Conn, alarm: Alarm) -> Result<Cookie<'_, Conn, QueryAlarmReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let alarm_bytes = alarm.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_ALARM_REQUEST,
-        0,
-        0,
-        alarm_bytes[0],
-        alarm_bytes[1],
-        alarm_bytes[2],
-        alarm_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryAlarmRequest {
+        alarm: alarm,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1398,63 +1635,103 @@ impl TryFrom<&[u8]> for QueryAlarmReply {
     }
 }
 
-/// Opcode for the SetPriority request
-pub const SET_PRIORITY_REQUEST: u8 = 12;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetPriorityRequest {
+    pub id: u32,
+    pub priority: i32,
+}
+impl SetPriorityRequest {
+    /// Opcode for the SetPriority request
+    pub const fn opcode() -> u8 { 12 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let id_bytes = self.id.serialize();
+        let priority_bytes = self.priority.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetPriorityRequest::opcode(),
+            0,
+            0,
+            id_bytes[0],
+            id_bytes[1],
+            id_bytes[2],
+            id_bytes[3],
+            priority_bytes[0],
+            priority_bytes[1],
+            priority_bytes[2],
+            priority_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_priority<Conn>(conn: &Conn, id: u32, priority: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let id_bytes = id.serialize();
-    let priority_bytes = priority.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_PRIORITY_REQUEST,
-        0,
-        0,
-        id_bytes[0],
-        id_bytes[1],
-        id_bytes[2],
-        id_bytes[3],
-        priority_bytes[0],
-        priority_bytes[1],
-        priority_bytes[2],
-        priority_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetPriorityRequest {
+        id: id,
+        priority: priority,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetPriority request
-pub const GET_PRIORITY_REQUEST: u8 = 13;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetPriorityRequest {
+    pub id: u32,
+}
+impl GetPriorityRequest {
+    /// Opcode for the GetPriority request
+    pub const fn opcode() -> u8 { 13 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let id_bytes = self.id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetPriorityRequest::opcode(),
+            0,
+            0,
+            id_bytes[0],
+            id_bytes[1],
+            id_bytes[2],
+            id_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_priority<Conn>(conn: &Conn, id: u32) -> Result<Cookie<'_, Conn, GetPriorityReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let id_bytes = id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_PRIORITY_REQUEST,
-        0,
-        0,
-        id_bytes[0],
-        id_bytes[1],
-        id_bytes[2],
-        id_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetPriorityRequest {
+        id: id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1482,149 +1759,248 @@ impl TryFrom<&[u8]> for GetPriorityReply {
     }
 }
 
-/// Opcode for the CreateFence request
-pub const CREATE_FENCE_REQUEST: u8 = 14;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateFenceRequest {
+    pub drawable: xproto::Drawable,
+    pub fence: Fence,
+    pub initially_triggered: bool,
+}
+impl CreateFenceRequest {
+    /// Opcode for the CreateFence request
+    pub const fn opcode() -> u8 { 14 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let fence_bytes = self.fence.serialize();
+        let initially_triggered_bytes = self.initially_triggered.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateFenceRequest::opcode(),
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            fence_bytes[0],
+            fence_bytes[1],
+            fence_bytes[2],
+            fence_bytes[3],
+            initially_triggered_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_fence<Conn>(conn: &Conn, drawable: xproto::Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let fence_bytes = fence.serialize();
-    let initially_triggered_bytes = initially_triggered.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_FENCE_REQUEST,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        fence_bytes[0],
-        fence_bytes[1],
-        fence_bytes[2],
-        fence_bytes[3],
-        initially_triggered_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateFenceRequest {
+        drawable: drawable,
+        fence: fence,
+        initially_triggered: initially_triggered,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the TriggerFence request
-pub const TRIGGER_FENCE_REQUEST: u8 = 15;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TriggerFenceRequest {
+    pub fence: Fence,
+}
+impl TriggerFenceRequest {
+    /// Opcode for the TriggerFence request
+    pub const fn opcode() -> u8 { 15 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let fence_bytes = self.fence.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            TriggerFenceRequest::opcode(),
+            0,
+            0,
+            fence_bytes[0],
+            fence_bytes[1],
+            fence_bytes[2],
+            fence_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn trigger_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let fence_bytes = fence.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        TRIGGER_FENCE_REQUEST,
-        0,
-        0,
-        fence_bytes[0],
-        fence_bytes[1],
-        fence_bytes[2],
-        fence_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = TriggerFenceRequest {
+        fence: fence,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ResetFence request
-pub const RESET_FENCE_REQUEST: u8 = 16;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResetFenceRequest {
+    pub fence: Fence,
+}
+impl ResetFenceRequest {
+    /// Opcode for the ResetFence request
+    pub const fn opcode() -> u8 { 16 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let fence_bytes = self.fence.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ResetFenceRequest::opcode(),
+            0,
+            0,
+            fence_bytes[0],
+            fence_bytes[1],
+            fence_bytes[2],
+            fence_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn reset_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let fence_bytes = fence.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        RESET_FENCE_REQUEST,
-        0,
-        0,
-        fence_bytes[0],
-        fence_bytes[1],
-        fence_bytes[2],
-        fence_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ResetFenceRequest {
+        fence: fence,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DestroyFence request
-pub const DESTROY_FENCE_REQUEST: u8 = 17;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroyFenceRequest {
+    pub fence: Fence,
+}
+impl DestroyFenceRequest {
+    /// Opcode for the DestroyFence request
+    pub const fn opcode() -> u8 { 17 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let fence_bytes = self.fence.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroyFenceRequest::opcode(),
+            0,
+            0,
+            fence_bytes[0],
+            fence_bytes[1],
+            fence_bytes[2],
+            fence_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let fence_bytes = fence.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_FENCE_REQUEST,
-        0,
-        0,
-        fence_bytes[0],
-        fence_bytes[1],
-        fence_bytes[2],
-        fence_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroyFenceRequest {
+        fence: fence,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the QueryFence request
-pub const QUERY_FENCE_REQUEST: u8 = 18;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryFenceRequest {
+    pub fence: Fence,
+}
+impl QueryFenceRequest {
+    /// Opcode for the QueryFence request
+    pub const fn opcode() -> u8 { 18 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let fence_bytes = self.fence.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryFenceRequest::opcode(),
+            0,
+            0,
+            fence_bytes[0],
+            fence_bytes[1],
+            fence_bytes[2],
+            fence_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_fence<Conn>(conn: &Conn, fence: Fence) -> Result<Cookie<'_, Conn, QueryFenceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let fence_bytes = fence.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_FENCE_REQUEST,
-        0,
-        0,
-        fence_bytes[0],
-        fence_bytes[1],
-        fence_bytes[2],
-        fence_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryFenceRequest {
+        fence: fence,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1653,30 +2029,49 @@ impl TryFrom<&[u8]> for QueryFenceReply {
     }
 }
 
-/// Opcode for the AwaitFence request
-pub const AWAIT_FENCE_REQUEST: u8 = 19;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwaitFenceRequest<'input> {
+    pub fence_list: &'input [Fence],
+}
+impl<'input> AwaitFenceRequest<'input> {
+    /// Opcode for the AwaitFence request
+    pub const fn opcode() -> u8 { 19 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            AwaitFenceRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let fence_list_bytes = self.fence_list.serialize();
+        let length_so_far = length_so_far + fence_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), fence_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn await_fence<'c, 'input, Conn>(conn: &'c Conn, fence_list: &'input [Fence]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        AWAIT_FENCE_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let fence_list_bytes = fence_list.serialize();
-    let length_so_far = length_so_far + fence_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&fence_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = AwaitFenceRequest {
+        fence_list: fence_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Opcode for the CounterNotify event

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -74,8 +74,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -212,7 +212,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetXIDListRequest {
-        count: count,
+        count,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -32,32 +33,53 @@ pub const X11_EXTENSION_NAME: &str = "XC-MISC";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
-/// Opcode for the GetVersion request
-pub const GET_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetVersionRequest {
+    pub client_major_version: u16,
+    pub client_minor_version: u16,
+}
+impl GetVersionRequest {
+    /// Opcode for the GetVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let client_major_version_bytes = self.client_major_version.serialize();
+        let client_minor_version_bytes = self.client_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetVersionRequest::opcode(),
+            0,
+            0,
+            client_major_version_bytes[0],
+            client_major_version_bytes[1],
+            client_minor_version_bytes[0],
+            client_minor_version_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_version<Conn>(conn: &Conn, client_major_version: u16, client_minor_version: u16) -> Result<Cookie<'_, Conn, GetVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let client_major_version_bytes = client_major_version.serialize();
-    let client_minor_version_bytes = client_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_VERSION_REQUEST,
-        0,
-        0,
-        client_major_version_bytes[0],
-        client_major_version_bytes[1],
-        client_minor_version_bytes[0],
-        client_minor_version_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetVersionRequest {
+        client_major_version: client_major_version,
+        client_minor_version: client_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -87,26 +109,41 @@ impl TryFrom<&[u8]> for GetVersionReply {
     }
 }
 
-/// Opcode for the GetXIDRange request
-pub const GET_XID_RANGE_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetXIDRangeRequest;
+impl GetXIDRangeRequest {
+    /// Opcode for the GetXIDRange request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetXIDRangeRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_xid_range<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetXIDRangeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_XID_RANGE_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetXIDRangeRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,31 +173,50 @@ impl TryFrom<&[u8]> for GetXIDRangeReply {
     }
 }
 
-/// Opcode for the GetXIDList request
-pub const GET_XID_LIST_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetXIDListRequest {
+    pub count: u32,
+}
+impl GetXIDListRequest {
+    /// Opcode for the GetXIDList request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let count_bytes = self.count.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetXIDListRequest::opcode(),
+            0,
+            0,
+            count_bytes[0],
+            count_bytes[1],
+            count_bytes[2],
+            count_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_xid_list<Conn>(conn: &Conn, count: u32) -> Result<Cookie<'_, Conn, GetXIDListReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let count_bytes = count.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_XID_LIST_REQUEST,
-        0,
-        0,
-        count_bytes[0],
-        count_bytes[1],
-        count_bytes[2],
-        count_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetXIDListRequest {
+        count: count,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -54,7 +54,7 @@ impl GetVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -125,7 +125,7 @@ impl GetXIDRangeRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetXIDRangeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -192,7 +192,7 @@ impl GetXIDListRequest {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetXIDListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             count_bytes[0],

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -42,7 +42,6 @@ impl GetVersionRequest {
     /// Opcode for the GetVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -115,7 +114,6 @@ impl GetXIDRangeRequest {
     /// Opcode for the GetXIDRange request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -181,7 +179,6 @@ impl GetXIDListRequest {
     /// Opcode for the GetXIDList request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -32,14 +32,14 @@ pub const X11_EXTENSION_NAME: &str = "XC-MISC";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
+/// Opcode for the GetVersion request
+pub const GET_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
 impl GetVersionRequest {
-    /// Opcode for the GetVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -52,7 +52,7 @@ impl GetVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -107,11 +107,11 @@ impl TryFrom<&[u8]> for GetVersionReply {
     }
 }
 
+/// Opcode for the GetXIDRange request
+pub const GET_XID_RANGE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetXIDRangeRequest;
 impl GetXIDRangeRequest {
-    /// Opcode for the GetXIDRange request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -122,7 +122,7 @@ impl GetXIDRangeRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_XID_RANGE_REQUEST,
             0,
             0,
         ];
@@ -170,13 +170,13 @@ impl TryFrom<&[u8]> for GetXIDRangeReply {
     }
 }
 
+/// Opcode for the GetXIDList request
+pub const GET_XID_LIST_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetXIDListRequest {
     pub count: u32,
 }
 impl GetXIDListRequest {
-    /// Opcode for the GetXIDList request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -188,7 +188,7 @@ impl GetXIDListRequest {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_XID_LIST_REQUEST,
             0,
             0,
             count_bytes[0],

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -42,7 +41,7 @@ impl GetVersionRequest {
     /// Opcode for the GetVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -114,7 +113,7 @@ impl GetXIDRangeRequest {
     /// Opcode for the GetXIDRange request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -179,7 +178,7 @@ impl GetXIDListRequest {
     /// Opcode for the GetXIDList request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -74,8 +74,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -149,7 +149,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = StartRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -219,7 +219,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = EndRequest {
-        cmap: cmap,
+        cmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -517,8 +517,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SendRequest {
-        event: event,
-        data_type: data_type,
+        event,
+        data_type,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -588,7 +588,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SelectInputRequest {
-        event_mask: event_mask,
+        event_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -54,7 +54,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -129,7 +129,7 @@ impl StartRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            StartRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -199,7 +199,7 @@ impl EndRequest {
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            EndRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cmap_bytes[0],
@@ -401,7 +401,7 @@ impl SendRequest {
         let data_type_bytes = self.data_type.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SendRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             event_bytes[0],
@@ -568,7 +568,7 @@ impl SelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             event_mask_bytes[0],

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -32,14 +32,14 @@ pub const X11_EXTENSION_NAME: &str = "XEVIE";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -52,7 +52,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -108,13 +108,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the Start request
+pub const START_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StartRequest {
     pub screen: u32,
 }
 impl StartRequest {
-    /// Opcode for the Start request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -126,7 +126,7 @@ impl StartRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            START_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -177,13 +177,13 @@ impl TryFrom<&[u8]> for StartReply {
     }
 }
 
+/// Opcode for the End request
+pub const END_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EndRequest {
     pub cmap: u32,
 }
 impl EndRequest {
-    /// Opcode for the End request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -195,7 +195,7 @@ impl EndRequest {
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            END_REQUEST,
             0,
             0,
             cmap_bytes[0],
@@ -376,14 +376,14 @@ impl Serialize for Event {
     }
 }
 
+/// Opcode for the Send request
+pub const SEND_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SendRequest {
     pub event: Event,
     pub data_type: u32,
 }
 impl SendRequest {
-    /// Opcode for the Send request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -396,7 +396,7 @@ impl SendRequest {
         let data_type_bytes = self.data_type.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SEND_REQUEST,
             0,
             0,
             event_bytes[0],
@@ -544,13 +544,13 @@ impl TryFrom<&[u8]> for SendReply {
     }
 }
 
+/// Opcode for the SelectInput request
+pub const SELECT_INPUT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectInputRequest {
     pub event_mask: u32,
 }
 impl SelectInputRequest {
-    /// Opcode for the SelectInput request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -562,7 +562,7 @@ impl SelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_INPUT_REQUEST,
             0,
             0,
             event_mask_bytes[0],

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -42,7 +41,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -117,7 +116,7 @@ impl StartRequest {
     /// Opcode for the Start request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -186,7 +185,7 @@ impl EndRequest {
     /// Opcode for the End request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -386,7 +385,7 @@ impl SendRequest {
     /// Opcode for the Send request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -553,7 +552,7 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -42,7 +42,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -118,7 +117,6 @@ impl StartRequest {
     /// Opcode for the Start request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -188,7 +186,6 @@ impl EndRequest {
     /// Opcode for the End request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -389,7 +386,6 @@ impl SendRequest {
     /// Opcode for the Send request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -557,7 +553,6 @@ impl SelectInputRequest {
     /// Opcode for the SelectInput request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -32,32 +33,53 @@ pub const X11_EXTENSION_NAME: &str = "XEVIE";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest {
+    pub client_major_version: u16,
+    pub client_minor_version: u16,
+}
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let client_major_version_bytes = self.client_major_version.serialize();
+        let client_minor_version_bytes = self.client_minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+            client_major_version_bytes[0],
+            client_major_version_bytes[1],
+            client_minor_version_bytes[0],
+            client_minor_version_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u16, client_minor_version: u16) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let client_major_version_bytes = client_major_version.serialize();
-    let client_minor_version_bytes = client_minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-        client_major_version_bytes[0],
-        client_major_version_bytes[1],
-        client_minor_version_bytes[0],
-        client_minor_version_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest {
+        client_major_version: client_major_version,
+        client_minor_version: client_minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,31 +110,50 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the Start request
-pub const START_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StartRequest {
+    pub screen: u32,
+}
+impl StartRequest {
+    /// Opcode for the Start request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let screen_bytes = self.screen.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            StartRequest::opcode(),
+            0,
+            0,
+            screen_bytes[0],
+            screen_bytes[1],
+            screen_bytes[2],
+            screen_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn start<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, StartReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let screen_bytes = screen.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        START_REQUEST,
-        0,
-        0,
-        screen_bytes[0],
-        screen_bytes[1],
-        screen_bytes[2],
-        screen_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = StartRequest {
+        screen: screen,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -139,31 +180,50 @@ impl TryFrom<&[u8]> for StartReply {
     }
 }
 
-/// Opcode for the End request
-pub const END_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EndRequest {
+    pub cmap: u32,
+}
+impl EndRequest {
+    /// Opcode for the End request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            EndRequest::opcode(),
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn end<Conn>(conn: &Conn, cmap: u32) -> Result<Cookie<'_, Conn, EndReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        END_REQUEST,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = EndRequest {
+        cmap: cmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -320,128 +380,149 @@ impl Serialize for Event {
     }
 }
 
-/// Opcode for the Send request
-pub const SEND_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SendRequest {
+    pub event: Event,
+    pub data_type: u32,
+}
+impl SendRequest {
+    /// Opcode for the Send request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let event_bytes = self.event.serialize();
+        let data_type_bytes = self.data_type.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SendRequest::opcode(),
+            0,
+            0,
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            event_bytes[4],
+            event_bytes[5],
+            event_bytes[6],
+            event_bytes[7],
+            event_bytes[8],
+            event_bytes[9],
+            event_bytes[10],
+            event_bytes[11],
+            event_bytes[12],
+            event_bytes[13],
+            event_bytes[14],
+            event_bytes[15],
+            event_bytes[16],
+            event_bytes[17],
+            event_bytes[18],
+            event_bytes[19],
+            event_bytes[20],
+            event_bytes[21],
+            event_bytes[22],
+            event_bytes[23],
+            event_bytes[24],
+            event_bytes[25],
+            event_bytes[26],
+            event_bytes[27],
+            event_bytes[28],
+            event_bytes[29],
+            event_bytes[30],
+            event_bytes[31],
+            data_type_bytes[0],
+            data_type_bytes[1],
+            data_type_bytes[2],
+            data_type_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn send<Conn>(conn: &Conn, event: Event, data_type: u32) -> Result<Cookie<'_, Conn, SendReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let event_bytes = event.serialize();
-    let data_type_bytes = data_type.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SEND_REQUEST,
-        0,
-        0,
-        event_bytes[0],
-        event_bytes[1],
-        event_bytes[2],
-        event_bytes[3],
-        event_bytes[4],
-        event_bytes[5],
-        event_bytes[6],
-        event_bytes[7],
-        event_bytes[8],
-        event_bytes[9],
-        event_bytes[10],
-        event_bytes[11],
-        event_bytes[12],
-        event_bytes[13],
-        event_bytes[14],
-        event_bytes[15],
-        event_bytes[16],
-        event_bytes[17],
-        event_bytes[18],
-        event_bytes[19],
-        event_bytes[20],
-        event_bytes[21],
-        event_bytes[22],
-        event_bytes[23],
-        event_bytes[24],
-        event_bytes[25],
-        event_bytes[26],
-        event_bytes[27],
-        event_bytes[28],
-        event_bytes[29],
-        event_bytes[30],
-        event_bytes[31],
-        data_type_bytes[0],
-        data_type_bytes[1],
-        data_type_bytes[2],
-        data_type_bytes[3],
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SendRequest {
+        event: event,
+        data_type: data_type,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -468,31 +549,50 @@ impl TryFrom<&[u8]> for SendReply {
     }
 }
 
-/// Opcode for the SelectInput request
-pub const SELECT_INPUT_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectInputRequest {
+    pub event_mask: u32,
+}
+impl SelectInputRequest {
+    /// Opcode for the SelectInput request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let event_mask_bytes = self.event_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SelectInputRequest::opcode(),
+            0,
+            0,
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            event_mask_bytes[2],
+            event_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn select_input<Conn>(conn: &Conn, event_mask: u32) -> Result<Cookie<'_, Conn, SelectInputReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let event_mask_bytes = event_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SELECT_INPUT_REQUEST,
-        0,
-        0,
-        event_mask_bytes[0],
-        event_mask_bytes[1],
-        event_mask_bytes[2],
-        event_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SelectInputRequest {
+        event_mask: event_mask,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -188,7 +188,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryDirectRenderingCapableRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -259,7 +259,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = OpenConnectionRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -352,7 +352,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CloseConnectionRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -398,7 +398,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetClientDriverNameRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -505,9 +505,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateContextRequest {
-        screen: screen,
-        visual: visual,
-        context: context,
+        screen,
+        visual,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -584,8 +584,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyContextRequest {
-        screen: screen,
-        context: context,
+        screen,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -637,8 +637,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateDrawableRequest {
-        screen: screen,
-        drawable: drawable,
+        screen,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -715,8 +715,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyDrawableRequest {
-        screen: screen,
-        drawable: drawable,
+        screen,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -768,8 +768,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDrawableInfoRequest {
-        screen: screen,
-        drawable: drawable,
+        screen,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -888,7 +888,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceInfoRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -991,8 +991,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AuthConnectionRequest {
-        screen: screen,
-        magic: magic,
+        screen,
+        magic,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -99,7 +99,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -168,7 +168,7 @@ impl QueryDirectRenderingCapableRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryDirectRenderingCapableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -239,7 +239,7 @@ impl OpenConnectionRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            OpenConnectionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -332,7 +332,7 @@ impl CloseConnectionRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CloseConnectionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -378,7 +378,7 @@ impl GetClientDriverNameRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetClientDriverNameRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -477,7 +477,7 @@ impl CreateContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -560,7 +560,7 @@ impl DestroyContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -613,7 +613,7 @@ impl CreateDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateDrawableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -691,7 +691,7 @@ impl DestroyDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyDrawableRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -744,7 +744,7 @@ impl GetDrawableInfoRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDrawableInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -868,7 +868,7 @@ impl GetDeviceInfoRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -967,7 +967,7 @@ impl AuthConnectionRequest {
         let magic_bytes = self.magic.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AuthConnectionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -89,7 +88,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -156,7 +155,7 @@ impl QueryDirectRenderingCapableRequest {
     /// Opcode for the QueryDirectRenderingCapable request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -226,7 +225,7 @@ impl OpenConnectionRequest {
     /// Opcode for the OpenConnection request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -318,7 +317,7 @@ impl CloseConnectionRequest {
     /// Opcode for the CloseConnection request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -363,7 +362,7 @@ impl GetClientDriverNameRequest {
     /// Opcode for the GetClientDriverName request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -459,7 +458,7 @@ impl CreateContextRequest {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -542,7 +541,7 @@ impl DestroyContextRequest {
     /// Opcode for the DestroyContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -594,7 +593,7 @@ impl CreateDrawableRequest {
     /// Opcode for the CreateDrawable request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -671,7 +670,7 @@ impl DestroyDrawableRequest {
     /// Opcode for the DestroyDrawable request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -723,7 +722,7 @@ impl GetDrawableInfoRequest {
     /// Opcode for the GetDrawableInfo request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -847,7 +846,7 @@ impl GetDeviceInfoRequest {
     /// Opcode for the GetDeviceInfo request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -944,7 +943,7 @@ impl AuthConnectionRequest {
     /// Opcode for the AuthConnection request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -89,7 +89,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -157,7 +156,6 @@ impl QueryDirectRenderingCapableRequest {
     /// Opcode for the QueryDirectRenderingCapable request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -228,7 +226,6 @@ impl OpenConnectionRequest {
     /// Opcode for the OpenConnection request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -321,7 +318,6 @@ impl CloseConnectionRequest {
     /// Opcode for the CloseConnection request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -367,7 +363,6 @@ impl GetClientDriverNameRequest {
     /// Opcode for the GetClientDriverName request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -464,7 +459,6 @@ impl CreateContextRequest {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -548,7 +542,6 @@ impl DestroyContextRequest {
     /// Opcode for the DestroyContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -601,7 +594,6 @@ impl CreateDrawableRequest {
     /// Opcode for the CreateDrawable request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -679,7 +671,6 @@ impl DestroyDrawableRequest {
     /// Opcode for the DestroyDrawable request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -732,7 +723,6 @@ impl GetDrawableInfoRequest {
     /// Opcode for the GetDrawableInfo request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -857,7 +847,6 @@ impl GetDeviceInfoRequest {
     /// Opcode for the GetDeviceInfo request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -955,7 +944,6 @@ impl AuthConnectionRequest {
     /// Opcode for the AuthConnection request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -82,11 +82,11 @@ impl Serialize for DrmClipRect {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -97,7 +97,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
         ];
@@ -147,13 +147,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the QueryDirectRenderingCapable request
+pub const QUERY_DIRECT_RENDERING_CAPABLE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryDirectRenderingCapableRequest {
     pub screen: u32,
 }
 impl QueryDirectRenderingCapableRequest {
-    /// Opcode for the QueryDirectRenderingCapable request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -165,7 +165,7 @@ impl QueryDirectRenderingCapableRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_DIRECT_RENDERING_CAPABLE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -217,13 +217,13 @@ impl TryFrom<&[u8]> for QueryDirectRenderingCapableReply {
     }
 }
 
+/// Opcode for the OpenConnection request
+pub const OPEN_CONNECTION_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OpenConnectionRequest {
     pub screen: u32,
 }
 impl OpenConnectionRequest {
-    /// Opcode for the OpenConnection request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -235,7 +235,7 @@ impl OpenConnectionRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            OPEN_CONNECTION_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -309,13 +309,13 @@ impl OpenConnectionReply {
     }
 }
 
+/// Opcode for the CloseConnection request
+pub const CLOSE_CONNECTION_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CloseConnectionRequest {
     pub screen: u32,
 }
 impl CloseConnectionRequest {
-    /// Opcode for the CloseConnection request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -327,7 +327,7 @@ impl CloseConnectionRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CLOSE_CONNECTION_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -354,13 +354,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetClientDriverName request
+pub const GET_CLIENT_DRIVER_NAME_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetClientDriverNameRequest {
     pub screen: u32,
 }
 impl GetClientDriverNameRequest {
-    /// Opcode for the GetClientDriverName request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -372,7 +372,7 @@ impl GetClientDriverNameRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CLIENT_DRIVER_NAME_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -448,6 +448,8 @@ impl GetClientDriverNameReply {
     }
 }
 
+/// Opcode for the CreateContext request
+pub const CREATE_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateContextRequest {
     pub screen: u32,
@@ -455,8 +457,6 @@ pub struct CreateContextRequest {
     pub context: u32,
 }
 impl CreateContextRequest {
-    /// Opcode for the CreateContext request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -470,7 +470,7 @@ impl CreateContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CONTEXT_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -532,14 +532,14 @@ impl TryFrom<&[u8]> for CreateContextReply {
     }
 }
 
+/// Opcode for the DestroyContext request
+pub const DESTROY_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyContextRequest {
     pub screen: u32,
     pub context: u32,
 }
 impl DestroyContextRequest {
-    /// Opcode for the DestroyContext request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -552,7 +552,7 @@ impl DestroyContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_CONTEXT_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -584,14 +584,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateDrawable request
+pub const CREATE_DRAWABLE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
 }
 impl CreateDrawableRequest {
-    /// Opcode for the CreateDrawable request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -604,7 +604,7 @@ impl CreateDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_DRAWABLE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -661,14 +661,14 @@ impl TryFrom<&[u8]> for CreateDrawableReply {
     }
 }
 
+/// Opcode for the DestroyDrawable request
+pub const DESTROY_DRAWABLE_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
 }
 impl DestroyDrawableRequest {
-    /// Opcode for the DestroyDrawable request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -681,7 +681,7 @@ impl DestroyDrawableRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_DRAWABLE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -713,14 +713,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDrawableInfo request
+pub const GET_DRAWABLE_INFO_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDrawableInfoRequest {
     pub screen: u32,
     pub drawable: u32,
 }
 impl GetDrawableInfoRequest {
-    /// Opcode for the GetDrawableInfo request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -733,7 +733,7 @@ impl GetDrawableInfoRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DRAWABLE_INFO_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -838,13 +838,13 @@ impl GetDrawableInfoReply {
     }
 }
 
+/// Opcode for the GetDeviceInfo request
+pub const GET_DEVICE_INFO_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceInfoRequest {
     pub screen: u32,
 }
 impl GetDeviceInfoRequest {
-    /// Opcode for the GetDeviceInfo request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -856,7 +856,7 @@ impl GetDeviceInfoRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_INFO_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -934,14 +934,14 @@ impl GetDeviceInfoReply {
     }
 }
 
+/// Opcode for the AuthConnection request
+pub const AUTH_CONNECTION_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuthConnectionRequest {
     pub screen: u32,
     pub magic: u32,
 }
 impl AuthConnectionRequest {
-    /// Opcode for the AuthConnection request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -954,7 +954,7 @@ impl AuthConnectionRequest {
         let magic_bytes = self.magic.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            AUTH_CONNECTION_REQUEST,
             0,
             0,
             screen_bytes[0],

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -469,7 +469,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetModeLineRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -649,18 +649,18 @@ where
 {
     let flags: u32 = flags.into();
     let request0 = ModModeLineRequest {
-        screen: screen,
-        hdisplay: hdisplay,
-        hsyncstart: hsyncstart,
-        hsyncend: hsyncend,
-        htotal: htotal,
-        hskew: hskew,
-        vdisplay: vdisplay,
-        vsyncstart: vsyncstart,
-        vsyncend: vsyncend,
-        vtotal: vtotal,
-        flags: flags,
-        private: private,
+        screen,
+        hdisplay,
+        hsyncstart,
+        hsyncend,
+        htotal,
+        hskew,
+        vdisplay,
+        vsyncstart,
+        vsyncend,
+        vtotal,
+        flags,
+        private,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -708,8 +708,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SwitchModeRequest {
-        screen: screen,
-        zoom: zoom,
+        screen,
+        zoom,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -755,7 +755,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetMonitorRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -898,8 +898,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = LockModeSwitchRequest {
-        screen: screen,
-        lock: lock,
+        screen,
+        lock,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -945,7 +945,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetAllModeLinesRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1171,30 +1171,30 @@ where
     let flags: u32 = flags.into();
     let after_flags: u32 = after_flags.into();
     let request0 = AddModeLineRequest {
-        screen: screen,
-        dotclock: dotclock,
-        hdisplay: hdisplay,
-        hsyncstart: hsyncstart,
-        hsyncend: hsyncend,
-        htotal: htotal,
-        hskew: hskew,
-        vdisplay: vdisplay,
-        vsyncstart: vsyncstart,
-        vsyncend: vsyncend,
-        vtotal: vtotal,
-        flags: flags,
-        after_dotclock: after_dotclock,
-        after_hdisplay: after_hdisplay,
-        after_hsyncstart: after_hsyncstart,
-        after_hsyncend: after_hsyncend,
-        after_htotal: after_htotal,
-        after_hskew: after_hskew,
-        after_vdisplay: after_vdisplay,
-        after_vsyncstart: after_vsyncstart,
-        after_vsyncend: after_vsyncend,
-        after_vtotal: after_vtotal,
-        after_flags: after_flags,
-        private: private,
+        screen,
+        dotclock,
+        hdisplay,
+        hsyncstart,
+        hsyncend,
+        htotal,
+        hskew,
+        vdisplay,
+        vsyncstart,
+        vsyncend,
+        vtotal,
+        flags,
+        after_dotclock,
+        after_hdisplay,
+        after_hsyncstart,
+        after_hsyncend,
+        after_htotal,
+        after_hskew,
+        after_vdisplay,
+        after_vsyncstart,
+        after_vsyncend,
+        after_vtotal,
+        after_flags,
+        private,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1314,19 +1314,19 @@ where
 {
     let flags: u32 = flags.into();
     let request0 = DeleteModeLineRequest {
-        screen: screen,
-        dotclock: dotclock,
-        hdisplay: hdisplay,
-        hsyncstart: hsyncstart,
-        hsyncend: hsyncend,
-        htotal: htotal,
-        hskew: hskew,
-        vdisplay: vdisplay,
-        vsyncstart: vsyncstart,
-        vsyncend: vsyncend,
-        vtotal: vtotal,
-        flags: flags,
-        private: private,
+        screen,
+        dotclock,
+        hdisplay,
+        hsyncstart,
+        hsyncend,
+        htotal,
+        hskew,
+        vdisplay,
+        vsyncstart,
+        vsyncend,
+        vtotal,
+        flags,
+        private,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1446,19 +1446,19 @@ where
 {
     let flags: u32 = flags.into();
     let request0 = ValidateModeLineRequest {
-        screen: screen,
-        dotclock: dotclock,
-        hdisplay: hdisplay,
-        hsyncstart: hsyncstart,
-        hsyncend: hsyncend,
-        htotal: htotal,
-        hskew: hskew,
-        vdisplay: vdisplay,
-        vsyncstart: vsyncstart,
-        vsyncend: vsyncend,
-        vtotal: vtotal,
-        flags: flags,
-        private: private,
+        screen,
+        dotclock,
+        hdisplay,
+        hsyncstart,
+        hsyncend,
+        htotal,
+        hskew,
+        vdisplay,
+        vsyncstart,
+        vsyncend,
+        vtotal,
+        flags,
+        private,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1604,19 +1604,19 @@ where
 {
     let flags: u32 = flags.into();
     let request0 = SwitchToModeRequest {
-        screen: screen,
-        dotclock: dotclock,
-        hdisplay: hdisplay,
-        hsyncstart: hsyncstart,
-        hsyncend: hsyncend,
-        htotal: htotal,
-        hskew: hskew,
-        vdisplay: vdisplay,
-        vsyncstart: vsyncstart,
-        vsyncend: vsyncend,
-        vtotal: vtotal,
-        flags: flags,
-        private: private,
+        screen,
+        dotclock,
+        hdisplay,
+        hsyncstart,
+        hsyncend,
+        htotal,
+        hskew,
+        vdisplay,
+        vsyncstart,
+        vsyncend,
+        vtotal,
+        flags,
+        private,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1662,7 +1662,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetViewPortRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1748,9 +1748,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetViewPortRequest {
-        screen: screen,
-        x: x,
-        y: y,
+        screen,
+        x,
+        y,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1796,7 +1796,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDotClocksRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1876,8 +1876,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetClientVersionRequest {
-        major: major,
-        minor: minor,
+        major,
+        minor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1953,10 +1953,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetGammaRequest {
-        screen: screen,
-        red: red,
-        green: green,
-        blue: blue,
+        screen,
+        red,
+        green,
+        blue,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2026,7 +2026,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetGammaRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2104,8 +2104,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetGammaRampRequest {
-        screen: screen,
-        size: size,
+        screen,
+        size,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2199,11 +2199,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetGammaRampRequest {
-        screen: screen,
-        size: size,
-        red: red,
-        green: green,
-        blue: blue,
+        screen,
+        size,
+        red,
+        green,
+        blue,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2249,7 +2249,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetGammaRampSizeRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2321,7 +2321,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPermissionsRequest {
-        screen: screen,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -382,7 +382,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -449,7 +449,7 @@ impl GetModeLineRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetModeLineRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -584,7 +584,7 @@ impl<'input> ModModeLineRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ModModeLineRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -688,7 +688,7 @@ impl SwitchModeRequest {
         let zoom_bytes = self.zoom.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SwitchModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -735,7 +735,7 @@ impl GetMonitorRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMonitorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -878,7 +878,7 @@ impl LockModeSwitchRequest {
         let lock_bytes = self.lock.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            LockModeSwitchRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -925,7 +925,7 @@ impl GetAllModeLinesRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetAllModeLinesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1060,7 +1060,7 @@ impl<'input> AddModeLineRequest<'input> {
         let after_flags_bytes = self.after_flags.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AddModeLineRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1245,7 +1245,7 @@ impl<'input> DeleteModeLineRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteModeLineRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1377,7 +1377,7 @@ impl<'input> ValidateModeLineRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ValidateModeLineRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1535,7 +1535,7 @@ impl<'input> SwitchToModeRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SwitchToModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1642,7 +1642,7 @@ impl GetViewPortRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetViewPortRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1720,7 +1720,7 @@ impl SetViewPortRequest {
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetViewPortRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1776,7 +1776,7 @@ impl GetDotClocksRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDotClocksRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1856,7 +1856,7 @@ impl SetClientVersionRequest {
         let minor_bytes = self.minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetClientVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_bytes[0],
@@ -1909,7 +1909,7 @@ impl SetGammaRequest {
         let blue_bytes = self.blue.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetGammaRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -1982,7 +1982,7 @@ impl GetGammaRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetGammaRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2084,7 +2084,7 @@ impl GetGammaRampRequest {
         let size_bytes = self.size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetGammaRampRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2168,7 +2168,7 @@ impl<'input> SetGammaRampRequest<'input> {
         let size_bytes = self.size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetGammaRampRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2229,7 +2229,7 @@ impl GetGammaRampSizeRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetGammaRampSizeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],
@@ -2301,7 +2301,7 @@ impl GetPermissionsRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPermissionsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             screen_bytes[0],

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -509,7 +509,7 @@ impl GetModeLineReply {
 
 /// Opcode for the ModModeLine request
 pub const MOD_MODE_LINE_REQUEST: u8 = 2;
-pub fn mod_mode_line<'c, Conn, A>(conn: &'c Conn, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn mod_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
@@ -840,7 +840,7 @@ impl GetAllModeLinesReply {
 
 /// Opcode for the AddModeLine request
 pub const ADD_MODE_LINE_REQUEST: u8 = 7;
-pub fn add_mode_line<'c, Conn, A, B>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn add_mode_line<'c, 'input, Conn, A, B>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
@@ -982,7 +982,7 @@ where
 
 /// Opcode for the DeleteModeLine request
 pub const DELETE_MODE_LINE_REQUEST: u8 = 8;
-pub fn delete_mode_line<'c, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn delete_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
@@ -1071,7 +1071,7 @@ where
 
 /// Opcode for the ValidateModeLine request
 pub const VALIDATE_MODE_LINE_REQUEST: u8 = 9;
-pub fn validate_mode_line<'c, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
+pub fn validate_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
@@ -1186,7 +1186,7 @@ impl TryFrom<&[u8]> for ValidateModeLineReply {
 
 /// Opcode for the SwitchToMode request
 pub const SWITCH_TO_MODE_REQUEST: u8 = 10;
-pub fn switch_to_mode<'c, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn switch_to_mode<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
@@ -1649,7 +1649,7 @@ impl TryFrom<&[u8]> for GetGammaRampReply {
 
 /// Opcode for the SetGammaRamp request
 pub const SET_GAMMA_RAMP_REQUEST: u8 = 18;
-pub fn set_gamma_ramp<'c, Conn>(conn: &'c Conn, screen: u16, size: u16, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_gamma_ramp<'c, 'input, Conn>(conn: &'c Conn, screen: u16, size: u16, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2299,7 +2299,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_mode_line(self, screen)
     }
-    fn xf86vidmode_mod_mode_line<'c, A>(&'c self, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_mod_mode_line<'c, 'input, A>(&'c self, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u32>,
     {
@@ -2321,26 +2321,26 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_all_mode_lines(self, screen)
     }
-    fn xf86vidmode_add_mode_line<'c, A, B>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_add_mode_line<'c, 'input, A, B>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u32>,
         B: Into<u32>,
     {
         add_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, after_dotclock, after_hdisplay, after_hsyncstart, after_hsyncend, after_htotal, after_hskew, after_vdisplay, after_vsyncstart, after_vsyncend, after_vtotal, after_flags, private)
     }
-    fn xf86vidmode_delete_mode_line<'c, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_delete_mode_line<'c, 'input, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u32>,
     {
         delete_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }
-    fn xf86vidmode_validate_mode_line<'c, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<Cookie<'c, Self, ValidateModeLineReply>, ConnectionError>
+    fn xf86vidmode_validate_mode_line<'c, 'input, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<Cookie<'c, Self, ValidateModeLineReply>, ConnectionError>
     where
         A: Into<u32>,
     {
         validate_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }
-    fn xf86vidmode_switch_to_mode<'c, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_switch_to_mode<'c, 'input, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u32>,
     {
@@ -2374,7 +2374,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_gamma_ramp(self, screen, size)
     }
-    fn xf86vidmode_set_gamma_ramp<'c>(&'c self, screen: u16, size: u16, red: &[u16], green: &[u16], blue: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xf86vidmode_set_gamma_ramp<'c, 'input>(&'c self, screen: u16, size: u16, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_gamma_ramp(self, screen, size, red, green, blue)
     }

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -372,7 +372,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -438,7 +437,6 @@ impl GetModeLineRequest {
     /// Opcode for the GetModeLine request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -561,7 +559,6 @@ impl<'input> ModModeLineRequest<'input> {
     /// Opcode for the ModModeLine request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -676,7 +673,6 @@ impl SwitchModeRequest {
     /// Opcode for the SwitchMode request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -724,7 +720,6 @@ impl GetMonitorRequest {
     /// Opcode for the GetMonitor request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -866,7 +861,6 @@ impl LockModeSwitchRequest {
     /// Opcode for the LockModeSwitch request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -914,7 +908,6 @@ impl GetAllModeLinesRequest {
     /// Opcode for the GetAllModeLines request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1025,7 +1018,6 @@ impl<'input> AddModeLineRequest<'input> {
     /// Opcode for the AddModeLine request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1221,7 +1213,6 @@ impl<'input> DeleteModeLineRequest<'input> {
     /// Opcode for the DeleteModeLine request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1353,7 +1344,6 @@ impl<'input> ValidateModeLineRequest<'input> {
     /// Opcode for the ValidateModeLine request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1511,7 +1501,6 @@ impl<'input> SwitchToModeRequest<'input> {
     /// Opcode for the SwitchToMode request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1631,7 +1620,6 @@ impl GetViewPortRequest {
     /// Opcode for the GetViewPort request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1707,7 +1695,6 @@ impl SetViewPortRequest {
     /// Opcode for the SetViewPort request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1765,7 +1752,6 @@ impl GetDotClocksRequest {
     /// Opcode for the GetDotClocks request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1844,7 +1830,6 @@ impl SetClientVersionRequest {
     /// Opcode for the SetClientVersion request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1895,7 +1880,6 @@ impl SetGammaRequest {
     /// Opcode for the SetGamma request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1971,7 +1955,6 @@ impl GetGammaRequest {
     /// Opcode for the GetGamma request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2072,7 +2055,6 @@ impl GetGammaRampRequest {
     /// Opcode for the GetGammaRamp request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2156,7 +2138,6 @@ impl<'input> SetGammaRampRequest<'input> {
     /// Opcode for the SetGammaRamp request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2218,7 +2199,6 @@ impl GetGammaRampSizeRequest {
     /// Opcode for the GetGammaRampSize request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2290,7 +2270,6 @@ impl GetPermissionsRequest {
     /// Opcode for the GetPermissions request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -365,11 +365,11 @@ impl Serialize for ModeInfo {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -380,7 +380,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
         ];
@@ -428,13 +428,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the GetModeLine request
+pub const GET_MODE_LINE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetModeLineRequest {
     pub screen: u16,
 }
 impl GetModeLineRequest {
-    /// Opcode for the GetModeLine request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -446,7 +446,7 @@ impl GetModeLineRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MODE_LINE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -539,6 +539,8 @@ impl GetModeLineReply {
     }
 }
 
+/// Opcode for the ModModeLine request
+pub const MOD_MODE_LINE_REQUEST: u8 = 2;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModModeLineRequest<'input> {
     pub screen: u32,
@@ -555,8 +557,6 @@ pub struct ModModeLineRequest<'input> {
     pub private: &'input [u8],
 }
 impl<'input> ModModeLineRequest<'input> {
-    /// Opcode for the ModModeLine request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -580,7 +580,7 @@ impl<'input> ModModeLineRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            MOD_MODE_LINE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -663,14 +663,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SwitchMode request
+pub const SWITCH_MODE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SwitchModeRequest {
     pub screen: u16,
     pub zoom: u16,
 }
 impl SwitchModeRequest {
-    /// Opcode for the SwitchMode request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -683,7 +683,7 @@ impl SwitchModeRequest {
         let zoom_bytes = self.zoom.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SWITCH_MODE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -711,13 +711,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetMonitor request
+pub const GET_MONITOR_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMonitorRequest {
     pub screen: u16,
 }
 impl GetMonitorRequest {
-    /// Opcode for the GetMonitor request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -729,7 +729,7 @@ impl GetMonitorRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MONITOR_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -851,14 +851,14 @@ impl GetMonitorReply {
     }
 }
 
+/// Opcode for the LockModeSwitch request
+pub const LOCK_MODE_SWITCH_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LockModeSwitchRequest {
     pub screen: u16,
     pub lock: u16,
 }
 impl LockModeSwitchRequest {
-    /// Opcode for the LockModeSwitch request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -871,7 +871,7 @@ impl LockModeSwitchRequest {
         let lock_bytes = self.lock.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LOCK_MODE_SWITCH_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -899,13 +899,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetAllModeLines request
+pub const GET_ALL_MODE_LINES_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetAllModeLinesRequest {
     pub screen: u16,
 }
 impl GetAllModeLinesRequest {
-    /// Opcode for the GetAllModeLines request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -917,7 +917,7 @@ impl GetAllModeLinesRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_ALL_MODE_LINES_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -986,6 +986,8 @@ impl GetAllModeLinesReply {
     }
 }
 
+/// Opcode for the AddModeLine request
+pub const ADD_MODE_LINE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddModeLineRequest<'input> {
     pub screen: u32,
@@ -1014,8 +1016,6 @@ pub struct AddModeLineRequest<'input> {
     pub private: &'input [u8],
 }
 impl<'input> AddModeLineRequest<'input> {
-    /// Opcode for the AddModeLine request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1051,7 +1051,7 @@ impl<'input> AddModeLineRequest<'input> {
         let after_flags_bytes = self.after_flags.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ADD_MODE_LINE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1192,6 +1192,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteModeLine request
+pub const DELETE_MODE_LINE_REQUEST: u8 = 8;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteModeLineRequest<'input> {
     pub screen: u32,
@@ -1209,8 +1211,6 @@ pub struct DeleteModeLineRequest<'input> {
     pub private: &'input [u8],
 }
 impl<'input> DeleteModeLineRequest<'input> {
-    /// Opcode for the DeleteModeLine request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1235,7 +1235,7 @@ impl<'input> DeleteModeLineRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_MODE_LINE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1323,6 +1323,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ValidateModeLine request
+pub const VALIDATE_MODE_LINE_REQUEST: u8 = 9;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidateModeLineRequest<'input> {
     pub screen: u32,
@@ -1340,8 +1342,6 @@ pub struct ValidateModeLineRequest<'input> {
     pub private: &'input [u8],
 }
 impl<'input> ValidateModeLineRequest<'input> {
-    /// Opcode for the ValidateModeLine request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1366,7 +1366,7 @@ impl<'input> ValidateModeLineRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            VALIDATE_MODE_LINE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1480,6 +1480,8 @@ impl TryFrom<&[u8]> for ValidateModeLineReply {
     }
 }
 
+/// Opcode for the SwitchToMode request
+pub const SWITCH_TO_MODE_REQUEST: u8 = 10;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SwitchToModeRequest<'input> {
     pub screen: u32,
@@ -1497,8 +1499,6 @@ pub struct SwitchToModeRequest<'input> {
     pub private: &'input [u8],
 }
 impl<'input> SwitchToModeRequest<'input> {
-    /// Opcode for the SwitchToMode request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1523,7 +1523,7 @@ impl<'input> SwitchToModeRequest<'input> {
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SWITCH_TO_MODE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1611,13 +1611,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetViewPort request
+pub const GET_VIEW_PORT_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetViewPortRequest {
     pub screen: u16,
 }
 impl GetViewPortRequest {
-    /// Opcode for the GetViewPort request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1629,7 +1629,7 @@ impl GetViewPortRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_VIEW_PORT_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1684,6 +1684,8 @@ impl TryFrom<&[u8]> for GetViewPortReply {
     }
 }
 
+/// Opcode for the SetViewPort request
+pub const SET_VIEW_PORT_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetViewPortRequest {
     pub screen: u16,
@@ -1691,8 +1693,6 @@ pub struct SetViewPortRequest {
     pub y: u32,
 }
 impl SetViewPortRequest {
-    /// Opcode for the SetViewPort request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1706,7 +1706,7 @@ impl SetViewPortRequest {
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_VIEW_PORT_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1743,13 +1743,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDotClocks request
+pub const GET_DOT_CLOCKS_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDotClocksRequest {
     pub screen: u16,
 }
 impl GetDotClocksRequest {
-    /// Opcode for the GetDotClocks request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1761,7 +1761,7 @@ impl GetDotClocksRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DOT_CLOCKS_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1820,14 +1820,14 @@ impl TryFrom<&[u8]> for GetDotClocksReply {
     }
 }
 
+/// Opcode for the SetClientVersion request
+pub const SET_CLIENT_VERSION_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetClientVersionRequest {
     pub major: u16,
     pub minor: u16,
 }
 impl SetClientVersionRequest {
-    /// Opcode for the SetClientVersion request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1840,7 +1840,7 @@ impl SetClientVersionRequest {
         let minor_bytes = self.minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CLIENT_VERSION_REQUEST,
             0,
             0,
             major_bytes[0],
@@ -1868,6 +1868,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetGamma request
+pub const SET_GAMMA_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetGammaRequest {
     pub screen: u16,
@@ -1876,8 +1878,6 @@ pub struct SetGammaRequest {
     pub blue: u32,
 }
 impl SetGammaRequest {
-    /// Opcode for the SetGamma request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1892,7 +1892,7 @@ impl SetGammaRequest {
         let blue_bytes = self.blue.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_GAMMA_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -1946,13 +1946,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetGamma request
+pub const GET_GAMMA_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetGammaRequest {
     pub screen: u16,
 }
 impl GetGammaRequest {
-    /// Opcode for the GetGamma request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1964,7 +1964,7 @@ impl GetGammaRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_GAMMA_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -2045,14 +2045,14 @@ impl TryFrom<&[u8]> for GetGammaReply {
     }
 }
 
+/// Opcode for the GetGammaRamp request
+pub const GET_GAMMA_RAMP_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetGammaRampRequest {
     pub screen: u16,
     pub size: u16,
 }
 impl GetGammaRampRequest {
-    /// Opcode for the GetGammaRamp request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2065,7 +2065,7 @@ impl GetGammaRampRequest {
         let size_bytes = self.size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_GAMMA_RAMP_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -2125,6 +2125,8 @@ impl TryFrom<&[u8]> for GetGammaRampReply {
     }
 }
 
+/// Opcode for the SetGammaRamp request
+pub const SET_GAMMA_RAMP_REQUEST: u8 = 18;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetGammaRampRequest<'input> {
     pub screen: u16,
@@ -2134,8 +2136,6 @@ pub struct SetGammaRampRequest<'input> {
     pub blue: &'input [u16],
 }
 impl<'input> SetGammaRampRequest<'input> {
-    /// Opcode for the SetGammaRamp request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2148,7 +2148,7 @@ impl<'input> SetGammaRampRequest<'input> {
         let size_bytes = self.size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_GAMMA_RAMP_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -2190,13 +2190,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetGammaRampSize request
+pub const GET_GAMMA_RAMP_SIZE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetGammaRampSizeRequest {
     pub screen: u16,
 }
 impl GetGammaRampSizeRequest {
-    /// Opcode for the GetGammaRampSize request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2208,7 +2208,7 @@ impl GetGammaRampSizeRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_GAMMA_RAMP_SIZE_REQUEST,
             0,
             0,
             screen_bytes[0],
@@ -2261,13 +2261,13 @@ impl TryFrom<&[u8]> for GetGammaRampSizeReply {
     }
 }
 
+/// Opcode for the GetPermissions request
+pub const GET_PERMISSIONS_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPermissionsRequest {
     pub screen: u16,
 }
 impl GetPermissionsRequest {
-    /// Opcode for the GetPermissions request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2279,7 +2279,7 @@ impl GetPermissionsRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PERMISSIONS_REQUEST,
             0,
             0,
             screen_bytes[0],

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -45,7 +45,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -338,7 +337,6 @@ impl ChangeSaveSetRequest {
     /// Opcode for the ChangeSaveSet request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -614,7 +612,6 @@ impl SelectSelectionInputRequest {
     /// Opcode for the SelectSelectionInput request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -878,7 +875,6 @@ impl SelectCursorInputRequest {
     /// Opcode for the SelectCursorInput request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -930,7 +926,6 @@ impl GetCursorImageRequest {
     /// Opcode for the GetCursorImage request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1142,7 +1137,6 @@ impl<'input> CreateRegionRequest<'input> {
     /// Opcode for the CreateRegion request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1194,7 +1188,6 @@ impl CreateRegionFromBitmapRequest {
     /// Opcode for the CreateRegionFromBitmap request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1248,7 +1241,6 @@ impl CreateRegionFromWindowRequest {
     /// Opcode for the CreateRegionFromWindow request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1307,7 +1299,6 @@ impl CreateRegionFromGCRequest {
     /// Opcode for the CreateRegionFromGC request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1360,7 +1351,6 @@ impl CreateRegionFromPictureRequest {
     /// Opcode for the CreateRegionFromPicture request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1412,7 +1402,6 @@ impl DestroyRegionRequest {
     /// Opcode for the DestroyRegion request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1459,7 +1448,6 @@ impl<'input> SetRegionRequest<'input> {
     /// Opcode for the SetRegion request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1511,7 +1499,6 @@ impl CopyRegionRequest {
     /// Opcode for the CopyRegion request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1565,7 +1552,6 @@ impl UnionRegionRequest {
     /// Opcode for the UnionRegion request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1625,7 +1611,6 @@ impl IntersectRegionRequest {
     /// Opcode for the IntersectRegion request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1685,7 +1670,6 @@ impl SubtractRegionRequest {
     /// Opcode for the SubtractRegion request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1745,7 +1729,6 @@ impl InvertRegionRequest {
     /// Opcode for the InvertRegion request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1809,7 +1792,6 @@ impl TranslateRegionRequest {
     /// Opcode for the TranslateRegion request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1864,7 +1846,6 @@ impl RegionExtentsRequest {
     /// Opcode for the RegionExtents request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1916,7 +1897,6 @@ impl FetchRegionRequest {
     /// Opcode for the FetchRegion request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2008,7 +1988,6 @@ impl SetGCClipRegionRequest {
     /// Opcode for the SetGCClipRegion request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2074,7 +2053,6 @@ impl SetWindowShapeRegionRequest {
     /// Opcode for the SetWindowShapeRegion request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2145,7 +2123,6 @@ impl SetPictureClipRegionRequest {
     /// Opcode for the SetPictureClipRegion request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2208,7 +2185,6 @@ impl<'input> SetCursorNameRequest<'input> {
     /// Opcode for the SetCursorName request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2264,7 +2240,6 @@ impl GetCursorNameRequest {
     /// Opcode for the GetCursorName request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2353,7 +2328,6 @@ impl GetCursorImageAndNameRequest {
     /// Opcode for the GetCursorImageAndName request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2454,7 +2428,6 @@ impl ChangeCursorRequest {
     /// Opcode for the ChangeCursor request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2507,7 +2480,6 @@ impl<'input> ChangeCursorByNameRequest<'input> {
     /// Opcode for the ChangeCursorByName request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2568,7 +2540,6 @@ impl ExpandRegionRequest {
     /// Opcode for the ExpandRegion request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2636,7 +2607,6 @@ impl HideCursorRequest {
     /// Opcode for the HideCursor request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2682,7 +2652,6 @@ impl ShowCursorRequest {
     /// Opcode for the ShowCursor request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2806,7 +2775,6 @@ impl<'input> CreatePointerBarrierRequest<'input> {
     /// Opcode for the CreatePointerBarrier request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2893,7 +2861,6 @@ impl DeletePointerBarrierRequest {
     /// Opcode for the DeletePointerBarrier request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -45,7 +44,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -337,7 +336,7 @@ impl ChangeSaveSetRequest {
     /// Opcode for the ChangeSaveSet request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -612,7 +611,7 @@ impl SelectSelectionInputRequest {
     /// Opcode for the SelectSelectionInput request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -875,7 +874,7 @@ impl SelectCursorInputRequest {
     /// Opcode for the SelectCursorInput request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -926,7 +925,7 @@ impl GetCursorImageRequest {
     /// Opcode for the GetCursorImage request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1137,7 +1136,7 @@ impl<'input> CreateRegionRequest<'input> {
     /// Opcode for the CreateRegion request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1163,7 +1162,7 @@ impl<'input> CreateRegionRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rectangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_region<'c, 'input, Conn>(conn: &'c Conn, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1188,7 +1187,7 @@ impl CreateRegionFromBitmapRequest {
     /// Opcode for the CreateRegionFromBitmap request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1241,7 +1240,7 @@ impl CreateRegionFromWindowRequest {
     /// Opcode for the CreateRegionFromWindow request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1299,7 +1298,7 @@ impl CreateRegionFromGCRequest {
     /// Opcode for the CreateRegionFromGC request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1351,7 +1350,7 @@ impl CreateRegionFromPictureRequest {
     /// Opcode for the CreateRegionFromPicture request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1402,7 +1401,7 @@ impl DestroyRegionRequest {
     /// Opcode for the DestroyRegion request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1448,7 +1447,7 @@ impl<'input> SetRegionRequest<'input> {
     /// Opcode for the SetRegion request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1474,7 +1473,7 @@ impl<'input> SetRegionRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rectangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_region<'c, 'input, Conn>(conn: &'c Conn, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1499,7 +1498,7 @@ impl CopyRegionRequest {
     /// Opcode for the CopyRegion request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1552,7 +1551,7 @@ impl UnionRegionRequest {
     /// Opcode for the UnionRegion request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1611,7 +1610,7 @@ impl IntersectRegionRequest {
     /// Opcode for the IntersectRegion request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1670,7 +1669,7 @@ impl SubtractRegionRequest {
     /// Opcode for the SubtractRegion request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1729,7 +1728,7 @@ impl InvertRegionRequest {
     /// Opcode for the InvertRegion request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1792,7 +1791,7 @@ impl TranslateRegionRequest {
     /// Opcode for the TranslateRegion request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1846,7 +1845,7 @@ impl RegionExtentsRequest {
     /// Opcode for the RegionExtents request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1897,7 +1896,7 @@ impl FetchRegionRequest {
     /// Opcode for the FetchRegion request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1988,7 +1987,7 @@ impl SetGCClipRegionRequest {
     /// Opcode for the SetGCClipRegion request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2053,7 +2052,7 @@ impl SetWindowShapeRegionRequest {
     /// Opcode for the SetWindowShapeRegion request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2123,7 +2122,7 @@ impl SetPictureClipRegionRequest {
     /// Opcode for the SetPictureClipRegion request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2185,7 +2184,7 @@ impl<'input> SetCursorNameRequest<'input> {
     /// Opcode for the SetCursorName request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2216,7 +2215,7 @@ impl<'input> SetCursorNameRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_cursor_name<'c, 'input, Conn>(conn: &'c Conn, cursor: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2240,7 +2239,7 @@ impl GetCursorNameRequest {
     /// Opcode for the GetCursorName request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2328,7 +2327,7 @@ impl GetCursorImageAndNameRequest {
     /// Opcode for the GetCursorImageAndName request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2428,7 +2427,7 @@ impl ChangeCursorRequest {
     /// Opcode for the ChangeCursor request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2480,7 +2479,7 @@ impl<'input> ChangeCursorByNameRequest<'input> {
     /// Opcode for the ChangeCursorByName request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2511,7 +2510,7 @@ impl<'input> ChangeCursorByNameRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn change_cursor_by_name<'c, 'input, Conn>(conn: &'c Conn, src: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2540,7 +2539,7 @@ impl ExpandRegionRequest {
     /// Opcode for the ExpandRegion request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2607,7 +2606,7 @@ impl HideCursorRequest {
     /// Opcode for the HideCursor request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2652,7 +2651,7 @@ impl ShowCursorRequest {
     /// Opcode for the ShowCursor request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2775,7 +2774,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
     /// Opcode for the CreatePointerBarrier request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2829,7 +2828,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), devices_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), devices_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_pointer_barrier<'c, 'input, Conn, A>(conn: &'c Conn, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2861,7 +2860,7 @@ impl DeletePointerBarrierRequest {
     /// Opcode for the DeletePointerBarrier request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -81,8 +81,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major_version: client_major_version,
-        client_minor_version: client_minor_version,
+        client_major_version,
+        client_minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -376,10 +376,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeSaveSetRequest {
-        mode: mode,
-        target: target,
-        map: map,
-        window: window,
+        mode,
+        target,
+        map,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -657,9 +657,9 @@ where
 {
     let event_mask: u32 = event_mask.into();
     let request0 = SelectSelectionInputRequest {
-        window: window,
-        selection: selection,
-        event_mask: event_mask,
+        window,
+        selection,
+        event_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -916,8 +916,8 @@ where
 {
     let event_mask: u32 = event_mask.into();
     let request0 = SelectCursorInputRequest {
-        window: window,
-        event_mask: event_mask,
+        window,
+        event_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1177,8 +1177,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRegionRequest {
-        region: region,
-        rectangles: rectangles,
+        region,
+        rectangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1230,8 +1230,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRegionFromBitmapRequest {
-        region: region,
-        bitmap: bitmap,
+        region,
+        bitmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1289,9 +1289,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRegionFromWindowRequest {
-        region: region,
-        window: window,
-        kind: kind,
+        region,
+        window,
+        kind,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1343,8 +1343,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRegionFromGCRequest {
-        region: region,
-        gc: gc,
+        region,
+        gc,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1396,8 +1396,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateRegionFromPictureRequest {
-        region: region,
-        picture: picture,
+        region,
+        picture,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1443,7 +1443,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyRegionRequest {
-        region: region,
+        region,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1494,8 +1494,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetRegionRequest {
-        region: region,
-        rectangles: rectangles,
+        region,
+        rectangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1547,8 +1547,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CopyRegionRequest {
-        source: source,
-        destination: destination,
+        source,
+        destination,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1606,9 +1606,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UnionRegionRequest {
-        source1: source1,
-        source2: source2,
-        destination: destination,
+        source1,
+        source2,
+        destination,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1666,9 +1666,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = IntersectRegionRequest {
-        source1: source1,
-        source2: source2,
-        destination: destination,
+        source1,
+        source2,
+        destination,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1726,9 +1726,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SubtractRegionRequest {
-        source1: source1,
-        source2: source2,
-        destination: destination,
+        source1,
+        source2,
+        destination,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1790,9 +1790,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = InvertRegionRequest {
-        source: source,
-        bounds: bounds,
-        destination: destination,
+        source,
+        bounds,
+        destination,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1846,9 +1846,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = TranslateRegionRequest {
-        region: region,
-        dx: dx,
-        dy: dy,
+        region,
+        dx,
+        dy,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1900,8 +1900,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RegionExtentsRequest {
-        source: source,
-        destination: destination,
+        source,
+        destination,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1947,7 +1947,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FetchRegionRequest {
-        region: region,
+        region,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2052,10 +2052,10 @@ where
 {
     let region: Region = region.into();
     let request0 = SetGCClipRegionRequest {
-        gc: gc,
-        region: region,
-        x_origin: x_origin,
-        y_origin: y_origin,
+        gc,
+        region,
+        x_origin,
+        y_origin,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2123,11 +2123,11 @@ where
 {
     let region: Region = region.into();
     let request0 = SetWindowShapeRegionRequest {
-        dest: dest,
-        dest_kind: dest_kind,
-        x_offset: x_offset,
-        y_offset: y_offset,
-        region: region,
+        dest,
+        dest_kind,
+        x_offset,
+        y_offset,
+        region,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2189,10 +2189,10 @@ where
 {
     let region: Region = region.into();
     let request0 = SetPictureClipRegionRequest {
-        picture: picture,
-        region: region,
-        x_origin: x_origin,
-        y_origin: y_origin,
+        picture,
+        region,
+        x_origin,
+        y_origin,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2248,8 +2248,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetCursorNameRequest {
-        cursor: cursor,
-        name: name,
+        cursor,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2295,7 +2295,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetCursorNameRequest {
-        cursor: cursor,
+        cursor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2490,8 +2490,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeCursorRequest {
-        source: source,
-        destination: destination,
+        source,
+        destination,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2547,8 +2547,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeCursorByNameRequest {
-        src: src,
-        name: name,
+        src,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2616,12 +2616,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ExpandRegionRequest {
-        source: source,
-        destination: destination,
-        left: left,
-        right: right,
-        top: top,
-        bottom: bottom,
+        source,
+        destination,
+        left,
+        right,
+        top,
+        bottom,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2667,7 +2667,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = HideCursorRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2713,7 +2713,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ShowCursorRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2871,14 +2871,14 @@ where
 {
     let directions: u32 = directions.into();
     let request0 = CreatePointerBarrierRequest {
-        barrier: barrier,
-        window: window,
-        x1: x1,
-        y1: y1,
-        x2: x2,
-        y2: y2,
-        directions: directions,
-        devices: devices,
+        barrier,
+        window,
+        x1,
+        y1,
+        x2,
+        y2,
+        directions,
+        devices,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2924,7 +2924,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeletePointerBarrierRequest {
-        barrier: barrier,
+        barrier,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -1029,7 +1029,7 @@ impl TryFrom<u32> for RegionEnum {
 
 /// Opcode for the CreateRegion request
 pub const CREATE_REGION_REQUEST: u8 = 5;
-pub fn create_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_region<'c, 'input, Conn>(conn: &'c Conn, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1220,7 +1220,7 @@ where
 
 /// Opcode for the SetRegion request
 pub const SET_REGION_REQUEST: u8 = 11;
-pub fn set_region<'c, Conn>(conn: &'c Conn, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_region<'c, 'input, Conn>(conn: &'c Conn, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1695,7 +1695,7 @@ where
 
 /// Opcode for the SetCursorName request
 pub const SET_CURSOR_NAME_REQUEST: u8 = 23;
-pub fn set_cursor_name<'c, Conn>(conn: &'c Conn, cursor: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_cursor_name<'c, 'input, Conn>(conn: &'c Conn, cursor: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1918,7 +1918,7 @@ where
 
 /// Opcode for the ChangeCursorByName request
 pub const CHANGE_CURSOR_BY_NAME_REQUEST: u8 = 27;
-pub fn change_cursor_by_name<'c, Conn>(conn: &'c Conn, src: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_cursor_by_name<'c, 'input, Conn>(conn: &'c Conn, src: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2123,7 +2123,7 @@ bitmask_binop!(BarrierDirections, u8);
 
 /// Opcode for the CreatePointerBarrier request
 pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;
-pub fn create_pointer_barrier<'c, Conn, A>(conn: &'c Conn, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &[u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pointer_barrier<'c, 'input, Conn, A>(conn: &'c Conn, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
@@ -2235,7 +2235,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_cursor_image(self)
     }
-    fn xfixes_create_region<'c>(&'c self, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_create_region<'c, 'input>(&'c self, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_region(self, region, rectangles)
     }
@@ -2259,7 +2259,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         destroy_region(self, region)
     }
-    fn xfixes_set_region<'c>(&'c self, region: Region, rectangles: &[xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_set_region<'c, 'input>(&'c self, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_region(self, region, rectangles)
     }
@@ -2313,7 +2313,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         set_picture_clip_region(self, picture, region, x_origin, y_origin)
     }
-    fn xfixes_set_cursor_name<'c>(&'c self, cursor: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_set_cursor_name<'c, 'input>(&'c self, cursor: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_cursor_name(self, cursor, name)
     }
@@ -2329,7 +2329,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         change_cursor(self, source, destination)
     }
-    fn xfixes_change_cursor_by_name<'c>(&'c self, src: xproto::Cursor, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_change_cursor_by_name<'c, 'input>(&'c self, src: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_cursor_by_name(self, src, name)
     }
@@ -2345,7 +2345,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         show_cursor(self, window)
     }
-    fn xfixes_create_pointer_barrier<'c, A>(&'c self, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &[u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xfixes_create_pointer_barrier<'c, 'input, A>(&'c self, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &'input [u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u32>,
     {

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -35,14 +35,14 @@ pub const X11_EXTENSION_NAME: &str = "XFIXES";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (5, 0);
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -55,7 +55,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_version_bytes[0],
@@ -325,6 +325,8 @@ impl TryFrom<u32> for SaveSetMapping {
     }
 }
 
+/// Opcode for the ChangeSaveSet request
+pub const CHANGE_SAVE_SET_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeSaveSetRequest {
     pub mode: SaveSetMode,
@@ -333,8 +335,6 @@ pub struct ChangeSaveSetRequest {
     pub window: xproto::Window,
 }
 impl ChangeSaveSetRequest {
-    /// Opcode for the ChangeSaveSet request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -349,7 +349,7 @@ impl ChangeSaveSetRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_SAVE_SET_REQUEST,
             0,
             0,
             mode_bytes[0],
@@ -601,6 +601,8 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
     }
 }
 
+/// Opcode for the SelectSelectionInput request
+pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectSelectionInputRequest {
     pub window: xproto::Window,
@@ -608,8 +610,6 @@ pub struct SelectSelectionInputRequest {
     pub event_mask: u32,
 }
 impl SelectSelectionInputRequest {
-    /// Opcode for the SelectSelectionInput request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -623,7 +623,7 @@ impl SelectSelectionInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_SELECTION_INPUT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -865,14 +865,14 @@ impl From<CursorNotifyEvent> for [u8; 32] {
     }
 }
 
+/// Opcode for the SelectCursorInput request
+pub const SELECT_CURSOR_INPUT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectCursorInputRequest {
     pub window: xproto::Window,
     pub event_mask: u32,
 }
 impl SelectCursorInputRequest {
-    /// Opcode for the SelectCursorInput request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -885,7 +885,7 @@ impl SelectCursorInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_CURSOR_INPUT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -919,11 +919,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetCursorImage request
+pub const GET_CURSOR_IMAGE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCursorImageRequest;
 impl GetCursorImageRequest {
-    /// Opcode for the GetCursorImage request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -934,7 +934,7 @@ impl GetCursorImageRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CURSOR_IMAGE_REQUEST,
             0,
             0,
         ];
@@ -1127,14 +1127,14 @@ impl TryFrom<u32> for RegionEnum {
     }
 }
 
+/// Opcode for the CreateRegion request
+pub const CREATE_REGION_REQUEST: u8 = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateRegionRequest<'input> {
     pub region: Region,
     pub rectangles: &'input [xproto::Rectangle],
 }
 impl<'input> CreateRegionRequest<'input> {
-    /// Opcode for the CreateRegion request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1146,7 +1146,7 @@ impl<'input> CreateRegionRequest<'input> {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_REGION_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1178,14 +1178,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateRegionFromBitmap request
+pub const CREATE_REGION_FROM_BITMAP_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateRegionFromBitmapRequest {
     pub region: Region,
     pub bitmap: xproto::Pixmap,
 }
 impl CreateRegionFromBitmapRequest {
-    /// Opcode for the CreateRegionFromBitmap request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1198,7 +1198,7 @@ impl CreateRegionFromBitmapRequest {
         let bitmap_bytes = self.bitmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_REGION_FROM_BITMAP_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1230,6 +1230,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateRegionFromWindow request
+pub const CREATE_REGION_FROM_WINDOW_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateRegionFromWindowRequest {
     pub region: Region,
@@ -1237,8 +1239,6 @@ pub struct CreateRegionFromWindowRequest {
     pub kind: shape::SK,
 }
 impl CreateRegionFromWindowRequest {
-    /// Opcode for the CreateRegionFromWindow request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1252,7 +1252,7 @@ impl CreateRegionFromWindowRequest {
         let kind_bytes = shape::Kind::from(self.kind).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_REGION_FROM_WINDOW_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1289,14 +1289,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateRegionFromGC request
+pub const CREATE_REGION_FROM_GC_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateRegionFromGCRequest {
     pub region: Region,
     pub gc: xproto::Gcontext,
 }
 impl CreateRegionFromGCRequest {
-    /// Opcode for the CreateRegionFromGC request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1309,7 +1309,7 @@ impl CreateRegionFromGCRequest {
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_REGION_FROM_GC_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1341,14 +1341,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateRegionFromPicture request
+pub const CREATE_REGION_FROM_PICTURE_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateRegionFromPictureRequest {
     pub region: Region,
     pub picture: render::Picture,
 }
 impl CreateRegionFromPictureRequest {
-    /// Opcode for the CreateRegionFromPicture request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1361,7 +1361,7 @@ impl CreateRegionFromPictureRequest {
         let picture_bytes = self.picture.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_REGION_FROM_PICTURE_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1393,13 +1393,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroyRegion request
+pub const DESTROY_REGION_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyRegionRequest {
     pub region: Region,
 }
 impl DestroyRegionRequest {
-    /// Opcode for the DestroyRegion request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1411,7 +1411,7 @@ impl DestroyRegionRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_REGION_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1438,14 +1438,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetRegion request
+pub const SET_REGION_REQUEST: u8 = 11;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetRegionRequest<'input> {
     pub region: Region,
     pub rectangles: &'input [xproto::Rectangle],
 }
 impl<'input> SetRegionRequest<'input> {
-    /// Opcode for the SetRegion request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1457,7 +1457,7 @@ impl<'input> SetRegionRequest<'input> {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_REGION_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1489,14 +1489,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CopyRegion request
+pub const COPY_REGION_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CopyRegionRequest {
     pub source: Region,
     pub destination: Region,
 }
 impl CopyRegionRequest {
-    /// Opcode for the CopyRegion request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1509,7 +1509,7 @@ impl CopyRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COPY_REGION_REQUEST,
             0,
             0,
             source_bytes[0],
@@ -1541,6 +1541,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UnionRegion request
+pub const UNION_REGION_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnionRegionRequest {
     pub source1: Region,
@@ -1548,8 +1550,6 @@ pub struct UnionRegionRequest {
     pub destination: Region,
 }
 impl UnionRegionRequest {
-    /// Opcode for the UnionRegion request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1563,7 +1563,7 @@ impl UnionRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNION_REGION_REQUEST,
             0,
             0,
             source1_bytes[0],
@@ -1600,6 +1600,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the IntersectRegion request
+pub const INTERSECT_REGION_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IntersectRegionRequest {
     pub source1: Region,
@@ -1607,8 +1609,6 @@ pub struct IntersectRegionRequest {
     pub destination: Region,
 }
 impl IntersectRegionRequest {
-    /// Opcode for the IntersectRegion request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1622,7 +1622,7 @@ impl IntersectRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            INTERSECT_REGION_REQUEST,
             0,
             0,
             source1_bytes[0],
@@ -1659,6 +1659,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SubtractRegion request
+pub const SUBTRACT_REGION_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SubtractRegionRequest {
     pub source1: Region,
@@ -1666,8 +1668,6 @@ pub struct SubtractRegionRequest {
     pub destination: Region,
 }
 impl SubtractRegionRequest {
-    /// Opcode for the SubtractRegion request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1681,7 +1681,7 @@ impl SubtractRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SUBTRACT_REGION_REQUEST,
             0,
             0,
             source1_bytes[0],
@@ -1718,6 +1718,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the InvertRegion request
+pub const INVERT_REGION_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InvertRegionRequest {
     pub source: Region,
@@ -1725,8 +1727,6 @@ pub struct InvertRegionRequest {
     pub destination: Region,
 }
 impl InvertRegionRequest {
-    /// Opcode for the InvertRegion request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1740,7 +1740,7 @@ impl InvertRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            INVERT_REGION_REQUEST,
             0,
             0,
             source_bytes[0],
@@ -1781,6 +1781,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the TranslateRegion request
+pub const TRANSLATE_REGION_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TranslateRegionRequest {
     pub region: Region,
@@ -1788,8 +1790,6 @@ pub struct TranslateRegionRequest {
     pub dy: i16,
 }
 impl TranslateRegionRequest {
-    /// Opcode for the TranslateRegion request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1803,7 +1803,7 @@ impl TranslateRegionRequest {
         let dy_bytes = self.dy.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            TRANSLATE_REGION_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1836,14 +1836,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the RegionExtents request
+pub const REGION_EXTENTS_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RegionExtentsRequest {
     pub source: Region,
     pub destination: Region,
 }
 impl RegionExtentsRequest {
-    /// Opcode for the RegionExtents request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1856,7 +1856,7 @@ impl RegionExtentsRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            REGION_EXTENTS_REQUEST,
             0,
             0,
             source_bytes[0],
@@ -1888,13 +1888,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FetchRegion request
+pub const FETCH_REGION_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FetchRegionRequest {
     pub region: Region,
 }
 impl FetchRegionRequest {
-    /// Opcode for the FetchRegion request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1906,7 +1906,7 @@ impl FetchRegionRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FETCH_REGION_REQUEST,
             0,
             0,
             region_bytes[0],
@@ -1976,6 +1976,8 @@ impl FetchRegionReply {
     }
 }
 
+/// Opcode for the SetGCClipRegion request
+pub const SET_GC_CLIP_REGION_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetGCClipRegionRequest {
     pub gc: xproto::Gcontext,
@@ -1984,8 +1986,6 @@ pub struct SetGCClipRegionRequest {
     pub y_origin: i16,
 }
 impl SetGCClipRegionRequest {
-    /// Opcode for the SetGCClipRegion request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2000,7 +2000,7 @@ impl SetGCClipRegionRequest {
         let y_origin_bytes = self.y_origin.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_GC_CLIP_REGION_REQUEST,
             0,
             0,
             gc_bytes[0],
@@ -2040,6 +2040,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetWindowShapeRegion request
+pub const SET_WINDOW_SHAPE_REGION_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetWindowShapeRegionRequest {
     pub dest: xproto::Window,
@@ -2049,8 +2051,6 @@ pub struct SetWindowShapeRegionRequest {
     pub region: Region,
 }
 impl SetWindowShapeRegionRequest {
-    /// Opcode for the SetWindowShapeRegion request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2066,7 +2066,7 @@ impl SetWindowShapeRegionRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_WINDOW_SHAPE_REGION_REQUEST,
             0,
             0,
             dest_bytes[0],
@@ -2111,6 +2111,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetPictureClipRegion request
+pub const SET_PICTURE_CLIP_REGION_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetPictureClipRegionRequest {
     pub picture: render::Picture,
@@ -2119,8 +2121,6 @@ pub struct SetPictureClipRegionRequest {
     pub y_origin: i16,
 }
 impl SetPictureClipRegionRequest {
-    /// Opcode for the SetPictureClipRegion request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2135,7 +2135,7 @@ impl SetPictureClipRegionRequest {
         let y_origin_bytes = self.y_origin.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PICTURE_CLIP_REGION_REQUEST,
             0,
             0,
             picture_bytes[0],
@@ -2175,14 +2175,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetCursorName request
+pub const SET_CURSOR_NAME_REQUEST: u8 = 23;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetCursorNameRequest<'input> {
     pub cursor: xproto::Cursor,
     pub name: &'input [u8],
 }
 impl<'input> SetCursorNameRequest<'input> {
-    /// Opcode for the SetCursorName request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2196,7 +2196,7 @@ impl<'input> SetCursorNameRequest<'input> {
         let nbytes_bytes = nbytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CURSOR_NAME_REQUEST,
             0,
             0,
             cursor_bytes[0],
@@ -2231,13 +2231,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetCursorName request
+pub const GET_CURSOR_NAME_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCursorNameRequest {
     pub cursor: xproto::Cursor,
 }
 impl GetCursorNameRequest {
-    /// Opcode for the GetCursorName request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2249,7 +2249,7 @@ impl GetCursorNameRequest {
         let cursor_bytes = self.cursor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CURSOR_NAME_REQUEST,
             0,
             0,
             cursor_bytes[0],
@@ -2321,11 +2321,11 @@ impl GetCursorNameReply {
     }
 }
 
+/// Opcode for the GetCursorImageAndName request
+pub const GET_CURSOR_IMAGE_AND_NAME_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCursorImageAndNameRequest;
 impl GetCursorImageAndNameRequest {
-    /// Opcode for the GetCursorImageAndName request
-    pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2336,7 +2336,7 @@ impl GetCursorImageAndNameRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CURSOR_IMAGE_AND_NAME_REQUEST,
             0,
             0,
         ];
@@ -2418,14 +2418,14 @@ impl GetCursorImageAndNameReply {
     }
 }
 
+/// Opcode for the ChangeCursor request
+pub const CHANGE_CURSOR_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeCursorRequest {
     pub source: xproto::Cursor,
     pub destination: xproto::Cursor,
 }
 impl ChangeCursorRequest {
-    /// Opcode for the ChangeCursor request
-    pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2438,7 +2438,7 @@ impl ChangeCursorRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_CURSOR_REQUEST,
             0,
             0,
             source_bytes[0],
@@ -2470,14 +2470,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ChangeCursorByName request
+pub const CHANGE_CURSOR_BY_NAME_REQUEST: u8 = 27;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeCursorByNameRequest<'input> {
     pub src: xproto::Cursor,
     pub name: &'input [u8],
 }
 impl<'input> ChangeCursorByNameRequest<'input> {
-    /// Opcode for the ChangeCursorByName request
-    pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2491,7 +2491,7 @@ impl<'input> ChangeCursorByNameRequest<'input> {
         let nbytes_bytes = nbytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_CURSOR_BY_NAME_REQUEST,
             0,
             0,
             src_bytes[0],
@@ -2526,6 +2526,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ExpandRegion request
+pub const EXPAND_REGION_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExpandRegionRequest {
     pub source: Region,
@@ -2536,8 +2538,6 @@ pub struct ExpandRegionRequest {
     pub bottom: u16,
 }
 impl ExpandRegionRequest {
-    /// Opcode for the ExpandRegion request
-    pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2554,7 +2554,7 @@ impl ExpandRegionRequest {
         let bottom_bytes = self.bottom.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            EXPAND_REGION_REQUEST,
             0,
             0,
             source_bytes[0],
@@ -2598,13 +2598,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the HideCursor request
+pub const HIDE_CURSOR_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HideCursorRequest {
     pub window: xproto::Window,
 }
 impl HideCursorRequest {
-    /// Opcode for the HideCursor request
-    pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2616,7 +2616,7 @@ impl HideCursorRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            HIDE_CURSOR_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -2643,13 +2643,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ShowCursor request
+pub const SHOW_CURSOR_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ShowCursorRequest {
     pub window: xproto::Window,
 }
 impl ShowCursorRequest {
-    /// Opcode for the ShowCursor request
-    pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2661,7 +2661,7 @@ impl ShowCursorRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SHOW_CURSOR_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -2759,6 +2759,8 @@ impl TryFrom<u32> for BarrierDirections {
 }
 bitmask_binop!(BarrierDirections, u8);
 
+/// Opcode for the CreatePointerBarrier request
+pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreatePointerBarrierRequest<'input> {
     pub barrier: Barrier,
@@ -2771,8 +2773,6 @@ pub struct CreatePointerBarrierRequest<'input> {
     pub devices: &'input [u16],
 }
 impl<'input> CreatePointerBarrierRequest<'input> {
-    /// Opcode for the CreatePointerBarrier request
-    pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2792,7 +2792,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         let num_devices_bytes = num_devices.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_POINTER_BARRIER_REQUEST,
             0,
             0,
             barrier_bytes[0],
@@ -2852,13 +2852,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeletePointerBarrier request
+pub const DELETE_POINTER_BARRIER_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeletePointerBarrierRequest {
     pub barrier: Barrier,
 }
 impl DeletePointerBarrierRequest {
-    /// Opcode for the DeletePointerBarrier request
-    pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2870,7 +2870,7 @@ impl DeletePointerBarrierRequest {
         let barrier_bytes = self.barrier.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_POINTER_BARRIER_REQUEST,
             0,
             0,
             barrier_bytes[0],

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -57,7 +57,7 @@ impl QueryVersionRequest {
         let client_minor_version_bytes = self.client_minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_version_bytes[0],
@@ -352,7 +352,7 @@ impl ChangeSaveSetRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeSaveSetRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             mode_bytes[0],
@@ -627,7 +627,7 @@ impl SelectSelectionInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectSelectionInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -890,7 +890,7 @@ impl SelectCursorInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectCursorInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -940,7 +940,7 @@ impl GetCursorImageRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCursorImageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1153,7 +1153,7 @@ impl<'input> CreateRegionRequest<'input> {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1206,7 +1206,7 @@ impl CreateRegionFromBitmapRequest {
         let bitmap_bytes = self.bitmap.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRegionFromBitmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1261,7 +1261,7 @@ impl CreateRegionFromWindowRequest {
         let kind_bytes = shape::Kind::from(self.kind).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRegionFromWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1319,7 +1319,7 @@ impl CreateRegionFromGCRequest {
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRegionFromGCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1372,7 +1372,7 @@ impl CreateRegionFromPictureRequest {
         let picture_bytes = self.picture.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateRegionFromPictureRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1423,7 +1423,7 @@ impl DestroyRegionRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1470,7 +1470,7 @@ impl<'input> SetRegionRequest<'input> {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1523,7 +1523,7 @@ impl CopyRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CopyRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source_bytes[0],
@@ -1578,7 +1578,7 @@ impl UnionRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UnionRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source1_bytes[0],
@@ -1638,7 +1638,7 @@ impl IntersectRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            IntersectRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source1_bytes[0],
@@ -1698,7 +1698,7 @@ impl SubtractRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SubtractRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source1_bytes[0],
@@ -1758,7 +1758,7 @@ impl InvertRegionRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            InvertRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source_bytes[0],
@@ -1822,7 +1822,7 @@ impl TranslateRegionRequest {
         let dy_bytes = self.dy.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            TranslateRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -1876,7 +1876,7 @@ impl RegionExtentsRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            RegionExtentsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source_bytes[0],
@@ -1927,7 +1927,7 @@ impl FetchRegionRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FetchRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             region_bytes[0],
@@ -2022,7 +2022,7 @@ impl SetGCClipRegionRequest {
         let y_origin_bytes = self.y_origin.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetGCClipRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             gc_bytes[0],
@@ -2089,7 +2089,7 @@ impl SetWindowShapeRegionRequest {
         let region_bytes = self.region.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetWindowShapeRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             dest_bytes[0],
@@ -2159,7 +2159,7 @@ impl SetPictureClipRegionRequest {
         let y_origin_bytes = self.y_origin.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPictureClipRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             picture_bytes[0],
@@ -2221,7 +2221,7 @@ impl<'input> SetCursorNameRequest<'input> {
         let nbytes_bytes = nbytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetCursorNameRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cursor_bytes[0],
@@ -2275,7 +2275,7 @@ impl GetCursorNameRequest {
         let cursor_bytes = self.cursor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCursorNameRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cursor_bytes[0],
@@ -2363,7 +2363,7 @@ impl GetCursorImageAndNameRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCursorImageAndNameRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -2466,7 +2466,7 @@ impl ChangeCursorRequest {
         let destination_bytes = self.destination.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source_bytes[0],
@@ -2520,7 +2520,7 @@ impl<'input> ChangeCursorByNameRequest<'input> {
         let nbytes_bytes = nbytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeCursorByNameRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             src_bytes[0],
@@ -2584,7 +2584,7 @@ impl ExpandRegionRequest {
         let bottom_bytes = self.bottom.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ExpandRegionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             source_bytes[0],
@@ -2647,7 +2647,7 @@ impl HideCursorRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            HideCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -2693,7 +2693,7 @@ impl ShowCursorRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ShowCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -2825,7 +2825,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         let num_devices_bytes = num_devices.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreatePointerBarrierRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             barrier_bytes[0],
@@ -2904,7 +2904,7 @@ impl DeletePointerBarrierRequest {
         let barrier_bytes = self.barrier.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeletePointerBarrierRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             barrier_bytes[0],

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -125,8 +125,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        major: major,
-        minor: minor,
+        major,
+        minor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -199,7 +199,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetStateRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -271,7 +271,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetScreenCountRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -349,8 +349,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetScreenSizeRequest {
-        window: window,
-        screen: screen,
+        window,
+        screen,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -93,7 +92,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -167,7 +166,7 @@ impl GetStateRequest {
     /// Opcode for the GetState request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -238,7 +237,7 @@ impl GetScreenCountRequest {
     /// Opcode for the GetScreenCount request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -310,7 +309,7 @@ impl GetScreenSizeRequest {
     /// Opcode for the GetScreenSize request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -390,7 +389,7 @@ impl IsActiveRequest {
     /// Opcode for the IsActive request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -451,7 +450,7 @@ impl QueryScreensRequest {
     /// Opcode for the QueryScreens request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -93,7 +93,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -168,7 +167,6 @@ impl GetStateRequest {
     /// Opcode for the GetState request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -240,7 +238,6 @@ impl GetScreenCountRequest {
     /// Opcode for the GetScreenCount request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -313,7 +310,6 @@ impl GetScreenSizeRequest {
     /// Opcode for the GetScreenSize request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -394,7 +390,6 @@ impl IsActiveRequest {
     /// Opcode for the IsActive request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -456,7 +451,6 @@ impl QueryScreensRequest {
     /// Opcode for the QueryScreens request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -105,7 +105,7 @@ impl QueryVersionRequest {
         let minor_bytes = self.minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_bytes[0],
@@ -179,7 +179,7 @@ impl GetStateRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetStateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -251,7 +251,7 @@ impl GetScreenCountRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetScreenCountRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -325,7 +325,7 @@ impl GetScreenSizeRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetScreenSizeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -404,7 +404,7 @@ impl IsActiveRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            IsActiveRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -466,7 +466,7 @@ impl QueryScreensRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryScreensRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -83,32 +84,53 @@ impl Serialize for ScreenInfo {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest {
+    pub major: u8,
+    pub minor: u8,
+}
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let major_bytes = self.major.serialize();
+        let minor_bytes = self.minor.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+            major_bytes[0],
+            minor_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn, major: u8, minor: u8) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let major_bytes = major.serialize();
-    let minor_bytes = minor.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-        major_bytes[0],
-        minor_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest {
+        major: major,
+        minor: minor,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,31 +160,50 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the GetState request
-pub const GET_STATE_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetStateRequest {
+    pub window: xproto::Window,
+}
+impl GetStateRequest {
+    /// Opcode for the GetState request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetStateRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_state<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_STATE_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetStateRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -191,31 +232,50 @@ impl TryFrom<&[u8]> for GetStateReply {
     }
 }
 
-/// Opcode for the GetScreenCount request
-pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetScreenCountRequest {
+    pub window: xproto::Window,
+}
+impl GetScreenCountRequest {
+    /// Opcode for the GetScreenCount request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetScreenCountRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_screen_count<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenCountReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_SCREEN_COUNT_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetScreenCountRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -244,36 +304,57 @@ impl TryFrom<&[u8]> for GetScreenCountReply {
     }
 }
 
-/// Opcode for the GetScreenSize request
-pub const GET_SCREEN_SIZE_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetScreenSizeRequest {
+    pub window: xproto::Window,
+    pub screen: u32,
+}
+impl GetScreenSizeRequest {
+    /// Opcode for the GetScreenSize request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let screen_bytes = self.screen.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetScreenSizeRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            screen_bytes[0],
+            screen_bytes[1],
+            screen_bytes[2],
+            screen_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_screen_size<Conn>(conn: &Conn, window: xproto::Window, screen: u32) -> Result<Cookie<'_, Conn, GetScreenSizeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let screen_bytes = screen.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_SCREEN_SIZE_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        screen_bytes[0],
-        screen_bytes[1],
-        screen_bytes[2],
-        screen_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetScreenSizeRequest {
+        window: window,
+        screen: screen,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -307,26 +388,41 @@ impl TryFrom<&[u8]> for GetScreenSizeReply {
     }
 }
 
-/// Opcode for the IsActive request
-pub const IS_ACTIVE_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IsActiveRequest;
+impl IsActiveRequest {
+    /// Opcode for the IsActive request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            IsActiveRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn is_active<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, IsActiveReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        IS_ACTIVE_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = IsActiveRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -354,26 +450,41 @@ impl TryFrom<&[u8]> for IsActiveReply {
     }
 }
 
-/// Opcode for the QueryScreens request
-pub const QUERY_SCREENS_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryScreensRequest;
+impl QueryScreensRequest {
+    /// Opcode for the QueryScreens request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryScreensRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_screens<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryScreensReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_SCREENS_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryScreensRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -83,14 +83,14 @@ impl Serialize for ScreenInfo {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub major: u8,
     pub minor: u8,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -103,7 +103,7 @@ impl QueryVersionRequest {
         let minor_bytes = self.minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             major_bytes[0],
@@ -158,13 +158,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the GetState request
+pub const GET_STATE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetStateRequest {
     pub window: xproto::Window,
 }
 impl GetStateRequest {
-    /// Opcode for the GetState request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -176,7 +176,7 @@ impl GetStateRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_STATE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -229,13 +229,13 @@ impl TryFrom<&[u8]> for GetStateReply {
     }
 }
 
+/// Opcode for the GetScreenCount request
+pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetScreenCountRequest {
     pub window: xproto::Window,
 }
 impl GetScreenCountRequest {
-    /// Opcode for the GetScreenCount request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -247,7 +247,7 @@ impl GetScreenCountRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SCREEN_COUNT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -300,14 +300,14 @@ impl TryFrom<&[u8]> for GetScreenCountReply {
     }
 }
 
+/// Opcode for the GetScreenSize request
+pub const GET_SCREEN_SIZE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetScreenSizeRequest {
     pub window: xproto::Window,
     pub screen: u32,
 }
 impl GetScreenSizeRequest {
-    /// Opcode for the GetScreenSize request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -320,7 +320,7 @@ impl GetScreenSizeRequest {
         let screen_bytes = self.screen.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SCREEN_SIZE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -383,11 +383,11 @@ impl TryFrom<&[u8]> for GetScreenSizeReply {
     }
 }
 
+/// Opcode for the IsActive request
+pub const IS_ACTIVE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IsActiveRequest;
 impl IsActiveRequest {
-    /// Opcode for the IsActive request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -398,7 +398,7 @@ impl IsActiveRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            IS_ACTIVE_REQUEST,
             0,
             0,
         ];
@@ -444,11 +444,11 @@ impl TryFrom<&[u8]> for IsActiveReply {
     }
 }
 
+/// Opcode for the QueryScreens request
+pub const QUERY_SCREENS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryScreensRequest;
 impl QueryScreensRequest {
-    /// Opcode for the QueryScreens request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -459,7 +459,7 @@ impl QueryScreensRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_SCREENS_REQUEST,
             0,
             0,
         ];

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -84,35 +85,54 @@ impl Serialize for Fp3232 {
     }
 }
 
-/// Opcode for the GetExtensionVersion request
-pub const GET_EXTENSION_VERSION_REQUEST: u8 = 1;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetExtensionVersionRequest<'input> {
+    pub name: &'input [u8],
+}
+impl<'input> GetExtensionVersionRequest<'input> {
+    /// Opcode for the GetExtensionVersion request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        let name_len_bytes = name_len.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetExtensionVersionRequest::opcode(),
+            0,
+            0,
+            name_len_bytes[0],
+            name_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn get_extension_version<'c, 'input, Conn>(conn: &'c Conn, name: &'input [u8]) -> Result<Cookie<'c, Conn, GetExtensionVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let name_len = u16::try_from(name.len()).expect("`name` has too many elements");
-    let name_len_bytes = name_len.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_EXTENSION_VERSION_REQUEST,
-        0,
-        0,
-        name_len_bytes[0],
-        name_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = GetExtensionVersionRequest {
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -924,26 +944,41 @@ impl DeviceName {
     }
 }
 
-/// Opcode for the ListInputDevices request
-pub const LIST_INPUT_DEVICES_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListInputDevicesRequest;
+impl ListInputDevicesRequest {
+    /// Opcode for the ListInputDevices request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListInputDevicesRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_input_devices<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListInputDevicesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_INPUT_DEVICES_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListInputDevicesRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1037,31 +1072,50 @@ impl Serialize for InputClassInfo {
     }
 }
 
-/// Opcode for the OpenDevice request
-pub const OPEN_DEVICE_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenDeviceRequest {
+    pub device_id: u8,
+}
+impl OpenDeviceRequest {
+    /// Opcode for the OpenDevice request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            OpenDeviceRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn open_device<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, OpenDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        OPEN_DEVICE_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = OpenDeviceRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1112,59 +1166,99 @@ impl OpenDeviceReply {
     }
 }
 
-/// Opcode for the CloseDevice request
-pub const CLOSE_DEVICE_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CloseDeviceRequest {
+    pub device_id: u8,
+}
+impl CloseDeviceRequest {
+    /// Opcode for the CloseDevice request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CloseDeviceRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn close_device<Conn>(conn: &Conn, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CLOSE_DEVICE_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CloseDeviceRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetDeviceMode request
-pub const SET_DEVICE_MODE_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetDeviceModeRequest {
+    pub device_id: u8,
+    pub mode: ValuatorMode,
+}
+impl SetDeviceModeRequest {
+    /// Opcode for the SetDeviceMode request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetDeviceModeRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            mode_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_device_mode<Conn>(conn: &Conn, device_id: u8, mode: ValuatorMode) -> Result<Cookie<'_, Conn, SetDeviceModeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mode_bytes = u8::from(mode).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_DEVICE_MODE_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        mode_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetDeviceModeRequest {
+        device_id: device_id,
+        mode: mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1195,68 +1289,108 @@ impl TryFrom<&[u8]> for SetDeviceModeReply {
     }
 }
 
-/// Opcode for the SelectExtensionEvent request
-pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectExtensionEventRequest<'input> {
+    pub window: xproto::Window,
+    pub classes: &'input [EventClass],
+}
+impl<'input> SelectExtensionEventRequest<'input> {
+    /// Opcode for the SelectExtensionEvent request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
+        let num_classes_bytes = num_classes.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SelectExtensionEventRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            num_classes_bytes[0],
+            num_classes_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let classes_bytes = self.classes.serialize();
+        let length_so_far = length_so_far + classes_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn select_extension_event<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let num_classes = u16::try_from(classes.len()).expect("`classes` has too many elements");
-    let num_classes_bytes = num_classes.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SELECT_EXTENSION_EVENT_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        num_classes_bytes[0],
-        num_classes_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let classes_bytes = classes.serialize();
-    let length_so_far = length_so_far + classes_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&classes_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SelectExtensionEventRequest {
+        window: window,
+        classes: classes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetSelectedExtensionEvents request
-pub const GET_SELECTED_EXTENSION_EVENTS_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetSelectedExtensionEventsRequest {
+    pub window: xproto::Window,
+}
+impl GetSelectedExtensionEventsRequest {
+    /// Opcode for the GetSelectedExtensionEvents request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetSelectedExtensionEventsRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_selected_extension_events<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetSelectedExtensionEventsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_SELECTED_EXTENSION_EVENTS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetSelectedExtensionEventsRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1388,69 +1522,111 @@ impl TryFrom<u32> for PropagateMode {
     }
 }
 
-/// Opcode for the ChangeDeviceDontPropagateList request
-pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeDeviceDontPropagateListRequest<'input> {
+    pub window: xproto::Window,
+    pub mode: PropagateMode,
+    pub classes: &'input [EventClass],
+}
+impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
+    /// Opcode for the ChangeDeviceDontPropagateList request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
+        let num_classes_bytes = num_classes.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeDeviceDontPropagateListRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            num_classes_bytes[0],
+            num_classes_bytes[1],
+            mode_bytes[0],
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let classes_bytes = self.classes.serialize();
+        let length_so_far = length_so_far + classes_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_device_dont_propagate_list<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode: PropagateMode, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let num_classes = u16::try_from(classes.len()).expect("`classes` has too many elements");
-    let num_classes_bytes = num_classes.serialize();
-    let mode_bytes = u8::from(mode).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        num_classes_bytes[0],
-        num_classes_bytes[1],
-        mode_bytes[0],
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let classes_bytes = classes.serialize();
-    let length_so_far = length_so_far + classes_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&classes_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeDeviceDontPropagateListRequest {
+        window: window,
+        mode: mode,
+        classes: classes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetDeviceDontPropagateList request
-pub const GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 9;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceDontPropagateListRequest {
+    pub window: xproto::Window,
+}
+impl GetDeviceDontPropagateListRequest {
+    /// Opcode for the GetDeviceDontPropagateList request
+    pub const fn opcode() -> u8 { 9 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceDontPropagateListRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_dont_propagate_list<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetDeviceDontPropagateListReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceDontPropagateListRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1524,43 +1700,66 @@ impl DeviceTimeCoord {
     }
 }
 
-/// Opcode for the GetDeviceMotionEvents request
-pub const GET_DEVICE_MOTION_EVENTS_REQUEST: u8 = 10;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceMotionEventsRequest {
+    pub start: xproto::Timestamp,
+    pub stop: xproto::Timestamp,
+    pub device_id: u8,
+}
+impl GetDeviceMotionEventsRequest {
+    /// Opcode for the GetDeviceMotionEvents request
+    pub const fn opcode() -> u8 { 10 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let start_bytes = self.start.serialize();
+        let stop_bytes = self.stop.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceMotionEventsRequest::opcode(),
+            0,
+            0,
+            start_bytes[0],
+            start_bytes[1],
+            start_bytes[2],
+            start_bytes[3],
+            stop_bytes[0],
+            stop_bytes[1],
+            stop_bytes[2],
+            stop_bytes[3],
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_motion_events<Conn, A>(conn: &Conn, start: xproto::Timestamp, stop: A, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceMotionEventsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let stop: xproto::Timestamp = stop.into();
-    let length_so_far = 0;
-    let start_bytes = start.serialize();
-    let stop_bytes = stop.serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_MOTION_EVENTS_REQUEST,
-        0,
-        0,
-        start_bytes[0],
-        start_bytes[1],
-        start_bytes[2],
-        start_bytes[3],
-        stop_bytes[0],
-        stop_bytes[1],
-        stop_bytes[2],
-        stop_bytes[3],
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceMotionEventsRequest {
+        start: start,
+        stop: stop,
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1618,31 +1817,50 @@ impl GetDeviceMotionEventsReply {
     }
 }
 
-/// Opcode for the ChangeKeyboardDevice request
-pub const CHANGE_KEYBOARD_DEVICE_REQUEST: u8 = 11;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeKeyboardDeviceRequest {
+    pub device_id: u8,
+}
+impl ChangeKeyboardDeviceRequest {
+    /// Opcode for the ChangeKeyboardDevice request
+    pub const fn opcode() -> u8 { 11 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeKeyboardDeviceRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn change_keyboard_device<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, ChangeKeyboardDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_KEYBOARD_DEVICE_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ChangeKeyboardDeviceRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1673,33 +1891,56 @@ impl TryFrom<&[u8]> for ChangeKeyboardDeviceReply {
     }
 }
 
-/// Opcode for the ChangePointerDevice request
-pub const CHANGE_POINTER_DEVICE_REQUEST: u8 = 12;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangePointerDeviceRequest {
+    pub x_axis: u8,
+    pub y_axis: u8,
+    pub device_id: u8,
+}
+impl ChangePointerDeviceRequest {
+    /// Opcode for the ChangePointerDevice request
+    pub const fn opcode() -> u8 { 12 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let x_axis_bytes = self.x_axis.serialize();
+        let y_axis_bytes = self.y_axis.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangePointerDeviceRequest::opcode(),
+            0,
+            0,
+            x_axis_bytes[0],
+            y_axis_bytes[0],
+            device_id_bytes[0],
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn change_pointer_device<Conn>(conn: &Conn, x_axis: u8, y_axis: u8, device_id: u8) -> Result<Cookie<'_, Conn, ChangePointerDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let x_axis_bytes = x_axis.serialize();
-    let y_axis_bytes = y_axis.serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_POINTER_DEVICE_REQUEST,
-        0,
-        0,
-        x_axis_bytes[0],
-        y_axis_bytes[0],
-        device_id_bytes[0],
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ChangePointerDeviceRequest {
+        x_axis: x_axis,
+        y_axis: y_axis,
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1730,56 +1971,87 @@ impl TryFrom<&[u8]> for ChangePointerDeviceReply {
     }
 }
 
-/// Opcode for the GrabDevice request
-pub const GRAB_DEVICE_REQUEST: u8 = 13;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrabDeviceRequest<'input> {
+    pub grab_window: xproto::Window,
+    pub time: xproto::Timestamp,
+    pub this_device_mode: xproto::GrabMode,
+    pub other_device_mode: xproto::GrabMode,
+    pub owner_events: bool,
+    pub device_id: u8,
+    pub classes: &'input [EventClass],
+}
+impl<'input> GrabDeviceRequest<'input> {
+    /// Opcode for the GrabDevice request
+    pub const fn opcode() -> u8 { 13 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let grab_window_bytes = self.grab_window.serialize();
+        let time_bytes = self.time.serialize();
+        let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
+        let num_classes_bytes = num_classes.serialize();
+        let this_device_mode_bytes = u8::from(self.this_device_mode).serialize();
+        let other_device_mode_bytes = u8::from(self.other_device_mode).serialize();
+        let owner_events_bytes = self.owner_events.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GrabDeviceRequest::opcode(),
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            num_classes_bytes[0],
+            num_classes_bytes[1],
+            this_device_mode_bytes[0],
+            other_device_mode_bytes[0],
+            owner_events_bytes[0],
+            device_id_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let classes_bytes = self.classes.serialize();
+        let length_so_far = length_so_far + classes_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn grab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, time: A, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, device_id: u8, classes: &'input [EventClass]) -> Result<Cookie<'c, Conn, GrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
-    let length_so_far = 0;
-    let grab_window_bytes = grab_window.serialize();
-    let time_bytes = time.serialize();
-    let num_classes = u16::try_from(classes.len()).expect("`classes` has too many elements");
-    let num_classes_bytes = num_classes.serialize();
-    let this_device_mode_bytes = u8::from(this_device_mode).serialize();
-    let other_device_mode_bytes = u8::from(other_device_mode).serialize();
-    let owner_events_bytes = owner_events.serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GRAB_DEVICE_REQUEST,
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        num_classes_bytes[0],
-        num_classes_bytes[1],
-        this_device_mode_bytes[0],
-        other_device_mode_bytes[0],
-        owner_events_bytes[0],
-        device_id_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let classes_bytes = classes.serialize();
-    let length_so_far = length_so_far + classes_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&classes_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = GrabDeviceRequest {
+        grab_window: grab_window,
+        time: time,
+        this_device_mode: this_device_mode,
+        other_device_mode: other_device_mode,
+        owner_events: owner_events,
+        device_id: device_id,
+        classes: classes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1810,38 +2082,59 @@ impl TryFrom<&[u8]> for GrabDeviceReply {
     }
 }
 
-/// Opcode for the UngrabDevice request
-pub const UNGRAB_DEVICE_REQUEST: u8 = 14;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabDeviceRequest {
+    pub time: xproto::Timestamp,
+    pub device_id: u8,
+}
+impl UngrabDeviceRequest {
+    /// Opcode for the UngrabDevice request
+    pub const fn opcode() -> u8 { 14 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            UngrabDeviceRequest::opcode(),
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn ungrab_device<Conn, A>(conn: &Conn, time: A, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
-    let length_so_far = 0;
-    let time_bytes = time.serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        UNGRAB_DEVICE_REQUEST,
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabDeviceRequest {
+        time: time,
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1903,8 +2196,73 @@ impl TryFrom<u32> for ModifierDevice {
     }
 }
 
-/// Opcode for the GrabDeviceKey request
-pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrabDeviceKeyRequest<'input> {
+    pub grab_window: xproto::Window,
+    pub modifiers: u16,
+    pub modifier_device: u8,
+    pub grabbed_device: u8,
+    pub key: u8,
+    pub this_device_mode: xproto::GrabMode,
+    pub other_device_mode: xproto::GrabMode,
+    pub owner_events: bool,
+    pub classes: &'input [EventClass],
+}
+impl<'input> GrabDeviceKeyRequest<'input> {
+    /// Opcode for the GrabDeviceKey request
+    pub const fn opcode() -> u8 { 15 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let grab_window_bytes = self.grab_window.serialize();
+        let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
+        let num_classes_bytes = num_classes.serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let modifier_device_bytes = self.modifier_device.serialize();
+        let grabbed_device_bytes = self.grabbed_device.serialize();
+        let key_bytes = self.key.serialize();
+        let this_device_mode_bytes = u8::from(self.this_device_mode).serialize();
+        let other_device_mode_bytes = u8::from(self.other_device_mode).serialize();
+        let owner_events_bytes = self.owner_events.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GrabDeviceKeyRequest::opcode(),
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            num_classes_bytes[0],
+            num_classes_bytes[1],
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+            modifier_device_bytes[0],
+            grabbed_device_bytes[0],
+            key_bytes[0],
+            this_device_mode_bytes[0],
+            other_device_mode_bytes[0],
+            owner_events_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let classes_bytes = self.classes.serialize();
+        let length_so_far = length_so_far + classes_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn grab_device_key<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1912,57 +2270,75 @@ where
     B: Into<u8>,
     C: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let modifiers: u16 = modifiers.into();
     let modifier_device: u8 = modifier_device.into();
     let key: u8 = key.into();
-    let length_so_far = 0;
-    let grab_window_bytes = grab_window.serialize();
-    let num_classes = u16::try_from(classes.len()).expect("`classes` has too many elements");
-    let num_classes_bytes = num_classes.serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let modifier_device_bytes = modifier_device.serialize();
-    let grabbed_device_bytes = grabbed_device.serialize();
-    let key_bytes = key.serialize();
-    let this_device_mode_bytes = u8::from(this_device_mode).serialize();
-    let other_device_mode_bytes = u8::from(other_device_mode).serialize();
-    let owner_events_bytes = owner_events.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GRAB_DEVICE_KEY_REQUEST,
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        num_classes_bytes[0],
-        num_classes_bytes[1],
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-        modifier_device_bytes[0],
-        grabbed_device_bytes[0],
-        key_bytes[0],
-        this_device_mode_bytes[0],
-        other_device_mode_bytes[0],
-        owner_events_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let classes_bytes = classes.serialize();
-    let length_so_far = length_so_far + classes_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&classes_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = GrabDeviceKeyRequest {
+        grab_window: grab_window,
+        modifiers: modifiers,
+        modifier_device: modifier_device,
+        grabbed_device: grabbed_device,
+        key: key,
+        this_device_mode: this_device_mode,
+        other_device_mode: other_device_mode,
+        owner_events: owner_events,
+        classes: classes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UngrabDeviceKey request
-pub const UNGRAB_DEVICE_KEY_REQUEST: u8 = 16;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabDeviceKeyRequest {
+    pub grab_window: xproto::Window,
+    pub modifiers: u16,
+    pub modifier_device: u8,
+    pub key: u8,
+    pub grabbed_device: u8,
+}
+impl UngrabDeviceKeyRequest {
+    /// Opcode for the UngrabDeviceKey request
+    pub const fn opcode() -> u8 { 16 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let grab_window_bytes = self.grab_window.serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let modifier_device_bytes = self.modifier_device.serialize();
+        let key_bytes = self.key.serialize();
+        let grabbed_device_bytes = self.grabbed_device.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            UngrabDeviceKeyRequest::opcode(),
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+            modifier_device_bytes[0],
+            key_bytes[0],
+            grabbed_device_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn ungrab_device_key<Conn, A, B, C>(conn: &Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, key: C, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1970,44 +2346,88 @@ where
     B: Into<u8>,
     C: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let modifiers: u16 = modifiers.into();
     let modifier_device: u8 = modifier_device.into();
     let key: u8 = key.into();
-    let length_so_far = 0;
-    let grab_window_bytes = grab_window.serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let modifier_device_bytes = modifier_device.serialize();
-    let key_bytes = key.serialize();
-    let grabbed_device_bytes = grabbed_device.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        UNGRAB_DEVICE_KEY_REQUEST,
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-        modifier_device_bytes[0],
-        key_bytes[0],
-        grabbed_device_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabDeviceKeyRequest {
+        grab_window: grab_window,
+        modifiers: modifiers,
+        modifier_device: modifier_device,
+        key: key,
+        grabbed_device: grabbed_device,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GrabDeviceButton request
-pub const GRAB_DEVICE_BUTTON_REQUEST: u8 = 17;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrabDeviceButtonRequest<'input> {
+    pub grab_window: xproto::Window,
+    pub grabbed_device: u8,
+    pub modifier_device: u8,
+    pub modifiers: u16,
+    pub this_device_mode: xproto::GrabMode,
+    pub other_device_mode: xproto::GrabMode,
+    pub button: u8,
+    pub owner_events: bool,
+    pub classes: &'input [EventClass],
+}
+impl<'input> GrabDeviceButtonRequest<'input> {
+    /// Opcode for the GrabDeviceButton request
+    pub const fn opcode() -> u8 { 17 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let grab_window_bytes = self.grab_window.serialize();
+        let grabbed_device_bytes = self.grabbed_device.serialize();
+        let modifier_device_bytes = self.modifier_device.serialize();
+        let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
+        let num_classes_bytes = num_classes.serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let this_device_mode_bytes = u8::from(self.this_device_mode).serialize();
+        let other_device_mode_bytes = u8::from(self.other_device_mode).serialize();
+        let button_bytes = self.button.serialize();
+        let owner_events_bytes = self.owner_events.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GrabDeviceButtonRequest::opcode(),
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            grabbed_device_bytes[0],
+            modifier_device_bytes[0],
+            num_classes_bytes[0],
+            num_classes_bytes[1],
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+            this_device_mode_bytes[0],
+            other_device_mode_bytes[0],
+            button_bytes[0],
+            owner_events_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let classes_bytes = self.classes.serialize();
+        let length_so_far = length_so_far + classes_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn grab_device_button<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2015,57 +2435,75 @@ where
     B: Into<u16>,
     C: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let modifier_device: u8 = modifier_device.into();
     let modifiers: u16 = modifiers.into();
     let button: u8 = button.into();
-    let length_so_far = 0;
-    let grab_window_bytes = grab_window.serialize();
-    let grabbed_device_bytes = grabbed_device.serialize();
-    let modifier_device_bytes = modifier_device.serialize();
-    let num_classes = u16::try_from(classes.len()).expect("`classes` has too many elements");
-    let num_classes_bytes = num_classes.serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let this_device_mode_bytes = u8::from(this_device_mode).serialize();
-    let other_device_mode_bytes = u8::from(other_device_mode).serialize();
-    let button_bytes = button.serialize();
-    let owner_events_bytes = owner_events.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GRAB_DEVICE_BUTTON_REQUEST,
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        grabbed_device_bytes[0],
-        modifier_device_bytes[0],
-        num_classes_bytes[0],
-        num_classes_bytes[1],
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-        this_device_mode_bytes[0],
-        other_device_mode_bytes[0],
-        button_bytes[0],
-        owner_events_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let classes_bytes = classes.serialize();
-    let length_so_far = length_so_far + classes_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&classes_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = GrabDeviceButtonRequest {
+        grab_window: grab_window,
+        grabbed_device: grabbed_device,
+        modifier_device: modifier_device,
+        modifiers: modifiers,
+        this_device_mode: this_device_mode,
+        other_device_mode: other_device_mode,
+        button: button,
+        owner_events: owner_events,
+        classes: classes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UngrabDeviceButton request
-pub const UNGRAB_DEVICE_BUTTON_REQUEST: u8 = 18;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabDeviceButtonRequest {
+    pub grab_window: xproto::Window,
+    pub modifiers: u16,
+    pub modifier_device: u8,
+    pub button: u8,
+    pub grabbed_device: u8,
+}
+impl UngrabDeviceButtonRequest {
+    /// Opcode for the UngrabDeviceButton request
+    pub const fn opcode() -> u8 { 18 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let grab_window_bytes = self.grab_window.serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let modifier_device_bytes = self.modifier_device.serialize();
+        let button_bytes = self.button.serialize();
+        let grabbed_device_bytes = self.grabbed_device.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            UngrabDeviceButtonRequest::opcode(),
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+            modifier_device_bytes[0],
+            button_bytes[0],
+            grabbed_device_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn ungrab_device_button<Conn, A, B, C>(conn: &Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, button: C, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2073,40 +2511,19 @@ where
     B: Into<u8>,
     C: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let modifiers: u16 = modifiers.into();
     let modifier_device: u8 = modifier_device.into();
     let button: u8 = button.into();
-    let length_so_far = 0;
-    let grab_window_bytes = grab_window.serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let modifier_device_bytes = modifier_device.serialize();
-    let button_bytes = button.serialize();
-    let grabbed_device_bytes = grabbed_device.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        UNGRAB_DEVICE_BUTTON_REQUEST,
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-        modifier_device_bytes[0],
-        button_bytes[0],
-        grabbed_device_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabDeviceButtonRequest {
+        grab_window: grab_window,
+        modifiers: modifiers,
+        modifier_device: modifier_device,
+        button: button,
+        grabbed_device: grabbed_device,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2183,66 +2600,108 @@ impl TryFrom<u32> for DeviceInputMode {
     }
 }
 
-/// Opcode for the AllowDeviceEvents request
-pub const ALLOW_DEVICE_EVENTS_REQUEST: u8 = 19;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllowDeviceEventsRequest {
+    pub time: xproto::Timestamp,
+    pub mode: DeviceInputMode,
+    pub device_id: u8,
+}
+impl AllowDeviceEventsRequest {
+    /// Opcode for the AllowDeviceEvents request
+    pub const fn opcode() -> u8 { 19 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let time_bytes = self.time.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            AllowDeviceEventsRequest::opcode(),
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            mode_bytes[0],
+            device_id_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn allow_device_events<Conn, A>(conn: &Conn, time: A, mode: DeviceInputMode, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
-    let length_so_far = 0;
-    let time_bytes = time.serialize();
-    let mode_bytes = u8::from(mode).serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        ALLOW_DEVICE_EVENTS_REQUEST,
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        mode_bytes[0],
-        device_id_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = AllowDeviceEventsRequest {
+        time: time,
+        mode: mode,
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetDeviceFocus request
-pub const GET_DEVICE_FOCUS_REQUEST: u8 = 20;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceFocusRequest {
+    pub device_id: u8,
+}
+impl GetDeviceFocusRequest {
+    /// Opcode for the GetDeviceFocus request
+    pub const fn opcode() -> u8 { 20 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceFocusRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_focus<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceFocusReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_FOCUS_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceFocusRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2277,46 +2736,71 @@ impl TryFrom<&[u8]> for GetDeviceFocusReply {
     }
 }
 
-/// Opcode for the SetDeviceFocus request
-pub const SET_DEVICE_FOCUS_REQUEST: u8 = 21;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetDeviceFocusRequest {
+    pub focus: xproto::Window,
+    pub time: xproto::Timestamp,
+    pub revert_to: xproto::InputFocus,
+    pub device_id: u8,
+}
+impl SetDeviceFocusRequest {
+    /// Opcode for the SetDeviceFocus request
+    pub const fn opcode() -> u8 { 21 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let focus_bytes = self.focus.serialize();
+        let time_bytes = self.time.serialize();
+        let revert_to_bytes = u8::from(self.revert_to).serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetDeviceFocusRequest::opcode(),
+            0,
+            0,
+            focus_bytes[0],
+            focus_bytes[1],
+            focus_bytes[2],
+            focus_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            revert_to_bytes[0],
+            device_id_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_device_focus<Conn, A, B>(conn: &Conn, focus: A, time: B, revert_to: xproto::InputFocus, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Window>,
     B: Into<xproto::Timestamp>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let focus: xproto::Window = focus.into();
     let time: xproto::Timestamp = time.into();
-    let length_so_far = 0;
-    let focus_bytes = focus.serialize();
-    let time_bytes = time.serialize();
-    let revert_to_bytes = u8::from(revert_to).serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_DEVICE_FOCUS_REQUEST,
-        0,
-        0,
-        focus_bytes[0],
-        focus_bytes[1],
-        focus_bytes[2],
-        focus_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        revert_to_bytes[0],
-        device_id_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetDeviceFocusRequest {
+        focus: focus,
+        time: time,
+        revert_to: revert_to,
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3340,31 +3824,50 @@ impl Serialize for FeedbackState {
     }
 }
 
-/// Opcode for the GetFeedbackControl request
-pub const GET_FEEDBACK_CONTROL_REQUEST: u8 = 22;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetFeedbackControlRequest {
+    pub device_id: u8,
+}
+impl GetFeedbackControlRequest {
+    /// Opcode for the GetFeedbackControl request
+    pub const fn opcode() -> u8 { 22 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetFeedbackControlRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_feedback_control<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetFeedbackControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_FEEDBACK_CONTROL_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetFeedbackControlRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4317,72 +4820,120 @@ impl From<ChangeFeedbackControlMask> for Option<u32> {
 }
 bitmask_binop!(ChangeFeedbackControlMask, u8);
 
-/// Opcode for the ChangeFeedbackControl request
-pub const CHANGE_FEEDBACK_CONTROL_REQUEST: u8 = 23;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeFeedbackControlRequest {
+    pub mask: u32,
+    pub device_id: u8,
+    pub feedback_id: u8,
+    pub feedback: FeedbackCtl,
+}
+impl ChangeFeedbackControlRequest {
+    /// Opcode for the ChangeFeedbackControl request
+    pub const fn opcode() -> u8 { 23 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mask_bytes = self.mask.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let feedback_id_bytes = self.feedback_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeFeedbackControlRequest::opcode(),
+            0,
+            0,
+            mask_bytes[0],
+            mask_bytes[1],
+            mask_bytes[2],
+            mask_bytes[3],
+            device_id_bytes[0],
+            feedback_id_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let feedback_bytes = self.feedback.serialize();
+        let length_so_far = length_so_far + feedback_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), feedback_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_feedback_control<Conn, A>(conn: &Conn, mask: A, device_id: u8, feedback_id: u8, feedback: FeedbackCtl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let mask: u32 = mask.into();
-    let length_so_far = 0;
-    let mask_bytes = mask.serialize();
-    let device_id_bytes = device_id.serialize();
-    let feedback_id_bytes = feedback_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_FEEDBACK_CONTROL_REQUEST,
-        0,
-        0,
-        mask_bytes[0],
-        mask_bytes[1],
-        mask_bytes[2],
-        mask_bytes[3],
-        device_id_bytes[0],
-        feedback_id_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let feedback_bytes = feedback.serialize();
-    let length_so_far = length_so_far + feedback_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&feedback_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeFeedbackControlRequest {
+        mask: mask,
+        device_id: device_id,
+        feedback_id: feedback_id,
+        feedback: feedback,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetDeviceKeyMapping request
-pub const GET_DEVICE_KEY_MAPPING_REQUEST: u8 = 24;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceKeyMappingRequest {
+    pub device_id: u8,
+    pub first_keycode: KeyCode,
+    pub count: u8,
+}
+impl GetDeviceKeyMappingRequest {
+    /// Opcode for the GetDeviceKeyMapping request
+    pub const fn opcode() -> u8 { 24 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let first_keycode_bytes = self.first_keycode.serialize();
+        let count_bytes = self.count.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceKeyMappingRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            first_keycode_bytes[0],
+            count_bytes[0],
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_key_mapping<Conn>(conn: &Conn, device_id: u8, first_keycode: KeyCode, count: u8) -> Result<Cookie<'_, Conn, GetDeviceKeyMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let first_keycode_bytes = first_keycode.serialize();
-    let count_bytes = count.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_KEY_MAPPING_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        first_keycode_bytes[0],
-        count_bytes[0],
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceKeyMappingRequest {
+        device_id: device_id,
+        first_keycode: first_keycode,
+        count: count,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4428,66 +4979,112 @@ impl GetDeviceKeyMappingReply {
     }
 }
 
-/// Opcode for the ChangeDeviceKeyMapping request
-pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeDeviceKeyMappingRequest<'input> {
+    pub device_id: u8,
+    pub first_keycode: KeyCode,
+    pub keysyms_per_keycode: u8,
+    pub keycode_count: u8,
+    pub keysyms: &'input [xproto::Keysym],
+}
+impl<'input> ChangeDeviceKeyMappingRequest<'input> {
+    /// Opcode for the ChangeDeviceKeyMapping request
+    pub const fn opcode() -> u8 { 25 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let first_keycode_bytes = self.first_keycode.serialize();
+        let keysyms_per_keycode_bytes = self.keysyms_per_keycode.serialize();
+        let keycode_count_bytes = self.keycode_count.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeDeviceKeyMappingRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            first_keycode_bytes[0],
+            keysyms_per_keycode_bytes[0],
+            keycode_count_bytes[0],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(self.keysyms.len(), usize::try_from(u32::from(self.keycode_count).checked_mul(u32::from(self.keysyms_per_keycode)).unwrap()).unwrap(), "`keysyms` has an incorrect length");
+        let keysyms_bytes = self.keysyms.serialize();
+        let length_so_far = length_so_far + keysyms_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), keysyms_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_device_key_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &'input [xproto::Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let first_keycode_bytes = first_keycode.serialize();
-    let keysyms_per_keycode_bytes = keysyms_per_keycode.serialize();
-    let keycode_count_bytes = keycode_count.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_DEVICE_KEY_MAPPING_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        first_keycode_bytes[0],
-        keysyms_per_keycode_bytes[0],
-        keycode_count_bytes[0],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(keysyms.len(), usize::try_from(u32::from(keycode_count).checked_mul(u32::from(keysyms_per_keycode)).unwrap()).unwrap(), "`keysyms` has an incorrect length");
-    let keysyms_bytes = keysyms.serialize();
-    let length_so_far = length_so_far + keysyms_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&keysyms_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeDeviceKeyMappingRequest {
+        device_id: device_id,
+        first_keycode: first_keycode,
+        keysyms_per_keycode: keysyms_per_keycode,
+        keycode_count: keycode_count,
+        keysyms: keysyms,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetDeviceModifierMapping request
-pub const GET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 26;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceModifierMappingRequest {
+    pub device_id: u8,
+}
+impl GetDeviceModifierMappingRequest {
+    /// Opcode for the GetDeviceModifierMapping request
+    pub const fn opcode() -> u8 { 26 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceModifierMappingRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_modifier_mapping<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_MODIFIER_MAPPING_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceModifierMappingRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4535,37 +5132,58 @@ impl GetDeviceModifierMappingReply {
     }
 }
 
-/// Opcode for the SetDeviceModifierMapping request
-pub const SET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 27;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetDeviceModifierMappingRequest<'input> {
+    pub device_id: u8,
+    pub keymaps: &'input [u8],
+}
+impl<'input> SetDeviceModifierMappingRequest<'input> {
+    /// Opcode for the SetDeviceModifierMapping request
+    pub const fn opcode() -> u8 { 27 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        assert_eq!(self.keymaps.len() % 8, 0, "`keymaps` has an incorrect length, must be a multiple of 8");
+        let keycodes_per_modifier = u8::try_from(self.keymaps.len() / 8).expect("`keymaps` has too many elements");
+        let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetDeviceModifierMappingRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            keycodes_per_modifier_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.keymaps[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.keymaps[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_device_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, keymaps: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    assert_eq!(keymaps.len() % 8, 0, "`keymaps` has an incorrect length, must be a multiple of 8");
-    let keycodes_per_modifier = u8::try_from(keymaps.len() / 8).expect("`keymaps` has too many elements");
-    let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_DEVICE_MODIFIER_MAPPING_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        keycodes_per_modifier_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + keymaps.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(keymaps), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetDeviceModifierMappingRequest {
+        device_id: device_id,
+        keymaps: keymaps,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4596,31 +5214,50 @@ impl TryFrom<&[u8]> for SetDeviceModifierMappingReply {
     }
 }
 
-/// Opcode for the GetDeviceButtonMapping request
-pub const GET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 28;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceButtonMappingRequest {
+    pub device_id: u8,
+}
+impl GetDeviceButtonMappingRequest {
+    /// Opcode for the GetDeviceButtonMapping request
+    pub const fn opcode() -> u8 { 28 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceButtonMappingRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_button_mapping<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceButtonMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_BUTTON_MAPPING_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceButtonMappingRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4672,36 +5309,57 @@ impl GetDeviceButtonMappingReply {
     }
 }
 
-/// Opcode for the SetDeviceButtonMapping request
-pub const SET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 29;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetDeviceButtonMappingRequest<'input> {
+    pub device_id: u8,
+    pub map: &'input [u8],
+}
+impl<'input> SetDeviceButtonMappingRequest<'input> {
+    /// Opcode for the SetDeviceButtonMapping request
+    pub const fn opcode() -> u8 { 29 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let map_size = u8::try_from(self.map.len()).expect("`map` has too many elements");
+        let map_size_bytes = map_size.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetDeviceButtonMappingRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            map_size_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.map[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.map[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_device_button_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceButtonMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let map_size = u8::try_from(map.len()).expect("`map` has too many elements");
-    let map_size_bytes = map_size.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_DEVICE_BUTTON_MAPPING_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        map_size_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + map.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(map), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetDeviceButtonMappingRequest {
+        device_id: device_id,
+        map: map,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -5319,31 +5977,50 @@ impl Serialize for InputState {
     }
 }
 
-/// Opcode for the QueryDeviceState request
-pub const QUERY_DEVICE_STATE_REQUEST: u8 = 30;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryDeviceStateRequest {
+    pub device_id: u8,
+}
+impl QueryDeviceStateRequest {
+    /// Opcode for the QueryDeviceState request
+    pub const fn opcode() -> u8 { 30 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryDeviceStateRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_device_state<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, QueryDeviceStateReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_DEVICE_STATE_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryDeviceStateRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5389,68 +6066,116 @@ impl QueryDeviceStateReply {
     }
 }
 
-/// Opcode for the DeviceBell request
-pub const DEVICE_BELL_REQUEST: u8 = 32;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeviceBellRequest {
+    pub device_id: u8,
+    pub feedback_id: u8,
+    pub feedback_class: u8,
+    pub percent: i8,
+}
+impl DeviceBellRequest {
+    /// Opcode for the DeviceBell request
+    pub const fn opcode() -> u8 { 32 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let feedback_id_bytes = self.feedback_id.serialize();
+        let feedback_class_bytes = self.feedback_class.serialize();
+        let percent_bytes = self.percent.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DeviceBellRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            feedback_id_bytes[0],
+            feedback_class_bytes[0],
+            percent_bytes[0],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn device_bell<Conn>(conn: &Conn, device_id: u8, feedback_id: u8, feedback_class: u8, percent: i8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let feedback_id_bytes = feedback_id.serialize();
-    let feedback_class_bytes = feedback_class.serialize();
-    let percent_bytes = percent.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DEVICE_BELL_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        feedback_id_bytes[0],
-        feedback_class_bytes[0],
-        percent_bytes[0],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DeviceBellRequest {
+        device_id: device_id,
+        feedback_id: feedback_id,
+        feedback_class: feedback_class,
+        percent: percent,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetDeviceValuators request
-pub const SET_DEVICE_VALUATORS_REQUEST: u8 = 33;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetDeviceValuatorsRequest<'input> {
+    pub device_id: u8,
+    pub first_valuator: u8,
+    pub valuators: &'input [i32],
+}
+impl<'input> SetDeviceValuatorsRequest<'input> {
+    /// Opcode for the SetDeviceValuators request
+    pub const fn opcode() -> u8 { 33 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let first_valuator_bytes = self.first_valuator.serialize();
+        let num_valuators = u8::try_from(self.valuators.len()).expect("`valuators` has too many elements");
+        let num_valuators_bytes = num_valuators.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetDeviceValuatorsRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            first_valuator_bytes[0],
+            num_valuators_bytes[0],
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let valuators_bytes = self.valuators.serialize();
+        let length_so_far = length_so_far + valuators_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), valuators_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_device_valuators<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_valuator: u8, valuators: &'input [i32]) -> Result<Cookie<'c, Conn, SetDeviceValuatorsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let first_valuator_bytes = first_valuator.serialize();
-    let num_valuators = u8::try_from(valuators.len()).expect("`valuators` has too many elements");
-    let num_valuators_bytes = num_valuators.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_DEVICE_VALUATORS_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        first_valuator_bytes[0],
-        num_valuators_bytes[0],
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let valuators_bytes = valuators.serialize();
-    let length_so_far = length_so_far + valuators_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&valuators_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetDeviceValuatorsRequest {
+        device_id: device_id,
+        first_valuator: first_valuator,
+        valuators: valuators,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6314,32 +7039,53 @@ impl Serialize for DeviceState {
     }
 }
 
-/// Opcode for the GetDeviceControl request
-pub const GET_DEVICE_CONTROL_REQUEST: u8 = 34;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceControlRequest {
+    pub control_id: DeviceControl,
+    pub device_id: u8,
+}
+impl GetDeviceControlRequest {
+    /// Opcode for the GetDeviceControl request
+    pub const fn opcode() -> u8 { 34 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let control_id_bytes = u16::from(self.control_id).serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceControlRequest::opcode(),
+            0,
+            0,
+            control_id_bytes[0],
+            control_id_bytes[1],
+            device_id_bytes[0],
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_control<Conn>(conn: &Conn, control_id: DeviceControl, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let control_id_bytes = u16::from(control_id).serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_CONTROL_REQUEST,
-        0,
-        0,
-        control_id_bytes[0],
-        control_id_bytes[1],
-        device_id_bytes[0],
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceControlRequest {
+        control_id: control_id,
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7120,36 +7866,59 @@ impl Serialize for DeviceCtl {
     }
 }
 
-/// Opcode for the ChangeDeviceControl request
-pub const CHANGE_DEVICE_CONTROL_REQUEST: u8 = 35;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeDeviceControlRequest {
+    pub control_id: DeviceControl,
+    pub device_id: u8,
+    pub control: DeviceCtl,
+}
+impl ChangeDeviceControlRequest {
+    /// Opcode for the ChangeDeviceControl request
+    pub const fn opcode() -> u8 { 35 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let control_id_bytes = u16::from(self.control_id).serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeDeviceControlRequest::opcode(),
+            0,
+            0,
+            control_id_bytes[0],
+            control_id_bytes[1],
+            device_id_bytes[0],
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let control_bytes = self.control.serialize();
+        let length_so_far = length_so_far + control_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), control_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_device_control<Conn>(conn: &Conn, control_id: DeviceControl, device_id: u8, control: DeviceCtl) -> Result<Cookie<'_, Conn, ChangeDeviceControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let control_id_bytes = u16::from(control_id).serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_DEVICE_CONTROL_REQUEST,
-        0,
-        0,
-        control_id_bytes[0],
-        control_id_bytes[1],
-        device_id_bytes[0],
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let control_bytes = control.serialize();
-    let length_so_far = length_so_far + control_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&control_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeDeviceControlRequest {
+        control_id: control_id,
+        device_id: device_id,
+        control: control,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7179,31 +7948,50 @@ impl TryFrom<&[u8]> for ChangeDeviceControlReply {
     }
 }
 
-/// Opcode for the ListDeviceProperties request
-pub const LIST_DEVICE_PROPERTIES_REQUEST: u8 = 36;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListDevicePropertiesRequest {
+    pub device_id: u8,
+}
+impl ListDevicePropertiesRequest {
+    /// Opcode for the ListDeviceProperties request
+    pub const fn opcode() -> u8 { 36 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListDevicePropertiesRequest::opcode(),
+            0,
+            0,
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_device_properties<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, ListDevicePropertiesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_DEVICE_PROPERTIES_REQUEST,
-        0,
-        0,
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListDevicePropertiesRequest {
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7314,8 +8102,6 @@ impl TryFrom<u32> for PropertyFormat {
     }
 }
 
-/// Opcode for the ChangeDeviceProperty request
-pub const CHANGE_DEVICE_PROPERTY_REQUEST: u8 = 37;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChangeDevicePropertyAux {
     Data8(Vec<u8>),
@@ -7378,131 +8164,212 @@ impl ChangeDevicePropertyAux {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeDevicePropertyRequest<'input> {
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub device_id: u8,
+    pub mode: xproto::PropMode,
+    pub num_items: u32,
+    pub items: &'input ChangeDevicePropertyAux,
+}
+impl<'input> ChangeDevicePropertyRequest<'input> {
+    /// Opcode for the ChangeDeviceProperty request
+    pub const fn opcode() -> u8 { 37 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let format = u8::try_from(self.items.switch_expr()).unwrap();
+        let format_bytes = format.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let num_items_bytes = self.num_items.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ChangeDevicePropertyRequest::opcode(),
+            0,
+            0,
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            device_id_bytes[0],
+            format_bytes[0],
+            mode_bytes[0],
+            0,
+            num_items_bytes[0],
+            num_items_bytes[1],
+            num_items_bytes[2],
+            num_items_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let items_bytes = self.items.serialize(format, self.num_items);
+        let length_so_far = length_so_far + items_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), items_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_device_property<'c, 'input, Conn>(conn: &'c Conn, property: xproto::Atom, type_: xproto::Atom, device_id: u8, mode: xproto::PropMode, num_items: u32, items: &'input ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let device_id_bytes = device_id.serialize();
-    let format = u8::try_from(items.switch_expr()).unwrap();
-    let format_bytes = format.serialize();
-    let mode_bytes = u8::from(mode).serialize();
-    let num_items_bytes = num_items.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CHANGE_DEVICE_PROPERTY_REQUEST,
-        0,
-        0,
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        device_id_bytes[0],
-        format_bytes[0],
-        mode_bytes[0],
-        0,
-        num_items_bytes[0],
-        num_items_bytes[1],
-        num_items_bytes[2],
-        num_items_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let items_bytes = items.serialize(format, num_items);
-    let length_so_far = length_so_far + items_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&items_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeDevicePropertyRequest {
+        property: property,
+        type_: type_,
+        device_id: device_id,
+        mode: mode,
+        num_items: num_items,
+        items: items,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DeleteDeviceProperty request
-pub const DELETE_DEVICE_PROPERTY_REQUEST: u8 = 38;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeleteDevicePropertyRequest {
+    pub property: xproto::Atom,
+    pub device_id: u8,
+}
+impl DeleteDevicePropertyRequest {
+    /// Opcode for the DeleteDeviceProperty request
+    pub const fn opcode() -> u8 { 38 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let property_bytes = self.property.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DeleteDevicePropertyRequest::opcode(),
+            0,
+            0,
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn delete_device_property<Conn>(conn: &Conn, property: xproto::Atom, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let property_bytes = property.serialize();
-    let device_id_bytes = device_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DELETE_DEVICE_PROPERTY_REQUEST,
-        0,
-        0,
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        device_id_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DeleteDevicePropertyRequest {
+        property: property,
+        device_id: device_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetDeviceProperty request
-pub const GET_DEVICE_PROPERTY_REQUEST: u8 = 39;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDevicePropertyRequest {
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub offset: u32,
+    pub len: u32,
+    pub device_id: u8,
+    pub delete: bool,
+}
+impl GetDevicePropertyRequest {
+    /// Opcode for the GetDeviceProperty request
+    pub const fn opcode() -> u8 { 39 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let offset_bytes = self.offset.serialize();
+        let len_bytes = self.len.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let delete_bytes = self.delete.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDevicePropertyRequest::opcode(),
+            0,
+            0,
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            offset_bytes[0],
+            offset_bytes[1],
+            offset_bytes[2],
+            offset_bytes[3],
+            len_bytes[0],
+            len_bytes[1],
+            len_bytes[2],
+            len_bytes[3],
+            device_id_bytes[0],
+            delete_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_property<Conn>(conn: &Conn, property: xproto::Atom, type_: xproto::Atom, offset: u32, len: u32, device_id: u8, delete: bool) -> Result<Cookie<'_, Conn, GetDevicePropertyReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let offset_bytes = offset.serialize();
-    let len_bytes = len.serialize();
-    let device_id_bytes = device_id.serialize();
-    let delete_bytes = delete.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_PROPERTY_REQUEST,
-        0,
-        0,
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        offset_bytes[0],
-        offset_bytes[1],
-        offset_bytes[2],
-        offset_bytes[3],
-        len_bytes[0],
-        len_bytes[1],
-        len_bytes[2],
-        len_bytes[3],
-        device_id_bytes[0],
-        delete_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDevicePropertyRequest {
+        property: property,
+        type_: type_,
+        offset: offset,
+        len: len,
+        device_id: device_id,
+        delete: delete,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7785,38 +8652,59 @@ impl Serialize for ModifierInfo {
     }
 }
 
-/// Opcode for the XIQueryPointer request
-pub const XI_QUERY_POINTER_REQUEST: u8 = 40;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIQueryPointerRequest {
+    pub window: xproto::Window,
+    pub deviceid: DeviceId,
+}
+impl XIQueryPointerRequest {
+    /// Opcode for the XIQueryPointer request
+    pub const fn opcode() -> u8 { 40 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIQueryPointerRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_query_pointer<Conn, A>(conn: &Conn, window: xproto::Window, deviceid: A) -> Result<Cookie<'_, Conn, XIQueryPointerReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_QUERY_POINTER_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIQueryPointerRequest {
+        window: window,
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7879,108 +8767,166 @@ impl XIQueryPointerReply {
     }
 }
 
-/// Opcode for the XIWarpPointer request
-pub const XI_WARP_POINTER_REQUEST: u8 = 41;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIWarpPointerRequest {
+    pub src_win: xproto::Window,
+    pub dst_win: xproto::Window,
+    pub src_x: Fp1616,
+    pub src_y: Fp1616,
+    pub src_width: u16,
+    pub src_height: u16,
+    pub dst_x: Fp1616,
+    pub dst_y: Fp1616,
+    pub deviceid: DeviceId,
+}
+impl XIWarpPointerRequest {
+    /// Opcode for the XIWarpPointer request
+    pub const fn opcode() -> u8 { 41 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let src_win_bytes = self.src_win.serialize();
+        let dst_win_bytes = self.dst_win.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let src_width_bytes = self.src_width.serialize();
+        let src_height_bytes = self.src_height.serialize();
+        let dst_x_bytes = self.dst_x.serialize();
+        let dst_y_bytes = self.dst_y.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIWarpPointerRequest::opcode(),
+            0,
+            0,
+            src_win_bytes[0],
+            src_win_bytes[1],
+            src_win_bytes[2],
+            src_win_bytes[3],
+            dst_win_bytes[0],
+            dst_win_bytes[1],
+            dst_win_bytes[2],
+            dst_win_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_x_bytes[2],
+            src_x_bytes[3],
+            src_y_bytes[0],
+            src_y_bytes[1],
+            src_y_bytes[2],
+            src_y_bytes[3],
+            src_width_bytes[0],
+            src_width_bytes[1],
+            src_height_bytes[0],
+            src_height_bytes[1],
+            dst_x_bytes[0],
+            dst_x_bytes[1],
+            dst_x_bytes[2],
+            dst_x_bytes[3],
+            dst_y_bytes[0],
+            dst_y_bytes[1],
+            dst_y_bytes[2],
+            dst_y_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_warp_pointer<Conn, A>(conn: &Conn, src_win: xproto::Window, dst_win: xproto::Window, src_x: Fp1616, src_y: Fp1616, src_width: u16, src_height: u16, dst_x: Fp1616, dst_y: Fp1616, deviceid: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let src_win_bytes = src_win.serialize();
-    let dst_win_bytes = dst_win.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let src_width_bytes = src_width.serialize();
-    let src_height_bytes = src_height.serialize();
-    let dst_x_bytes = dst_x.serialize();
-    let dst_y_bytes = dst_y.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_WARP_POINTER_REQUEST,
-        0,
-        0,
-        src_win_bytes[0],
-        src_win_bytes[1],
-        src_win_bytes[2],
-        src_win_bytes[3],
-        dst_win_bytes[0],
-        dst_win_bytes[1],
-        dst_win_bytes[2],
-        dst_win_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_x_bytes[2],
-        src_x_bytes[3],
-        src_y_bytes[0],
-        src_y_bytes[1],
-        src_y_bytes[2],
-        src_y_bytes[3],
-        src_width_bytes[0],
-        src_width_bytes[1],
-        src_height_bytes[0],
-        src_height_bytes[1],
-        dst_x_bytes[0],
-        dst_x_bytes[1],
-        dst_x_bytes[2],
-        dst_x_bytes[3],
-        dst_y_bytes[0],
-        dst_y_bytes[1],
-        dst_y_bytes[2],
-        dst_y_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIWarpPointerRequest {
+        src_win: src_win,
+        dst_win: dst_win,
+        src_x: src_x,
+        src_y: src_y,
+        src_width: src_width,
+        src_height: src_height,
+        dst_x: dst_x,
+        dst_y: dst_y,
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XIChangeCursor request
-pub const XI_CHANGE_CURSOR_REQUEST: u8 = 42;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIChangeCursorRequest {
+    pub window: xproto::Window,
+    pub cursor: xproto::Cursor,
+    pub deviceid: DeviceId,
+}
+impl XIChangeCursorRequest {
+    /// Opcode for the XIChangeCursor request
+    pub const fn opcode() -> u8 { 42 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let cursor_bytes = self.cursor.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIChangeCursorRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_change_cursor<Conn, A>(conn: &Conn, window: xproto::Window, cursor: xproto::Cursor, deviceid: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let cursor_bytes = cursor.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_CHANGE_CURSOR_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIChangeCursorRequest {
+        window: window,
+        cursor: cursor,
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8662,97 +9608,156 @@ impl Serialize for HierarchyChange {
     }
 }
 
-/// Opcode for the XIChangeHierarchy request
-pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XIChangeHierarchyRequest<'input> {
+    pub changes: &'input [HierarchyChange],
+}
+impl<'input> XIChangeHierarchyRequest<'input> {
+    /// Opcode for the XIChangeHierarchy request
+    pub const fn opcode() -> u8 { 43 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let num_changes = u8::try_from(self.changes.len()).expect("`changes` has too many elements");
+        let num_changes_bytes = num_changes.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIChangeHierarchyRequest::opcode(),
+            0,
+            0,
+            num_changes_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let changes_bytes = self.changes.serialize();
+        let length_so_far = length_so_far + changes_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), changes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn xi_change_hierarchy<'c, 'input, Conn>(conn: &'c Conn, changes: &'input [HierarchyChange]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let num_changes = u8::try_from(changes.len()).expect("`changes` has too many elements");
-    let num_changes_bytes = num_changes.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_CHANGE_HIERARCHY_REQUEST,
-        0,
-        0,
-        num_changes_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let changes_bytes = changes.serialize();
-    let length_so_far = length_so_far + changes_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&changes_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = XIChangeHierarchyRequest {
+        changes: changes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XISetClientPointer request
-pub const XI_SET_CLIENT_POINTER_REQUEST: u8 = 44;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XISetClientPointerRequest {
+    pub window: xproto::Window,
+    pub deviceid: DeviceId,
+}
+impl XISetClientPointerRequest {
+    /// Opcode for the XISetClientPointer request
+    pub const fn opcode() -> u8 { 44 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XISetClientPointerRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_set_client_pointer<Conn, A>(conn: &Conn, window: xproto::Window, deviceid: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_SET_CLIENT_POINTER_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XISetClientPointerRequest {
+        window: window,
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XIGetClientPointer request
-pub const XI_GET_CLIENT_POINTER_REQUEST: u8 = 45;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIGetClientPointerRequest {
+    pub window: xproto::Window,
+}
+impl XIGetClientPointerRequest {
+    /// Opcode for the XIGetClientPointer request
+    pub const fn opcode() -> u8 { 45 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIGetClientPointerRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_get_client_pointer<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, XIGetClientPointerReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_GET_CLIENT_POINTER_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIGetClientPointerRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8938,69 +9943,111 @@ impl EventMask {
     }
 }
 
-/// Opcode for the XISelectEvents request
-pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XISelectEventsRequest<'input> {
+    pub window: xproto::Window,
+    pub masks: &'input [EventMask],
+}
+impl<'input> XISelectEventsRequest<'input> {
+    /// Opcode for the XISelectEvents request
+    pub const fn opcode() -> u8 { 46 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let num_mask = u16::try_from(self.masks.len()).expect("`masks` has too many elements");
+        let num_mask_bytes = num_mask.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XISelectEventsRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            num_mask_bytes[0],
+            num_mask_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let masks_bytes = self.masks.serialize();
+        let length_so_far = length_so_far + masks_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), masks_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn xi_select_events<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, masks: &'input [EventMask]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let num_mask = u16::try_from(masks.len()).expect("`masks` has too many elements");
-    let num_mask_bytes = num_mask.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_SELECT_EVENTS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        num_mask_bytes[0],
-        num_mask_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let masks_bytes = masks.serialize();
-    let length_so_far = length_so_far + masks_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&masks_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = XISelectEventsRequest {
+        window: window,
+        masks: masks,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XIQueryVersion request
-pub const XI_QUERY_VERSION_REQUEST: u8 = 47;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIQueryVersionRequest {
+    pub major_version: u16,
+    pub minor_version: u16,
+}
+impl XIQueryVersionRequest {
+    /// Opcode for the XIQueryVersion request
+    pub const fn opcode() -> u8 { 47 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIQueryVersionRequest::opcode(),
+            0,
+            0,
+            major_version_bytes[0],
+            major_version_bytes[1],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_query_version<Conn>(conn: &Conn, major_version: u16, minor_version: u16) -> Result<Cookie<'_, Conn, XIQueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let major_version_bytes = major_version.serialize();
-    let minor_version_bytes = minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_QUERY_VERSION_REQUEST,
-        0,
-        0,
-        major_version_bytes[0],
-        major_version_bytes[1],
-        minor_version_bytes[0],
-        minor_version_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIQueryVersionRequest {
+        major_version: major_version,
+        minor_version: minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10258,33 +11305,52 @@ impl XIDeviceInfo {
     }
 }
 
-/// Opcode for the XIQueryDevice request
-pub const XI_QUERY_DEVICE_REQUEST: u8 = 48;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIQueryDeviceRequest {
+    pub deviceid: DeviceId,
+}
+impl XIQueryDeviceRequest {
+    /// Opcode for the XIQueryDevice request
+    pub const fn opcode() -> u8 { 48 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIQueryDeviceRequest::opcode(),
+            0,
+            0,
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_query_device<Conn, A>(conn: &Conn, deviceid: A) -> Result<Cookie<'_, Conn, XIQueryDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_QUERY_DEVICE_REQUEST,
-        0,
-        0,
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIQueryDeviceRequest {
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10329,74 +11395,116 @@ impl XIQueryDeviceReply {
     }
 }
 
-/// Opcode for the XISetFocus request
-pub const XI_SET_FOCUS_REQUEST: u8 = 49;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XISetFocusRequest {
+    pub window: xproto::Window,
+    pub time: xproto::Timestamp,
+    pub deviceid: DeviceId,
+}
+impl XISetFocusRequest {
+    /// Opcode for the XISetFocus request
+    pub const fn opcode() -> u8 { 49 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let time_bytes = self.time.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XISetFocusRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_set_focus<Conn, A, B>(conn: &Conn, window: xproto::Window, time: A, deviceid: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
     B: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let time_bytes = time.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_SET_FOCUS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XISetFocusRequest {
+        window: window,
+        time: time,
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XIGetFocus request
-pub const XI_GET_FOCUS_REQUEST: u8 = 50;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIGetFocusRequest {
+    pub deviceid: DeviceId,
+}
+impl XIGetFocusRequest {
+    /// Opcode for the XIGetFocus request
+    pub const fn opcode() -> u8 { 50 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIGetFocusRequest::opcode(),
+            0,
+            0,
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_get_focus<Conn, A>(conn: &Conn, deviceid: A) -> Result<Cookie<'_, Conn, XIGetFocusReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_GET_FOCUS_REQUEST,
-        0,
-        0,
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIGetFocusRequest {
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10495,63 +11603,96 @@ impl TryFrom<u32> for GrabOwner {
     }
 }
 
-/// Opcode for the XIGrabDevice request
-pub const XI_GRAB_DEVICE_REQUEST: u8 = 51;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XIGrabDeviceRequest<'input> {
+    pub window: xproto::Window,
+    pub time: xproto::Timestamp,
+    pub cursor: xproto::Cursor,
+    pub deviceid: DeviceId,
+    pub mode: xproto::GrabMode,
+    pub paired_device_mode: xproto::GrabMode,
+    pub owner_events: GrabOwner,
+    pub mask: &'input [u32],
+}
+impl<'input> XIGrabDeviceRequest<'input> {
+    /// Opcode for the XIGrabDevice request
+    pub const fn opcode() -> u8 { 51 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let time_bytes = self.time.serialize();
+        let cursor_bytes = self.cursor.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let paired_device_mode_bytes = u8::from(self.paired_device_mode).serialize();
+        let owner_events_bytes = bool::from(self.owner_events).serialize();
+        let mask_len = u16::try_from(self.mask.len()).expect("`mask` has too many elements");
+        let mask_len_bytes = mask_len.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIGrabDeviceRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            mode_bytes[0],
+            paired_device_mode_bytes[0],
+            owner_events_bytes[0],
+            0,
+            mask_len_bytes[0],
+            mask_len_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let mask_bytes = self.mask.serialize();
+        let length_so_far = length_so_far + mask_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), mask_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn xi_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, window: xproto::Window, time: A, cursor: xproto::Cursor, deviceid: B, mode: xproto::GrabMode, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32]) -> Result<Cookie<'c, Conn, XIGrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
     B: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let time_bytes = time.serialize();
-    let cursor_bytes = cursor.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mode_bytes = u8::from(mode).serialize();
-    let paired_device_mode_bytes = u8::from(paired_device_mode).serialize();
-    let owner_events_bytes = bool::from(owner_events).serialize();
-    let mask_len = u16::try_from(mask.len()).expect("`mask` has too many elements");
-    let mask_len_bytes = mask_len.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_GRAB_DEVICE_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        mode_bytes[0],
-        paired_device_mode_bytes[0],
-        owner_events_bytes[0],
-        0,
-        mask_len_bytes[0],
-        mask_len_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let mask_bytes = mask.serialize();
-    let length_so_far = length_so_far + mask_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&mask_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = XIGrabDeviceRequest {
+        window: window,
+        time: time,
+        cursor: cursor,
+        deviceid: deviceid,
+        mode: mode,
+        paired_device_mode: paired_device_mode,
+        owner_events: owner_events,
+        mask: mask,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10581,40 +11722,61 @@ impl TryFrom<&[u8]> for XIGrabDeviceReply {
     }
 }
 
-/// Opcode for the XIUngrabDevice request
-pub const XI_UNGRAB_DEVICE_REQUEST: u8 = 52;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIUngrabDeviceRequest {
+    pub time: xproto::Timestamp,
+    pub deviceid: DeviceId,
+}
+impl XIUngrabDeviceRequest {
+    /// Opcode for the XIUngrabDevice request
+    pub const fn opcode() -> u8 { 52 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let time_bytes = self.time.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIUngrabDeviceRequest::opcode(),
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_ungrab_device<Conn, A, B>(conn: &Conn, time: A, deviceid: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
     B: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let time_bytes = time.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_UNGRAB_DEVICE_REQUEST,
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIUngrabDeviceRequest {
+        time: time,
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10697,51 +11859,78 @@ impl TryFrom<u32> for EventMode {
     }
 }
 
-/// Opcode for the XIAllowEvents request
-pub const XI_ALLOW_EVENTS_REQUEST: u8 = 53;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIAllowEventsRequest {
+    pub time: xproto::Timestamp,
+    pub deviceid: DeviceId,
+    pub event_mode: EventMode,
+    pub touchid: u32,
+    pub grab_window: xproto::Window,
+}
+impl XIAllowEventsRequest {
+    /// Opcode for the XIAllowEvents request
+    pub const fn opcode() -> u8 { 53 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let time_bytes = self.time.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let event_mode_bytes = u8::from(self.event_mode).serialize();
+        let touchid_bytes = self.touchid.serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIAllowEventsRequest::opcode(),
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            event_mode_bytes[0],
+            0,
+            touchid_bytes[0],
+            touchid_bytes[1],
+            touchid_bytes[2],
+            touchid_bytes[3],
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_allow_events<Conn, A, B>(conn: &Conn, time: A, deviceid: B, event_mode: EventMode, touchid: u32, grab_window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
     B: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let time_bytes = time.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let event_mode_bytes = u8::from(event_mode).serialize();
-    let touchid_bytes = touchid.serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_ALLOW_EVENTS_REQUEST,
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        event_mode_bytes[0],
-        0,
-        touchid_bytes[0],
-        touchid_bytes[1],
-        touchid_bytes[2],
-        touchid_bytes[3],
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIAllowEventsRequest {
+        time: time,
+        deviceid: deviceid,
+        event_mode: event_mode,
+        touchid: touchid,
+        grab_window: grab_window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10953,77 +12142,116 @@ impl Serialize for GrabModifierInfo {
     }
 }
 
-/// Opcode for the XIPassiveGrabDevice request
-pub const XI_PASSIVE_GRAB_DEVICE_REQUEST: u8 = 54;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XIPassiveGrabDeviceRequest<'input> {
+    pub time: xproto::Timestamp,
+    pub grab_window: xproto::Window,
+    pub cursor: xproto::Cursor,
+    pub detail: u32,
+    pub deviceid: DeviceId,
+    pub grab_type: GrabType,
+    pub grab_mode: GrabMode22,
+    pub paired_device_mode: xproto::GrabMode,
+    pub owner_events: GrabOwner,
+    pub mask: &'input [u32],
+    pub modifiers: &'input [u32],
+}
+impl<'input> XIPassiveGrabDeviceRequest<'input> {
+    /// Opcode for the XIPassiveGrabDevice request
+    pub const fn opcode() -> u8 { 54 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let time_bytes = self.time.serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let cursor_bytes = self.cursor.serialize();
+        let detail_bytes = self.detail.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let num_modifiers = u16::try_from(self.modifiers.len()).expect("`modifiers` has too many elements");
+        let num_modifiers_bytes = num_modifiers.serialize();
+        let mask_len = u16::try_from(self.mask.len()).expect("`mask` has too many elements");
+        let mask_len_bytes = mask_len.serialize();
+        let grab_type_bytes = u8::from(self.grab_type).serialize();
+        let grab_mode_bytes = u8::from(self.grab_mode).serialize();
+        let paired_device_mode_bytes = u8::from(self.paired_device_mode).serialize();
+        let owner_events_bytes = bool::from(self.owner_events).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIPassiveGrabDeviceRequest::opcode(),
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+            detail_bytes[0],
+            detail_bytes[1],
+            detail_bytes[2],
+            detail_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            num_modifiers_bytes[0],
+            num_modifiers_bytes[1],
+            mask_len_bytes[0],
+            mask_len_bytes[1],
+            grab_type_bytes[0],
+            grab_mode_bytes[0],
+            paired_device_mode_bytes[0],
+            owner_events_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let mask_bytes = self.mask.serialize();
+        let length_so_far = length_so_far + mask_bytes.len();
+        let modifiers_bytes = self.modifiers.serialize();
+        let length_so_far = length_so_far + modifiers_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), mask_bytes.into(), modifiers_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn xi_passive_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, time: A, grab_window: xproto::Window, cursor: xproto::Cursor, detail: u32, deviceid: B, grab_type: GrabType, grab_mode: GrabMode22, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32], modifiers: &'input [u32]) -> Result<Cookie<'c, Conn, XIPassiveGrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
     B: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let time_bytes = time.serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let cursor_bytes = cursor.serialize();
-    let detail_bytes = detail.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let num_modifiers = u16::try_from(modifiers.len()).expect("`modifiers` has too many elements");
-    let num_modifiers_bytes = num_modifiers.serialize();
-    let mask_len = u16::try_from(mask.len()).expect("`mask` has too many elements");
-    let mask_len_bytes = mask_len.serialize();
-    let grab_type_bytes = u8::from(grab_type).serialize();
-    let grab_mode_bytes = u8::from(grab_mode).serialize();
-    let paired_device_mode_bytes = u8::from(paired_device_mode).serialize();
-    let owner_events_bytes = bool::from(owner_events).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_PASSIVE_GRAB_DEVICE_REQUEST,
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-        detail_bytes[0],
-        detail_bytes[1],
-        detail_bytes[2],
-        detail_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        num_modifiers_bytes[0],
-        num_modifiers_bytes[1],
-        mask_len_bytes[0],
-        mask_len_bytes[1],
-        grab_type_bytes[0],
-        grab_mode_bytes[0],
-        paired_device_mode_bytes[0],
-        owner_events_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let mask_bytes = mask.serialize();
-    let length_so_far = length_so_far + mask_bytes.len();
-    let modifiers_bytes = modifiers.serialize();
-    let length_so_far = length_so_far + modifiers_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&mask_bytes), IoSlice::new(&modifiers_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = XIPassiveGrabDeviceRequest {
+        time: time,
+        grab_window: grab_window,
+        cursor: cursor,
+        detail: detail,
+        deviceid: deviceid,
+        grab_type: grab_type,
+        grab_mode: grab_mode,
+        paired_device_mode: paired_device_mode,
+        owner_events: owner_events,
+        mask: mask,
+        modifiers: modifiers,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11068,83 +12296,129 @@ impl XIPassiveGrabDeviceReply {
     }
 }
 
-/// Opcode for the XIPassiveUngrabDevice request
-pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XIPassiveUngrabDeviceRequest<'input> {
+    pub grab_window: xproto::Window,
+    pub detail: u32,
+    pub deviceid: DeviceId,
+    pub grab_type: GrabType,
+    pub modifiers: &'input [u32],
+}
+impl<'input> XIPassiveUngrabDeviceRequest<'input> {
+    /// Opcode for the XIPassiveUngrabDevice request
+    pub const fn opcode() -> u8 { 55 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let grab_window_bytes = self.grab_window.serialize();
+        let detail_bytes = self.detail.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let num_modifiers = u16::try_from(self.modifiers.len()).expect("`modifiers` has too many elements");
+        let num_modifiers_bytes = num_modifiers.serialize();
+        let grab_type_bytes = u8::from(self.grab_type).serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIPassiveUngrabDeviceRequest::opcode(),
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            detail_bytes[0],
+            detail_bytes[1],
+            detail_bytes[2],
+            detail_bytes[3],
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            num_modifiers_bytes[0],
+            num_modifiers_bytes[1],
+            grab_type_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let modifiers_bytes = self.modifiers.serialize();
+        let length_so_far = length_so_far + modifiers_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), modifiers_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn xi_passive_ungrab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, detail: u32, deviceid: A, grab_type: GrabType, modifiers: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let grab_window_bytes = grab_window.serialize();
-    let detail_bytes = detail.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let num_modifiers = u16::try_from(modifiers.len()).expect("`modifiers` has too many elements");
-    let num_modifiers_bytes = num_modifiers.serialize();
-    let grab_type_bytes = u8::from(grab_type).serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_PASSIVE_UNGRAB_DEVICE_REQUEST,
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        detail_bytes[0],
-        detail_bytes[1],
-        detail_bytes[2],
-        detail_bytes[3],
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        num_modifiers_bytes[0],
-        num_modifiers_bytes[1],
-        grab_type_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let modifiers_bytes = modifiers.serialize();
-    let length_so_far = length_so_far + modifiers_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&modifiers_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = XIPassiveUngrabDeviceRequest {
+        grab_window: grab_window,
+        detail: detail,
+        deviceid: deviceid,
+        grab_type: grab_type,
+        modifiers: modifiers,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XIListProperties request
-pub const XI_LIST_PROPERTIES_REQUEST: u8 = 56;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIListPropertiesRequest {
+    pub deviceid: DeviceId,
+}
+impl XIListPropertiesRequest {
+    /// Opcode for the XIListProperties request
+    pub const fn opcode() -> u8 { 56 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIListPropertiesRequest::opcode(),
+            0,
+            0,
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_list_properties<Conn, A>(conn: &Conn, deviceid: A) -> Result<Cookie<'_, Conn, XIListPropertiesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_LIST_PROPERTIES_REQUEST,
-        0,
-        0,
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIListPropertiesRequest {
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11189,8 +12463,6 @@ impl XIListPropertiesReply {
     }
 }
 
-/// Opcode for the XIChangeProperty request
-pub const XI_CHANGE_PROPERTY_REQUEST: u8 = 57;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum XIChangePropertyAux {
     Data8(Vec<u8>),
@@ -11253,137 +12525,218 @@ impl XIChangePropertyAux {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XIChangePropertyRequest<'input> {
+    pub deviceid: DeviceId,
+    pub mode: xproto::PropMode,
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub num_items: u32,
+    pub items: &'input XIChangePropertyAux,
+}
+impl<'input> XIChangePropertyRequest<'input> {
+    /// Opcode for the XIChangeProperty request
+    pub const fn opcode() -> u8 { 57 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let deviceid_bytes = self.deviceid.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let format = u8::try_from(self.items.switch_expr()).unwrap();
+        let format_bytes = format.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let num_items_bytes = self.num_items.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIChangePropertyRequest::opcode(),
+            0,
+            0,
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            mode_bytes[0],
+            format_bytes[0],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            num_items_bytes[0],
+            num_items_bytes[1],
+            num_items_bytes[2],
+            num_items_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let items_bytes = self.items.serialize(format, self.num_items);
+        let length_so_far = length_so_far + items_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), items_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn xi_change_property<'c, 'input, Conn, A>(conn: &'c Conn, deviceid: A, mode: xproto::PropMode, property: xproto::Atom, type_: xproto::Atom, num_items: u32, items: &'input XIChangePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let deviceid_bytes = deviceid.serialize();
-    let mode_bytes = u8::from(mode).serialize();
-    let format = u8::try_from(items.switch_expr()).unwrap();
-    let format_bytes = format.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let num_items_bytes = num_items.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_CHANGE_PROPERTY_REQUEST,
-        0,
-        0,
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        mode_bytes[0],
-        format_bytes[0],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        num_items_bytes[0],
-        num_items_bytes[1],
-        num_items_bytes[2],
-        num_items_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let items_bytes = items.serialize(format, num_items);
-    let length_so_far = length_so_far + items_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&items_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = XIChangePropertyRequest {
+        deviceid: deviceid,
+        mode: mode,
+        property: property,
+        type_: type_,
+        num_items: num_items,
+        items: items,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XIDeleteProperty request
-pub const XI_DELETE_PROPERTY_REQUEST: u8 = 58;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIDeletePropertyRequest {
+    pub deviceid: DeviceId,
+    pub property: xproto::Atom,
+}
+impl XIDeletePropertyRequest {
+    /// Opcode for the XIDeleteProperty request
+    pub const fn opcode() -> u8 { 58 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let deviceid_bytes = self.deviceid.serialize();
+        let property_bytes = self.property.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIDeletePropertyRequest::opcode(),
+            0,
+            0,
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            0,
+            0,
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_delete_property<Conn, A>(conn: &Conn, deviceid: A, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let deviceid_bytes = deviceid.serialize();
-    let property_bytes = property.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_DELETE_PROPERTY_REQUEST,
-        0,
-        0,
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        0,
-        0,
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIDeletePropertyRequest {
+        deviceid: deviceid,
+        property: property,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the XIGetProperty request
-pub const XI_GET_PROPERTY_REQUEST: u8 = 59;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIGetPropertyRequest {
+    pub deviceid: DeviceId,
+    pub delete: bool,
+    pub property: xproto::Atom,
+    pub type_: xproto::Atom,
+    pub offset: u32,
+    pub len: u32,
+}
+impl XIGetPropertyRequest {
+    /// Opcode for the XIGetProperty request
+    pub const fn opcode() -> u8 { 59 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let deviceid_bytes = self.deviceid.serialize();
+        let delete_bytes = self.delete.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let offset_bytes = self.offset.serialize();
+        let len_bytes = self.len.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIGetPropertyRequest::opcode(),
+            0,
+            0,
+            deviceid_bytes[0],
+            deviceid_bytes[1],
+            delete_bytes[0],
+            0,
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            offset_bytes[0],
+            offset_bytes[1],
+            offset_bytes[2],
+            offset_bytes[3],
+            len_bytes[0],
+            len_bytes[1],
+            len_bytes[2],
+            len_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_get_property<Conn, A>(conn: &Conn, deviceid: A, delete: bool, property: xproto::Atom, type_: xproto::Atom, offset: u32, len: u32) -> Result<Cookie<'_, Conn, XIGetPropertyReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let deviceid: DeviceId = deviceid.into();
-    let length_so_far = 0;
-    let deviceid_bytes = deviceid.serialize();
-    let delete_bytes = delete.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let offset_bytes = offset.serialize();
-    let len_bytes = len.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_GET_PROPERTY_REQUEST,
-        0,
-        0,
-        deviceid_bytes[0],
-        deviceid_bytes[1],
-        delete_bytes[0],
-        0,
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        offset_bytes[0],
-        offset_bytes[1],
-        offset_bytes[2],
-        offset_bytes[3],
-        len_bytes[0],
-        len_bytes[1],
-        len_bytes[2],
-        len_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIGetPropertyRequest {
+        deviceid: deviceid,
+        delete: delete,
+        property: property,
+        type_: type_,
+        offset: offset,
+        len: len,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11489,31 +12842,50 @@ impl TryFrom<&[u8]> for XIGetPropertyReply {
     }
 }
 
-/// Opcode for the XIGetSelectedEvents request
-pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XIGetSelectedEventsRequest {
+    pub window: xproto::Window,
+}
+impl XIGetSelectedEventsRequest {
+    /// Opcode for the XIGetSelectedEvents request
+    pub const fn opcode() -> u8 { 60 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIGetSelectedEventsRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn xi_get_selected_events<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, XIGetSelectedEventsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_GET_SELECTED_EVENTS_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = XIGetSelectedEventsRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11610,36 +12982,55 @@ impl Serialize for BarrierReleasePointerInfo {
     }
 }
 
-/// Opcode for the XIBarrierReleasePointer request
-pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XIBarrierReleasePointerRequest<'input> {
+    pub barriers: &'input [BarrierReleasePointerInfo],
+}
+impl<'input> XIBarrierReleasePointerRequest<'input> {
+    /// Opcode for the XIBarrierReleasePointer request
+    pub const fn opcode() -> u8 { 61 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let num_barriers = u32::try_from(self.barriers.len()).expect("`barriers` has too many elements");
+        let num_barriers_bytes = num_barriers.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            XIBarrierReleasePointerRequest::opcode(),
+            0,
+            0,
+            num_barriers_bytes[0],
+            num_barriers_bytes[1],
+            num_barriers_bytes[2],
+            num_barriers_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let barriers_bytes = self.barriers.serialize();
+        let length_so_far = length_so_far + barriers_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), barriers_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn xi_barrier_release_pointer<'c, 'input, Conn>(conn: &'c Conn, barriers: &'input [BarrierReleasePointerInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let num_barriers = u32::try_from(barriers.len()).expect("`barriers` has too many elements");
-    let num_barriers_bytes = num_barriers.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        XI_BARRIER_RELEASE_POINTER_REQUEST,
-        0,
-        0,
-        num_barriers_bytes[0],
-        num_barriers_bytes[1],
-        num_barriers_bytes[2],
-        num_barriers_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let barriers_bytes = barriers.serialize();
-    let length_so_far = length_so_far + barriers_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&barriers_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = XIBarrierReleasePointerRequest {
+        barriers: barriers,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Opcode for the DeviceValuator event
@@ -14497,51 +15888,78 @@ impl From<&DevicePropertyNotifyEvent> for EventForSend {
     }
 }
 
-/// Opcode for the SendExtensionEvent request
-pub const SEND_EXTENSION_EVENT_REQUEST: u8 = 31;
+#[derive(Debug, Clone)]
+pub struct SendExtensionEventRequest<'input> {
+    pub destination: xproto::Window,
+    pub device_id: u8,
+    pub propagate: bool,
+    pub events: &'input [EventForSend],
+    pub classes: &'input [EventClass],
+}
+impl<'input> SendExtensionEventRequest<'input> {
+    /// Opcode for the SendExtensionEvent request
+    pub const fn opcode() -> u8 { 31 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let destination_bytes = self.destination.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let propagate_bytes = self.propagate.serialize();
+        let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
+        let num_classes_bytes = num_classes.serialize();
+        let num_events = u8::try_from(self.events.len()).expect("`events` has too many elements");
+        let num_events_bytes = num_events.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SendExtensionEventRequest::opcode(),
+            0,
+            0,
+            destination_bytes[0],
+            destination_bytes[1],
+            destination_bytes[2],
+            destination_bytes[3],
+            device_id_bytes[0],
+            propagate_bytes[0],
+            num_classes_bytes[0],
+            num_classes_bytes[1],
+            num_events_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let events_bytes = self.events.serialize();
+        let length_so_far = length_so_far + events_bytes.len();
+        let classes_bytes = self.classes.serialize();
+        let length_so_far = length_so_far + classes_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), events_bytes.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn send_extension_event<'c, 'input, Conn>(conn: &'c Conn, destination: xproto::Window, device_id: u8, propagate: bool, events: &'input [EventForSend], classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let destination_bytes = destination.serialize();
-    let device_id_bytes = device_id.serialize();
-    let propagate_bytes = propagate.serialize();
-    let num_classes = u16::try_from(classes.len()).expect("`classes` has too many elements");
-    let num_classes_bytes = num_classes.serialize();
-    let num_events = u8::try_from(events.len()).expect("`events` has too many elements");
-    let num_events_bytes = num_events.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SEND_EXTENSION_EVENT_REQUEST,
-        0,
-        0,
-        destination_bytes[0],
-        destination_bytes[1],
-        destination_bytes[2],
-        destination_bytes[3],
-        device_id_bytes[0],
-        propagate_bytes[0],
-        num_classes_bytes[0],
-        num_classes_bytes[1],
-        num_events_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let events_bytes = events.serialize();
-    let length_so_far = length_so_far + events_bytes.len();
-    let classes_bytes = classes.serialize();
-    let length_so_far = length_so_far + classes_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&events_bytes), IoSlice::new(&classes_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SendExtensionEventRequest {
+        destination: destination,
+        device_id: device_id,
+        propagate: propagate,
+        events: events,
+        classes: classes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Opcode for the Device error

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -86,7 +86,7 @@ impl Serialize for Fp3232 {
 
 /// Opcode for the GetExtensionVersion request
 pub const GET_EXTENSION_VERSION_REQUEST: u8 = 1;
-pub fn get_extension_version<'c, Conn>(conn: &'c Conn, name: &[u8]) -> Result<Cookie<'c, Conn, GetExtensionVersionReply>, ConnectionError>
+pub fn get_extension_version<'c, 'input, Conn>(conn: &'c Conn, name: &'input [u8]) -> Result<Cookie<'c, Conn, GetExtensionVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1197,7 +1197,7 @@ impl TryFrom<&[u8]> for SetDeviceModeReply {
 
 /// Opcode for the SelectExtensionEvent request
 pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
-pub fn select_extension_event<'c, Conn>(conn: &'c Conn, window: xproto::Window, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn select_extension_event<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1390,7 +1390,7 @@ impl TryFrom<u32> for PropagateMode {
 
 /// Opcode for the ChangeDeviceDontPropagateList request
 pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
-pub fn change_device_dont_propagate_list<'c, Conn>(conn: &'c Conn, window: xproto::Window, mode: PropagateMode, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_device_dont_propagate_list<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode: PropagateMode, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1732,7 +1732,7 @@ impl TryFrom<&[u8]> for ChangePointerDeviceReply {
 
 /// Opcode for the GrabDevice request
 pub const GRAB_DEVICE_REQUEST: u8 = 13;
-pub fn grab_device<'c, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, time: A, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, device_id: u8, classes: &[EventClass]) -> Result<Cookie<'c, Conn, GrabDeviceReply>, ConnectionError>
+pub fn grab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, time: A, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, device_id: u8, classes: &'input [EventClass]) -> Result<Cookie<'c, Conn, GrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
@@ -1905,7 +1905,7 @@ impl TryFrom<u32> for ModifierDevice {
 
 /// Opcode for the GrabDeviceKey request
 pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
-pub fn grab_device_key<'c, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn grab_device_key<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
@@ -2008,7 +2008,7 @@ where
 
 /// Opcode for the GrabDeviceButton request
 pub const GRAB_DEVICE_BUTTON_REQUEST: u8 = 17;
-pub fn grab_device_button<'c, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn grab_device_button<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
@@ -4430,7 +4430,7 @@ impl GetDeviceKeyMappingReply {
 
 /// Opcode for the ChangeDeviceKeyMapping request
 pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
-pub fn change_device_key_mapping<'c, Conn>(conn: &'c Conn, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &[xproto::Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_device_key_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &'input [xproto::Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -4537,7 +4537,7 @@ impl GetDeviceModifierMappingReply {
 
 /// Opcode for the SetDeviceModifierMapping request
 pub const SET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 27;
-pub fn set_device_modifier_mapping<'c, Conn>(conn: &'c Conn, device_id: u8, keymaps: &[u8]) -> Result<Cookie<'c, Conn, SetDeviceModifierMappingReply>, ConnectionError>
+pub fn set_device_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, keymaps: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -4674,7 +4674,7 @@ impl GetDeviceButtonMappingReply {
 
 /// Opcode for the SetDeviceButtonMapping request
 pub const SET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 29;
-pub fn set_device_button_mapping<'c, Conn>(conn: &'c Conn, device_id: u8, map: &[u8]) -> Result<Cookie<'c, Conn, SetDeviceButtonMappingReply>, ConnectionError>
+pub fn set_device_button_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceButtonMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -5421,7 +5421,7 @@ where
 
 /// Opcode for the SetDeviceValuators request
 pub const SET_DEVICE_VALUATORS_REQUEST: u8 = 33;
-pub fn set_device_valuators<'c, Conn>(conn: &'c Conn, device_id: u8, first_valuator: u8, valuators: &[i32]) -> Result<Cookie<'c, Conn, SetDeviceValuatorsReply>, ConnectionError>
+pub fn set_device_valuators<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_valuator: u8, valuators: &'input [i32]) -> Result<Cookie<'c, Conn, SetDeviceValuatorsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -7378,7 +7378,7 @@ impl ChangeDevicePropertyAux {
     }
 }
 
-pub fn change_device_property<'c, Conn>(conn: &'c Conn, property: xproto::Atom, type_: xproto::Atom, device_id: u8, mode: xproto::PropMode, num_items: u32, items: &ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_device_property<'c, 'input, Conn>(conn: &'c Conn, property: xproto::Atom, type_: xproto::Atom, device_id: u8, mode: xproto::PropMode, num_items: u32, items: &'input ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -8664,7 +8664,7 @@ impl Serialize for HierarchyChange {
 
 /// Opcode for the XIChangeHierarchy request
 pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
-pub fn xi_change_hierarchy<'c, Conn>(conn: &'c Conn, changes: &[HierarchyChange]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_change_hierarchy<'c, 'input, Conn>(conn: &'c Conn, changes: &'input [HierarchyChange]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -8940,7 +8940,7 @@ impl EventMask {
 
 /// Opcode for the XISelectEvents request
 pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
-pub fn xi_select_events<'c, Conn>(conn: &'c Conn, window: xproto::Window, masks: &[EventMask]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_select_events<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, masks: &'input [EventMask]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -10497,7 +10497,7 @@ impl TryFrom<u32> for GrabOwner {
 
 /// Opcode for the XIGrabDevice request
 pub const XI_GRAB_DEVICE_REQUEST: u8 = 51;
-pub fn xi_grab_device<'c, Conn, A, B>(conn: &'c Conn, window: xproto::Window, time: A, cursor: xproto::Cursor, deviceid: B, mode: xproto::GrabMode, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &[u32]) -> Result<Cookie<'c, Conn, XIGrabDeviceReply>, ConnectionError>
+pub fn xi_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, window: xproto::Window, time: A, cursor: xproto::Cursor, deviceid: B, mode: xproto::GrabMode, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32]) -> Result<Cookie<'c, Conn, XIGrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
@@ -10955,7 +10955,7 @@ impl Serialize for GrabModifierInfo {
 
 /// Opcode for the XIPassiveGrabDevice request
 pub const XI_PASSIVE_GRAB_DEVICE_REQUEST: u8 = 54;
-pub fn xi_passive_grab_device<'c, Conn, A, B>(conn: &'c Conn, time: A, grab_window: xproto::Window, cursor: xproto::Cursor, detail: u32, deviceid: B, grab_type: GrabType, grab_mode: GrabMode22, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &[u32], modifiers: &[u32]) -> Result<Cookie<'c, Conn, XIPassiveGrabDeviceReply>, ConnectionError>
+pub fn xi_passive_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, time: A, grab_window: xproto::Window, cursor: xproto::Cursor, detail: u32, deviceid: B, grab_type: GrabType, grab_mode: GrabMode22, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32], modifiers: &'input [u32]) -> Result<Cookie<'c, Conn, XIPassiveGrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<xproto::Timestamp>,
@@ -11070,7 +11070,7 @@ impl XIPassiveGrabDeviceReply {
 
 /// Opcode for the XIPassiveUngrabDevice request
 pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
-pub fn xi_passive_ungrab_device<'c, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, detail: u32, deviceid: A, grab_type: GrabType, modifiers: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_passive_ungrab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, detail: u32, deviceid: A, grab_type: GrabType, modifiers: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
@@ -11253,7 +11253,7 @@ impl XIChangePropertyAux {
     }
 }
 
-pub fn xi_change_property<'c, Conn, A>(conn: &'c Conn, deviceid: A, mode: xproto::PropMode, property: xproto::Atom, type_: xproto::Atom, num_items: u32, items: &XIChangePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_change_property<'c, 'input, Conn, A>(conn: &'c Conn, deviceid: A, mode: xproto::PropMode, property: xproto::Atom, type_: xproto::Atom, num_items: u32, items: &'input XIChangePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<DeviceId>,
@@ -11612,7 +11612,7 @@ impl Serialize for BarrierReleasePointerInfo {
 
 /// Opcode for the XIBarrierReleasePointer request
 pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
-pub fn xi_barrier_release_pointer<'c, Conn>(conn: &'c Conn, barriers: &[BarrierReleasePointerInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn xi_barrier_release_pointer<'c, 'input, Conn>(conn: &'c Conn, barriers: &'input [BarrierReleasePointerInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14499,7 +14499,7 @@ impl From<&DevicePropertyNotifyEvent> for EventForSend {
 
 /// Opcode for the SendExtensionEvent request
 pub const SEND_EXTENSION_EVENT_REQUEST: u8 = 31;
-pub fn send_extension_event<'c, Conn>(conn: &'c Conn, destination: xproto::Window, device_id: u8, propagate: bool, events: &[EventForSend], classes: &[EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn send_extension_event<'c, 'input, Conn>(conn: &'c Conn, destination: xproto::Window, device_id: u8, propagate: bool, events: &'input [EventForSend], classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14901,7 +14901,7 @@ impl From<ClassError> for [u8; 32] {
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {
-    fn xinput_get_extension_version<'c>(&'c self, name: &[u8]) -> Result<Cookie<'c, Self, GetExtensionVersionReply>, ConnectionError>
+    fn xinput_get_extension_version<'c, 'input>(&'c self, name: &'input [u8]) -> Result<Cookie<'c, Self, GetExtensionVersionReply>, ConnectionError>
     {
         get_extension_version(self, name)
     }
@@ -14921,7 +14921,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         set_device_mode(self, device_id, mode)
     }
-    fn xinput_select_extension_event<'c>(&'c self, window: xproto::Window, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_select_extension_event<'c, 'input>(&'c self, window: xproto::Window, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         select_extension_event(self, window, classes)
     }
@@ -14929,7 +14929,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_selected_extension_events(self, window)
     }
-    fn xinput_change_device_dont_propagate_list<'c>(&'c self, window: xproto::Window, mode: PropagateMode, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_change_device_dont_propagate_list<'c, 'input>(&'c self, window: xproto::Window, mode: PropagateMode, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_device_dont_propagate_list(self, window, mode, classes)
     }
@@ -14951,7 +14951,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         change_pointer_device(self, x_axis, y_axis, device_id)
     }
-    fn xinput_grab_device<'c, A>(&'c self, grab_window: xproto::Window, time: A, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, device_id: u8, classes: &[EventClass]) -> Result<Cookie<'c, Self, GrabDeviceReply>, ConnectionError>
+    fn xinput_grab_device<'c, 'input, A>(&'c self, grab_window: xproto::Window, time: A, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, device_id: u8, classes: &'input [EventClass]) -> Result<Cookie<'c, Self, GrabDeviceReply>, ConnectionError>
     where
         A: Into<xproto::Timestamp>,
     {
@@ -14963,7 +14963,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         ungrab_device(self, time, device_id)
     }
-    fn xinput_grab_device_key<'c, A, B, C>(&'c self, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_grab_device_key<'c, 'input, A, B, C>(&'c self, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u16>,
         B: Into<u8>,
@@ -14979,7 +14979,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         ungrab_device_key(self, grab_window, modifiers, modifier_device, key, grabbed_device)
     }
-    fn xinput_grab_device_button<'c, A, B, C>(&'c self, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_grab_device_button<'c, 'input, A, B, C>(&'c self, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u8>,
         B: Into<u16>,
@@ -15026,7 +15026,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_device_key_mapping(self, device_id, first_keycode, count)
     }
-    fn xinput_change_device_key_mapping<'c>(&'c self, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &[xproto::Keysym]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_change_device_key_mapping<'c, 'input>(&'c self, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &'input [xproto::Keysym]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_device_key_mapping(self, device_id, first_keycode, keysyms_per_keycode, keycode_count, keysyms)
     }
@@ -15034,7 +15034,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_device_modifier_mapping(self, device_id)
     }
-    fn xinput_set_device_modifier_mapping<'c>(&'c self, device_id: u8, keymaps: &[u8]) -> Result<Cookie<'c, Self, SetDeviceModifierMappingReply>, ConnectionError>
+    fn xinput_set_device_modifier_mapping<'c, 'input>(&'c self, device_id: u8, keymaps: &'input [u8]) -> Result<Cookie<'c, Self, SetDeviceModifierMappingReply>, ConnectionError>
     {
         set_device_modifier_mapping(self, device_id, keymaps)
     }
@@ -15042,7 +15042,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_device_button_mapping(self, device_id)
     }
-    fn xinput_set_device_button_mapping<'c>(&'c self, device_id: u8, map: &[u8]) -> Result<Cookie<'c, Self, SetDeviceButtonMappingReply>, ConnectionError>
+    fn xinput_set_device_button_mapping<'c, 'input>(&'c self, device_id: u8, map: &'input [u8]) -> Result<Cookie<'c, Self, SetDeviceButtonMappingReply>, ConnectionError>
     {
         set_device_button_mapping(self, device_id, map)
     }
@@ -15054,7 +15054,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         device_bell(self, device_id, feedback_id, feedback_class, percent)
     }
-    fn xinput_set_device_valuators<'c>(&'c self, device_id: u8, first_valuator: u8, valuators: &[i32]) -> Result<Cookie<'c, Self, SetDeviceValuatorsReply>, ConnectionError>
+    fn xinput_set_device_valuators<'c, 'input>(&'c self, device_id: u8, first_valuator: u8, valuators: &'input [i32]) -> Result<Cookie<'c, Self, SetDeviceValuatorsReply>, ConnectionError>
     {
         set_device_valuators(self, device_id, first_valuator, valuators)
     }
@@ -15070,7 +15070,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         list_device_properties(self, device_id)
     }
-    fn xinput_change_device_property<'c>(&'c self, property: xproto::Atom, type_: xproto::Atom, device_id: u8, mode: xproto::PropMode, num_items: u32, items: &ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_change_device_property<'c, 'input>(&'c self, property: xproto::Atom, type_: xproto::Atom, device_id: u8, mode: xproto::PropMode, num_items: u32, items: &'input ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_device_property(self, property, type_, device_id, mode, num_items, items)
     }
@@ -15100,7 +15100,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         xi_change_cursor(self, window, cursor, deviceid)
     }
-    fn xinput_xi_change_hierarchy<'c>(&'c self, changes: &[HierarchyChange]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_change_hierarchy<'c, 'input>(&'c self, changes: &'input [HierarchyChange]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         xi_change_hierarchy(self, changes)
     }
@@ -15114,7 +15114,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         xi_get_client_pointer(self, window)
     }
-    fn xinput_xi_select_events<'c>(&'c self, window: xproto::Window, masks: &[EventMask]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_select_events<'c, 'input>(&'c self, window: xproto::Window, masks: &'input [EventMask]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         xi_select_events(self, window, masks)
     }
@@ -15141,7 +15141,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         xi_get_focus(self, deviceid)
     }
-    fn xinput_xi_grab_device<'c, A, B>(&'c self, window: xproto::Window, time: A, cursor: xproto::Cursor, deviceid: B, mode: xproto::GrabMode, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &[u32]) -> Result<Cookie<'c, Self, XIGrabDeviceReply>, ConnectionError>
+    fn xinput_xi_grab_device<'c, 'input, A, B>(&'c self, window: xproto::Window, time: A, cursor: xproto::Cursor, deviceid: B, mode: xproto::GrabMode, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32]) -> Result<Cookie<'c, Self, XIGrabDeviceReply>, ConnectionError>
     where
         A: Into<xproto::Timestamp>,
         B: Into<DeviceId>,
@@ -15162,14 +15162,14 @@ pub trait ConnectionExt: RequestConnection {
     {
         xi_allow_events(self, time, deviceid, event_mode, touchid, grab_window)
     }
-    fn xinput_xi_passive_grab_device<'c, A, B>(&'c self, time: A, grab_window: xproto::Window, cursor: xproto::Cursor, detail: u32, deviceid: B, grab_type: GrabType, grab_mode: GrabMode22, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &[u32], modifiers: &[u32]) -> Result<Cookie<'c, Self, XIPassiveGrabDeviceReply>, ConnectionError>
+    fn xinput_xi_passive_grab_device<'c, 'input, A, B>(&'c self, time: A, grab_window: xproto::Window, cursor: xproto::Cursor, detail: u32, deviceid: B, grab_type: GrabType, grab_mode: GrabMode22, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32], modifiers: &'input [u32]) -> Result<Cookie<'c, Self, XIPassiveGrabDeviceReply>, ConnectionError>
     where
         A: Into<xproto::Timestamp>,
         B: Into<DeviceId>,
     {
         xi_passive_grab_device(self, time, grab_window, cursor, detail, deviceid, grab_type, grab_mode, paired_device_mode, owner_events, mask, modifiers)
     }
-    fn xinput_xi_passive_ungrab_device<'c, A>(&'c self, grab_window: xproto::Window, detail: u32, deviceid: A, grab_type: GrabType, modifiers: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_passive_ungrab_device<'c, 'input, A>(&'c self, grab_window: xproto::Window, detail: u32, deviceid: A, grab_type: GrabType, modifiers: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<DeviceId>,
     {
@@ -15181,7 +15181,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         xi_list_properties(self, deviceid)
     }
-    fn xinput_xi_change_property<'c, A>(&'c self, deviceid: A, mode: xproto::PropMode, property: xproto::Atom, type_: xproto::Atom, num_items: u32, items: &XIChangePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_change_property<'c, 'input, A>(&'c self, deviceid: A, mode: xproto::PropMode, property: xproto::Atom, type_: xproto::Atom, num_items: u32, items: &'input XIChangePropertyAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<DeviceId>,
     {
@@ -15203,11 +15203,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         xi_get_selected_events(self, window)
     }
-    fn xinput_xi_barrier_release_pointer<'c>(&'c self, barriers: &[BarrierReleasePointerInfo]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_xi_barrier_release_pointer<'c, 'input>(&'c self, barriers: &'input [BarrierReleasePointerInfo]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         xi_barrier_release_pointer(self, barriers)
     }
-    fn xinput_send_extension_event<'c>(&'c self, destination: xproto::Window, device_id: u8, propagate: bool, events: &[EventForSend], classes: &[EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_send_extension_event<'c, 'input>(&'c self, destination: xproto::Window, device_id: u8, propagate: bool, events: &'input [EventForSend], classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         send_extension_event(self, destination, device_id, propagate, events, classes)
     }

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -84,13 +84,13 @@ impl Serialize for Fp3232 {
     }
 }
 
+/// Opcode for the GetExtensionVersion request
+pub const GET_EXTENSION_VERSION_REQUEST: u8 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetExtensionVersionRequest<'input> {
     pub name: &'input [u8],
 }
 impl<'input> GetExtensionVersionRequest<'input> {
-    /// Opcode for the GetExtensionVersion request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -103,7 +103,7 @@ impl<'input> GetExtensionVersionRequest<'input> {
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_EXTENSION_VERSION_REQUEST,
             0,
             0,
             name_len_bytes[0],
@@ -942,11 +942,11 @@ impl DeviceName {
     }
 }
 
+/// Opcode for the ListInputDevices request
+pub const LIST_INPUT_DEVICES_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListInputDevicesRequest;
 impl ListInputDevicesRequest {
-    /// Opcode for the ListInputDevices request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -957,7 +957,7 @@ impl ListInputDevicesRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_INPUT_DEVICES_REQUEST,
             0,
             0,
         ];
@@ -1069,13 +1069,13 @@ impl Serialize for InputClassInfo {
     }
 }
 
+/// Opcode for the OpenDevice request
+pub const OPEN_DEVICE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OpenDeviceRequest {
     pub device_id: u8,
 }
 impl OpenDeviceRequest {
-    /// Opcode for the OpenDevice request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1087,7 +1087,7 @@ impl OpenDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            OPEN_DEVICE_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -1162,13 +1162,13 @@ impl OpenDeviceReply {
     }
 }
 
+/// Opcode for the CloseDevice request
+pub const CLOSE_DEVICE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CloseDeviceRequest {
     pub device_id: u8,
 }
 impl CloseDeviceRequest {
-    /// Opcode for the CloseDevice request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1180,7 +1180,7 @@ impl CloseDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CLOSE_DEVICE_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -1207,14 +1207,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetDeviceMode request
+pub const SET_DEVICE_MODE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetDeviceModeRequest {
     pub device_id: u8,
     pub mode: ValuatorMode,
 }
 impl SetDeviceModeRequest {
-    /// Opcode for the SetDeviceMode request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1227,7 +1227,7 @@ impl SetDeviceModeRequest {
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_MODE_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -1283,14 +1283,14 @@ impl TryFrom<&[u8]> for SetDeviceModeReply {
     }
 }
 
+/// Opcode for the SelectExtensionEvent request
+pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectExtensionEventRequest<'input> {
     pub window: xproto::Window,
     pub classes: &'input [EventClass],
 }
 impl<'input> SelectExtensionEventRequest<'input> {
-    /// Opcode for the SelectExtensionEvent request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1304,7 +1304,7 @@ impl<'input> SelectExtensionEventRequest<'input> {
         let num_classes_bytes = num_classes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_EXTENSION_EVENT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1340,13 +1340,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetSelectedExtensionEvents request
+pub const GET_SELECTED_EXTENSION_EVENTS_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetSelectedExtensionEventsRequest {
     pub window: xproto::Window,
 }
 impl GetSelectedExtensionEventsRequest {
-    /// Opcode for the GetSelectedExtensionEvents request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1358,7 +1358,7 @@ impl GetSelectedExtensionEventsRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SELECTED_EXTENSION_EVENTS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1514,6 +1514,8 @@ impl TryFrom<u32> for PropagateMode {
     }
 }
 
+/// Opcode for the ChangeDeviceDontPropagateList request
+pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeDeviceDontPropagateListRequest<'input> {
     pub window: xproto::Window,
@@ -1521,8 +1523,6 @@ pub struct ChangeDeviceDontPropagateListRequest<'input> {
     pub classes: &'input [EventClass],
 }
 impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
-    /// Opcode for the ChangeDeviceDontPropagateList request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1537,7 +1537,7 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1574,13 +1574,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDeviceDontPropagateList request
+pub const GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceDontPropagateListRequest {
     pub window: xproto::Window,
 }
 impl GetDeviceDontPropagateListRequest {
-    /// Opcode for the GetDeviceDontPropagateList request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1592,7 +1592,7 @@ impl GetDeviceDontPropagateListRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1690,6 +1690,8 @@ impl DeviceTimeCoord {
     }
 }
 
+/// Opcode for the GetDeviceMotionEvents request
+pub const GET_DEVICE_MOTION_EVENTS_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceMotionEventsRequest {
     pub start: xproto::Timestamp,
@@ -1697,8 +1699,6 @@ pub struct GetDeviceMotionEventsRequest {
     pub device_id: u8,
 }
 impl GetDeviceMotionEventsRequest {
-    /// Opcode for the GetDeviceMotionEvents request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1712,7 +1712,7 @@ impl GetDeviceMotionEventsRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_MOTION_EVENTS_REQUEST,
             0,
             0,
             start_bytes[0],
@@ -1806,13 +1806,13 @@ impl GetDeviceMotionEventsReply {
     }
 }
 
+/// Opcode for the ChangeKeyboardDevice request
+pub const CHANGE_KEYBOARD_DEVICE_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeKeyboardDeviceRequest {
     pub device_id: u8,
 }
 impl ChangeKeyboardDeviceRequest {
-    /// Opcode for the ChangeKeyboardDevice request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1824,7 +1824,7 @@ impl ChangeKeyboardDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_KEYBOARD_DEVICE_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -1879,6 +1879,8 @@ impl TryFrom<&[u8]> for ChangeKeyboardDeviceReply {
     }
 }
 
+/// Opcode for the ChangePointerDevice request
+pub const CHANGE_POINTER_DEVICE_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangePointerDeviceRequest {
     pub x_axis: u8,
@@ -1886,8 +1888,6 @@ pub struct ChangePointerDeviceRequest {
     pub device_id: u8,
 }
 impl ChangePointerDeviceRequest {
-    /// Opcode for the ChangePointerDevice request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1901,7 +1901,7 @@ impl ChangePointerDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_POINTER_DEVICE_REQUEST,
             0,
             0,
             x_axis_bytes[0],
@@ -1958,6 +1958,8 @@ impl TryFrom<&[u8]> for ChangePointerDeviceReply {
     }
 }
 
+/// Opcode for the GrabDevice request
+pub const GRAB_DEVICE_REQUEST: u8 = 13;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
@@ -1969,8 +1971,6 @@ pub struct GrabDeviceRequest<'input> {
     pub classes: &'input [EventClass],
 }
 impl<'input> GrabDeviceRequest<'input> {
-    /// Opcode for the GrabDevice request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1989,7 +1989,7 @@ impl<'input> GrabDeviceRequest<'input> {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GRAB_DEVICE_REQUEST,
             0,
             0,
             grab_window_bytes[0],
@@ -2068,14 +2068,14 @@ impl TryFrom<&[u8]> for GrabDeviceReply {
     }
 }
 
+/// Opcode for the UngrabDevice request
+pub const UNGRAB_DEVICE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub device_id: u8,
 }
 impl UngrabDeviceRequest {
-    /// Opcode for the UngrabDevice request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2088,7 +2088,7 @@ impl UngrabDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNGRAB_DEVICE_REQUEST,
             0,
             0,
             time_bytes[0],
@@ -2181,6 +2181,8 @@ impl TryFrom<u32> for ModifierDevice {
     }
 }
 
+/// Opcode for the GrabDeviceKey request
+pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrabDeviceKeyRequest<'input> {
     pub grab_window: xproto::Window,
@@ -2194,8 +2196,6 @@ pub struct GrabDeviceKeyRequest<'input> {
     pub classes: &'input [EventClass],
 }
 impl<'input> GrabDeviceKeyRequest<'input> {
-    /// Opcode for the GrabDeviceKey request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2216,7 +2216,7 @@ impl<'input> GrabDeviceKeyRequest<'input> {
         let owner_events_bytes = self.owner_events.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GRAB_DEVICE_KEY_REQUEST,
             0,
             0,
             grab_window_bytes[0],
@@ -2273,6 +2273,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UngrabDeviceKey request
+pub const UNGRAB_DEVICE_KEY_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UngrabDeviceKeyRequest {
     pub grab_window: xproto::Window,
@@ -2282,8 +2284,6 @@ pub struct UngrabDeviceKeyRequest {
     pub grabbed_device: u8,
 }
 impl UngrabDeviceKeyRequest {
-    /// Opcode for the UngrabDeviceKey request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2299,7 +2299,7 @@ impl UngrabDeviceKeyRequest {
         let grabbed_device_bytes = self.grabbed_device.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNGRAB_DEVICE_KEY_REQUEST,
             0,
             0,
             grab_window_bytes[0],
@@ -2344,6 +2344,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GrabDeviceButton request
+pub const GRAB_DEVICE_BUTTON_REQUEST: u8 = 17;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrabDeviceButtonRequest<'input> {
     pub grab_window: xproto::Window,
@@ -2357,8 +2359,6 @@ pub struct GrabDeviceButtonRequest<'input> {
     pub classes: &'input [EventClass],
 }
 impl<'input> GrabDeviceButtonRequest<'input> {
-    /// Opcode for the GrabDeviceButton request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2379,7 +2379,7 @@ impl<'input> GrabDeviceButtonRequest<'input> {
         let owner_events_bytes = self.owner_events.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GRAB_DEVICE_BUTTON_REQUEST,
             0,
             0,
             grab_window_bytes[0],
@@ -2436,6 +2436,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UngrabDeviceButton request
+pub const UNGRAB_DEVICE_BUTTON_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UngrabDeviceButtonRequest {
     pub grab_window: xproto::Window,
@@ -2445,8 +2447,6 @@ pub struct UngrabDeviceButtonRequest {
     pub grabbed_device: u8,
 }
 impl UngrabDeviceButtonRequest {
-    /// Opcode for the UngrabDeviceButton request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2462,7 +2462,7 @@ impl UngrabDeviceButtonRequest {
         let grabbed_device_bytes = self.grabbed_device.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNGRAB_DEVICE_BUTTON_REQUEST,
             0,
             0,
             grab_window_bytes[0],
@@ -2581,6 +2581,8 @@ impl TryFrom<u32> for DeviceInputMode {
     }
 }
 
+/// Opcode for the AllowDeviceEvents request
+pub const ALLOW_DEVICE_EVENTS_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllowDeviceEventsRequest {
     pub time: xproto::Timestamp,
@@ -2588,8 +2590,6 @@ pub struct AllowDeviceEventsRequest {
     pub device_id: u8,
 }
 impl AllowDeviceEventsRequest {
-    /// Opcode for the AllowDeviceEvents request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2603,7 +2603,7 @@ impl AllowDeviceEventsRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            ALLOW_DEVICE_EVENTS_REQUEST,
             0,
             0,
             time_bytes[0],
@@ -2638,13 +2638,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDeviceFocus request
+pub const GET_DEVICE_FOCUS_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceFocusRequest {
     pub device_id: u8,
 }
 impl GetDeviceFocusRequest {
-    /// Opcode for the GetDeviceFocus request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2656,7 +2656,7 @@ impl GetDeviceFocusRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_FOCUS_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -2715,6 +2715,8 @@ impl TryFrom<&[u8]> for GetDeviceFocusReply {
     }
 }
 
+/// Opcode for the SetDeviceFocus request
+pub const SET_DEVICE_FOCUS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetDeviceFocusRequest {
     pub focus: xproto::Window,
@@ -2723,8 +2725,6 @@ pub struct SetDeviceFocusRequest {
     pub device_id: u8,
 }
 impl SetDeviceFocusRequest {
-    /// Opcode for the SetDeviceFocus request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2739,7 +2739,7 @@ impl SetDeviceFocusRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_FOCUS_REQUEST,
             0,
             0,
             focus_bytes[0],
@@ -3802,13 +3802,13 @@ impl Serialize for FeedbackState {
     }
 }
 
+/// Opcode for the GetFeedbackControl request
+pub const GET_FEEDBACK_CONTROL_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetFeedbackControlRequest {
     pub device_id: u8,
 }
 impl GetFeedbackControlRequest {
-    /// Opcode for the GetFeedbackControl request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3820,7 +3820,7 @@ impl GetFeedbackControlRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_FEEDBACK_CONTROL_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -4797,6 +4797,8 @@ impl From<ChangeFeedbackControlMask> for Option<u32> {
 }
 bitmask_binop!(ChangeFeedbackControlMask, u8);
 
+/// Opcode for the ChangeFeedbackControl request
+pub const CHANGE_FEEDBACK_CONTROL_REQUEST: u8 = 23;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeFeedbackControlRequest {
     pub mask: u32,
@@ -4805,8 +4807,6 @@ pub struct ChangeFeedbackControlRequest {
     pub feedback: FeedbackCtl,
 }
 impl ChangeFeedbackControlRequest {
-    /// Opcode for the ChangeFeedbackControl request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4820,7 +4820,7 @@ impl ChangeFeedbackControlRequest {
         let feedback_id_bytes = self.feedback_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_FEEDBACK_CONTROL_REQUEST,
             0,
             0,
             mask_bytes[0],
@@ -4860,6 +4860,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDeviceKeyMapping request
+pub const GET_DEVICE_KEY_MAPPING_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceKeyMappingRequest {
     pub device_id: u8,
@@ -4867,8 +4869,6 @@ pub struct GetDeviceKeyMappingRequest {
     pub count: u8,
 }
 impl GetDeviceKeyMappingRequest {
-    /// Opcode for the GetDeviceKeyMapping request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4882,7 +4882,7 @@ impl GetDeviceKeyMappingRequest {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_KEY_MAPPING_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -4954,6 +4954,8 @@ impl GetDeviceKeyMappingReply {
     }
 }
 
+/// Opcode for the ChangeDeviceKeyMapping request
+pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub device_id: u8,
@@ -4963,8 +4965,6 @@ pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub keysyms: &'input [xproto::Keysym],
 }
 impl<'input> ChangeDeviceKeyMappingRequest<'input> {
-    /// Opcode for the ChangeDeviceKeyMapping request
-    pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -4979,7 +4979,7 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
         let keycode_count_bytes = self.keycode_count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_DEVICE_KEY_MAPPING_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -5015,13 +5015,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDeviceModifierMapping request
+pub const GET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceModifierMappingRequest {
     pub device_id: u8,
 }
 impl GetDeviceModifierMappingRequest {
-    /// Opcode for the GetDeviceModifierMapping request
-    pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5033,7 +5033,7 @@ impl GetDeviceModifierMappingRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_MODIFIER_MAPPING_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -5105,14 +5105,14 @@ impl GetDeviceModifierMappingReply {
     }
 }
 
+/// Opcode for the SetDeviceModifierMapping request
+pub const SET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 27;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetDeviceModifierMappingRequest<'input> {
     pub device_id: u8,
     pub keymaps: &'input [u8],
 }
 impl<'input> SetDeviceModifierMappingRequest<'input> {
-    /// Opcode for the SetDeviceModifierMapping request
-    pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5127,7 +5127,7 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
         let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_MODIFIER_MAPPING_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -5186,13 +5186,13 @@ impl TryFrom<&[u8]> for SetDeviceModifierMappingReply {
     }
 }
 
+/// Opcode for the GetDeviceButtonMapping request
+pub const GET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceButtonMappingRequest {
     pub device_id: u8,
 }
 impl GetDeviceButtonMappingRequest {
-    /// Opcode for the GetDeviceButtonMapping request
-    pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5204,7 +5204,7 @@ impl GetDeviceButtonMappingRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_BUTTON_MAPPING_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -5280,14 +5280,14 @@ impl GetDeviceButtonMappingReply {
     }
 }
 
+/// Opcode for the SetDeviceButtonMapping request
+pub const SET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 29;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetDeviceButtonMappingRequest<'input> {
     pub device_id: u8,
     pub map: &'input [u8],
 }
 impl<'input> SetDeviceButtonMappingRequest<'input> {
-    /// Opcode for the SetDeviceButtonMapping request
-    pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5301,7 +5301,7 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
         let map_size_bytes = map_size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_BUTTON_MAPPING_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -5947,13 +5947,13 @@ impl Serialize for InputState {
     }
 }
 
+/// Opcode for the QueryDeviceState request
+pub const QUERY_DEVICE_STATE_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryDeviceStateRequest {
     pub device_id: u8,
 }
 impl QueryDeviceStateRequest {
-    /// Opcode for the QueryDeviceState request
-    pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -5965,7 +5965,7 @@ impl QueryDeviceStateRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_DEVICE_STATE_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -6035,6 +6035,8 @@ impl QueryDeviceStateReply {
     }
 }
 
+/// Opcode for the DeviceBell request
+pub const DEVICE_BELL_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeviceBellRequest {
     pub device_id: u8,
@@ -6043,8 +6045,6 @@ pub struct DeviceBellRequest {
     pub percent: i8,
 }
 impl DeviceBellRequest {
-    /// Opcode for the DeviceBell request
-    pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6059,7 +6059,7 @@ impl DeviceBellRequest {
         let percent_bytes = self.percent.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DEVICE_BELL_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -6089,6 +6089,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetDeviceValuators request
+pub const SET_DEVICE_VALUATORS_REQUEST: u8 = 33;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetDeviceValuatorsRequest<'input> {
     pub device_id: u8,
@@ -6096,8 +6098,6 @@ pub struct SetDeviceValuatorsRequest<'input> {
     pub valuators: &'input [i32],
 }
 impl<'input> SetDeviceValuatorsRequest<'input> {
-    /// Opcode for the SetDeviceValuators request
-    pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6112,7 +6112,7 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
         let num_valuators_bytes = num_valuators.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_VALUATORS_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -7006,14 +7006,14 @@ impl Serialize for DeviceState {
     }
 }
 
+/// Opcode for the GetDeviceControl request
+pub const GET_DEVICE_CONTROL_REQUEST: u8 = 34;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
 }
 impl GetDeviceControlRequest {
-    /// Opcode for the GetDeviceControl request
-    pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7026,7 +7026,7 @@ impl GetDeviceControlRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_CONTROL_REQUEST,
             0,
             0,
             control_id_bytes[0],
@@ -7832,6 +7832,8 @@ impl Serialize for DeviceCtl {
     }
 }
 
+/// Opcode for the ChangeDeviceControl request
+pub const CHANGE_DEVICE_CONTROL_REQUEST: u8 = 35;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeDeviceControlRequest {
     pub control_id: DeviceControl,
@@ -7839,8 +7841,6 @@ pub struct ChangeDeviceControlRequest {
     pub control: DeviceCtl,
 }
 impl ChangeDeviceControlRequest {
-    /// Opcode for the ChangeDeviceControl request
-    pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7853,7 +7853,7 @@ impl ChangeDeviceControlRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_DEVICE_CONTROL_REQUEST,
             0,
             0,
             control_id_bytes[0],
@@ -7913,13 +7913,13 @@ impl TryFrom<&[u8]> for ChangeDeviceControlReply {
     }
 }
 
+/// Opcode for the ListDeviceProperties request
+pub const LIST_DEVICE_PROPERTIES_REQUEST: u8 = 36;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListDevicePropertiesRequest {
     pub device_id: u8,
 }
 impl ListDevicePropertiesRequest {
-    /// Opcode for the ListDeviceProperties request
-    pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7931,7 +7931,7 @@ impl ListDevicePropertiesRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_DEVICE_PROPERTIES_REQUEST,
             0,
             0,
             device_id_bytes[0],
@@ -8128,6 +8128,8 @@ impl ChangeDevicePropertyAux {
     }
 }
 
+/// Opcode for the ChangeDeviceProperty request
+pub const CHANGE_DEVICE_PROPERTY_REQUEST: u8 = 37;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeDevicePropertyRequest<'input> {
     pub property: xproto::Atom,
@@ -8138,8 +8140,6 @@ pub struct ChangeDevicePropertyRequest<'input> {
     pub items: &'input ChangeDevicePropertyAux,
 }
 impl<'input> ChangeDevicePropertyRequest<'input> {
-    /// Opcode for the ChangeDeviceProperty request
-    pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8157,7 +8157,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         let num_items_bytes = self.num_items.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CHANGE_DEVICE_PROPERTY_REQUEST,
             0,
             0,
             property_bytes[0],
@@ -8205,14 +8205,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteDeviceProperty request
+pub const DELETE_DEVICE_PROPERTY_REQUEST: u8 = 38;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeleteDevicePropertyRequest {
     pub property: xproto::Atom,
     pub device_id: u8,
 }
 impl DeleteDevicePropertyRequest {
-    /// Opcode for the DeleteDeviceProperty request
-    pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8225,7 +8225,7 @@ impl DeleteDevicePropertyRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DELETE_DEVICE_PROPERTY_REQUEST,
             0,
             0,
             property_bytes[0],
@@ -8257,6 +8257,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDeviceProperty request
+pub const GET_DEVICE_PROPERTY_REQUEST: u8 = 39;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDevicePropertyRequest {
     pub property: xproto::Atom,
@@ -8267,8 +8269,6 @@ pub struct GetDevicePropertyRequest {
     pub delete: bool,
 }
 impl GetDevicePropertyRequest {
-    /// Opcode for the GetDeviceProperty request
-    pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8285,7 +8285,7 @@ impl GetDevicePropertyRequest {
         let delete_bytes = self.delete.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_PROPERTY_REQUEST,
             0,
             0,
             property_bytes[0],
@@ -8613,14 +8613,14 @@ impl Serialize for ModifierInfo {
     }
 }
 
+/// Opcode for the XIQueryPointer request
+pub const XI_QUERY_POINTER_REQUEST: u8 = 40;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIQueryPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
 }
 impl XIQueryPointerRequest {
-    /// Opcode for the XIQueryPointer request
-    pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8633,7 +8633,7 @@ impl XIQueryPointerRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_QUERY_POINTER_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -8727,6 +8727,8 @@ impl XIQueryPointerReply {
     }
 }
 
+/// Opcode for the XIWarpPointer request
+pub const XI_WARP_POINTER_REQUEST: u8 = 41;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIWarpPointerRequest {
     pub src_win: xproto::Window,
@@ -8740,8 +8742,6 @@ pub struct XIWarpPointerRequest {
     pub deviceid: DeviceId,
 }
 impl XIWarpPointerRequest {
-    /// Opcode for the XIWarpPointer request
-    pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8761,7 +8761,7 @@ impl XIWarpPointerRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_WARP_POINTER_REQUEST,
             0,
             0,
             src_win_bytes[0],
@@ -8826,6 +8826,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XIChangeCursor request
+pub const XI_CHANGE_CURSOR_REQUEST: u8 = 42;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIChangeCursorRequest {
     pub window: xproto::Window,
@@ -8833,8 +8835,6 @@ pub struct XIChangeCursorRequest {
     pub deviceid: DeviceId,
 }
 impl XIChangeCursorRequest {
-    /// Opcode for the XIChangeCursor request
-    pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8848,7 +8848,7 @@ impl XIChangeCursorRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_CHANGE_CURSOR_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -9566,13 +9566,13 @@ impl Serialize for HierarchyChange {
     }
 }
 
+/// Opcode for the XIChangeHierarchy request
+pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIChangeHierarchyRequest<'input> {
     pub changes: &'input [HierarchyChange],
 }
 impl<'input> XIChangeHierarchyRequest<'input> {
-    /// Opcode for the XIChangeHierarchy request
-    pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9585,7 +9585,7 @@ impl<'input> XIChangeHierarchyRequest<'input> {
         let num_changes_bytes = num_changes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_CHANGE_HIERARCHY_REQUEST,
             0,
             0,
             num_changes_bytes[0],
@@ -9616,14 +9616,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XISetClientPointer request
+pub const XI_SET_CLIENT_POINTER_REQUEST: u8 = 44;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XISetClientPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
 }
 impl XISetClientPointerRequest {
-    /// Opcode for the XISetClientPointer request
-    pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9636,7 +9636,7 @@ impl XISetClientPointerRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_SET_CLIENT_POINTER_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -9670,13 +9670,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XIGetClientPointer request
+pub const XI_GET_CLIENT_POINTER_REQUEST: u8 = 45;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIGetClientPointerRequest {
     pub window: xproto::Window,
 }
 impl XIGetClientPointerRequest {
-    /// Opcode for the XIGetClientPointer request
-    pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9688,7 +9688,7 @@ impl XIGetClientPointerRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_GET_CLIENT_POINTER_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -9898,14 +9898,14 @@ impl EventMask {
     }
 }
 
+/// Opcode for the XISelectEvents request
+pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XISelectEventsRequest<'input> {
     pub window: xproto::Window,
     pub masks: &'input [EventMask],
 }
 impl<'input> XISelectEventsRequest<'input> {
-    /// Opcode for the XISelectEvents request
-    pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9919,7 +9919,7 @@ impl<'input> XISelectEventsRequest<'input> {
         let num_mask_bytes = num_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_SELECT_EVENTS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -9955,14 +9955,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XIQueryVersion request
+pub const XI_QUERY_VERSION_REQUEST: u8 = 47;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIQueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
 }
 impl XIQueryVersionRequest {
-    /// Opcode for the XIQueryVersion request
-    pub const fn opcode() -> u8 { 47 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9975,7 +9975,7 @@ impl XIQueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_QUERY_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -11258,13 +11258,13 @@ impl XIDeviceInfo {
     }
 }
 
+/// Opcode for the XIQueryDevice request
+pub const XI_QUERY_DEVICE_REQUEST: u8 = 48;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIQueryDeviceRequest {
     pub deviceid: DeviceId,
 }
 impl XIQueryDeviceRequest {
-    /// Opcode for the XIQueryDevice request
-    pub const fn opcode() -> u8 { 48 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11276,7 +11276,7 @@ impl XIQueryDeviceRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_QUERY_DEVICE_REQUEST,
             0,
             0,
             deviceid_bytes[0],
@@ -11347,6 +11347,8 @@ impl XIQueryDeviceReply {
     }
 }
 
+/// Opcode for the XISetFocus request
+pub const XI_SET_FOCUS_REQUEST: u8 = 49;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XISetFocusRequest {
     pub window: xproto::Window,
@@ -11354,8 +11356,6 @@ pub struct XISetFocusRequest {
     pub deviceid: DeviceId,
 }
 impl XISetFocusRequest {
-    /// Opcode for the XISetFocus request
-    pub const fn opcode() -> u8 { 49 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11369,7 +11369,7 @@ impl XISetFocusRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_SET_FOCUS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -11410,13 +11410,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XIGetFocus request
+pub const XI_GET_FOCUS_REQUEST: u8 = 50;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIGetFocusRequest {
     pub deviceid: DeviceId,
 }
 impl XIGetFocusRequest {
-    /// Opcode for the XIGetFocus request
-    pub const fn opcode() -> u8 { 50 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11428,7 +11428,7 @@ impl XIGetFocusRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_GET_FOCUS_REQUEST,
             0,
             0,
             deviceid_bytes[0],
@@ -11553,6 +11553,8 @@ impl TryFrom<u32> for GrabOwner {
     }
 }
 
+/// Opcode for the XIGrabDevice request
+pub const XI_GRAB_DEVICE_REQUEST: u8 = 51;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIGrabDeviceRequest<'input> {
     pub window: xproto::Window,
@@ -11565,8 +11567,6 @@ pub struct XIGrabDeviceRequest<'input> {
     pub mask: &'input [u32],
 }
 impl<'input> XIGrabDeviceRequest<'input> {
-    /// Opcode for the XIGrabDevice request
-    pub const fn opcode() -> u8 { 51 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11586,7 +11586,7 @@ impl<'input> XIGrabDeviceRequest<'input> {
         let mask_len_bytes = mask_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_GRAB_DEVICE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -11671,14 +11671,14 @@ impl TryFrom<&[u8]> for XIGrabDeviceReply {
     }
 }
 
+/// Opcode for the XIUngrabDevice request
+pub const XI_UNGRAB_DEVICE_REQUEST: u8 = 52;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIUngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
 }
 impl XIUngrabDeviceRequest {
-    /// Opcode for the XIUngrabDevice request
-    pub const fn opcode() -> u8 { 52 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11691,7 +11691,7 @@ impl XIUngrabDeviceRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_UNGRAB_DEVICE_REQUEST,
             0,
             0,
             time_bytes[0],
@@ -11807,6 +11807,8 @@ impl TryFrom<u32> for EventMode {
     }
 }
 
+/// Opcode for the XIAllowEvents request
+pub const XI_ALLOW_EVENTS_REQUEST: u8 = 53;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIAllowEventsRequest {
     pub time: xproto::Timestamp,
@@ -11816,8 +11818,6 @@ pub struct XIAllowEventsRequest {
     pub grab_window: xproto::Window,
 }
 impl XIAllowEventsRequest {
-    /// Opcode for the XIAllowEvents request
-    pub const fn opcode() -> u8 { 53 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11833,7 +11833,7 @@ impl XIAllowEventsRequest {
         let grab_window_bytes = self.grab_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_ALLOW_EVENTS_REQUEST,
             0,
             0,
             time_bytes[0],
@@ -12089,6 +12089,8 @@ impl Serialize for GrabModifierInfo {
     }
 }
 
+/// Opcode for the XIPassiveGrabDevice request
+pub const XI_PASSIVE_GRAB_DEVICE_REQUEST: u8 = 54;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIPassiveGrabDeviceRequest<'input> {
     pub time: xproto::Timestamp,
@@ -12104,8 +12106,6 @@ pub struct XIPassiveGrabDeviceRequest<'input> {
     pub modifiers: &'input [u32],
 }
 impl<'input> XIPassiveGrabDeviceRequest<'input> {
-    /// Opcode for the XIPassiveGrabDevice request
-    pub const fn opcode() -> u8 { 54 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12129,7 +12129,7 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
         let owner_events_bytes = bool::from(self.owner_events).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_PASSIVE_GRAB_DEVICE_REQUEST,
             0,
             0,
             time_bytes[0],
@@ -12242,6 +12242,8 @@ impl XIPassiveGrabDeviceReply {
     }
 }
 
+/// Opcode for the XIPassiveUngrabDevice request
+pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
@@ -12251,8 +12253,6 @@ pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub modifiers: &'input [u32],
 }
 impl<'input> XIPassiveUngrabDeviceRequest<'input> {
-    /// Opcode for the XIPassiveUngrabDevice request
-    pub const fn opcode() -> u8 { 55 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12269,7 +12269,7 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
         let grab_type_bytes = u8::from(self.grab_type).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_PASSIVE_UNGRAB_DEVICE_REQUEST,
             0,
             0,
             grab_window_bytes[0],
@@ -12318,13 +12318,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XIListProperties request
+pub const XI_LIST_PROPERTIES_REQUEST: u8 = 56;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIListPropertiesRequest {
     pub deviceid: DeviceId,
 }
 impl XIListPropertiesRequest {
-    /// Opcode for the XIListProperties request
-    pub const fn opcode() -> u8 { 56 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12336,7 +12336,7 @@ impl XIListPropertiesRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_LIST_PROPERTIES_REQUEST,
             0,
             0,
             deviceid_bytes[0],
@@ -12469,6 +12469,8 @@ impl XIChangePropertyAux {
     }
 }
 
+/// Opcode for the XIChangeProperty request
+pub const XI_CHANGE_PROPERTY_REQUEST: u8 = 57;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIChangePropertyRequest<'input> {
     pub deviceid: DeviceId,
@@ -12479,8 +12481,6 @@ pub struct XIChangePropertyRequest<'input> {
     pub items: &'input XIChangePropertyAux,
 }
 impl<'input> XIChangePropertyRequest<'input> {
-    /// Opcode for the XIChangeProperty request
-    pub const fn opcode() -> u8 { 57 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12498,7 +12498,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         let num_items_bytes = self.num_items.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_CHANGE_PROPERTY_REQUEST,
             0,
             0,
             deviceid_bytes[0],
@@ -12548,14 +12548,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XIDeleteProperty request
+pub const XI_DELETE_PROPERTY_REQUEST: u8 = 58;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIDeletePropertyRequest {
     pub deviceid: DeviceId,
     pub property: xproto::Atom,
 }
 impl XIDeletePropertyRequest {
-    /// Opcode for the XIDeleteProperty request
-    pub const fn opcode() -> u8 { 58 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12568,7 +12568,7 @@ impl XIDeletePropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_DELETE_PROPERTY_REQUEST,
             0,
             0,
             deviceid_bytes[0],
@@ -12602,6 +12602,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the XIGetProperty request
+pub const XI_GET_PROPERTY_REQUEST: u8 = 59;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIGetPropertyRequest {
     pub deviceid: DeviceId,
@@ -12612,8 +12614,6 @@ pub struct XIGetPropertyRequest {
     pub len: u32,
 }
 impl XIGetPropertyRequest {
-    /// Opcode for the XIGetProperty request
-    pub const fn opcode() -> u8 { 59 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12630,7 +12630,7 @@ impl XIGetPropertyRequest {
         let len_bytes = self.len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_GET_PROPERTY_REQUEST,
             0,
             0,
             deviceid_bytes[0],
@@ -12783,13 +12783,13 @@ impl TryFrom<&[u8]> for XIGetPropertyReply {
     }
 }
 
+/// Opcode for the XIGetSelectedEvents request
+pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XIGetSelectedEventsRequest {
     pub window: xproto::Window,
 }
 impl XIGetSelectedEventsRequest {
-    /// Opcode for the XIGetSelectedEvents request
-    pub const fn opcode() -> u8 { 60 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12801,7 +12801,7 @@ impl XIGetSelectedEventsRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_GET_SELECTED_EVENTS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -12922,13 +12922,13 @@ impl Serialize for BarrierReleasePointerInfo {
     }
 }
 
+/// Opcode for the XIBarrierReleasePointer request
+pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIBarrierReleasePointerRequest<'input> {
     pub barriers: &'input [BarrierReleasePointerInfo],
 }
 impl<'input> XIBarrierReleasePointerRequest<'input> {
-    /// Opcode for the XIBarrierReleasePointer request
-    pub const fn opcode() -> u8 { 61 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12941,7 +12941,7 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
         let num_barriers_bytes = num_barriers.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            XI_BARRIER_RELEASE_POINTER_REQUEST,
             0,
             0,
             num_barriers_bytes[0],
@@ -15827,6 +15827,8 @@ impl From<&DevicePropertyNotifyEvent> for EventForSend {
     }
 }
 
+/// Opcode for the SendExtensionEvent request
+pub const SEND_EXTENSION_EVENT_REQUEST: u8 = 31;
 #[derive(Debug, Clone)]
 pub struct SendExtensionEventRequest<'input> {
     pub destination: xproto::Window,
@@ -15836,8 +15838,6 @@ pub struct SendExtensionEventRequest<'input> {
     pub classes: &'input [EventClass],
 }
 impl<'input> SendExtensionEventRequest<'input> {
-    /// Opcode for the SendExtensionEvent request
-    pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15855,7 +15855,7 @@ impl<'input> SendExtensionEventRequest<'input> {
         let num_events_bytes = num_events.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SEND_EXTENSION_EVENT_REQUEST,
             0,
             0,
             destination_bytes[0],

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -128,7 +128,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetExtensionVersionRequest {
-        name: name,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1111,7 +1111,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = OpenDeviceRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1205,7 +1205,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CloseDeviceRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1253,8 +1253,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDeviceModeRequest {
-        device_id: device_id,
-        mode: mode,
+        device_id,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1339,8 +1339,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SelectExtensionEventRequest {
-        window: window,
-        classes: classes,
+        window,
+        classes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1386,7 +1386,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetSelectedExtensionEventsRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1574,9 +1574,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeDeviceDontPropagateListRequest {
-        window: window,
-        mode: mode,
-        classes: classes,
+        window,
+        mode,
+        classes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1622,7 +1622,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceDontPropagateListRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1753,9 +1753,9 @@ where
 {
     let stop: xproto::Timestamp = stop.into();
     let request0 = GetDeviceMotionEventsRequest {
-        start: start,
-        stop: stop,
-        device_id: device_id,
+        start,
+        stop,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1856,7 +1856,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeKeyboardDeviceRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1934,9 +1934,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangePointerDeviceRequest {
-        x_axis: x_axis,
-        y_axis: y_axis,
-        device_id: device_id,
+        x_axis,
+        y_axis,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2041,13 +2041,13 @@ where
 {
     let time: xproto::Timestamp = time.into();
     let request0 = GrabDeviceRequest {
-        grab_window: grab_window,
-        time: time,
-        this_device_mode: this_device_mode,
-        other_device_mode: other_device_mode,
-        owner_events: owner_events,
-        device_id: device_id,
-        classes: classes,
+        grab_window,
+        time,
+        this_device_mode,
+        other_device_mode,
+        owner_events,
+        device_id,
+        classes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2129,8 +2129,8 @@ where
 {
     let time: xproto::Timestamp = time.into();
     let request0 = UngrabDeviceRequest {
-        time: time,
-        device_id: device_id,
+        time,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2274,15 +2274,15 @@ where
     let modifier_device: u8 = modifier_device.into();
     let key: u8 = key.into();
     let request0 = GrabDeviceKeyRequest {
-        grab_window: grab_window,
-        modifiers: modifiers,
-        modifier_device: modifier_device,
-        grabbed_device: grabbed_device,
-        key: key,
-        this_device_mode: this_device_mode,
-        other_device_mode: other_device_mode,
-        owner_events: owner_events,
-        classes: classes,
+        grab_window,
+        modifiers,
+        modifier_device,
+        grabbed_device,
+        key,
+        this_device_mode,
+        other_device_mode,
+        owner_events,
+        classes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2350,11 +2350,11 @@ where
     let modifier_device: u8 = modifier_device.into();
     let key: u8 = key.into();
     let request0 = UngrabDeviceKeyRequest {
-        grab_window: grab_window,
-        modifiers: modifiers,
-        modifier_device: modifier_device,
-        key: key,
-        grabbed_device: grabbed_device,
+        grab_window,
+        modifiers,
+        modifier_device,
+        key,
+        grabbed_device,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2439,15 +2439,15 @@ where
     let modifiers: u16 = modifiers.into();
     let button: u8 = button.into();
     let request0 = GrabDeviceButtonRequest {
-        grab_window: grab_window,
-        grabbed_device: grabbed_device,
-        modifier_device: modifier_device,
-        modifiers: modifiers,
-        this_device_mode: this_device_mode,
-        other_device_mode: other_device_mode,
-        button: button,
-        owner_events: owner_events,
-        classes: classes,
+        grab_window,
+        grabbed_device,
+        modifier_device,
+        modifiers,
+        this_device_mode,
+        other_device_mode,
+        button,
+        owner_events,
+        classes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2515,11 +2515,11 @@ where
     let modifier_device: u8 = modifier_device.into();
     let button: u8 = button.into();
     let request0 = UngrabDeviceButtonRequest {
-        grab_window: grab_window,
-        modifiers: modifiers,
-        modifier_device: modifier_device,
-        button: button,
-        grabbed_device: grabbed_device,
+        grab_window,
+        modifiers,
+        modifier_device,
+        button,
+        grabbed_device,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2649,9 +2649,9 @@ where
 {
     let time: xproto::Timestamp = time.into();
     let request0 = AllowDeviceEventsRequest {
-        time: time,
-        mode: mode,
-        device_id: device_id,
+        time,
+        mode,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2697,7 +2697,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceFocusRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2793,10 +2793,10 @@ where
     let focus: xproto::Window = focus.into();
     let time: xproto::Timestamp = time.into();
     let request0 = SetDeviceFocusRequest {
-        focus: focus,
-        time: time,
-        revert_to: revert_to,
-        device_id: device_id,
+        focus,
+        time,
+        revert_to,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3863,7 +3863,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetFeedbackControlRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4874,10 +4874,10 @@ where
 {
     let mask: u32 = mask.into();
     let request0 = ChangeFeedbackControlRequest {
-        mask: mask,
-        device_id: device_id,
-        feedback_id: feedback_id,
-        feedback: feedback,
+        mask,
+        device_id,
+        feedback_id,
+        feedback,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4927,9 +4927,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceKeyMappingRequest {
-        device_id: device_id,
-        first_keycode: first_keycode,
-        count: count,
+        device_id,
+        first_keycode,
+        count,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5030,11 +5030,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeDeviceKeyMappingRequest {
-        device_id: device_id,
-        first_keycode: first_keycode,
-        keysyms_per_keycode: keysyms_per_keycode,
-        keycode_count: keycode_count,
-        keysyms: keysyms,
+        device_id,
+        first_keycode,
+        keysyms_per_keycode,
+        keycode_count,
+        keysyms,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5080,7 +5080,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceModifierMappingRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5178,8 +5178,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDeviceModifierMappingRequest {
-        device_id: device_id,
-        keymaps: keymaps,
+        device_id,
+        keymaps,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5253,7 +5253,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceButtonMappingRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5354,8 +5354,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDeviceButtonMappingRequest {
-        device_id: device_id,
-        map: map,
+        device_id,
+        map,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6016,7 +6016,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryDeviceStateRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6111,10 +6111,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeviceBellRequest {
-        device_id: device_id,
-        feedback_id: feedback_id,
-        feedback_class: feedback_class,
-        percent: percent,
+        device_id,
+        feedback_id,
+        feedback_class,
+        percent,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6169,9 +6169,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDeviceValuatorsRequest {
-        device_id: device_id,
-        first_valuator: first_valuator,
-        valuators: valuators,
+        device_id,
+        first_valuator,
+        valuators,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7080,8 +7080,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceControlRequest {
-        control_id: control_id,
-        device_id: device_id,
+        control_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7912,9 +7912,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeDeviceControlRequest {
-        control_id: control_id,
-        device_id: device_id,
-        control: control,
+        control_id,
+        device_id,
+        control,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7987,7 +7987,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListDevicePropertiesRequest {
-        device_id: device_id,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8230,12 +8230,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeDevicePropertyRequest {
-        property: property,
-        type_: type_,
-        device_id: device_id,
-        mode: mode,
-        num_items: num_items,
-        items: items,
+        property,
+        type_,
+        device_id,
+        mode,
+        num_items,
+        items,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8287,8 +8287,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeleteDevicePropertyRequest {
-        property: property,
-        device_id: device_id,
+        property,
+        device_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8360,12 +8360,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDevicePropertyRequest {
-        property: property,
-        type_: type_,
-        offset: offset,
-        len: len,
-        device_id: device_id,
-        delete: delete,
+        property,
+        type_,
+        offset,
+        len,
+        device_id,
+        delete,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8699,8 +8699,8 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIQueryPointerRequest {
-        window: window,
-        deviceid: deviceid,
+        window,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8852,15 +8852,15 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIWarpPointerRequest {
-        src_win: src_win,
-        dst_win: dst_win,
-        src_x: src_x,
-        src_y: src_y,
-        src_width: src_width,
-        src_height: src_height,
-        dst_x: dst_x,
-        dst_y: dst_y,
-        deviceid: deviceid,
+        src_win,
+        dst_win,
+        src_x,
+        src_y,
+        src_width,
+        src_height,
+        dst_x,
+        dst_y,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8920,9 +8920,9 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIChangeCursorRequest {
-        window: window,
-        cursor: cursor,
-        deviceid: deviceid,
+        window,
+        cursor,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9652,7 +9652,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XIChangeHierarchyRequest {
-        changes: changes,
+        changes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9706,8 +9706,8 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XISetClientPointerRequest {
-        window: window,
-        deviceid: deviceid,
+        window,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9753,7 +9753,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XIGetClientPointerRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9993,8 +9993,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XISelectEventsRequest {
-        window: window,
-        masks: masks,
+        window,
+        masks,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10042,8 +10042,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XIQueryVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11346,7 +11346,7 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIQueryDeviceRequest {
-        deviceid: deviceid,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11450,9 +11450,9 @@ where
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
     let request0 = XISetFocusRequest {
-        window: window,
-        time: time,
-        deviceid: deviceid,
+        window,
+        time,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11500,7 +11500,7 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIGetFocusRequest {
-        deviceid: deviceid,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11681,14 +11681,14 @@ where
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIGrabDeviceRequest {
-        window: window,
-        time: time,
-        cursor: cursor,
-        deviceid: deviceid,
-        mode: mode,
-        paired_device_mode: paired_device_mode,
-        owner_events: owner_events,
-        mask: mask,
+        window,
+        time,
+        cursor,
+        deviceid,
+        mode,
+        paired_device_mode,
+        owner_events,
+        mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11771,8 +11771,8 @@ where
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIUngrabDeviceRequest {
-        time: time,
-        deviceid: deviceid,
+        time,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11922,11 +11922,11 @@ where
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIAllowEventsRequest {
-        time: time,
-        deviceid: deviceid,
-        event_mode: event_mode,
-        touchid: touchid,
-        grab_window: grab_window,
+        time,
+        deviceid,
+        event_mode,
+        touchid,
+        grab_window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12237,17 +12237,17 @@ where
     let time: xproto::Timestamp = time.into();
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIPassiveGrabDeviceRequest {
-        time: time,
-        grab_window: grab_window,
-        cursor: cursor,
-        detail: detail,
-        deviceid: deviceid,
-        grab_type: grab_type,
-        grab_mode: grab_mode,
-        paired_device_mode: paired_device_mode,
-        owner_events: owner_events,
-        mask: mask,
-        modifiers: modifiers,
+        time,
+        grab_window,
+        cursor,
+        detail,
+        deviceid,
+        grab_type,
+        grab_mode,
+        paired_device_mode,
+        owner_events,
+        mask,
+        modifiers,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12362,11 +12362,11 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIPassiveUngrabDeviceRequest {
-        grab_window: grab_window,
-        detail: detail,
-        deviceid: deviceid,
-        grab_type: grab_type,
-        modifiers: modifiers,
+        grab_window,
+        detail,
+        deviceid,
+        grab_type,
+        modifiers,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12414,7 +12414,7 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIListPropertiesRequest {
-        deviceid: deviceid,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12593,12 +12593,12 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIChangePropertyRequest {
-        deviceid: deviceid,
-        mode: mode,
-        property: property,
-        type_: type_,
-        num_items: num_items,
-        items: items,
+        deviceid,
+        mode,
+        property,
+        type_,
+        num_items,
+        items,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12652,8 +12652,8 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIDeletePropertyRequest {
-        deviceid: deviceid,
-        property: property,
+        deviceid,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12727,12 +12727,12 @@ where
 {
     let deviceid: DeviceId = deviceid.into();
     let request0 = XIGetPropertyRequest {
-        deviceid: deviceid,
-        delete: delete,
-        property: property,
-        type_: type_,
-        offset: offset,
-        len: len,
+        deviceid,
+        delete,
+        property,
+        type_,
+        offset,
+        len,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12881,7 +12881,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XIGetSelectedEventsRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13026,7 +13026,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XIBarrierReleasePointerRequest {
-        barriers: barriers,
+        barriers,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15951,11 +15951,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SendExtensionEventRequest {
-        destination: destination,
-        device_id: device_id,
-        propagate: propagate,
-        events: events,
-        classes: classes,
+        destination,
+        device_id,
+        propagate,
+        events,
+        classes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -93,7 +92,7 @@ impl<'input> GetExtensionVersionRequest<'input> {
     /// Opcode for the GetExtensionVersion request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -119,7 +118,7 @@ impl<'input> GetExtensionVersionRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn get_extension_version<'c, 'input, Conn>(conn: &'c Conn, name: &'input [u8]) -> Result<Cookie<'c, Conn, GetExtensionVersionReply>, ConnectionError>
@@ -949,7 +948,7 @@ impl ListInputDevicesRequest {
     /// Opcode for the ListInputDevices request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1078,7 +1077,7 @@ impl OpenDeviceRequest {
     /// Opcode for the OpenDevice request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1171,7 +1170,7 @@ impl CloseDeviceRequest {
     /// Opcode for the CloseDevice request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1217,7 +1216,7 @@ impl SetDeviceModeRequest {
     /// Opcode for the SetDeviceMode request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1293,7 +1292,7 @@ impl<'input> SelectExtensionEventRequest<'input> {
     /// Opcode for the SelectExtensionEvent request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1325,7 +1324,7 @@ impl<'input> SelectExtensionEventRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), classes_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn select_extension_event<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1349,7 +1348,7 @@ impl GetSelectedExtensionEventsRequest {
     /// Opcode for the GetSelectedExtensionEvents request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1525,7 +1524,7 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
     /// Opcode for the ChangeDeviceDontPropagateList request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1558,7 +1557,7 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), classes_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_device_dont_propagate_list<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode: PropagateMode, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1583,7 +1582,7 @@ impl GetDeviceDontPropagateListRequest {
     /// Opcode for the GetDeviceDontPropagateList request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1701,7 +1700,7 @@ impl GetDeviceMotionEventsRequest {
     /// Opcode for the GetDeviceMotionEvents request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1815,7 +1814,7 @@ impl ChangeKeyboardDeviceRequest {
     /// Opcode for the ChangeKeyboardDevice request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1890,7 +1889,7 @@ impl ChangePointerDeviceRequest {
     /// Opcode for the ChangePointerDevice request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1973,7 +1972,7 @@ impl<'input> GrabDeviceRequest<'input> {
     /// Opcode for the GrabDevice request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2018,7 +2017,7 @@ impl<'input> GrabDeviceRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), classes_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn grab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, time: A, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, device_id: u8, classes: &'input [EventClass]) -> Result<Cookie<'c, Conn, GrabDeviceReply>, ConnectionError>
@@ -2078,7 +2077,7 @@ impl UngrabDeviceRequest {
     /// Opcode for the UngrabDevice request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2198,7 +2197,7 @@ impl<'input> GrabDeviceKeyRequest<'input> {
     /// Opcode for the GrabDeviceKey request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2245,7 +2244,7 @@ impl<'input> GrabDeviceKeyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), classes_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn grab_device_key<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2286,7 +2285,7 @@ impl UngrabDeviceKeyRequest {
     /// Opcode for the UngrabDeviceKey request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2361,7 +2360,7 @@ impl<'input> GrabDeviceButtonRequest<'input> {
     /// Opcode for the GrabDeviceButton request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2408,7 +2407,7 @@ impl<'input> GrabDeviceButtonRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), classes_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn grab_device_button<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2449,7 +2448,7 @@ impl UngrabDeviceButtonRequest {
     /// Opcode for the UngrabDeviceButton request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2592,7 +2591,7 @@ impl AllowDeviceEventsRequest {
     /// Opcode for the AllowDeviceEvents request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2647,7 +2646,7 @@ impl GetDeviceFocusRequest {
     /// Opcode for the GetDeviceFocus request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2727,7 +2726,7 @@ impl SetDeviceFocusRequest {
     /// Opcode for the SetDeviceFocus request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3811,7 +3810,7 @@ impl GetFeedbackControlRequest {
     /// Opcode for the GetFeedbackControl request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4809,7 +4808,7 @@ impl ChangeFeedbackControlRequest {
     /// Opcode for the ChangeFeedbackControl request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4841,7 +4840,7 @@ impl ChangeFeedbackControlRequest {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), feedback_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), feedback_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_feedback_control<Conn, A>(conn: &Conn, mask: A, device_id: u8, feedback_id: u8, feedback: FeedbackCtl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
@@ -4871,7 +4870,7 @@ impl GetDeviceKeyMappingRequest {
     /// Opcode for the GetDeviceKeyMapping request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4967,7 +4966,7 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
     /// Opcode for the ChangeDeviceKeyMapping request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -4997,7 +4996,7 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), keysyms_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), keysyms_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_device_key_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &'input [xproto::Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -5024,7 +5023,7 @@ impl GetDeviceModifierMappingRequest {
     /// Opcode for the GetDeviceModifierMapping request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5115,7 +5114,7 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
     /// Opcode for the SetDeviceModifierMapping request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5143,7 +5142,7 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.keymaps[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.keymaps[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, keymaps: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceModifierMappingReply>, ConnectionError>
@@ -5195,7 +5194,7 @@ impl GetDeviceButtonMappingRequest {
     /// Opcode for the GetDeviceButtonMapping request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5290,7 +5289,7 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
     /// Opcode for the SetDeviceButtonMapping request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -5317,7 +5316,7 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.map[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.map[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_button_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceButtonMappingReply>, ConnectionError>
@@ -5956,7 +5955,7 @@ impl QueryDeviceStateRequest {
     /// Opcode for the QueryDeviceState request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6047,7 +6046,7 @@ impl DeviceBellRequest {
     /// Opcode for the DeviceBell request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6100,7 +6099,7 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
     /// Opcode for the SetDeviceValuators request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6129,7 +6128,7 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), valuators_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), valuators_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_valuators<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_valuator: u8, valuators: &'input [i32]) -> Result<Cookie<'c, Conn, SetDeviceValuatorsReply>, ConnectionError>
@@ -7016,7 +7015,7 @@ impl GetDeviceControlRequest {
     /// Opcode for the GetDeviceControl request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7843,7 +7842,7 @@ impl ChangeDeviceControlRequest {
     /// Opcode for the ChangeDeviceControl request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7870,7 +7869,7 @@ impl ChangeDeviceControlRequest {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), control_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), control_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_device_control<Conn>(conn: &Conn, control_id: DeviceControl, device_id: u8, control: DeviceCtl) -> Result<Cookie<'_, Conn, ChangeDeviceControlReply>, ConnectionError>
@@ -7922,7 +7921,7 @@ impl ListDevicePropertiesRequest {
     /// Opcode for the ListDeviceProperties request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8142,7 +8141,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
     /// Opcode for the ChangeDeviceProperty request
     pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8186,7 +8185,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), items_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), items_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_device_property<'c, 'input, Conn>(conn: &'c Conn, property: xproto::Atom, type_: xproto::Atom, device_id: u8, mode: xproto::PropMode, num_items: u32, items: &'input ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -8215,7 +8214,7 @@ impl DeleteDevicePropertyRequest {
     /// Opcode for the DeleteDeviceProperty request
     pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8271,7 +8270,7 @@ impl GetDevicePropertyRequest {
     /// Opcode for the GetDeviceProperty request
     pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8623,7 +8622,7 @@ impl XIQueryPointerRequest {
     /// Opcode for the XIQueryPointer request
     pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8744,7 +8743,7 @@ impl XIWarpPointerRequest {
     /// Opcode for the XIWarpPointer request
     pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8837,7 +8836,7 @@ impl XIChangeCursorRequest {
     /// Opcode for the XIChangeCursor request
     pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9575,7 +9574,7 @@ impl<'input> XIChangeHierarchyRequest<'input> {
     /// Opcode for the XIChangeHierarchy request
     pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9602,7 +9601,7 @@ impl<'input> XIChangeHierarchyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), changes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), changes_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn xi_change_hierarchy<'c, 'input, Conn>(conn: &'c Conn, changes: &'input [HierarchyChange]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -9626,7 +9625,7 @@ impl XISetClientPointerRequest {
     /// Opcode for the XISetClientPointer request
     pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9679,7 +9678,7 @@ impl XIGetClientPointerRequest {
     /// Opcode for the XIGetClientPointer request
     pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9908,7 +9907,7 @@ impl<'input> XISelectEventsRequest<'input> {
     /// Opcode for the XISelectEvents request
     pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9940,7 +9939,7 @@ impl<'input> XISelectEventsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), masks_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), masks_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn xi_select_events<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, masks: &'input [EventMask]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -9965,7 +9964,7 @@ impl XIQueryVersionRequest {
     /// Opcode for the XIQueryVersion request
     pub const fn opcode() -> u8 { 47 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11267,7 +11266,7 @@ impl XIQueryDeviceRequest {
     /// Opcode for the XIQueryDevice request
     pub const fn opcode() -> u8 { 48 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11358,7 +11357,7 @@ impl XISetFocusRequest {
     /// Opcode for the XISetFocus request
     pub const fn opcode() -> u8 { 49 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11419,7 +11418,7 @@ impl XIGetFocusRequest {
     /// Opcode for the XIGetFocus request
     pub const fn opcode() -> u8 { 50 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11569,7 +11568,7 @@ impl<'input> XIGrabDeviceRequest<'input> {
     /// Opcode for the XIGrabDevice request
     pub const fn opcode() -> u8 { 51 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11619,7 +11618,7 @@ impl<'input> XIGrabDeviceRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), mask_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), mask_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn xi_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, window: xproto::Window, time: A, cursor: xproto::Cursor, deviceid: B, mode: xproto::GrabMode, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32]) -> Result<Cookie<'c, Conn, XIGrabDeviceReply>, ConnectionError>
@@ -11681,7 +11680,7 @@ impl XIUngrabDeviceRequest {
     /// Opcode for the XIUngrabDevice request
     pub const fn opcode() -> u8 { 52 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11820,7 +11819,7 @@ impl XIAllowEventsRequest {
     /// Opcode for the XIAllowEvents request
     pub const fn opcode() -> u8 { 53 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12108,7 +12107,7 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
     /// Opcode for the XIPassiveGrabDevice request
     pub const fn opcode() -> u8 { 54 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12172,7 +12171,7 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), mask_bytes.into(), modifiers_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), mask_bytes.into(), modifiers_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn xi_passive_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, time: A, grab_window: xproto::Window, cursor: xproto::Cursor, detail: u32, deviceid: B, grab_type: GrabType, grab_mode: GrabMode22, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32], modifiers: &'input [u32]) -> Result<Cookie<'c, Conn, XIPassiveGrabDeviceReply>, ConnectionError>
@@ -12255,7 +12254,7 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
     /// Opcode for the XIPassiveUngrabDevice request
     pub const fn opcode() -> u8 { 55 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12298,7 +12297,7 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), modifiers_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), modifiers_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn xi_passive_ungrab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, detail: u32, deviceid: A, grab_type: GrabType, modifiers: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -12327,7 +12326,7 @@ impl XIListPropertiesRequest {
     /// Opcode for the XIListProperties request
     pub const fn opcode() -> u8 { 56 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12483,7 +12482,7 @@ impl<'input> XIChangePropertyRequest<'input> {
     /// Opcode for the XIChangeProperty request
     pub const fn opcode() -> u8 { 57 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12527,7 +12526,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), items_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), items_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn xi_change_property<'c, 'input, Conn, A>(conn: &'c Conn, deviceid: A, mode: xproto::PropMode, property: xproto::Atom, type_: xproto::Atom, num_items: u32, items: &'input XIChangePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -12558,7 +12557,7 @@ impl XIDeletePropertyRequest {
     /// Opcode for the XIDeleteProperty request
     pub const fn opcode() -> u8 { 58 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12616,7 +12615,7 @@ impl XIGetPropertyRequest {
     /// Opcode for the XIGetProperty request
     pub const fn opcode() -> u8 { 59 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12792,7 +12791,7 @@ impl XIGetSelectedEventsRequest {
     /// Opcode for the XIGetSelectedEvents request
     pub const fn opcode() -> u8 { 60 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12931,7 +12930,7 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
     /// Opcode for the XIBarrierReleasePointer request
     pub const fn opcode() -> u8 { 61 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12958,7 +12957,7 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), barriers_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), barriers_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn xi_barrier_release_pointer<'c, 'input, Conn>(conn: &'c Conn, barriers: &'input [BarrierReleasePointerInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -15840,7 +15839,7 @@ impl<'input> SendExtensionEventRequest<'input> {
     /// Opcode for the SendExtensionEvent request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15882,7 +15881,7 @@ impl<'input> SendExtensionEventRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), events_bytes.into(), classes_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), events_bytes.into(), classes_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn send_extension_event<'c, 'input, Conn>(conn: &'c Conn, destination: xproto::Window, device_id: u8, propagate: bool, events: &'input [EventForSend], classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -105,7 +105,7 @@ impl<'input> GetExtensionVersionRequest<'input> {
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetExtensionVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             name_len_bytes[0],
@@ -960,7 +960,7 @@ impl ListInputDevicesRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListInputDevicesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1091,7 +1091,7 @@ impl OpenDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            OpenDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -1185,7 +1185,7 @@ impl CloseDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CloseDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -1233,7 +1233,7 @@ impl SetDeviceModeRequest {
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceModeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -1311,7 +1311,7 @@ impl<'input> SelectExtensionEventRequest<'input> {
         let num_classes_bytes = num_classes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectExtensionEventRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1366,7 +1366,7 @@ impl GetSelectedExtensionEventsRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetSelectedExtensionEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1546,7 +1546,7 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeDeviceDontPropagateListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1602,7 +1602,7 @@ impl GetDeviceDontPropagateListRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceDontPropagateListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1723,7 +1723,7 @@ impl GetDeviceMotionEventsRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceMotionEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             start_bytes[0],
@@ -1836,7 +1836,7 @@ impl ChangeKeyboardDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeKeyboardDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -1914,7 +1914,7 @@ impl ChangePointerDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangePointerDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             x_axis_bytes[0],
@@ -2003,7 +2003,7 @@ impl<'input> GrabDeviceRequest<'input> {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GrabDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             grab_window_bytes[0],
@@ -2103,7 +2103,7 @@ impl UngrabDeviceRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UngrabDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             time_bytes[0],
@@ -2232,7 +2232,7 @@ impl<'input> GrabDeviceKeyRequest<'input> {
         let owner_events_bytes = self.owner_events.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GrabDeviceKeyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             grab_window_bytes[0],
@@ -2316,7 +2316,7 @@ impl UngrabDeviceKeyRequest {
         let grabbed_device_bytes = self.grabbed_device.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UngrabDeviceKeyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             grab_window_bytes[0],
@@ -2397,7 +2397,7 @@ impl<'input> GrabDeviceButtonRequest<'input> {
         let owner_events_bytes = self.owner_events.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GrabDeviceButtonRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             grab_window_bytes[0],
@@ -2481,7 +2481,7 @@ impl UngrabDeviceButtonRequest {
         let grabbed_device_bytes = self.grabbed_device.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UngrabDeviceButtonRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             grab_window_bytes[0],
@@ -2623,7 +2623,7 @@ impl AllowDeviceEventsRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            AllowDeviceEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             time_bytes[0],
@@ -2677,7 +2677,7 @@ impl GetDeviceFocusRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceFocusRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -2761,7 +2761,7 @@ impl SetDeviceFocusRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceFocusRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             focus_bytes[0],
@@ -3843,7 +3843,7 @@ impl GetFeedbackControlRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetFeedbackControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -4844,7 +4844,7 @@ impl ChangeFeedbackControlRequest {
         let feedback_id_bytes = self.feedback_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeFeedbackControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             mask_bytes[0],
@@ -4907,7 +4907,7 @@ impl GetDeviceKeyMappingRequest {
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceKeyMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -5005,7 +5005,7 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
         let keycode_count_bytes = self.keycode_count.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeDeviceKeyMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -5060,7 +5060,7 @@ impl GetDeviceModifierMappingRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceModifierMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -5155,7 +5155,7 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
         let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceModifierMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -5233,7 +5233,7 @@ impl GetDeviceButtonMappingRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceButtonMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -5331,7 +5331,7 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
         let map_size_bytes = map_size.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceButtonMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -5996,7 +5996,7 @@ impl QueryDeviceStateRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryDeviceStateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -6091,7 +6091,7 @@ impl DeviceBellRequest {
         let percent_bytes = self.percent.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeviceBellRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -6145,7 +6145,7 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
         let num_valuators_bytes = num_valuators.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceValuatorsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -7060,7 +7060,7 @@ impl GetDeviceControlRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             control_id_bytes[0],
@@ -7888,7 +7888,7 @@ impl ChangeDeviceControlRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeDeviceControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             control_id_bytes[0],
@@ -7967,7 +7967,7 @@ impl ListDevicePropertiesRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListDevicePropertiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_id_bytes[0],
@@ -8194,7 +8194,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         let num_items_bytes = self.num_items.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ChangeDevicePropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             property_bytes[0],
@@ -8263,7 +8263,7 @@ impl DeleteDevicePropertyRequest {
         let device_id_bytes = self.device_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DeleteDevicePropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             property_bytes[0],
@@ -8324,7 +8324,7 @@ impl GetDevicePropertyRequest {
         let delete_bytes = self.delete.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDevicePropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             property_bytes[0],
@@ -8673,7 +8673,7 @@ impl XIQueryPointerRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIQueryPointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -8802,7 +8802,7 @@ impl XIWarpPointerRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIWarpPointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             src_win_bytes[0],
@@ -8890,7 +8890,7 @@ impl XIChangeCursorRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIChangeCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -9628,7 +9628,7 @@ impl<'input> XIChangeHierarchyRequest<'input> {
         let num_changes_bytes = num_changes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIChangeHierarchyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             num_changes_bytes[0],
@@ -9680,7 +9680,7 @@ impl XISetClientPointerRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XISetClientPointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -9733,7 +9733,7 @@ impl XIGetClientPointerRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIGetClientPointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -9965,7 +9965,7 @@ impl<'input> XISelectEventsRequest<'input> {
         let num_mask_bytes = num_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XISelectEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -10022,7 +10022,7 @@ impl XIQueryVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIQueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -11324,7 +11324,7 @@ impl XIQueryDeviceRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIQueryDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             deviceid_bytes[0],
@@ -11418,7 +11418,7 @@ impl XISetFocusRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XISetFocusRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -11478,7 +11478,7 @@ impl XIGetFocusRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIGetFocusRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             deviceid_bytes[0],
@@ -11637,7 +11637,7 @@ impl<'input> XIGrabDeviceRequest<'input> {
         let mask_len_bytes = mask_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIGrabDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -11743,7 +11743,7 @@ impl XIUngrabDeviceRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIUngrabDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             time_bytes[0],
@@ -11886,7 +11886,7 @@ impl XIAllowEventsRequest {
         let grab_window_bytes = self.grab_window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIAllowEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             time_bytes[0],
@@ -12183,7 +12183,7 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
         let owner_events_bytes = bool::from(self.owner_events).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIPassiveGrabDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             time_bytes[0],
@@ -12324,7 +12324,7 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
         let grab_type_bytes = u8::from(self.grab_type).serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIPassiveUngrabDeviceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             grab_window_bytes[0],
@@ -12392,7 +12392,7 @@ impl XIListPropertiesRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIListPropertiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             deviceid_bytes[0],
@@ -12555,7 +12555,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         let num_items_bytes = self.num_items.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIChangePropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             deviceid_bytes[0],
@@ -12626,7 +12626,7 @@ impl XIDeletePropertyRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIDeletePropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             deviceid_bytes[0],
@@ -12689,7 +12689,7 @@ impl XIGetPropertyRequest {
         let len_bytes = self.len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIGetPropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             deviceid_bytes[0],
@@ -12861,7 +12861,7 @@ impl XIGetSelectedEventsRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIGetSelectedEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -13002,7 +13002,7 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
         let num_barriers_bytes = num_barriers.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            XIBarrierReleasePointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             num_barriers_bytes[0],
@@ -15917,7 +15917,7 @@ impl<'input> SendExtensionEventRequest<'input> {
         let num_events_bytes = num_events.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SendExtensionEventRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             destination_bytes[0],

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -93,7 +93,6 @@ impl<'input> GetExtensionVersionRequest<'input> {
     /// Opcode for the GetExtensionVersion request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -950,7 +949,6 @@ impl ListInputDevicesRequest {
     /// Opcode for the ListInputDevices request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1080,7 +1078,6 @@ impl OpenDeviceRequest {
     /// Opcode for the OpenDevice request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1174,7 +1171,6 @@ impl CloseDeviceRequest {
     /// Opcode for the CloseDevice request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1221,7 +1217,6 @@ impl SetDeviceModeRequest {
     /// Opcode for the SetDeviceMode request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1298,7 +1293,6 @@ impl<'input> SelectExtensionEventRequest<'input> {
     /// Opcode for the SelectExtensionEvent request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1355,7 +1349,6 @@ impl GetSelectedExtensionEventsRequest {
     /// Opcode for the GetSelectedExtensionEvents request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1532,7 +1525,6 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
     /// Opcode for the ChangeDeviceDontPropagateList request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1591,7 +1583,6 @@ impl GetDeviceDontPropagateListRequest {
     /// Opcode for the GetDeviceDontPropagateList request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1710,7 +1701,6 @@ impl GetDeviceMotionEventsRequest {
     /// Opcode for the GetDeviceMotionEvents request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1825,7 +1815,6 @@ impl ChangeKeyboardDeviceRequest {
     /// Opcode for the ChangeKeyboardDevice request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1901,7 +1890,6 @@ impl ChangePointerDeviceRequest {
     /// Opcode for the ChangePointerDevice request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1985,7 +1973,6 @@ impl<'input> GrabDeviceRequest<'input> {
     /// Opcode for the GrabDevice request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2091,7 +2078,6 @@ impl UngrabDeviceRequest {
     /// Opcode for the UngrabDevice request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2212,7 +2198,6 @@ impl<'input> GrabDeviceKeyRequest<'input> {
     /// Opcode for the GrabDeviceKey request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2301,7 +2286,6 @@ impl UngrabDeviceKeyRequest {
     /// Opcode for the UngrabDeviceKey request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2377,7 +2361,6 @@ impl<'input> GrabDeviceButtonRequest<'input> {
     /// Opcode for the GrabDeviceButton request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2466,7 +2449,6 @@ impl UngrabDeviceButtonRequest {
     /// Opcode for the UngrabDeviceButton request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2610,7 +2592,6 @@ impl AllowDeviceEventsRequest {
     /// Opcode for the AllowDeviceEvents request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2666,7 +2647,6 @@ impl GetDeviceFocusRequest {
     /// Opcode for the GetDeviceFocus request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2747,7 +2727,6 @@ impl SetDeviceFocusRequest {
     /// Opcode for the SetDeviceFocus request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3832,7 +3811,6 @@ impl GetFeedbackControlRequest {
     /// Opcode for the GetFeedbackControl request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4831,7 +4809,6 @@ impl ChangeFeedbackControlRequest {
     /// Opcode for the ChangeFeedbackControl request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4894,7 +4871,6 @@ impl GetDeviceKeyMappingRequest {
     /// Opcode for the GetDeviceKeyMapping request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -4991,7 +4967,6 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
     /// Opcode for the ChangeDeviceKeyMapping request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5049,7 +5024,6 @@ impl GetDeviceModifierMappingRequest {
     /// Opcode for the GetDeviceModifierMapping request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5141,7 +5115,6 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
     /// Opcode for the SetDeviceModifierMapping request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5222,7 +5195,6 @@ impl GetDeviceButtonMappingRequest {
     /// Opcode for the GetDeviceButtonMapping request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5318,7 +5290,6 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
     /// Opcode for the SetDeviceButtonMapping request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -5985,7 +5956,6 @@ impl QueryDeviceStateRequest {
     /// Opcode for the QueryDeviceState request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6077,7 +6047,6 @@ impl DeviceBellRequest {
     /// Opcode for the DeviceBell request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6131,7 +6100,6 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
     /// Opcode for the SetDeviceValuators request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7048,7 +7016,6 @@ impl GetDeviceControlRequest {
     /// Opcode for the GetDeviceControl request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7876,7 +7843,6 @@ impl ChangeDeviceControlRequest {
     /// Opcode for the ChangeDeviceControl request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7956,7 +7922,6 @@ impl ListDevicePropertiesRequest {
     /// Opcode for the ListDeviceProperties request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8177,7 +8142,6 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
     /// Opcode for the ChangeDeviceProperty request
     pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8251,7 +8215,6 @@ impl DeleteDevicePropertyRequest {
     /// Opcode for the DeleteDeviceProperty request
     pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8308,7 +8271,6 @@ impl GetDevicePropertyRequest {
     /// Opcode for the GetDeviceProperty request
     pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8661,7 +8623,6 @@ impl XIQueryPointerRequest {
     /// Opcode for the XIQueryPointer request
     pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8783,7 +8744,6 @@ impl XIWarpPointerRequest {
     /// Opcode for the XIWarpPointer request
     pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8877,7 +8837,6 @@ impl XIChangeCursorRequest {
     /// Opcode for the XIChangeCursor request
     pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9616,7 +9575,6 @@ impl<'input> XIChangeHierarchyRequest<'input> {
     /// Opcode for the XIChangeHierarchy request
     pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9668,7 +9626,6 @@ impl XISetClientPointerRequest {
     /// Opcode for the XISetClientPointer request
     pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9722,7 +9679,6 @@ impl XIGetClientPointerRequest {
     /// Opcode for the XIGetClientPointer request
     pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9952,7 +9908,6 @@ impl<'input> XISelectEventsRequest<'input> {
     /// Opcode for the XISelectEvents request
     pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -10010,7 +9965,6 @@ impl XIQueryVersionRequest {
     /// Opcode for the XIQueryVersion request
     pub const fn opcode() -> u8 { 47 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -11313,7 +11267,6 @@ impl XIQueryDeviceRequest {
     /// Opcode for the XIQueryDevice request
     pub const fn opcode() -> u8 { 48 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -11405,7 +11358,6 @@ impl XISetFocusRequest {
     /// Opcode for the XISetFocus request
     pub const fn opcode() -> u8 { 49 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -11467,7 +11419,6 @@ impl XIGetFocusRequest {
     /// Opcode for the XIGetFocus request
     pub const fn opcode() -> u8 { 50 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -11618,7 +11569,6 @@ impl<'input> XIGrabDeviceRequest<'input> {
     /// Opcode for the XIGrabDevice request
     pub const fn opcode() -> u8 { 51 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -11731,7 +11681,6 @@ impl XIUngrabDeviceRequest {
     /// Opcode for the XIUngrabDevice request
     pub const fn opcode() -> u8 { 52 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -11871,7 +11820,6 @@ impl XIAllowEventsRequest {
     /// Opcode for the XIAllowEvents request
     pub const fn opcode() -> u8 { 53 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12160,7 +12108,6 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
     /// Opcode for the XIPassiveGrabDevice request
     pub const fn opcode() -> u8 { 54 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12308,7 +12255,6 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
     /// Opcode for the XIPassiveUngrabDevice request
     pub const fn opcode() -> u8 { 55 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12381,7 +12327,6 @@ impl XIListPropertiesRequest {
     /// Opcode for the XIListProperties request
     pub const fn opcode() -> u8 { 56 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12538,7 +12483,6 @@ impl<'input> XIChangePropertyRequest<'input> {
     /// Opcode for the XIChangeProperty request
     pub const fn opcode() -> u8 { 57 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12614,7 +12558,6 @@ impl XIDeletePropertyRequest {
     /// Opcode for the XIDeleteProperty request
     pub const fn opcode() -> u8 { 58 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12673,7 +12616,6 @@ impl XIGetPropertyRequest {
     /// Opcode for the XIGetProperty request
     pub const fn opcode() -> u8 { 59 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12850,7 +12792,6 @@ impl XIGetSelectedEventsRequest {
     /// Opcode for the XIGetSelectedEvents request
     pub const fn opcode() -> u8 { 60 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -12990,7 +12931,6 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
     /// Opcode for the XIBarrierReleasePointer request
     pub const fn opcode() -> u8 { 61 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -15900,7 +15840,6 @@ impl<'input> SendExtensionEventRequest<'input> {
     /// Opcode for the SendExtensionEvent request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -6317,7 +6316,7 @@ impl UseExtensionRequest {
     /// Opcode for the UseExtension request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6818,7 +6817,7 @@ impl<'input> SelectEventsRequest<'input> {
     /// Opcode for the SelectEvents request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6857,7 +6856,7 @@ impl<'input> SelectEventsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), details_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), details_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn select_events<'c, 'input, Conn, A, B, C, D, E>(conn: &'c Conn, device_spec: DeviceSpec, affect_which: A, clear: B, select_all: C, affect_map: D, map: E, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -6905,7 +6904,7 @@ impl BellRequest {
     /// Opcode for the Bell request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6988,7 +6987,7 @@ impl GetStateRequest {
     /// Opcode for the GetState request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7096,7 +7095,7 @@ impl LatchLockStateRequest {
     /// Opcode for the LatchLockState request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7169,7 +7168,7 @@ impl GetControlsRequest {
     /// Opcode for the GetControls request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7322,7 +7321,7 @@ impl<'input> SetControlsRequest<'input> {
     /// Opcode for the SetControls request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7534,7 +7533,7 @@ impl GetMapRequest {
     /// Opcode for the GetMap request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8011,7 +8010,7 @@ impl<'input> SetMapRequest<'input> {
     /// Opcode for the SetMap request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8091,7 +8090,7 @@ impl<'input> SetMapRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), values_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_map<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &'input SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -8147,7 +8146,7 @@ impl GetCompatMapRequest {
     /// Opcode for the GetCompatMap request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8264,7 +8263,7 @@ impl<'input> SetCompatMapRequest<'input> {
     /// Opcode for the SetCompatMap request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8307,7 +8306,7 @@ impl<'input> SetCompatMapRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), si_bytes.into(), group_maps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), si_bytes.into(), group_maps_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_compat_map<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -8338,7 +8337,7 @@ impl GetIndicatorStateRequest {
     /// Opcode for the GetIndicatorState request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8411,7 +8410,7 @@ impl GetIndicatorMapRequest {
     /// Opcode for the GetIndicatorMap request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8497,7 +8496,7 @@ impl<'input> SetIndicatorMapRequest<'input> {
     /// Opcode for the SetIndicatorMap request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8529,7 +8528,7 @@ impl<'input> SetIndicatorMapRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), maps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), maps_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_indicator_map<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, which: u32, maps: &'input [IndicatorMap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -8557,7 +8556,7 @@ impl GetNamedIndicatorRequest {
     /// Opcode for the GetNamedIndicator request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8685,7 +8684,7 @@ impl SetNamedIndicatorRequest {
     /// Opcode for the SetNamedIndicator request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8799,7 +8798,7 @@ impl GetNamesRequest {
     /// Opcode for the GetNames request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9294,7 +9293,7 @@ impl<'input> SetNamesRequest<'input> {
     /// Opcode for the SetNames request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9354,7 +9353,7 @@ impl<'input> SetNamesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), values_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_names<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -9399,7 +9398,7 @@ impl PerClientFlagsRequest {
     /// Opcode for the PerClientFlags request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9518,7 +9517,7 @@ impl ListComponentsRequest {
     /// Opcode for the ListComponents request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9693,7 +9692,7 @@ impl GetKbdByNameRequest {
     /// Opcode for the GetKbdByName request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10397,7 +10396,7 @@ impl GetDeviceInfoRequest {
     /// Opcode for the GetDeviceInfo request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10573,7 +10572,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
     /// Opcode for the SetDeviceInfo request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10611,7 +10610,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), btn_actions_bytes.into(), leds_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), btn_actions_bytes.into(), leds_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_info<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -10644,7 +10643,7 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
     /// Opcode for the SetDebuggingFlags request
     pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10690,7 +10689,7 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.message[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.message[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_debugging_flags<'c, 'input, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &'input [String8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6329,7 +6329,7 @@ impl UseExtensionRequest {
         let wanted_minor_bytes = self.wanted_minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UseExtensionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             wanted_major_bytes[0],
@@ -6835,7 +6835,7 @@ impl<'input> SelectEventsRequest<'input> {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -6927,7 +6927,7 @@ impl BellRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            BellRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -7002,7 +7002,7 @@ impl GetStateRequest {
         let device_spec_bytes = self.device_spec.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetStateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -7118,7 +7118,7 @@ impl LatchLockStateRequest {
         let group_latch_bytes = self.group_latch.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            LatchLockStateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -7185,7 +7185,7 @@ impl GetControlsRequest {
         let device_spec_bytes = self.device_spec.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetControlsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -7367,7 +7367,7 @@ impl<'input> SetControlsRequest<'input> {
         let access_x_timeout_options_values_bytes = self.access_x_timeout_options_values.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetControlsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -7569,7 +7569,7 @@ impl GetMapRequest {
         let n_v_mod_map_keys_bytes = self.n_v_mod_map_keys.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetMapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8056,7 +8056,7 @@ impl<'input> SetMapRequest<'input> {
         let virtual_mods_bytes = self.virtual_mods.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetMapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8171,7 +8171,7 @@ impl GetCompatMapRequest {
         let n_si_bytes = self.n_si.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetCompatMapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8291,7 +8291,7 @@ impl<'input> SetCompatMapRequest<'input> {
         let n_si_bytes = n_si.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetCompatMapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8360,7 +8360,7 @@ impl GetIndicatorStateRequest {
         let device_spec_bytes = self.device_spec.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetIndicatorStateRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8435,7 +8435,7 @@ impl GetIndicatorMapRequest {
         let which_bytes = self.which.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetIndicatorMapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8522,7 +8522,7 @@ impl<'input> SetIndicatorMapRequest<'input> {
         let which_bytes = self.which.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetIndicatorMapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8585,7 +8585,7 @@ impl GetNamedIndicatorRequest {
         let indicator_bytes = self.indicator.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetNamedIndicatorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8725,7 +8725,7 @@ impl SetNamedIndicatorRequest {
         let map_ctrls_bytes = self.map_ctrls.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetNamedIndicatorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -8827,7 +8827,7 @@ impl GetNamesRequest {
         let which_bytes = self.which.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetNamesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -9336,7 +9336,7 @@ impl<'input> SetNamesRequest<'input> {
         let total_kt_level_names_bytes = self.total_kt_level_names.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetNamesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -9433,7 +9433,7 @@ impl PerClientFlagsRequest {
         let auto_ctrls_values_bytes = self.auto_ctrls_values.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PerClientFlagsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -9549,7 +9549,7 @@ impl ListComponentsRequest {
         let max_names_bytes = self.max_names.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListComponentsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -9727,7 +9727,7 @@ impl GetKbdByNameRequest {
         let load_bytes = self.load.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetKbdByNameRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -10435,7 +10435,7 @@ impl GetDeviceInfoRequest {
         let led_id_bytes = self.led_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -10612,7 +10612,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
         let n_device_led_f_bs_bytes = n_device_led_f_bs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_spec_bytes[0],
@@ -10683,7 +10683,7 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
         let ctrls_bytes = self.ctrls.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDebuggingFlagsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             msg_length_bytes[0],

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6785,7 +6785,7 @@ impl SelectEventsAux {
     }
 }
 
-pub fn select_events<'c, Conn, A, B, C, D, E>(conn: &'c Conn, device_spec: DeviceSpec, affect_which: A, clear: B, select_all: C, affect_map: D, map: E, details: &SelectEventsAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn select_events<'c, 'input, Conn, A, B, C, D, E>(conn: &'c Conn, device_spec: DeviceSpec, affect_which: A, clear: B, select_all: C, affect_map: D, map: E, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
@@ -7132,7 +7132,7 @@ impl TryFrom<&[u8]> for GetControlsReply {
 
 /// Opcode for the SetControls request
 pub const SET_CONTROLS_REQUEST: u8 = 7;
-pub fn set_controls<'c, Conn, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(conn: &'c Conn, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &[u8; 32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_controls<'c, 'input, Conn, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(conn: &'c Conn, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
@@ -7697,7 +7697,7 @@ impl SetMapAux {
     }
 }
 
-pub fn set_map<'c, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_map<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &'input SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
@@ -7875,7 +7875,7 @@ impl GetCompatMapReply {
 
 /// Opcode for the SetCompatMap request
 pub const SET_COMPAT_MAP_REQUEST: u8 = 11;
-pub fn set_compat_map<'c, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &[SymInterpret], group_maps: &[ModDef]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_compat_map<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
@@ -8044,7 +8044,7 @@ impl TryFrom<&[u8]> for GetIndicatorMapReply {
 
 /// Opcode for the SetIndicatorMap request
 pub const SET_INDICATOR_MAP_REQUEST: u8 = 14;
-pub fn set_indicator_map<'c, Conn>(conn: &'c Conn, device_spec: DeviceSpec, which: u32, maps: &[IndicatorMap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_indicator_map<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, which: u32, maps: &'input [IndicatorMap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -8718,7 +8718,7 @@ impl SetNamesAux {
     }
 }
 
-pub fn set_names<'c, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_names<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
@@ -9860,7 +9860,7 @@ impl GetDeviceInfoReply {
 
 /// Opcode for the SetDeviceInfo request
 pub const SET_DEVICE_INFO_REQUEST: u8 = 25;
-pub fn set_device_info<'c, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &[Action], leds: &[DeviceLedInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_device_info<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
@@ -9905,7 +9905,7 @@ where
 
 /// Opcode for the SetDebuggingFlags request
 pub const SET_DEBUGGING_FLAGS_REQUEST: u8 = 101;
-pub fn set_debugging_flags<'c, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &[String8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>
+pub fn set_debugging_flags<'c, 'input, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &'input [String8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -11229,7 +11229,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         use_extension(self, wanted_major, wanted_minor)
     }
-    fn xkb_select_events<'c, A, B, C, D, E>(&'c self, device_spec: DeviceSpec, affect_which: A, clear: B, select_all: C, affect_map: D, map: E, details: &SelectEventsAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_select_events<'c, 'input, A, B, C, D, E>(&'c self, device_spec: DeviceSpec, affect_which: A, clear: B, select_all: C, affect_map: D, map: E, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u16>,
         B: Into<u16>,
@@ -11259,7 +11259,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_controls(self, device_spec)
     }
-    fn xkb_set_controls<'c, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(&'c self, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &[u8; 32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_controls<'c, 'input, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(&'c self, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u8>,
         B: Into<u8>,
@@ -11288,7 +11288,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_map(self, device_spec, full, partial, first_type, n_types, first_key_sym, n_key_syms, first_key_action, n_key_actions, first_key_behavior, n_key_behaviors, virtual_mods, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys)
     }
-    fn xkb_set_map<'c, A, B>(&'c self, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_map<'c, 'input, A, B>(&'c self, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &'input SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u16>,
         B: Into<u16>,
@@ -11301,7 +11301,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_compat_map(self, device_spec, groups, get_all_si, first_si, n_si)
     }
-    fn xkb_set_compat_map<'c, A>(&'c self, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &[SymInterpret], group_maps: &[ModDef]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_compat_map<'c, 'input, A>(&'c self, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u8>,
     {
@@ -11315,7 +11315,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_indicator_map(self, device_spec, which)
     }
-    fn xkb_set_indicator_map<'c>(&'c self, device_spec: DeviceSpec, which: u32, maps: &[IndicatorMap]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_indicator_map<'c, 'input>(&'c self, device_spec: DeviceSpec, which: u32, maps: &'input [IndicatorMap]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_indicator_map(self, device_spec, which, maps)
     }
@@ -11344,7 +11344,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_names(self, device_spec, which)
     }
-    fn xkb_set_names<'c, A, B>(&'c self, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_names<'c, 'input, A, B>(&'c self, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u16>,
         B: Into<u8>,
@@ -11379,13 +11379,13 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_device_info(self, device_spec, wanted, all_buttons, first_button, n_buttons, led_class, led_id)
     }
-    fn xkb_set_device_info<'c, A>(&'c self, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &[Action], leds: &[DeviceLedInfo]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xkb_set_device_info<'c, 'input, A>(&'c self, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u16>,
     {
         set_device_info(self, device_spec, first_btn, change, btn_actions, leds)
     }
-    fn xkb_set_debugging_flags<'c>(&'c self, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &[String8]) -> Result<Cookie<'c, Self, SetDebuggingFlagsReply>, ConnectionError>
+    fn xkb_set_debugging_flags<'c, 'input>(&'c self, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &'input [String8]) -> Result<Cookie<'c, Self, SetDebuggingFlagsReply>, ConnectionError>
     {
         set_debugging_flags(self, affect_flags, flags, affect_ctrls, ctrls, message)
     }

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6307,14 +6307,14 @@ impl From<SAType> for Action {
     }
 }
 
+/// Opcode for the UseExtension request
+pub const USE_EXTENSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UseExtensionRequest {
     pub wanted_major: u16,
     pub wanted_minor: u16,
 }
 impl UseExtensionRequest {
-    /// Opcode for the UseExtension request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6327,7 +6327,7 @@ impl UseExtensionRequest {
         let wanted_minor_bytes = self.wanted_minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            USE_EXTENSION_REQUEST,
             0,
             0,
             wanted_major_bytes[0],
@@ -6803,6 +6803,8 @@ impl SelectEventsAux {
     }
 }
 
+/// Opcode for the SelectEvents request
+pub const SELECT_EVENTS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectEventsRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -6814,8 +6816,6 @@ pub struct SelectEventsRequest<'input> {
     pub details: &'input SelectEventsAux,
 }
 impl<'input> SelectEventsRequest<'input> {
-    /// Opcode for the SelectEvents request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6832,7 +6832,7 @@ impl<'input> SelectEventsRequest<'input> {
         let map_bytes = self.map.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_EVENTS_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -6887,6 +6887,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the Bell request
+pub const BELL_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BellRequest {
     pub device_spec: DeviceSpec,
@@ -6901,8 +6903,6 @@ pub struct BellRequest {
     pub window: xproto::Window,
 }
 impl BellRequest {
-    /// Opcode for the Bell request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6923,7 +6923,7 @@ impl BellRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            BELL_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -6979,13 +6979,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetState request
+pub const GET_STATE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetStateRequest {
     pub device_spec: DeviceSpec,
 }
 impl GetStateRequest {
-    /// Opcode for the GetState request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6997,7 +6997,7 @@ impl GetStateRequest {
         let device_spec_bytes = self.device_spec.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_STATE_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -7080,6 +7080,8 @@ impl TryFrom<&[u8]> for GetStateReply {
     }
 }
 
+/// Opcode for the LatchLockState request
+pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LatchLockStateRequest {
     pub device_spec: DeviceSpec,
@@ -7092,8 +7094,6 @@ pub struct LatchLockStateRequest {
     pub group_latch: u16,
 }
 impl LatchLockStateRequest {
-    /// Opcode for the LatchLockState request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7112,7 +7112,7 @@ impl LatchLockStateRequest {
         let group_latch_bytes = self.group_latch.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LATCH_LOCK_STATE_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -7160,13 +7160,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetControls request
+pub const GET_CONTROLS_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetControlsRequest {
     pub device_spec: DeviceSpec,
 }
 impl GetControlsRequest {
-    /// Opcode for the GetControls request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7178,7 +7178,7 @@ impl GetControlsRequest {
         let device_spec_bytes = self.device_spec.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CONTROLS_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -7284,6 +7284,8 @@ impl TryFrom<&[u8]> for GetControlsReply {
     }
 }
 
+/// Opcode for the SetControls request
+pub const SET_CONTROLS_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetControlsRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -7318,8 +7320,6 @@ pub struct SetControlsRequest<'input> {
     pub per_key_repeat: &'input [u8; 32],
 }
 impl<'input> SetControlsRequest<'input> {
-    /// Opcode for the SetControls request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7359,7 +7359,7 @@ impl<'input> SetControlsRequest<'input> {
         let access_x_timeout_options_values_bytes = self.access_x_timeout_options_values.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_CONTROLS_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -7508,6 +7508,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetMap request
+pub const GET_MAP_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMapRequest {
     pub device_spec: DeviceSpec,
@@ -7530,8 +7532,6 @@ pub struct GetMapRequest {
     pub n_v_mod_map_keys: u8,
 }
 impl GetMapRequest {
-    /// Opcode for the GetMap request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7560,7 +7560,7 @@ impl GetMapRequest {
         let n_v_mod_map_keys_bytes = self.n_v_mod_map_keys.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_MAP_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -7977,6 +7977,8 @@ impl SetMapAux {
     }
 }
 
+/// Opcode for the SetMap request
+pub const SET_MAP_REQUEST: u8 = 9;
 #[derive(Debug, Clone)]
 pub struct SetMapRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -8007,8 +8009,6 @@ pub struct SetMapRequest<'input> {
     pub values: &'input SetMapAux,
 }
 impl<'input> SetMapRequest<'input> {
-    /// Opcode for the SetMap request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8046,7 +8046,7 @@ impl<'input> SetMapRequest<'input> {
         let virtual_mods_bytes = self.virtual_mods.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_MAP_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8134,6 +8134,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetCompatMap request
+pub const GET_COMPAT_MAP_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetCompatMapRequest {
     pub device_spec: DeviceSpec,
@@ -8143,8 +8145,6 @@ pub struct GetCompatMapRequest {
     pub n_si: u16,
 }
 impl GetCompatMapRequest {
-    /// Opcode for the GetCompatMap request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8160,7 +8160,7 @@ impl GetCompatMapRequest {
         let n_si_bytes = self.n_si.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_COMPAT_MAP_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8249,6 +8249,8 @@ impl GetCompatMapReply {
     }
 }
 
+/// Opcode for the SetCompatMap request
+pub const SET_COMPAT_MAP_REQUEST: u8 = 11;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetCompatMapRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -8260,8 +8262,6 @@ pub struct SetCompatMapRequest<'input> {
     pub group_maps: &'input [ModDef],
 }
 impl<'input> SetCompatMapRequest<'input> {
-    /// Opcode for the SetCompatMap request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8279,7 +8279,7 @@ impl<'input> SetCompatMapRequest<'input> {
         let n_si_bytes = n_si.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_COMPAT_MAP_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8329,13 +8329,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetIndicatorState request
+pub const GET_INDICATOR_STATE_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetIndicatorStateRequest {
     pub device_spec: DeviceSpec,
 }
 impl GetIndicatorStateRequest {
-    /// Opcode for the GetIndicatorState request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8347,7 +8347,7 @@ impl GetIndicatorStateRequest {
         let device_spec_bytes = self.device_spec.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_INDICATOR_STATE_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8401,14 +8401,14 @@ impl TryFrom<&[u8]> for GetIndicatorStateReply {
     }
 }
 
+/// Opcode for the GetIndicatorMap request
+pub const GET_INDICATOR_MAP_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetIndicatorMapRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
 }
 impl GetIndicatorMapRequest {
-    /// Opcode for the GetIndicatorMap request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8421,7 +8421,7 @@ impl GetIndicatorMapRequest {
         let which_bytes = self.which.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_INDICATOR_MAP_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8486,6 +8486,8 @@ impl TryFrom<&[u8]> for GetIndicatorMapReply {
     }
 }
 
+/// Opcode for the SetIndicatorMap request
+pub const SET_INDICATOR_MAP_REQUEST: u8 = 14;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetIndicatorMapRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -8493,8 +8495,6 @@ pub struct SetIndicatorMapRequest<'input> {
     pub maps: &'input [IndicatorMap],
 }
 impl<'input> SetIndicatorMapRequest<'input> {
-    /// Opcode for the SetIndicatorMap request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8507,7 +8507,7 @@ impl<'input> SetIndicatorMapRequest<'input> {
         let which_bytes = self.which.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_INDICATOR_MAP_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8545,6 +8545,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetNamedIndicator request
+pub const GET_NAMED_INDICATOR_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
@@ -8553,8 +8555,6 @@ pub struct GetNamedIndicatorRequest {
     pub indicator: xproto::Atom,
 }
 impl GetNamedIndicatorRequest {
-    /// Opcode for the GetNamedIndicator request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8569,7 +8569,7 @@ impl GetNamedIndicatorRequest {
         let indicator_bytes = self.indicator.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_NAMED_INDICATOR_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8662,6 +8662,8 @@ impl TryFrom<&[u8]> for GetNamedIndicatorReply {
     }
 }
 
+/// Opcode for the SetNamedIndicator request
+pub const SET_NAMED_INDICATOR_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
@@ -8681,8 +8683,6 @@ pub struct SetNamedIndicatorRequest {
     pub map_ctrls: u32,
 }
 impl SetNamedIndicatorRequest {
-    /// Opcode for the SetNamedIndicator request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8708,7 +8708,7 @@ impl SetNamedIndicatorRequest {
         let map_ctrls_bytes = self.map_ctrls.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_NAMED_INDICATOR_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -8789,14 +8789,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetNames request
+pub const GET_NAMES_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetNamesRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
 }
 impl GetNamesRequest {
-    /// Opcode for the GetNames request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8809,7 +8809,7 @@ impl GetNamesRequest {
         let which_bytes = self.which.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_NAMES_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -9272,6 +9272,8 @@ impl SetNamesAux {
     }
 }
 
+/// Opcode for the SetNames request
+pub const SET_NAMES_REQUEST: u8 = 18;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetNamesRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -9290,8 +9292,6 @@ pub struct SetNamesRequest<'input> {
     pub values: &'input SetNamesAux,
 }
 impl<'input> SetNamesRequest<'input> {
-    /// Opcode for the SetNames request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9317,7 +9317,7 @@ impl<'input> SetNamesRequest<'input> {
         let total_kt_level_names_bytes = self.total_kt_level_names.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_NAMES_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -9385,6 +9385,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PerClientFlags request
+pub const PER_CLIENT_FLAGS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PerClientFlagsRequest {
     pub device_spec: DeviceSpec,
@@ -9395,8 +9397,6 @@ pub struct PerClientFlagsRequest {
     pub auto_ctrls_values: u32,
 }
 impl PerClientFlagsRequest {
-    /// Opcode for the PerClientFlags request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9413,7 +9413,7 @@ impl PerClientFlagsRequest {
         let auto_ctrls_values_bytes = self.auto_ctrls_values.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PER_CLIENT_FLAGS_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -9508,14 +9508,14 @@ impl TryFrom<&[u8]> for PerClientFlagsReply {
     }
 }
 
+/// Opcode for the ListComponents request
+pub const LIST_COMPONENTS_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListComponentsRequest {
     pub device_spec: DeviceSpec,
     pub max_names: u16,
 }
 impl ListComponentsRequest {
-    /// Opcode for the ListComponents request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9528,7 +9528,7 @@ impl ListComponentsRequest {
         let max_names_bytes = self.max_names.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_COMPONENTS_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -9681,6 +9681,8 @@ impl ListComponentsReply {
     }
 }
 
+/// Opcode for the GetKbdByName request
+pub const GET_KBD_BY_NAME_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetKbdByNameRequest {
     pub device_spec: DeviceSpec,
@@ -9689,8 +9691,6 @@ pub struct GetKbdByNameRequest {
     pub load: bool,
 }
 impl GetKbdByNameRequest {
-    /// Opcode for the GetKbdByName request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9705,7 +9705,7 @@ impl GetKbdByNameRequest {
         let load_bytes = self.load.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_KBD_BY_NAME_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -10382,6 +10382,8 @@ impl TryFrom<&[u8]> for GetKbdByNameReply {
     }
 }
 
+/// Opcode for the GetDeviceInfo request
+pub const GET_DEVICE_INFO_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceInfoRequest {
     pub device_spec: DeviceSpec,
@@ -10393,8 +10395,6 @@ pub struct GetDeviceInfoRequest {
     pub led_id: IDSpec,
 }
 impl GetDeviceInfoRequest {
-    /// Opcode for the GetDeviceInfo request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10412,7 +10412,7 @@ impl GetDeviceInfoRequest {
         let led_id_bytes = self.led_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_INFO_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -10560,6 +10560,8 @@ impl GetDeviceInfoReply {
     }
 }
 
+/// Opcode for the SetDeviceInfo request
+pub const SET_DEVICE_INFO_REQUEST: u8 = 25;
 #[derive(Debug, Clone)]
 pub struct SetDeviceInfoRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -10569,8 +10571,6 @@ pub struct SetDeviceInfoRequest<'input> {
     pub leds: &'input [DeviceLedInfo],
 }
 impl<'input> SetDeviceInfoRequest<'input> {
-    /// Opcode for the SetDeviceInfo request
-    pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10588,7 +10588,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
         let n_device_led_f_bs_bytes = n_device_led_f_bs.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_INFO_REQUEST,
             0,
             0,
             device_spec_bytes[0],
@@ -10631,6 +10631,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetDebuggingFlags request
+pub const SET_DEBUGGING_FLAGS_REQUEST: u8 = 101;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetDebuggingFlagsRequest<'input> {
     pub affect_flags: u32,
@@ -10640,8 +10642,6 @@ pub struct SetDebuggingFlagsRequest<'input> {
     pub message: &'input [String8],
 }
 impl<'input> SetDebuggingFlagsRequest<'input> {
-    /// Opcode for the SetDebuggingFlags request
-    pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10658,7 +10658,7 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
         let ctrls_bytes = self.ctrls.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEBUGGING_FLAGS_REQUEST,
             0,
             0,
             msg_length_bytes[0],

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -6307,32 +6308,53 @@ impl From<SAType> for Action {
     }
 }
 
-/// Opcode for the UseExtension request
-pub const USE_EXTENSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UseExtensionRequest {
+    pub wanted_major: u16,
+    pub wanted_minor: u16,
+}
+impl UseExtensionRequest {
+    /// Opcode for the UseExtension request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let wanted_major_bytes = self.wanted_major.serialize();
+        let wanted_minor_bytes = self.wanted_minor.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            UseExtensionRequest::opcode(),
+            0,
+            0,
+            wanted_major_bytes[0],
+            wanted_major_bytes[1],
+            wanted_minor_bytes[0],
+            wanted_minor_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn use_extension<Conn>(conn: &Conn, wanted_major: u16, wanted_minor: u16) -> Result<Cookie<'_, Conn, UseExtensionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let wanted_major_bytes = wanted_major.serialize();
-    let wanted_minor_bytes = wanted_minor.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        USE_EXTENSION_REQUEST,
-        0,
-        0,
-        wanted_major_bytes[0],
-        wanted_major_bytes[1],
-        wanted_minor_bytes[0],
-        wanted_minor_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UseExtensionRequest {
+        wanted_major: wanted_major,
+        wanted_minor: wanted_minor,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6364,8 +6386,6 @@ impl TryFrom<&[u8]> for UseExtensionReply {
     }
 }
 
-/// Opcode for the SelectEvents request
-pub const SELECT_EVENTS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectEventsAuxBitcase1 {
     pub affect_new_keyboard: u16,
@@ -6785,6 +6805,63 @@ impl SelectEventsAux {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectEventsRequest<'input> {
+    pub device_spec: DeviceSpec,
+    pub affect_which: u16,
+    pub clear: u16,
+    pub select_all: u16,
+    pub affect_map: u16,
+    pub map: u16,
+    pub details: &'input SelectEventsAux,
+}
+impl<'input> SelectEventsRequest<'input> {
+    /// Opcode for the SelectEvents request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let affect_which_bytes = self.affect_which.serialize();
+        let clear_bytes = self.clear.serialize();
+        let select_all_bytes = self.select_all.serialize();
+        let affect_map_bytes = self.affect_map.serialize();
+        let map_bytes = self.map.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SelectEventsRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            affect_which_bytes[0],
+            affect_which_bytes[1],
+            clear_bytes[0],
+            clear_bytes[1],
+            select_all_bytes[0],
+            select_all_bytes[1],
+            affect_map_bytes[0],
+            affect_map_bytes[1],
+            map_bytes[0],
+            map_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let details_bytes = self.details.serialize(self.affect_which, self.clear, self.select_all);
+        let length_so_far = length_so_far + details_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), details_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn select_events<'c, 'input, Conn, A, B, C, D, E>(conn: &'c Conn, device_spec: DeviceSpec, affect_which: A, clear: B, select_all: C, affect_map: D, map: E, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6794,130 +6871,162 @@ where
     D: Into<u16>,
     E: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let affect_which: u16 = affect_which.into();
     let clear: u16 = clear.into();
     let select_all: u16 = select_all.into();
     let affect_map: u16 = affect_map.into();
     let map: u16 = map.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let affect_which_bytes = affect_which.serialize();
-    let clear_bytes = clear.serialize();
-    let select_all_bytes = select_all.serialize();
-    let affect_map_bytes = affect_map.serialize();
-    let map_bytes = map.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SELECT_EVENTS_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        affect_which_bytes[0],
-        affect_which_bytes[1],
-        clear_bytes[0],
-        clear_bytes[1],
-        select_all_bytes[0],
-        select_all_bytes[1],
-        affect_map_bytes[0],
-        affect_map_bytes[1],
-        map_bytes[0],
-        map_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let details_bytes = details.serialize(affect_which, clear, select_all);
-    let length_so_far = length_so_far + details_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&details_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SelectEventsRequest {
+        device_spec: device_spec,
+        affect_which: affect_which,
+        clear: clear,
+        select_all: select_all,
+        affect_map: affect_map,
+        map: map,
+        details: details,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the Bell request
-pub const BELL_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BellRequest {
+    pub device_spec: DeviceSpec,
+    pub bell_class: BellClassSpec,
+    pub bell_id: IDSpec,
+    pub percent: i8,
+    pub force_sound: bool,
+    pub event_only: bool,
+    pub pitch: i16,
+    pub duration: i16,
+    pub name: xproto::Atom,
+    pub window: xproto::Window,
+}
+impl BellRequest {
+    /// Opcode for the Bell request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let bell_class_bytes = self.bell_class.serialize();
+        let bell_id_bytes = self.bell_id.serialize();
+        let percent_bytes = self.percent.serialize();
+        let force_sound_bytes = self.force_sound.serialize();
+        let event_only_bytes = self.event_only.serialize();
+        let pitch_bytes = self.pitch.serialize();
+        let duration_bytes = self.duration.serialize();
+        let name_bytes = self.name.serialize();
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            BellRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            bell_class_bytes[0],
+            bell_class_bytes[1],
+            bell_id_bytes[0],
+            bell_id_bytes[1],
+            percent_bytes[0],
+            force_sound_bytes[0],
+            event_only_bytes[0],
+            0,
+            pitch_bytes[0],
+            pitch_bytes[1],
+            duration_bytes[0],
+            duration_bytes[1],
+            0,
+            0,
+            name_bytes[0],
+            name_bytes[1],
+            name_bytes[2],
+            name_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn bell<Conn>(conn: &Conn, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: xproto::Atom, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let bell_class_bytes = bell_class.serialize();
-    let bell_id_bytes = bell_id.serialize();
-    let percent_bytes = percent.serialize();
-    let force_sound_bytes = force_sound.serialize();
-    let event_only_bytes = event_only.serialize();
-    let pitch_bytes = pitch.serialize();
-    let duration_bytes = duration.serialize();
-    let name_bytes = name.serialize();
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        BELL_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        bell_class_bytes[0],
-        bell_class_bytes[1],
-        bell_id_bytes[0],
-        bell_id_bytes[1],
-        percent_bytes[0],
-        force_sound_bytes[0],
-        event_only_bytes[0],
-        0,
-        pitch_bytes[0],
-        pitch_bytes[1],
-        duration_bytes[0],
-        duration_bytes[1],
-        0,
-        0,
-        name_bytes[0],
-        name_bytes[1],
-        name_bytes[2],
-        name_bytes[3],
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = BellRequest {
+        device_spec: device_spec,
+        bell_class: bell_class,
+        bell_id: bell_id,
+        percent: percent,
+        force_sound: force_sound,
+        event_only: event_only,
+        pitch: pitch,
+        duration: duration,
+        name: name,
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetState request
-pub const GET_STATE_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetStateRequest {
+    pub device_spec: DeviceSpec,
+}
+impl GetStateRequest {
+    /// Opcode for the GetState request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetStateRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_state<Conn>(conn: &Conn, device_spec: DeviceSpec) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_STATE_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetStateRequest {
+        device_spec: device_spec,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6976,8 +7085,62 @@ impl TryFrom<&[u8]> for GetStateReply {
     }
 }
 
-/// Opcode for the LatchLockState request
-pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LatchLockStateRequest {
+    pub device_spec: DeviceSpec,
+    pub affect_mod_locks: u8,
+    pub mod_locks: u8,
+    pub lock_group: bool,
+    pub group_lock: Group,
+    pub affect_mod_latches: u8,
+    pub latch_group: bool,
+    pub group_latch: u16,
+}
+impl LatchLockStateRequest {
+    /// Opcode for the LatchLockState request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let affect_mod_locks_bytes = self.affect_mod_locks.serialize();
+        let mod_locks_bytes = self.mod_locks.serialize();
+        let lock_group_bytes = self.lock_group.serialize();
+        let group_lock_bytes = u8::from(self.group_lock).serialize();
+        let affect_mod_latches_bytes = self.affect_mod_latches.serialize();
+        let latch_group_bytes = self.latch_group.serialize();
+        let group_latch_bytes = self.group_latch.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            LatchLockStateRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            affect_mod_locks_bytes[0],
+            mod_locks_bytes[0],
+            lock_group_bytes[0],
+            group_lock_bytes[0],
+            affect_mod_latches_bytes[0],
+            0,
+            0,
+            latch_group_bytes[0],
+            group_latch_bytes[0],
+            group_latch_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn latch_lock_state<Conn, A, B, C>(conn: &Conn, device_spec: DeviceSpec, affect_mod_locks: A, mod_locks: B, lock_group: bool, group_lock: Group, affect_mod_latches: C, latch_group: bool, group_latch: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6985,70 +7148,68 @@ where
     B: Into<u8>,
     C: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let affect_mod_locks: u8 = affect_mod_locks.into();
     let mod_locks: u8 = mod_locks.into();
     let affect_mod_latches: u8 = affect_mod_latches.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let affect_mod_locks_bytes = affect_mod_locks.serialize();
-    let mod_locks_bytes = mod_locks.serialize();
-    let lock_group_bytes = lock_group.serialize();
-    let group_lock_bytes = u8::from(group_lock).serialize();
-    let affect_mod_latches_bytes = affect_mod_latches.serialize();
-    let latch_group_bytes = latch_group.serialize();
-    let group_latch_bytes = group_latch.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        LATCH_LOCK_STATE_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        affect_mod_locks_bytes[0],
-        mod_locks_bytes[0],
-        lock_group_bytes[0],
-        group_lock_bytes[0],
-        affect_mod_latches_bytes[0],
-        0,
-        0,
-        latch_group_bytes[0],
-        group_latch_bytes[0],
-        group_latch_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = LatchLockStateRequest {
+        device_spec: device_spec,
+        affect_mod_locks: affect_mod_locks,
+        mod_locks: mod_locks,
+        lock_group: lock_group,
+        group_lock: group_lock,
+        affect_mod_latches: affect_mod_latches,
+        latch_group: latch_group,
+        group_latch: group_latch,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetControls request
-pub const GET_CONTROLS_REQUEST: u8 = 6;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetControlsRequest {
+    pub device_spec: DeviceSpec,
+}
+impl GetControlsRequest {
+    /// Opcode for the GetControls request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetControlsRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_controls<Conn>(conn: &Conn, device_spec: DeviceSpec) -> Result<Cookie<'_, Conn, GetControlsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_CONTROLS_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetControlsRequest {
+        device_spec: device_spec,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7130,8 +7291,158 @@ impl TryFrom<&[u8]> for GetControlsReply {
     }
 }
 
-/// Opcode for the SetControls request
-pub const SET_CONTROLS_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetControlsRequest<'input> {
+    pub device_spec: DeviceSpec,
+    pub affect_internal_real_mods: u8,
+    pub internal_real_mods: u8,
+    pub affect_ignore_lock_real_mods: u8,
+    pub ignore_lock_real_mods: u8,
+    pub affect_internal_virtual_mods: u16,
+    pub internal_virtual_mods: u16,
+    pub affect_ignore_lock_virtual_mods: u16,
+    pub ignore_lock_virtual_mods: u16,
+    pub mouse_keys_dflt_btn: u8,
+    pub groups_wrap: u8,
+    pub access_x_options: u16,
+    pub affect_enabled_controls: u32,
+    pub enabled_controls: u32,
+    pub change_controls: u32,
+    pub repeat_delay: u16,
+    pub repeat_interval: u16,
+    pub slow_keys_delay: u16,
+    pub debounce_delay: u16,
+    pub mouse_keys_delay: u16,
+    pub mouse_keys_interval: u16,
+    pub mouse_keys_time_to_max: u16,
+    pub mouse_keys_max_speed: u16,
+    pub mouse_keys_curve: i16,
+    pub access_x_timeout: u16,
+    pub access_x_timeout_mask: u32,
+    pub access_x_timeout_values: u32,
+    pub access_x_timeout_options_mask: u16,
+    pub access_x_timeout_options_values: u16,
+    pub per_key_repeat: &'input [u8; 32],
+}
+impl<'input> SetControlsRequest<'input> {
+    /// Opcode for the SetControls request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let affect_internal_real_mods_bytes = self.affect_internal_real_mods.serialize();
+        let internal_real_mods_bytes = self.internal_real_mods.serialize();
+        let affect_ignore_lock_real_mods_bytes = self.affect_ignore_lock_real_mods.serialize();
+        let ignore_lock_real_mods_bytes = self.ignore_lock_real_mods.serialize();
+        let affect_internal_virtual_mods_bytes = self.affect_internal_virtual_mods.serialize();
+        let internal_virtual_mods_bytes = self.internal_virtual_mods.serialize();
+        let affect_ignore_lock_virtual_mods_bytes = self.affect_ignore_lock_virtual_mods.serialize();
+        let ignore_lock_virtual_mods_bytes = self.ignore_lock_virtual_mods.serialize();
+        let mouse_keys_dflt_btn_bytes = self.mouse_keys_dflt_btn.serialize();
+        let groups_wrap_bytes = self.groups_wrap.serialize();
+        let access_x_options_bytes = self.access_x_options.serialize();
+        let affect_enabled_controls_bytes = self.affect_enabled_controls.serialize();
+        let enabled_controls_bytes = self.enabled_controls.serialize();
+        let change_controls_bytes = self.change_controls.serialize();
+        let repeat_delay_bytes = self.repeat_delay.serialize();
+        let repeat_interval_bytes = self.repeat_interval.serialize();
+        let slow_keys_delay_bytes = self.slow_keys_delay.serialize();
+        let debounce_delay_bytes = self.debounce_delay.serialize();
+        let mouse_keys_delay_bytes = self.mouse_keys_delay.serialize();
+        let mouse_keys_interval_bytes = self.mouse_keys_interval.serialize();
+        let mouse_keys_time_to_max_bytes = self.mouse_keys_time_to_max.serialize();
+        let mouse_keys_max_speed_bytes = self.mouse_keys_max_speed.serialize();
+        let mouse_keys_curve_bytes = self.mouse_keys_curve.serialize();
+        let access_x_timeout_bytes = self.access_x_timeout.serialize();
+        let access_x_timeout_mask_bytes = self.access_x_timeout_mask.serialize();
+        let access_x_timeout_values_bytes = self.access_x_timeout_values.serialize();
+        let access_x_timeout_options_mask_bytes = self.access_x_timeout_options_mask.serialize();
+        let access_x_timeout_options_values_bytes = self.access_x_timeout_options_values.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetControlsRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            affect_internal_real_mods_bytes[0],
+            internal_real_mods_bytes[0],
+            affect_ignore_lock_real_mods_bytes[0],
+            ignore_lock_real_mods_bytes[0],
+            affect_internal_virtual_mods_bytes[0],
+            affect_internal_virtual_mods_bytes[1],
+            internal_virtual_mods_bytes[0],
+            internal_virtual_mods_bytes[1],
+            affect_ignore_lock_virtual_mods_bytes[0],
+            affect_ignore_lock_virtual_mods_bytes[1],
+            ignore_lock_virtual_mods_bytes[0],
+            ignore_lock_virtual_mods_bytes[1],
+            mouse_keys_dflt_btn_bytes[0],
+            groups_wrap_bytes[0],
+            access_x_options_bytes[0],
+            access_x_options_bytes[1],
+            0,
+            0,
+            affect_enabled_controls_bytes[0],
+            affect_enabled_controls_bytes[1],
+            affect_enabled_controls_bytes[2],
+            affect_enabled_controls_bytes[3],
+            enabled_controls_bytes[0],
+            enabled_controls_bytes[1],
+            enabled_controls_bytes[2],
+            enabled_controls_bytes[3],
+            change_controls_bytes[0],
+            change_controls_bytes[1],
+            change_controls_bytes[2],
+            change_controls_bytes[3],
+            repeat_delay_bytes[0],
+            repeat_delay_bytes[1],
+            repeat_interval_bytes[0],
+            repeat_interval_bytes[1],
+            slow_keys_delay_bytes[0],
+            slow_keys_delay_bytes[1],
+            debounce_delay_bytes[0],
+            debounce_delay_bytes[1],
+            mouse_keys_delay_bytes[0],
+            mouse_keys_delay_bytes[1],
+            mouse_keys_interval_bytes[0],
+            mouse_keys_interval_bytes[1],
+            mouse_keys_time_to_max_bytes[0],
+            mouse_keys_time_to_max_bytes[1],
+            mouse_keys_max_speed_bytes[0],
+            mouse_keys_max_speed_bytes[1],
+            mouse_keys_curve_bytes[0],
+            mouse_keys_curve_bytes[1],
+            access_x_timeout_bytes[0],
+            access_x_timeout_bytes[1],
+            access_x_timeout_mask_bytes[0],
+            access_x_timeout_mask_bytes[1],
+            access_x_timeout_mask_bytes[2],
+            access_x_timeout_mask_bytes[3],
+            access_x_timeout_values_bytes[0],
+            access_x_timeout_values_bytes[1],
+            access_x_timeout_values_bytes[2],
+            access_x_timeout_values_bytes[3],
+            access_x_timeout_options_mask_bytes[0],
+            access_x_timeout_options_mask_bytes[1],
+            access_x_timeout_options_values_bytes[0],
+            access_x_timeout_options_values_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.per_key_repeat[..]).len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.per_key_repeat[..]).into()], vec![]))
+    }
+}
 pub fn set_controls<'c, 'input, Conn, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(conn: &'c Conn, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7152,8 +7463,6 @@ where
     O: Into<u16>,
     P: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let affect_internal_real_mods: u8 = affect_internal_real_mods.into();
     let internal_real_mods: u8 = internal_real_mods.into();
     let affect_ignore_lock_real_mods: u8 = affect_ignore_lock_real_mods.into();
@@ -7170,116 +7479,131 @@ where
     let access_x_timeout_values: u32 = access_x_timeout_values.into();
     let access_x_timeout_options_mask: u16 = access_x_timeout_options_mask.into();
     let access_x_timeout_options_values: u16 = access_x_timeout_options_values.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let affect_internal_real_mods_bytes = affect_internal_real_mods.serialize();
-    let internal_real_mods_bytes = internal_real_mods.serialize();
-    let affect_ignore_lock_real_mods_bytes = affect_ignore_lock_real_mods.serialize();
-    let ignore_lock_real_mods_bytes = ignore_lock_real_mods.serialize();
-    let affect_internal_virtual_mods_bytes = affect_internal_virtual_mods.serialize();
-    let internal_virtual_mods_bytes = internal_virtual_mods.serialize();
-    let affect_ignore_lock_virtual_mods_bytes = affect_ignore_lock_virtual_mods.serialize();
-    let ignore_lock_virtual_mods_bytes = ignore_lock_virtual_mods.serialize();
-    let mouse_keys_dflt_btn_bytes = mouse_keys_dflt_btn.serialize();
-    let groups_wrap_bytes = groups_wrap.serialize();
-    let access_x_options_bytes = access_x_options.serialize();
-    let affect_enabled_controls_bytes = affect_enabled_controls.serialize();
-    let enabled_controls_bytes = enabled_controls.serialize();
-    let change_controls_bytes = change_controls.serialize();
-    let repeat_delay_bytes = repeat_delay.serialize();
-    let repeat_interval_bytes = repeat_interval.serialize();
-    let slow_keys_delay_bytes = slow_keys_delay.serialize();
-    let debounce_delay_bytes = debounce_delay.serialize();
-    let mouse_keys_delay_bytes = mouse_keys_delay.serialize();
-    let mouse_keys_interval_bytes = mouse_keys_interval.serialize();
-    let mouse_keys_time_to_max_bytes = mouse_keys_time_to_max.serialize();
-    let mouse_keys_max_speed_bytes = mouse_keys_max_speed.serialize();
-    let mouse_keys_curve_bytes = mouse_keys_curve.serialize();
-    let access_x_timeout_bytes = access_x_timeout.serialize();
-    let access_x_timeout_mask_bytes = access_x_timeout_mask.serialize();
-    let access_x_timeout_values_bytes = access_x_timeout_values.serialize();
-    let access_x_timeout_options_mask_bytes = access_x_timeout_options_mask.serialize();
-    let access_x_timeout_options_values_bytes = access_x_timeout_options_values.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_CONTROLS_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        affect_internal_real_mods_bytes[0],
-        internal_real_mods_bytes[0],
-        affect_ignore_lock_real_mods_bytes[0],
-        ignore_lock_real_mods_bytes[0],
-        affect_internal_virtual_mods_bytes[0],
-        affect_internal_virtual_mods_bytes[1],
-        internal_virtual_mods_bytes[0],
-        internal_virtual_mods_bytes[1],
-        affect_ignore_lock_virtual_mods_bytes[0],
-        affect_ignore_lock_virtual_mods_bytes[1],
-        ignore_lock_virtual_mods_bytes[0],
-        ignore_lock_virtual_mods_bytes[1],
-        mouse_keys_dflt_btn_bytes[0],
-        groups_wrap_bytes[0],
-        access_x_options_bytes[0],
-        access_x_options_bytes[1],
-        0,
-        0,
-        affect_enabled_controls_bytes[0],
-        affect_enabled_controls_bytes[1],
-        affect_enabled_controls_bytes[2],
-        affect_enabled_controls_bytes[3],
-        enabled_controls_bytes[0],
-        enabled_controls_bytes[1],
-        enabled_controls_bytes[2],
-        enabled_controls_bytes[3],
-        change_controls_bytes[0],
-        change_controls_bytes[1],
-        change_controls_bytes[2],
-        change_controls_bytes[3],
-        repeat_delay_bytes[0],
-        repeat_delay_bytes[1],
-        repeat_interval_bytes[0],
-        repeat_interval_bytes[1],
-        slow_keys_delay_bytes[0],
-        slow_keys_delay_bytes[1],
-        debounce_delay_bytes[0],
-        debounce_delay_bytes[1],
-        mouse_keys_delay_bytes[0],
-        mouse_keys_delay_bytes[1],
-        mouse_keys_interval_bytes[0],
-        mouse_keys_interval_bytes[1],
-        mouse_keys_time_to_max_bytes[0],
-        mouse_keys_time_to_max_bytes[1],
-        mouse_keys_max_speed_bytes[0],
-        mouse_keys_max_speed_bytes[1],
-        mouse_keys_curve_bytes[0],
-        mouse_keys_curve_bytes[1],
-        access_x_timeout_bytes[0],
-        access_x_timeout_bytes[1],
-        access_x_timeout_mask_bytes[0],
-        access_x_timeout_mask_bytes[1],
-        access_x_timeout_mask_bytes[2],
-        access_x_timeout_mask_bytes[3],
-        access_x_timeout_values_bytes[0],
-        access_x_timeout_values_bytes[1],
-        access_x_timeout_values_bytes[2],
-        access_x_timeout_values_bytes[3],
-        access_x_timeout_options_mask_bytes[0],
-        access_x_timeout_options_mask_bytes[1],
-        access_x_timeout_options_values_bytes[0],
-        access_x_timeout_options_values_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + per_key_repeat.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(per_key_repeat)], vec![])?)
+    let request0 = SetControlsRequest {
+        device_spec: device_spec,
+        affect_internal_real_mods: affect_internal_real_mods,
+        internal_real_mods: internal_real_mods,
+        affect_ignore_lock_real_mods: affect_ignore_lock_real_mods,
+        ignore_lock_real_mods: ignore_lock_real_mods,
+        affect_internal_virtual_mods: affect_internal_virtual_mods,
+        internal_virtual_mods: internal_virtual_mods,
+        affect_ignore_lock_virtual_mods: affect_ignore_lock_virtual_mods,
+        ignore_lock_virtual_mods: ignore_lock_virtual_mods,
+        mouse_keys_dflt_btn: mouse_keys_dflt_btn,
+        groups_wrap: groups_wrap,
+        access_x_options: access_x_options,
+        affect_enabled_controls: affect_enabled_controls,
+        enabled_controls: enabled_controls,
+        change_controls: change_controls,
+        repeat_delay: repeat_delay,
+        repeat_interval: repeat_interval,
+        slow_keys_delay: slow_keys_delay,
+        debounce_delay: debounce_delay,
+        mouse_keys_delay: mouse_keys_delay,
+        mouse_keys_interval: mouse_keys_interval,
+        mouse_keys_time_to_max: mouse_keys_time_to_max,
+        mouse_keys_max_speed: mouse_keys_max_speed,
+        mouse_keys_curve: mouse_keys_curve,
+        access_x_timeout: access_x_timeout,
+        access_x_timeout_mask: access_x_timeout_mask,
+        access_x_timeout_values: access_x_timeout_values,
+        access_x_timeout_options_mask: access_x_timeout_options_mask,
+        access_x_timeout_options_values: access_x_timeout_options_values,
+        per_key_repeat: per_key_repeat,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetMap request
-pub const GET_MAP_REQUEST: u8 = 8;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetMapRequest {
+    pub device_spec: DeviceSpec,
+    pub full: u16,
+    pub partial: u16,
+    pub first_type: u8,
+    pub n_types: u8,
+    pub first_key_sym: xproto::Keycode,
+    pub n_key_syms: u8,
+    pub first_key_action: xproto::Keycode,
+    pub n_key_actions: u8,
+    pub first_key_behavior: xproto::Keycode,
+    pub n_key_behaviors: u8,
+    pub virtual_mods: u16,
+    pub first_key_explicit: xproto::Keycode,
+    pub n_key_explicit: u8,
+    pub first_mod_map_key: xproto::Keycode,
+    pub n_mod_map_keys: u8,
+    pub first_v_mod_map_key: xproto::Keycode,
+    pub n_v_mod_map_keys: u8,
+}
+impl GetMapRequest {
+    /// Opcode for the GetMap request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let full_bytes = self.full.serialize();
+        let partial_bytes = self.partial.serialize();
+        let first_type_bytes = self.first_type.serialize();
+        let n_types_bytes = self.n_types.serialize();
+        let first_key_sym_bytes = self.first_key_sym.serialize();
+        let n_key_syms_bytes = self.n_key_syms.serialize();
+        let first_key_action_bytes = self.first_key_action.serialize();
+        let n_key_actions_bytes = self.n_key_actions.serialize();
+        let first_key_behavior_bytes = self.first_key_behavior.serialize();
+        let n_key_behaviors_bytes = self.n_key_behaviors.serialize();
+        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let first_key_explicit_bytes = self.first_key_explicit.serialize();
+        let n_key_explicit_bytes = self.n_key_explicit.serialize();
+        let first_mod_map_key_bytes = self.first_mod_map_key.serialize();
+        let n_mod_map_keys_bytes = self.n_mod_map_keys.serialize();
+        let first_v_mod_map_key_bytes = self.first_v_mod_map_key.serialize();
+        let n_v_mod_map_keys_bytes = self.n_v_mod_map_keys.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetMapRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            full_bytes[0],
+            full_bytes[1],
+            partial_bytes[0],
+            partial_bytes[1],
+            first_type_bytes[0],
+            n_types_bytes[0],
+            first_key_sym_bytes[0],
+            n_key_syms_bytes[0],
+            first_key_action_bytes[0],
+            n_key_actions_bytes[0],
+            first_key_behavior_bytes[0],
+            n_key_behaviors_bytes[0],
+            virtual_mods_bytes[0],
+            virtual_mods_bytes[1],
+            first_key_explicit_bytes[0],
+            n_key_explicit_bytes[0],
+            first_mod_map_key_bytes[0],
+            n_mod_map_keys_bytes[0],
+            first_v_mod_map_key_bytes[0],
+            n_v_mod_map_keys_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_map<Conn, A, B, C>(conn: &Conn, device_spec: DeviceSpec, full: A, partial: B, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: C, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7287,65 +7611,32 @@ where
     B: Into<u16>,
     C: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let full: u16 = full.into();
     let partial: u16 = partial.into();
     let virtual_mods: u16 = virtual_mods.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let full_bytes = full.serialize();
-    let partial_bytes = partial.serialize();
-    let first_type_bytes = first_type.serialize();
-    let n_types_bytes = n_types.serialize();
-    let first_key_sym_bytes = first_key_sym.serialize();
-    let n_key_syms_bytes = n_key_syms.serialize();
-    let first_key_action_bytes = first_key_action.serialize();
-    let n_key_actions_bytes = n_key_actions.serialize();
-    let first_key_behavior_bytes = first_key_behavior.serialize();
-    let n_key_behaviors_bytes = n_key_behaviors.serialize();
-    let virtual_mods_bytes = virtual_mods.serialize();
-    let first_key_explicit_bytes = first_key_explicit.serialize();
-    let n_key_explicit_bytes = n_key_explicit.serialize();
-    let first_mod_map_key_bytes = first_mod_map_key.serialize();
-    let n_mod_map_keys_bytes = n_mod_map_keys.serialize();
-    let first_v_mod_map_key_bytes = first_v_mod_map_key.serialize();
-    let n_v_mod_map_keys_bytes = n_v_mod_map_keys.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_MAP_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        full_bytes[0],
-        full_bytes[1],
-        partial_bytes[0],
-        partial_bytes[1],
-        first_type_bytes[0],
-        n_types_bytes[0],
-        first_key_sym_bytes[0],
-        n_key_syms_bytes[0],
-        first_key_action_bytes[0],
-        n_key_actions_bytes[0],
-        first_key_behavior_bytes[0],
-        n_key_behaviors_bytes[0],
-        virtual_mods_bytes[0],
-        virtual_mods_bytes[1],
-        first_key_explicit_bytes[0],
-        n_key_explicit_bytes[0],
-        first_mod_map_key_bytes[0],
-        n_mod_map_keys_bytes[0],
-        first_v_mod_map_key_bytes[0],
-        n_v_mod_map_keys_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetMapRequest {
+        device_spec: device_spec,
+        full: full,
+        partial: partial,
+        first_type: first_type,
+        n_types: n_types,
+        first_key_sym: first_key_sym,
+        n_key_syms: n_key_syms,
+        first_key_action: first_key_action,
+        n_key_actions: n_key_actions,
+        first_key_behavior: first_key_behavior,
+        n_key_behaviors: n_key_behaviors,
+        virtual_mods: virtual_mods,
+        first_key_explicit: first_key_explicit,
+        n_key_explicit: n_key_explicit,
+        first_mod_map_key: first_mod_map_key,
+        n_mod_map_keys: n_mod_map_keys,
+        first_v_mod_map_key: first_v_mod_map_key,
+        n_v_mod_map_keys: n_v_mod_map_keys,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone)]
@@ -7544,8 +7835,6 @@ impl TryFrom<&[u8]> for GetMapReply {
     }
 }
 
-/// Opcode for the SetMap request
-pub const SET_MAP_REQUEST: u8 = 9;
 #[derive(Debug, Clone)]
 pub struct SetMapAuxBitcase3 {
     pub actions_count: Vec<u8>,
@@ -7697,128 +7986,226 @@ impl SetMapAux {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SetMapRequest<'input> {
+    pub device_spec: DeviceSpec,
+    pub flags: u16,
+    pub min_key_code: xproto::Keycode,
+    pub max_key_code: xproto::Keycode,
+    pub first_type: u8,
+    pub n_types: u8,
+    pub first_key_sym: xproto::Keycode,
+    pub n_key_syms: u8,
+    pub total_syms: u16,
+    pub first_key_action: xproto::Keycode,
+    pub n_key_actions: u8,
+    pub total_actions: u16,
+    pub first_key_behavior: xproto::Keycode,
+    pub n_key_behaviors: u8,
+    pub total_key_behaviors: u8,
+    pub first_key_explicit: xproto::Keycode,
+    pub n_key_explicit: u8,
+    pub total_key_explicit: u8,
+    pub first_mod_map_key: xproto::Keycode,
+    pub n_mod_map_keys: u8,
+    pub total_mod_map_keys: u8,
+    pub first_v_mod_map_key: xproto::Keycode,
+    pub n_v_mod_map_keys: u8,
+    pub total_v_mod_map_keys: u8,
+    pub virtual_mods: u16,
+    pub values: &'input SetMapAux,
+}
+impl<'input> SetMapRequest<'input> {
+    /// Opcode for the SetMap request
+    pub const fn opcode() -> u8 { 9 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let present = u16::try_from(self.values.switch_expr()).unwrap();
+        let present_bytes = present.serialize();
+        let flags_bytes = self.flags.serialize();
+        let min_key_code_bytes = self.min_key_code.serialize();
+        let max_key_code_bytes = self.max_key_code.serialize();
+        let first_type_bytes = self.first_type.serialize();
+        let n_types_bytes = self.n_types.serialize();
+        let first_key_sym_bytes = self.first_key_sym.serialize();
+        let n_key_syms_bytes = self.n_key_syms.serialize();
+        let total_syms_bytes = self.total_syms.serialize();
+        let first_key_action_bytes = self.first_key_action.serialize();
+        let n_key_actions_bytes = self.n_key_actions.serialize();
+        let total_actions_bytes = self.total_actions.serialize();
+        let first_key_behavior_bytes = self.first_key_behavior.serialize();
+        let n_key_behaviors_bytes = self.n_key_behaviors.serialize();
+        let total_key_behaviors_bytes = self.total_key_behaviors.serialize();
+        let first_key_explicit_bytes = self.first_key_explicit.serialize();
+        let n_key_explicit_bytes = self.n_key_explicit.serialize();
+        let total_key_explicit_bytes = self.total_key_explicit.serialize();
+        let first_mod_map_key_bytes = self.first_mod_map_key.serialize();
+        let n_mod_map_keys_bytes = self.n_mod_map_keys.serialize();
+        let total_mod_map_keys_bytes = self.total_mod_map_keys.serialize();
+        let first_v_mod_map_key_bytes = self.first_v_mod_map_key.serialize();
+        let n_v_mod_map_keys_bytes = self.n_v_mod_map_keys.serialize();
+        let total_v_mod_map_keys_bytes = self.total_v_mod_map_keys.serialize();
+        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetMapRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            present_bytes[0],
+            present_bytes[1],
+            flags_bytes[0],
+            flags_bytes[1],
+            min_key_code_bytes[0],
+            max_key_code_bytes[0],
+            first_type_bytes[0],
+            n_types_bytes[0],
+            first_key_sym_bytes[0],
+            n_key_syms_bytes[0],
+            total_syms_bytes[0],
+            total_syms_bytes[1],
+            first_key_action_bytes[0],
+            n_key_actions_bytes[0],
+            total_actions_bytes[0],
+            total_actions_bytes[1],
+            first_key_behavior_bytes[0],
+            n_key_behaviors_bytes[0],
+            total_key_behaviors_bytes[0],
+            first_key_explicit_bytes[0],
+            n_key_explicit_bytes[0],
+            total_key_explicit_bytes[0],
+            first_mod_map_key_bytes[0],
+            n_mod_map_keys_bytes[0],
+            total_mod_map_keys_bytes[0],
+            first_v_mod_map_key_bytes[0],
+            n_v_mod_map_keys_bytes[0],
+            total_v_mod_map_keys_bytes[0],
+            virtual_mods_bytes[0],
+            virtual_mods_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let values_bytes = self.values.serialize(present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
+        let length_so_far = length_so_far + values_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_map<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &'input SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
     B: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let flags: u16 = flags.into();
     let virtual_mods: u16 = virtual_mods.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let present = u16::try_from(values.switch_expr()).unwrap();
-    let present_bytes = present.serialize();
-    let flags_bytes = flags.serialize();
-    let min_key_code_bytes = min_key_code.serialize();
-    let max_key_code_bytes = max_key_code.serialize();
-    let first_type_bytes = first_type.serialize();
-    let n_types_bytes = n_types.serialize();
-    let first_key_sym_bytes = first_key_sym.serialize();
-    let n_key_syms_bytes = n_key_syms.serialize();
-    let total_syms_bytes = total_syms.serialize();
-    let first_key_action_bytes = first_key_action.serialize();
-    let n_key_actions_bytes = n_key_actions.serialize();
-    let total_actions_bytes = total_actions.serialize();
-    let first_key_behavior_bytes = first_key_behavior.serialize();
-    let n_key_behaviors_bytes = n_key_behaviors.serialize();
-    let total_key_behaviors_bytes = total_key_behaviors.serialize();
-    let first_key_explicit_bytes = first_key_explicit.serialize();
-    let n_key_explicit_bytes = n_key_explicit.serialize();
-    let total_key_explicit_bytes = total_key_explicit.serialize();
-    let first_mod_map_key_bytes = first_mod_map_key.serialize();
-    let n_mod_map_keys_bytes = n_mod_map_keys.serialize();
-    let total_mod_map_keys_bytes = total_mod_map_keys.serialize();
-    let first_v_mod_map_key_bytes = first_v_mod_map_key.serialize();
-    let n_v_mod_map_keys_bytes = n_v_mod_map_keys.serialize();
-    let total_v_mod_map_keys_bytes = total_v_mod_map_keys.serialize();
-    let virtual_mods_bytes = virtual_mods.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_MAP_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        present_bytes[0],
-        present_bytes[1],
-        flags_bytes[0],
-        flags_bytes[1],
-        min_key_code_bytes[0],
-        max_key_code_bytes[0],
-        first_type_bytes[0],
-        n_types_bytes[0],
-        first_key_sym_bytes[0],
-        n_key_syms_bytes[0],
-        total_syms_bytes[0],
-        total_syms_bytes[1],
-        first_key_action_bytes[0],
-        n_key_actions_bytes[0],
-        total_actions_bytes[0],
-        total_actions_bytes[1],
-        first_key_behavior_bytes[0],
-        n_key_behaviors_bytes[0],
-        total_key_behaviors_bytes[0],
-        first_key_explicit_bytes[0],
-        n_key_explicit_bytes[0],
-        total_key_explicit_bytes[0],
-        first_mod_map_key_bytes[0],
-        n_mod_map_keys_bytes[0],
-        total_mod_map_keys_bytes[0],
-        first_v_mod_map_key_bytes[0],
-        n_v_mod_map_keys_bytes[0],
-        total_v_mod_map_keys_bytes[0],
-        virtual_mods_bytes[0],
-        virtual_mods_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let values_bytes = values.serialize(present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys);
-    let length_so_far = length_so_far + values_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&values_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetMapRequest {
+        device_spec: device_spec,
+        flags: flags,
+        min_key_code: min_key_code,
+        max_key_code: max_key_code,
+        first_type: first_type,
+        n_types: n_types,
+        first_key_sym: first_key_sym,
+        n_key_syms: n_key_syms,
+        total_syms: total_syms,
+        first_key_action: first_key_action,
+        n_key_actions: n_key_actions,
+        total_actions: total_actions,
+        first_key_behavior: first_key_behavior,
+        n_key_behaviors: n_key_behaviors,
+        total_key_behaviors: total_key_behaviors,
+        first_key_explicit: first_key_explicit,
+        n_key_explicit: n_key_explicit,
+        total_key_explicit: total_key_explicit,
+        first_mod_map_key: first_mod_map_key,
+        n_mod_map_keys: n_mod_map_keys,
+        total_mod_map_keys: total_mod_map_keys,
+        first_v_mod_map_key: first_v_mod_map_key,
+        n_v_mod_map_keys: n_v_mod_map_keys,
+        total_v_mod_map_keys: total_v_mod_map_keys,
+        virtual_mods: virtual_mods,
+        values: values,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetCompatMap request
-pub const GET_COMPAT_MAP_REQUEST: u8 = 10;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetCompatMapRequest {
+    pub device_spec: DeviceSpec,
+    pub groups: u8,
+    pub get_all_si: bool,
+    pub first_si: u16,
+    pub n_si: u16,
+}
+impl GetCompatMapRequest {
+    /// Opcode for the GetCompatMap request
+    pub const fn opcode() -> u8 { 10 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let groups_bytes = self.groups.serialize();
+        let get_all_si_bytes = self.get_all_si.serialize();
+        let first_si_bytes = self.first_si.serialize();
+        let n_si_bytes = self.n_si.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetCompatMapRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            groups_bytes[0],
+            get_all_si_bytes[0],
+            first_si_bytes[0],
+            first_si_bytes[1],
+            n_si_bytes[0],
+            n_si_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_compat_map<Conn, A>(conn: &Conn, device_spec: DeviceSpec, groups: A, get_all_si: bool, first_si: u16, n_si: u16) -> Result<Cookie<'_, Conn, GetCompatMapReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let groups: u8 = groups.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let groups_bytes = groups.serialize();
-    let get_all_si_bytes = get_all_si.serialize();
-    let first_si_bytes = first_si.serialize();
-    let n_si_bytes = n_si.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_COMPAT_MAP_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        groups_bytes[0],
-        get_all_si_bytes[0],
-        first_si_bytes[0],
-        first_si_bytes[1],
-        n_si_bytes[0],
-        n_si_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetCompatMapRequest {
+        device_spec: device_spec,
+        groups: groups,
+        get_all_si: get_all_si,
+        first_si: first_si,
+        n_si: n_si,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7873,81 +8260,131 @@ impl GetCompatMapReply {
     }
 }
 
-/// Opcode for the SetCompatMap request
-pub const SET_COMPAT_MAP_REQUEST: u8 = 11;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetCompatMapRequest<'input> {
+    pub device_spec: DeviceSpec,
+    pub recompute_actions: bool,
+    pub truncate_si: bool,
+    pub groups: u8,
+    pub first_si: u16,
+    pub si: &'input [SymInterpret],
+    pub group_maps: &'input [ModDef],
+}
+impl<'input> SetCompatMapRequest<'input> {
+    /// Opcode for the SetCompatMap request
+    pub const fn opcode() -> u8 { 11 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let recompute_actions_bytes = self.recompute_actions.serialize();
+        let truncate_si_bytes = self.truncate_si.serialize();
+        let groups_bytes = self.groups.serialize();
+        let first_si_bytes = self.first_si.serialize();
+        let n_si = u16::try_from(self.si.len()).expect("`si` has too many elements");
+        let n_si_bytes = n_si.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetCompatMapRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            recompute_actions_bytes[0],
+            truncate_si_bytes[0],
+            groups_bytes[0],
+            first_si_bytes[0],
+            first_si_bytes[1],
+            n_si_bytes[0],
+            n_si_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let si_bytes = self.si.serialize();
+        let length_so_far = length_so_far + si_bytes.len();
+        assert_eq!(self.group_maps.len(), usize::try_from(self.groups.count_ones()).unwrap(), "`group_maps` has an incorrect length");
+        let group_maps_bytes = self.group_maps.serialize();
+        let length_so_far = length_so_far + group_maps_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), si_bytes.into(), group_maps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_compat_map<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let groups: u8 = groups.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let recompute_actions_bytes = recompute_actions.serialize();
-    let truncate_si_bytes = truncate_si.serialize();
-    let groups_bytes = groups.serialize();
-    let first_si_bytes = first_si.serialize();
-    let n_si = u16::try_from(si.len()).expect("`si` has too many elements");
-    let n_si_bytes = n_si.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_COMPAT_MAP_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        recompute_actions_bytes[0],
-        truncate_si_bytes[0],
-        groups_bytes[0],
-        first_si_bytes[0],
-        first_si_bytes[1],
-        n_si_bytes[0],
-        n_si_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let si_bytes = si.serialize();
-    let length_so_far = length_so_far + si_bytes.len();
-    assert_eq!(group_maps.len(), usize::try_from(groups.count_ones()).unwrap(), "`group_maps` has an incorrect length");
-    let group_maps_bytes = group_maps.serialize();
-    let length_so_far = length_so_far + group_maps_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&si_bytes), IoSlice::new(&group_maps_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetCompatMapRequest {
+        device_spec: device_spec,
+        recompute_actions: recompute_actions,
+        truncate_si: truncate_si,
+        groups: groups,
+        first_si: first_si,
+        si: si,
+        group_maps: group_maps,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetIndicatorState request
-pub const GET_INDICATOR_STATE_REQUEST: u8 = 12;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetIndicatorStateRequest {
+    pub device_spec: DeviceSpec,
+}
+impl GetIndicatorStateRequest {
+    /// Opcode for the GetIndicatorState request
+    pub const fn opcode() -> u8 { 12 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetIndicatorStateRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_indicator_state<Conn>(conn: &Conn, device_spec: DeviceSpec) -> Result<Cookie<'_, Conn, GetIndicatorStateReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_INDICATOR_STATE_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetIndicatorStateRequest {
+        device_spec: device_spec,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7977,36 +8414,57 @@ impl TryFrom<&[u8]> for GetIndicatorStateReply {
     }
 }
 
-/// Opcode for the GetIndicatorMap request
-pub const GET_INDICATOR_MAP_REQUEST: u8 = 13;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetIndicatorMapRequest {
+    pub device_spec: DeviceSpec,
+    pub which: u32,
+}
+impl GetIndicatorMapRequest {
+    /// Opcode for the GetIndicatorMap request
+    pub const fn opcode() -> u8 { 13 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let which_bytes = self.which.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetIndicatorMapRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            0,
+            which_bytes[0],
+            which_bytes[1],
+            which_bytes[2],
+            which_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_indicator_map<Conn>(conn: &Conn, device_spec: DeviceSpec, which: u32) -> Result<Cookie<'_, Conn, GetIndicatorMapReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let which_bytes = which.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_INDICATOR_MAP_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        0,
-        which_bytes[0],
-        which_bytes[1],
-        which_bytes[2],
-        which_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetIndicatorMapRequest {
+        device_spec: device_spec,
+        which: which,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8042,81 +8500,129 @@ impl TryFrom<&[u8]> for GetIndicatorMapReply {
     }
 }
 
-/// Opcode for the SetIndicatorMap request
-pub const SET_INDICATOR_MAP_REQUEST: u8 = 14;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetIndicatorMapRequest<'input> {
+    pub device_spec: DeviceSpec,
+    pub which: u32,
+    pub maps: &'input [IndicatorMap],
+}
+impl<'input> SetIndicatorMapRequest<'input> {
+    /// Opcode for the SetIndicatorMap request
+    pub const fn opcode() -> u8 { 14 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let which_bytes = self.which.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetIndicatorMapRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            0,
+            which_bytes[0],
+            which_bytes[1],
+            which_bytes[2],
+            which_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(self.maps.len(), usize::try_from(self.which.count_ones()).unwrap(), "`maps` has an incorrect length");
+        let maps_bytes = self.maps.serialize();
+        let length_so_far = length_so_far + maps_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), maps_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_indicator_map<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, which: u32, maps: &'input [IndicatorMap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let which_bytes = which.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_INDICATOR_MAP_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        0,
-        which_bytes[0],
-        which_bytes[1],
-        which_bytes[2],
-        which_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(maps.len(), usize::try_from(which.count_ones()).unwrap(), "`maps` has an incorrect length");
-    let maps_bytes = maps.serialize();
-    let length_so_far = length_so_far + maps_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&maps_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetIndicatorMapRequest {
+        device_spec: device_spec,
+        which: which,
+        maps: maps,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetNamedIndicator request
-pub const GET_NAMED_INDICATOR_REQUEST: u8 = 15;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetNamedIndicatorRequest {
+    pub device_spec: DeviceSpec,
+    pub led_class: LedClass,
+    pub led_id: IDSpec,
+    pub indicator: xproto::Atom,
+}
+impl GetNamedIndicatorRequest {
+    /// Opcode for the GetNamedIndicator request
+    pub const fn opcode() -> u8 { 15 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let led_class_bytes = LedClassSpec::from(self.led_class).serialize();
+        let led_id_bytes = self.led_id.serialize();
+        let indicator_bytes = self.indicator.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetNamedIndicatorRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            led_class_bytes[0],
+            led_class_bytes[1],
+            led_id_bytes[0],
+            led_id_bytes[1],
+            0,
+            0,
+            indicator_bytes[0],
+            indicator_bytes[1],
+            indicator_bytes[2],
+            indicator_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom) -> Result<Cookie<'_, Conn, GetNamedIndicatorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<IDSpec>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let led_id: IDSpec = led_id.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let led_class_bytes = LedClassSpec::from(led_class).serialize();
-    let led_id_bytes = led_id.serialize();
-    let indicator_bytes = indicator.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_NAMED_INDICATOR_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        led_class_bytes[0],
-        led_class_bytes[1],
-        led_id_bytes[0],
-        led_id_bytes[1],
-        0,
-        0,
-        indicator_bytes[0],
-        indicator_bytes[1],
-        indicator_bytes[2],
-        indicator_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetNamedIndicatorRequest {
+        device_spec: device_spec,
+        led_class: led_class,
+        led_id: led_id,
+        indicator: indicator,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8172,8 +8678,92 @@ impl TryFrom<&[u8]> for GetNamedIndicatorReply {
     }
 }
 
-/// Opcode for the SetNamedIndicator request
-pub const SET_NAMED_INDICATOR_REQUEST: u8 = 16;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetNamedIndicatorRequest {
+    pub device_spec: DeviceSpec,
+    pub led_class: LedClass,
+    pub led_id: IDSpec,
+    pub indicator: xproto::Atom,
+    pub set_state: bool,
+    pub on: bool,
+    pub set_map: bool,
+    pub create_map: bool,
+    pub map_flags: u8,
+    pub map_which_groups: u8,
+    pub map_groups: u8,
+    pub map_which_mods: u8,
+    pub map_real_mods: u8,
+    pub map_vmods: u16,
+    pub map_ctrls: u32,
+}
+impl SetNamedIndicatorRequest {
+    /// Opcode for the SetNamedIndicator request
+    pub const fn opcode() -> u8 { 16 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let led_class_bytes = LedClassSpec::from(self.led_class).serialize();
+        let led_id_bytes = self.led_id.serialize();
+        let indicator_bytes = self.indicator.serialize();
+        let set_state_bytes = self.set_state.serialize();
+        let on_bytes = self.on.serialize();
+        let set_map_bytes = self.set_map.serialize();
+        let create_map_bytes = self.create_map.serialize();
+        let map_flags_bytes = self.map_flags.serialize();
+        let map_which_groups_bytes = self.map_which_groups.serialize();
+        let map_groups_bytes = self.map_groups.serialize();
+        let map_which_mods_bytes = self.map_which_mods.serialize();
+        let map_real_mods_bytes = self.map_real_mods.serialize();
+        let map_vmods_bytes = self.map_vmods.serialize();
+        let map_ctrls_bytes = self.map_ctrls.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetNamedIndicatorRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            led_class_bytes[0],
+            led_class_bytes[1],
+            led_id_bytes[0],
+            led_id_bytes[1],
+            0,
+            0,
+            indicator_bytes[0],
+            indicator_bytes[1],
+            indicator_bytes[2],
+            indicator_bytes[3],
+            set_state_bytes[0],
+            on_bytes[0],
+            set_map_bytes[0],
+            create_map_bytes[0],
+            0,
+            map_flags_bytes[0],
+            map_which_groups_bytes[0],
+            map_groups_bytes[0],
+            map_which_mods_bytes[0],
+            map_real_mods_bytes[0],
+            map_vmods_bytes[0],
+            map_vmods_bytes[1],
+            map_ctrls_bytes[0],
+            map_ctrls_bytes[1],
+            map_ctrls_bytes[2],
+            map_ctrls_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_named_indicator<Conn, A, B, C, D, E, F, G, H>(conn: &Conn, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: B, map_which_groups: C, map_groups: D, map_which_mods: E, map_real_mods: F, map_vmods: G, map_ctrls: H) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8186,8 +8776,6 @@ where
     G: Into<u16>,
     H: Into<u32>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let led_id: IDSpec = led_id.into();
     let map_flags: u8 = map_flags.into();
     let map_which_groups: u8 = map_which_groups.into();
@@ -8196,95 +8784,81 @@ where
     let map_real_mods: u8 = map_real_mods.into();
     let map_vmods: u16 = map_vmods.into();
     let map_ctrls: u32 = map_ctrls.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let led_class_bytes = LedClassSpec::from(led_class).serialize();
-    let led_id_bytes = led_id.serialize();
-    let indicator_bytes = indicator.serialize();
-    let set_state_bytes = set_state.serialize();
-    let on_bytes = on.serialize();
-    let set_map_bytes = set_map.serialize();
-    let create_map_bytes = create_map.serialize();
-    let map_flags_bytes = map_flags.serialize();
-    let map_which_groups_bytes = map_which_groups.serialize();
-    let map_groups_bytes = map_groups.serialize();
-    let map_which_mods_bytes = map_which_mods.serialize();
-    let map_real_mods_bytes = map_real_mods.serialize();
-    let map_vmods_bytes = map_vmods.serialize();
-    let map_ctrls_bytes = map_ctrls.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_NAMED_INDICATOR_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        led_class_bytes[0],
-        led_class_bytes[1],
-        led_id_bytes[0],
-        led_id_bytes[1],
-        0,
-        0,
-        indicator_bytes[0],
-        indicator_bytes[1],
-        indicator_bytes[2],
-        indicator_bytes[3],
-        set_state_bytes[0],
-        on_bytes[0],
-        set_map_bytes[0],
-        create_map_bytes[0],
-        0,
-        map_flags_bytes[0],
-        map_which_groups_bytes[0],
-        map_groups_bytes[0],
-        map_which_mods_bytes[0],
-        map_real_mods_bytes[0],
-        map_vmods_bytes[0],
-        map_vmods_bytes[1],
-        map_ctrls_bytes[0],
-        map_ctrls_bytes[1],
-        map_ctrls_bytes[2],
-        map_ctrls_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetNamedIndicatorRequest {
+        device_spec: device_spec,
+        led_class: led_class,
+        led_id: led_id,
+        indicator: indicator,
+        set_state: set_state,
+        on: on,
+        set_map: set_map,
+        create_map: create_map,
+        map_flags: map_flags,
+        map_which_groups: map_which_groups,
+        map_groups: map_groups,
+        map_which_mods: map_which_mods,
+        map_real_mods: map_real_mods,
+        map_vmods: map_vmods,
+        map_ctrls: map_ctrls,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetNames request
-pub const GET_NAMES_REQUEST: u8 = 17;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetNamesRequest {
+    pub device_spec: DeviceSpec,
+    pub which: u32,
+}
+impl GetNamesRequest {
+    /// Opcode for the GetNames request
+    pub const fn opcode() -> u8 { 17 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let which_bytes = self.which.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetNamesRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            0,
+            which_bytes[0],
+            which_bytes[1],
+            which_bytes[2],
+            which_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_names<Conn, A>(conn: &Conn, device_spec: DeviceSpec, which: A) -> Result<Cookie<'_, Conn, GetNamesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let which: u32 = which.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let which_bytes = which.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_NAMES_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        0,
-        which_bytes[0],
-        which_bytes[1],
-        which_bytes[2],
-        which_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetNamesRequest {
+        device_spec: device_spec,
+        which: which,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8494,8 +9068,6 @@ impl TryFrom<&[u8]> for GetNamesReply {
     }
 }
 
-/// Opcode for the SetNames request
-pub const SET_NAMES_REQUEST: u8 = 18;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetNamesAuxBitcase8 {
     pub n_levels_per_type: Vec<u8>,
@@ -8718,75 +9290,184 @@ impl SetNamesAux {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetNamesRequest<'input> {
+    pub device_spec: DeviceSpec,
+    pub virtual_mods: u16,
+    pub first_type: u8,
+    pub n_types: u8,
+    pub first_kt_levelt: u8,
+    pub n_kt_levels: u8,
+    pub indicators: u32,
+    pub group_names: u8,
+    pub n_radio_groups: u8,
+    pub first_key: xproto::Keycode,
+    pub n_keys: u8,
+    pub n_key_aliases: u8,
+    pub total_kt_level_names: u16,
+    pub values: &'input SetNamesAux,
+}
+impl<'input> SetNamesRequest<'input> {
+    /// Opcode for the SetNames request
+    pub const fn opcode() -> u8 { 18 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let which = u32::try_from(self.values.switch_expr()).unwrap();
+        let which_bytes = which.serialize();
+        let first_type_bytes = self.first_type.serialize();
+        let n_types_bytes = self.n_types.serialize();
+        let first_kt_levelt_bytes = self.first_kt_levelt.serialize();
+        let n_kt_levels_bytes = self.n_kt_levels.serialize();
+        let indicators_bytes = self.indicators.serialize();
+        let group_names_bytes = self.group_names.serialize();
+        let n_radio_groups_bytes = self.n_radio_groups.serialize();
+        let first_key_bytes = self.first_key.serialize();
+        let n_keys_bytes = self.n_keys.serialize();
+        let n_key_aliases_bytes = self.n_key_aliases.serialize();
+        let total_kt_level_names_bytes = self.total_kt_level_names.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetNamesRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            virtual_mods_bytes[0],
+            virtual_mods_bytes[1],
+            which_bytes[0],
+            which_bytes[1],
+            which_bytes[2],
+            which_bytes[3],
+            first_type_bytes[0],
+            n_types_bytes[0],
+            first_kt_levelt_bytes[0],
+            n_kt_levels_bytes[0],
+            indicators_bytes[0],
+            indicators_bytes[1],
+            indicators_bytes[2],
+            indicators_bytes[3],
+            group_names_bytes[0],
+            n_radio_groups_bytes[0],
+            first_key_bytes[0],
+            n_keys_bytes[0],
+            n_key_aliases_bytes[0],
+            0,
+            total_kt_level_names_bytes[0],
+            total_kt_level_names_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let values_bytes = self.values.serialize(which, self.n_types, self.indicators, self.virtual_mods, self.group_names, self.n_keys, self.n_key_aliases, self.n_radio_groups);
+        let length_so_far = length_so_far + values_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), values_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_names<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
     B: Into<u8>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let virtual_mods: u16 = virtual_mods.into();
     let group_names: u8 = group_names.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let virtual_mods_bytes = virtual_mods.serialize();
-    let which = u32::try_from(values.switch_expr()).unwrap();
-    let which_bytes = which.serialize();
-    let first_type_bytes = first_type.serialize();
-    let n_types_bytes = n_types.serialize();
-    let first_kt_levelt_bytes = first_kt_levelt.serialize();
-    let n_kt_levels_bytes = n_kt_levels.serialize();
-    let indicators_bytes = indicators.serialize();
-    let group_names_bytes = group_names.serialize();
-    let n_radio_groups_bytes = n_radio_groups.serialize();
-    let first_key_bytes = first_key.serialize();
-    let n_keys_bytes = n_keys.serialize();
-    let n_key_aliases_bytes = n_key_aliases.serialize();
-    let total_kt_level_names_bytes = total_kt_level_names.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_NAMES_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        virtual_mods_bytes[0],
-        virtual_mods_bytes[1],
-        which_bytes[0],
-        which_bytes[1],
-        which_bytes[2],
-        which_bytes[3],
-        first_type_bytes[0],
-        n_types_bytes[0],
-        first_kt_levelt_bytes[0],
-        n_kt_levels_bytes[0],
-        indicators_bytes[0],
-        indicators_bytes[1],
-        indicators_bytes[2],
-        indicators_bytes[3],
-        group_names_bytes[0],
-        n_radio_groups_bytes[0],
-        first_key_bytes[0],
-        n_keys_bytes[0],
-        n_key_aliases_bytes[0],
-        0,
-        total_kt_level_names_bytes[0],
-        total_kt_level_names_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let values_bytes = values.serialize(which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups);
-    let length_so_far = length_so_far + values_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&values_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetNamesRequest {
+        device_spec: device_spec,
+        virtual_mods: virtual_mods,
+        first_type: first_type,
+        n_types: n_types,
+        first_kt_levelt: first_kt_levelt,
+        n_kt_levels: n_kt_levels,
+        indicators: indicators,
+        group_names: group_names,
+        n_radio_groups: n_radio_groups,
+        first_key: first_key,
+        n_keys: n_keys,
+        n_key_aliases: n_key_aliases,
+        total_kt_level_names: total_kt_level_names,
+        values: values,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the PerClientFlags request
-pub const PER_CLIENT_FLAGS_REQUEST: u8 = 21;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PerClientFlagsRequest {
+    pub device_spec: DeviceSpec,
+    pub change: u32,
+    pub value: u32,
+    pub ctrls_to_change: u32,
+    pub auto_ctrls: u32,
+    pub auto_ctrls_values: u32,
+}
+impl PerClientFlagsRequest {
+    /// Opcode for the PerClientFlags request
+    pub const fn opcode() -> u8 { 21 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let change_bytes = self.change.serialize();
+        let value_bytes = self.value.serialize();
+        let ctrls_to_change_bytes = self.ctrls_to_change.serialize();
+        let auto_ctrls_bytes = self.auto_ctrls.serialize();
+        let auto_ctrls_values_bytes = self.auto_ctrls_values.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            PerClientFlagsRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            0,
+            0,
+            change_bytes[0],
+            change_bytes[1],
+            change_bytes[2],
+            change_bytes[3],
+            value_bytes[0],
+            value_bytes[1],
+            value_bytes[2],
+            value_bytes[3],
+            ctrls_to_change_bytes[0],
+            ctrls_to_change_bytes[1],
+            ctrls_to_change_bytes[2],
+            ctrls_to_change_bytes[3],
+            auto_ctrls_bytes[0],
+            auto_ctrls_bytes[1],
+            auto_ctrls_bytes[2],
+            auto_ctrls_bytes[3],
+            auto_ctrls_values_bytes[0],
+            auto_ctrls_values_bytes[1],
+            auto_ctrls_values_bytes[2],
+            auto_ctrls_values_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn per_client_flags<Conn, A, B, C, D, E>(conn: &Conn, device_spec: DeviceSpec, change: A, value: B, ctrls_to_change: C, auto_ctrls: D, auto_ctrls_values: E) -> Result<Cookie<'_, Conn, PerClientFlagsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8796,55 +9477,22 @@ where
     D: Into<u32>,
     E: Into<u32>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let change: u32 = change.into();
     let value: u32 = value.into();
     let ctrls_to_change: u32 = ctrls_to_change.into();
     let auto_ctrls: u32 = auto_ctrls.into();
     let auto_ctrls_values: u32 = auto_ctrls_values.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let change_bytes = change.serialize();
-    let value_bytes = value.serialize();
-    let ctrls_to_change_bytes = ctrls_to_change.serialize();
-    let auto_ctrls_bytes = auto_ctrls.serialize();
-    let auto_ctrls_values_bytes = auto_ctrls_values.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        PER_CLIENT_FLAGS_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        0,
-        0,
-        change_bytes[0],
-        change_bytes[1],
-        change_bytes[2],
-        change_bytes[3],
-        value_bytes[0],
-        value_bytes[1],
-        value_bytes[2],
-        value_bytes[3],
-        ctrls_to_change_bytes[0],
-        ctrls_to_change_bytes[1],
-        ctrls_to_change_bytes[2],
-        ctrls_to_change_bytes[3],
-        auto_ctrls_bytes[0],
-        auto_ctrls_bytes[1],
-        auto_ctrls_bytes[2],
-        auto_ctrls_bytes[3],
-        auto_ctrls_values_bytes[0],
-        auto_ctrls_values_bytes[1],
-        auto_ctrls_values_bytes[2],
-        auto_ctrls_values_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = PerClientFlagsRequest {
+        device_spec: device_spec,
+        change: change,
+        value: value,
+        ctrls_to_change: ctrls_to_change,
+        auto_ctrls: auto_ctrls,
+        auto_ctrls_values: auto_ctrls_values,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8880,32 +9528,53 @@ impl TryFrom<&[u8]> for PerClientFlagsReply {
     }
 }
 
-/// Opcode for the ListComponents request
-pub const LIST_COMPONENTS_REQUEST: u8 = 22;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListComponentsRequest {
+    pub device_spec: DeviceSpec,
+    pub max_names: u16,
+}
+impl ListComponentsRequest {
+    /// Opcode for the ListComponents request
+    pub const fn opcode() -> u8 { 22 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let max_names_bytes = self.max_names.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListComponentsRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            max_names_bytes[0],
+            max_names_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_components<Conn>(conn: &Conn, device_spec: DeviceSpec, max_names: u16) -> Result<Cookie<'_, Conn, ListComponentsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let max_names_bytes = max_names.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_COMPONENTS_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        max_names_bytes[0],
-        max_names_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListComponentsRequest {
+        device_spec: device_spec,
+        max_names: max_names,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9033,42 +9702,67 @@ impl ListComponentsReply {
     }
 }
 
-/// Opcode for the GetKbdByName request
-pub const GET_KBD_BY_NAME_REQUEST: u8 = 23;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetKbdByNameRequest {
+    pub device_spec: DeviceSpec,
+    pub need: u16,
+    pub want: u16,
+    pub load: bool,
+}
+impl GetKbdByNameRequest {
+    /// Opcode for the GetKbdByName request
+    pub const fn opcode() -> u8 { 23 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let need_bytes = self.need.serialize();
+        let want_bytes = self.want.serialize();
+        let load_bytes = self.load.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetKbdByNameRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            need_bytes[0],
+            need_bytes[1],
+            want_bytes[0],
+            want_bytes[1],
+            load_bytes[0],
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_kbd_by_name<Conn, A, B>(conn: &Conn, device_spec: DeviceSpec, need: A, want: B, load: bool) -> Result<Cookie<'_, Conn, GetKbdByNameReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
     B: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let need: u16 = need.into();
     let want: u16 = want.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let need_bytes = need.serialize();
-    let want_bytes = want.serialize();
-    let load_bytes = load.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_KBD_BY_NAME_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        need_bytes[0],
-        need_bytes[1],
-        want_bytes[0],
-        want_bytes[1],
-        load_bytes[0],
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetKbdByNameRequest {
+        device_spec: device_spec,
+        need: need,
+        want: want,
+        load: load,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone)]
@@ -9710,49 +10404,80 @@ impl TryFrom<&[u8]> for GetKbdByNameReply {
     }
 }
 
-/// Opcode for the GetDeviceInfo request
-pub const GET_DEVICE_INFO_REQUEST: u8 = 24;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetDeviceInfoRequest {
+    pub device_spec: DeviceSpec,
+    pub wanted: u16,
+    pub all_buttons: bool,
+    pub first_button: u8,
+    pub n_buttons: u8,
+    pub led_class: LedClass,
+    pub led_id: IDSpec,
+}
+impl GetDeviceInfoRequest {
+    /// Opcode for the GetDeviceInfo request
+    pub const fn opcode() -> u8 { 24 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let wanted_bytes = self.wanted.serialize();
+        let all_buttons_bytes = self.all_buttons.serialize();
+        let first_button_bytes = self.first_button.serialize();
+        let n_buttons_bytes = self.n_buttons.serialize();
+        let led_class_bytes = LedClassSpec::from(self.led_class).serialize();
+        let led_id_bytes = self.led_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetDeviceInfoRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            wanted_bytes[0],
+            wanted_bytes[1],
+            all_buttons_bytes[0],
+            first_button_bytes[0],
+            n_buttons_bytes[0],
+            0,
+            led_class_bytes[0],
+            led_class_bytes[1],
+            led_id_bytes[0],
+            led_id_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_device_info<Conn, A, B>(conn: &Conn, device_spec: DeviceSpec, wanted: A, all_buttons: bool, first_button: u8, n_buttons: u8, led_class: LedClass, led_id: B) -> Result<Cookie<'_, Conn, GetDeviceInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
     B: Into<IDSpec>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let wanted: u16 = wanted.into();
     let led_id: IDSpec = led_id.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let wanted_bytes = wanted.serialize();
-    let all_buttons_bytes = all_buttons.serialize();
-    let first_button_bytes = first_button.serialize();
-    let n_buttons_bytes = n_buttons.serialize();
-    let led_class_bytes = LedClassSpec::from(led_class).serialize();
-    let led_id_bytes = led_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_DEVICE_INFO_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        wanted_bytes[0],
-        wanted_bytes[1],
-        all_buttons_bytes[0],
-        first_button_bytes[0],
-        n_buttons_bytes[0],
-        0,
-        led_class_bytes[0],
-        led_class_bytes[1],
-        led_id_bytes[0],
-        led_id_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetDeviceInfoRequest {
+        device_spec: device_spec,
+        wanted: wanted,
+        all_buttons: all_buttons,
+        first_button: first_button,
+        n_buttons: n_buttons,
+        led_class: led_class,
+        led_id: led_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone)]
@@ -9858,100 +10583,154 @@ impl GetDeviceInfoReply {
     }
 }
 
-/// Opcode for the SetDeviceInfo request
-pub const SET_DEVICE_INFO_REQUEST: u8 = 25;
+#[derive(Debug, Clone)]
+pub struct SetDeviceInfoRequest<'input> {
+    pub device_spec: DeviceSpec,
+    pub first_btn: u8,
+    pub change: u16,
+    pub btn_actions: &'input [Action],
+    pub leds: &'input [DeviceLedInfo],
+}
+impl<'input> SetDeviceInfoRequest<'input> {
+    /// Opcode for the SetDeviceInfo request
+    pub const fn opcode() -> u8 { 25 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let device_spec_bytes = self.device_spec.serialize();
+        let first_btn_bytes = self.first_btn.serialize();
+        let n_btns = u8::try_from(self.btn_actions.len()).expect("`btn_actions` has too many elements");
+        let n_btns_bytes = n_btns.serialize();
+        let change_bytes = self.change.serialize();
+        let n_device_led_f_bs = u16::try_from(self.leds.len()).expect("`leds` has too many elements");
+        let n_device_led_f_bs_bytes = n_device_led_f_bs.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetDeviceInfoRequest::opcode(),
+            0,
+            0,
+            device_spec_bytes[0],
+            device_spec_bytes[1],
+            first_btn_bytes[0],
+            n_btns_bytes[0],
+            change_bytes[0],
+            change_bytes[1],
+            n_device_led_f_bs_bytes[0],
+            n_device_led_f_bs_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let btn_actions_bytes = self.btn_actions.serialize();
+        let length_so_far = length_so_far + btn_actions_bytes.len();
+        let leds_bytes = self.leds.serialize();
+        let length_so_far = length_so_far + leds_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), btn_actions_bytes.into(), leds_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_device_info<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
     let change: u16 = change.into();
-    let length_so_far = 0;
-    let device_spec_bytes = device_spec.serialize();
-    let first_btn_bytes = first_btn.serialize();
-    let n_btns = u8::try_from(btn_actions.len()).expect("`btn_actions` has too many elements");
-    let n_btns_bytes = n_btns.serialize();
-    let change_bytes = change.serialize();
-    let n_device_led_f_bs = u16::try_from(leds.len()).expect("`leds` has too many elements");
-    let n_device_led_f_bs_bytes = n_device_led_f_bs.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_DEVICE_INFO_REQUEST,
-        0,
-        0,
-        device_spec_bytes[0],
-        device_spec_bytes[1],
-        first_btn_bytes[0],
-        n_btns_bytes[0],
-        change_bytes[0],
-        change_bytes[1],
-        n_device_led_f_bs_bytes[0],
-        n_device_led_f_bs_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let btn_actions_bytes = btn_actions.serialize();
-    let length_so_far = length_so_far + btn_actions_bytes.len();
-    let leds_bytes = leds.serialize();
-    let length_so_far = length_so_far + leds_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&btn_actions_bytes), IoSlice::new(&leds_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetDeviceInfoRequest {
+        device_spec: device_spec,
+        first_btn: first_btn,
+        change: change,
+        btn_actions: btn_actions,
+        leds: leds,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetDebuggingFlags request
-pub const SET_DEBUGGING_FLAGS_REQUEST: u8 = 101;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetDebuggingFlagsRequest<'input> {
+    pub affect_flags: u32,
+    pub flags: u32,
+    pub affect_ctrls: u32,
+    pub ctrls: u32,
+    pub message: &'input [String8],
+}
+impl<'input> SetDebuggingFlagsRequest<'input> {
+    /// Opcode for the SetDebuggingFlags request
+    pub const fn opcode() -> u8 { 101 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let msg_length = u16::try_from(self.message.len()).expect("`message` has too many elements");
+        let msg_length_bytes = msg_length.serialize();
+        let affect_flags_bytes = self.affect_flags.serialize();
+        let flags_bytes = self.flags.serialize();
+        let affect_ctrls_bytes = self.affect_ctrls.serialize();
+        let ctrls_bytes = self.ctrls.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            SetDebuggingFlagsRequest::opcode(),
+            0,
+            0,
+            msg_length_bytes[0],
+            msg_length_bytes[1],
+            0,
+            0,
+            affect_flags_bytes[0],
+            affect_flags_bytes[1],
+            affect_flags_bytes[2],
+            affect_flags_bytes[3],
+            flags_bytes[0],
+            flags_bytes[1],
+            flags_bytes[2],
+            flags_bytes[3],
+            affect_ctrls_bytes[0],
+            affect_ctrls_bytes[1],
+            affect_ctrls_bytes[2],
+            affect_ctrls_bytes[3],
+            ctrls_bytes[0],
+            ctrls_bytes[1],
+            ctrls_bytes[2],
+            ctrls_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.message[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.message[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_debugging_flags<'c, 'input, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &'input [String8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let msg_length = u16::try_from(message.len()).expect("`message` has too many elements");
-    let msg_length_bytes = msg_length.serialize();
-    let affect_flags_bytes = affect_flags.serialize();
-    let flags_bytes = flags.serialize();
-    let affect_ctrls_bytes = affect_ctrls.serialize();
-    let ctrls_bytes = ctrls.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        SET_DEBUGGING_FLAGS_REQUEST,
-        0,
-        0,
-        msg_length_bytes[0],
-        msg_length_bytes[1],
-        0,
-        0,
-        affect_flags_bytes[0],
-        affect_flags_bytes[1],
-        affect_flags_bytes[2],
-        affect_flags_bytes[3],
-        flags_bytes[0],
-        flags_bytes[1],
-        flags_bytes[2],
-        flags_bytes[3],
-        affect_ctrls_bytes[0],
-        affect_ctrls_bytes[1],
-        affect_ctrls_bytes[2],
-        affect_ctrls_bytes[3],
-        ctrls_bytes[0],
-        ctrls_bytes[1],
-        ctrls_bytes[2],
-        ctrls_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + message.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(message), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetDebuggingFlagsRequest {
+        affect_flags: affect_flags,
+        flags: flags,
+        affect_ctrls: affect_ctrls,
+        ctrls: ctrls,
+        message: message,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6349,8 +6349,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UseExtensionRequest {
-        wanted_major: wanted_major,
-        wanted_minor: wanted_minor,
+        wanted_major,
+        wanted_minor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6877,13 +6877,13 @@ where
     let affect_map: u16 = affect_map.into();
     let map: u16 = map.into();
     let request0 = SelectEventsRequest {
-        device_spec: device_spec,
-        affect_which: affect_which,
-        clear: clear,
-        select_all: select_all,
-        affect_map: affect_map,
-        map: map,
-        details: details,
+        device_spec,
+        affect_which,
+        clear,
+        select_all,
+        affect_map,
+        map,
+        details,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6967,16 +6967,16 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = BellRequest {
-        device_spec: device_spec,
-        bell_class: bell_class,
-        bell_id: bell_id,
-        percent: percent,
-        force_sound: force_sound,
-        event_only: event_only,
-        pitch: pitch,
-        duration: duration,
-        name: name,
-        window: window,
+        device_spec,
+        bell_class,
+        bell_id,
+        percent,
+        force_sound,
+        event_only,
+        pitch,
+        duration,
+        name,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7022,7 +7022,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetStateRequest {
-        device_spec: device_spec,
+        device_spec,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7152,14 +7152,14 @@ where
     let mod_locks: u8 = mod_locks.into();
     let affect_mod_latches: u8 = affect_mod_latches.into();
     let request0 = LatchLockStateRequest {
-        device_spec: device_spec,
-        affect_mod_locks: affect_mod_locks,
-        mod_locks: mod_locks,
-        lock_group: lock_group,
-        group_lock: group_lock,
-        affect_mod_latches: affect_mod_latches,
-        latch_group: latch_group,
-        group_latch: group_latch,
+        device_spec,
+        affect_mod_locks,
+        mod_locks,
+        lock_group,
+        group_lock,
+        affect_mod_latches,
+        latch_group,
+        group_latch,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7205,7 +7205,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetControlsRequest {
-        device_spec: device_spec,
+        device_spec,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7480,36 +7480,36 @@ where
     let access_x_timeout_options_mask: u16 = access_x_timeout_options_mask.into();
     let access_x_timeout_options_values: u16 = access_x_timeout_options_values.into();
     let request0 = SetControlsRequest {
-        device_spec: device_spec,
-        affect_internal_real_mods: affect_internal_real_mods,
-        internal_real_mods: internal_real_mods,
-        affect_ignore_lock_real_mods: affect_ignore_lock_real_mods,
-        ignore_lock_real_mods: ignore_lock_real_mods,
-        affect_internal_virtual_mods: affect_internal_virtual_mods,
-        internal_virtual_mods: internal_virtual_mods,
-        affect_ignore_lock_virtual_mods: affect_ignore_lock_virtual_mods,
-        ignore_lock_virtual_mods: ignore_lock_virtual_mods,
-        mouse_keys_dflt_btn: mouse_keys_dflt_btn,
-        groups_wrap: groups_wrap,
-        access_x_options: access_x_options,
-        affect_enabled_controls: affect_enabled_controls,
-        enabled_controls: enabled_controls,
-        change_controls: change_controls,
-        repeat_delay: repeat_delay,
-        repeat_interval: repeat_interval,
-        slow_keys_delay: slow_keys_delay,
-        debounce_delay: debounce_delay,
-        mouse_keys_delay: mouse_keys_delay,
-        mouse_keys_interval: mouse_keys_interval,
-        mouse_keys_time_to_max: mouse_keys_time_to_max,
-        mouse_keys_max_speed: mouse_keys_max_speed,
-        mouse_keys_curve: mouse_keys_curve,
-        access_x_timeout: access_x_timeout,
-        access_x_timeout_mask: access_x_timeout_mask,
-        access_x_timeout_values: access_x_timeout_values,
-        access_x_timeout_options_mask: access_x_timeout_options_mask,
-        access_x_timeout_options_values: access_x_timeout_options_values,
-        per_key_repeat: per_key_repeat,
+        device_spec,
+        affect_internal_real_mods,
+        internal_real_mods,
+        affect_ignore_lock_real_mods,
+        ignore_lock_real_mods,
+        affect_internal_virtual_mods,
+        internal_virtual_mods,
+        affect_ignore_lock_virtual_mods,
+        ignore_lock_virtual_mods,
+        mouse_keys_dflt_btn,
+        groups_wrap,
+        access_x_options,
+        affect_enabled_controls,
+        enabled_controls,
+        change_controls,
+        repeat_delay,
+        repeat_interval,
+        slow_keys_delay,
+        debounce_delay,
+        mouse_keys_delay,
+        mouse_keys_interval,
+        mouse_keys_time_to_max,
+        mouse_keys_max_speed,
+        mouse_keys_curve,
+        access_x_timeout,
+        access_x_timeout_mask,
+        access_x_timeout_values,
+        access_x_timeout_options_mask,
+        access_x_timeout_options_values,
+        per_key_repeat,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7615,24 +7615,24 @@ where
     let partial: u16 = partial.into();
     let virtual_mods: u16 = virtual_mods.into();
     let request0 = GetMapRequest {
-        device_spec: device_spec,
-        full: full,
-        partial: partial,
-        first_type: first_type,
-        n_types: n_types,
-        first_key_sym: first_key_sym,
-        n_key_syms: n_key_syms,
-        first_key_action: first_key_action,
-        n_key_actions: n_key_actions,
-        first_key_behavior: first_key_behavior,
-        n_key_behaviors: n_key_behaviors,
-        virtual_mods: virtual_mods,
-        first_key_explicit: first_key_explicit,
-        n_key_explicit: n_key_explicit,
-        first_mod_map_key: first_mod_map_key,
-        n_mod_map_keys: n_mod_map_keys,
-        first_v_mod_map_key: first_v_mod_map_key,
-        n_v_mod_map_keys: n_v_mod_map_keys,
+        device_spec,
+        full,
+        partial,
+        first_type,
+        n_types,
+        first_key_sym,
+        n_key_syms,
+        first_key_action,
+        n_key_actions,
+        first_key_behavior,
+        n_key_behaviors,
+        virtual_mods,
+        first_key_explicit,
+        n_key_explicit,
+        first_mod_map_key,
+        n_mod_map_keys,
+        first_v_mod_map_key,
+        n_v_mod_map_keys,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8112,32 +8112,32 @@ where
     let flags: u16 = flags.into();
     let virtual_mods: u16 = virtual_mods.into();
     let request0 = SetMapRequest {
-        device_spec: device_spec,
-        flags: flags,
-        min_key_code: min_key_code,
-        max_key_code: max_key_code,
-        first_type: first_type,
-        n_types: n_types,
-        first_key_sym: first_key_sym,
-        n_key_syms: n_key_syms,
-        total_syms: total_syms,
-        first_key_action: first_key_action,
-        n_key_actions: n_key_actions,
-        total_actions: total_actions,
-        first_key_behavior: first_key_behavior,
-        n_key_behaviors: n_key_behaviors,
-        total_key_behaviors: total_key_behaviors,
-        first_key_explicit: first_key_explicit,
-        n_key_explicit: n_key_explicit,
-        total_key_explicit: total_key_explicit,
-        first_mod_map_key: first_mod_map_key,
-        n_mod_map_keys: n_mod_map_keys,
-        total_mod_map_keys: total_mod_map_keys,
-        first_v_mod_map_key: first_v_mod_map_key,
-        n_v_mod_map_keys: n_v_mod_map_keys,
-        total_v_mod_map_keys: total_v_mod_map_keys,
-        virtual_mods: virtual_mods,
-        values: values,
+        device_spec,
+        flags,
+        min_key_code,
+        max_key_code,
+        first_type,
+        n_types,
+        first_key_sym,
+        n_key_syms,
+        total_syms,
+        first_key_action,
+        n_key_actions,
+        total_actions,
+        first_key_behavior,
+        n_key_behaviors,
+        total_key_behaviors,
+        first_key_explicit,
+        n_key_explicit,
+        total_key_explicit,
+        first_mod_map_key,
+        n_mod_map_keys,
+        total_mod_map_keys,
+        first_v_mod_map_key,
+        n_v_mod_map_keys,
+        total_v_mod_map_keys,
+        virtual_mods,
+        values,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8197,11 +8197,11 @@ where
 {
     let groups: u8 = groups.into();
     let request0 = GetCompatMapRequest {
-        device_spec: device_spec,
-        groups: groups,
-        get_all_si: get_all_si,
-        first_si: first_si,
-        n_si: n_si,
+        device_spec,
+        groups,
+        get_all_si,
+        first_si,
+        n_si,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8328,13 +8328,13 @@ where
 {
     let groups: u8 = groups.into();
     let request0 = SetCompatMapRequest {
-        device_spec: device_spec,
-        recompute_actions: recompute_actions,
-        truncate_si: truncate_si,
-        groups: groups,
-        first_si: first_si,
-        si: si,
-        group_maps: group_maps,
+        device_spec,
+        recompute_actions,
+        truncate_si,
+        groups,
+        first_si,
+        si,
+        group_maps,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8380,7 +8380,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetIndicatorStateRequest {
-        device_spec: device_spec,
+        device_spec,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8459,8 +8459,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetIndicatorMapRequest {
-        device_spec: device_spec,
-        which: which,
+        device_spec,
+        which,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8551,9 +8551,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetIndicatorMapRequest {
-        device_spec: device_spec,
-        which: which,
-        maps: maps,
+        device_spec,
+        which,
+        maps,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8615,10 +8615,10 @@ where
 {
     let led_id: IDSpec = led_id.into();
     let request0 = GetNamedIndicatorRequest {
-        device_spec: device_spec,
-        led_class: led_class,
-        led_id: led_id,
-        indicator: indicator,
+        device_spec,
+        led_class,
+        led_id,
+        indicator,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8785,21 +8785,21 @@ where
     let map_vmods: u16 = map_vmods.into();
     let map_ctrls: u32 = map_ctrls.into();
     let request0 = SetNamedIndicatorRequest {
-        device_spec: device_spec,
-        led_class: led_class,
-        led_id: led_id,
-        indicator: indicator,
-        set_state: set_state,
-        on: on,
-        set_map: set_map,
-        create_map: create_map,
-        map_flags: map_flags,
-        map_which_groups: map_which_groups,
-        map_groups: map_groups,
-        map_which_mods: map_which_mods,
-        map_real_mods: map_real_mods,
-        map_vmods: map_vmods,
-        map_ctrls: map_ctrls,
+        device_spec,
+        led_class,
+        led_id,
+        indicator,
+        set_state,
+        on,
+        set_map,
+        create_map,
+        map_flags,
+        map_which_groups,
+        map_groups,
+        map_which_mods,
+        map_real_mods,
+        map_vmods,
+        map_ctrls,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8853,8 +8853,8 @@ where
 {
     let which: u32 = which.into();
     let request0 = GetNamesRequest {
-        device_spec: device_spec,
-        which: which,
+        device_spec,
+        which,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9384,20 +9384,20 @@ where
     let virtual_mods: u16 = virtual_mods.into();
     let group_names: u8 = group_names.into();
     let request0 = SetNamesRequest {
-        device_spec: device_spec,
-        virtual_mods: virtual_mods,
-        first_type: first_type,
-        n_types: n_types,
-        first_kt_levelt: first_kt_levelt,
-        n_kt_levels: n_kt_levels,
-        indicators: indicators,
-        group_names: group_names,
-        n_radio_groups: n_radio_groups,
-        first_key: first_key,
-        n_keys: n_keys,
-        n_key_aliases: n_key_aliases,
-        total_kt_level_names: total_kt_level_names,
-        values: values,
+        device_spec,
+        virtual_mods,
+        first_type,
+        n_types,
+        first_kt_levelt,
+        n_kt_levels,
+        indicators,
+        group_names,
+        n_radio_groups,
+        first_key,
+        n_keys,
+        n_key_aliases,
+        total_kt_level_names,
+        values,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9483,12 +9483,12 @@ where
     let auto_ctrls: u32 = auto_ctrls.into();
     let auto_ctrls_values: u32 = auto_ctrls_values.into();
     let request0 = PerClientFlagsRequest {
-        device_spec: device_spec,
-        change: change,
-        value: value,
-        ctrls_to_change: ctrls_to_change,
-        auto_ctrls: auto_ctrls,
-        auto_ctrls_values: auto_ctrls_values,
+        device_spec,
+        change,
+        value,
+        ctrls_to_change,
+        auto_ctrls,
+        auto_ctrls_values,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9569,8 +9569,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListComponentsRequest {
-        device_spec: device_spec,
-        max_names: max_names,
+        device_spec,
+        max_names,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9755,10 +9755,10 @@ where
     let need: u16 = need.into();
     let want: u16 = want.into();
     let request0 = GetKbdByNameRequest {
-        device_spec: device_spec,
-        need: need,
-        want: want,
-        load: load,
+        device_spec,
+        need,
+        want,
+        load,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10467,13 +10467,13 @@ where
     let wanted: u16 = wanted.into();
     let led_id: IDSpec = led_id.into();
     let request0 = GetDeviceInfoRequest {
-        device_spec: device_spec,
-        wanted: wanted,
-        all_buttons: all_buttons,
-        first_button: first_button,
-        n_buttons: n_buttons,
-        led_class: led_class,
-        led_id: led_id,
+        device_spec,
+        wanted,
+        all_buttons,
+        first_button,
+        n_buttons,
+        led_class,
+        led_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10644,11 +10644,11 @@ where
 {
     let change: u16 = change.into();
     let request0 = SetDeviceInfoRequest {
-        device_spec: device_spec,
-        first_btn: first_btn,
-        change: change,
-        btn_actions: btn_actions,
-        leds: leds,
+        device_spec,
+        first_btn,
+        change,
+        btn_actions,
+        leds,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10722,11 +10722,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDebuggingFlagsRequest {
-        affect_flags: affect_flags,
-        flags: flags,
-        affect_ctrls: affect_ctrls,
-        ctrls: ctrls,
-        message: message,
+        affect_flags,
+        flags,
+        affect_ctrls,
+        ctrls,
+        message,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6317,7 +6317,6 @@ impl UseExtensionRequest {
     /// Opcode for the UseExtension request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6819,7 +6818,6 @@ impl<'input> SelectEventsRequest<'input> {
     /// Opcode for the SelectEvents request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6907,7 +6905,6 @@ impl BellRequest {
     /// Opcode for the Bell request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -6991,7 +6988,6 @@ impl GetStateRequest {
     /// Opcode for the GetState request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7100,7 +7096,6 @@ impl LatchLockStateRequest {
     /// Opcode for the LatchLockState request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7174,7 +7169,6 @@ impl GetControlsRequest {
     /// Opcode for the GetControls request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7328,7 +7322,6 @@ impl<'input> SetControlsRequest<'input> {
     /// Opcode for the SetControls request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -7541,7 +7534,6 @@ impl GetMapRequest {
     /// Opcode for the GetMap request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8019,7 +8011,6 @@ impl<'input> SetMapRequest<'input> {
     /// Opcode for the SetMap request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8156,7 +8147,6 @@ impl GetCompatMapRequest {
     /// Opcode for the GetCompatMap request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8274,7 +8264,6 @@ impl<'input> SetCompatMapRequest<'input> {
     /// Opcode for the SetCompatMap request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8349,7 +8338,6 @@ impl GetIndicatorStateRequest {
     /// Opcode for the GetIndicatorState request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8423,7 +8411,6 @@ impl GetIndicatorMapRequest {
     /// Opcode for the GetIndicatorMap request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8510,7 +8497,6 @@ impl<'input> SetIndicatorMapRequest<'input> {
     /// Opcode for the SetIndicatorMap request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8571,7 +8557,6 @@ impl GetNamedIndicatorRequest {
     /// Opcode for the GetNamedIndicator request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8700,7 +8685,6 @@ impl SetNamedIndicatorRequest {
     /// Opcode for the SetNamedIndicator request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -8815,7 +8799,6 @@ impl GetNamesRequest {
     /// Opcode for the GetNames request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9311,7 +9294,6 @@ impl<'input> SetNamesRequest<'input> {
     /// Opcode for the SetNames request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9417,7 +9399,6 @@ impl PerClientFlagsRequest {
     /// Opcode for the PerClientFlags request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9537,7 +9518,6 @@ impl ListComponentsRequest {
     /// Opcode for the ListComponents request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -9713,7 +9693,6 @@ impl GetKbdByNameRequest {
     /// Opcode for the GetKbdByName request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -10418,7 +10397,6 @@ impl GetDeviceInfoRequest {
     /// Opcode for the GetDeviceInfo request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -10595,7 +10573,6 @@ impl<'input> SetDeviceInfoRequest<'input> {
     /// Opcode for the SetDeviceInfo request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -10667,7 +10644,6 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
     /// Opcode for the SetDebuggingFlags request
     pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -420,7 +420,7 @@ impl PrintQueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintQueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -491,7 +491,7 @@ impl<'input> PrintGetPrinterListRequest<'input> {
         let locale_len_bytes = locale_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetPrinterListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             printer_name_len_bytes[0],
@@ -585,7 +585,7 @@ impl PrintRehashPrinterListRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintRehashPrinterListRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -631,7 +631,7 @@ impl<'input> CreateContextRequest<'input> {
         let locale_len_bytes = locale_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_id_bytes[0],
@@ -691,7 +691,7 @@ impl PrintSetContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintSetContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -734,7 +734,7 @@ impl PrintGetContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -799,7 +799,7 @@ impl PrintDestroyContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintDestroyContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -842,7 +842,7 @@ impl PrintGetScreenOfContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetScreenOfContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -907,7 +907,7 @@ impl PrintStartJobRequest {
         let output_mode_bytes = self.output_mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintStartJobRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             output_mode_bytes[0],
@@ -953,7 +953,7 @@ impl PrintEndJobRequest {
         let cancel_bytes = self.cancel.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintEndJobRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cancel_bytes[0],
@@ -999,7 +999,7 @@ impl PrintStartDocRequest {
         let driver_mode_bytes = self.driver_mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintStartDocRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             driver_mode_bytes[0],
@@ -1045,7 +1045,7 @@ impl PrintEndDocRequest {
         let cancel_bytes = self.cancel.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintEndDocRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cancel_bytes[0],
@@ -1100,7 +1100,7 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
         let len_options_bytes = len_options.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintPutDocumentDataRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -1164,7 +1164,7 @@ impl PrintGetDocumentDataRequest {
         let max_bytes_bytes = self.max_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetDocumentDataRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1262,7 +1262,7 @@ impl PrintStartPageRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintStartPageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1308,7 +1308,7 @@ impl PrintEndPageRequest {
         let cancel_bytes = self.cancel.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintEndPageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             cancel_bytes[0],
@@ -1356,7 +1356,7 @@ impl PrintSelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintSelectInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1407,7 +1407,7 @@ impl PrintInputSelectedRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintInputSelectedRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1482,7 +1482,7 @@ impl PrintGetAttributesRequest {
         let pool_bytes = self.pool.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1581,7 +1581,7 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
         let pool_bytes = self.pool.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetOneAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1690,7 +1690,7 @@ impl<'input> PrintSetAttributesRequest<'input> {
         let rule_bytes = self.rule.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintSetAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1751,7 +1751,7 @@ impl PrintGetPageDimensionsRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetPageDimensionsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1829,7 +1829,7 @@ impl PrintQueryScreensRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintQueryScreensRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1913,7 +1913,7 @@ impl PrintSetImageResolutionRequest {
         let image_resolution_bytes = self.image_resolution.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintSetImageResolutionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],
@@ -1990,7 +1990,7 @@ impl PrintGetImageResolutionRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PrintGetImageResolutionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_bytes[0],

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -410,7 +410,6 @@ impl PrintQueryVersionRequest {
     /// Opcode for the PrintQueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -477,7 +476,6 @@ impl<'input> PrintGetPrinterListRequest<'input> {
     /// Opcode for the PrintGetPrinterList request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -575,7 +573,6 @@ impl PrintRehashPrinterListRequest {
     /// Opcode for the PrintRehashPrinterList request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -616,7 +613,6 @@ impl<'input> CreateContextRequest<'input> {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -680,7 +676,6 @@ impl PrintSetContextRequest {
     /// Opcode for the PrintSetContext request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -724,7 +719,6 @@ impl PrintGetContextRequest {
     /// Opcode for the PrintGetContext request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -788,7 +782,6 @@ impl PrintDestroyContextRequest {
     /// Opcode for the PrintDestroyContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -832,7 +825,6 @@ impl PrintGetScreenOfContextRequest {
     /// Opcode for the PrintGetScreenOfContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -896,7 +888,6 @@ impl PrintStartJobRequest {
     /// Opcode for the PrintStartJob request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -942,7 +933,6 @@ impl PrintEndJobRequest {
     /// Opcode for the PrintEndJob request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -988,7 +978,6 @@ impl PrintStartDocRequest {
     /// Opcode for the PrintStartDoc request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1034,7 +1023,6 @@ impl PrintEndDocRequest {
     /// Opcode for the PrintEndDoc request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1083,7 +1071,6 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
     /// Opcode for the PrintPutDocumentData request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1152,7 +1139,6 @@ impl PrintGetDocumentDataRequest {
     /// Opcode for the PrintGetDocumentData request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1251,7 +1237,6 @@ impl PrintStartPageRequest {
     /// Opcode for the PrintStartPage request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1297,7 +1282,6 @@ impl PrintEndPageRequest {
     /// Opcode for the PrintEndPage request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1344,7 +1328,6 @@ impl PrintSelectInputRequest {
     /// Opcode for the PrintSelectInput request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1396,7 +1379,6 @@ impl PrintInputSelectedRequest {
     /// Opcode for the PrintInputSelected request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1470,7 +1452,6 @@ impl PrintGetAttributesRequest {
     /// Opcode for the PrintGetAttributes request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1567,7 +1548,6 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
     /// Opcode for the PrintGetOneAttributes request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1676,7 +1656,6 @@ impl<'input> PrintSetAttributesRequest<'input> {
     /// Opcode for the PrintSetAttributes request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1740,7 +1719,6 @@ impl PrintGetPageDimensionsRequest {
     /// Opcode for the PrintGetPageDimensions request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1819,7 +1797,6 @@ impl PrintQueryScreensRequest {
     /// Opcode for the PrintQueryScreens request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1901,7 +1878,6 @@ impl PrintSetImageResolutionRequest {
     /// Opcode for the PrintSetImageResolution request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1979,7 +1955,6 @@ impl PrintGetImageResolutionRequest {
     /// Opcode for the PrintGetImageResolution request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -519,8 +519,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintGetPrinterListRequest {
-        printer_name: printer_name,
-        locale: locale,
+        printer_name,
+        locale,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -663,9 +663,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateContextRequest {
-        context_id: context_id,
-        printer_name: printer_name,
-        locale: locale,
+        context_id,
+        printer_name,
+        locale,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -711,7 +711,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintSetContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -819,7 +819,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintDestroyContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -927,7 +927,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintStartJobRequest {
-        output_mode: output_mode,
+        output_mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -973,7 +973,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintEndJobRequest {
-        cancel: cancel,
+        cancel,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1019,7 +1019,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintStartDocRequest {
-        driver_mode: driver_mode,
+        driver_mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1065,7 +1065,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintEndDocRequest {
-        cancel: cancel,
+        cancel,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1133,10 +1133,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintPutDocumentDataRequest {
-        drawable: drawable,
-        data: data,
-        doc_format: doc_format,
-        options: options,
+        drawable,
+        data,
+        doc_format,
+        options,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1188,8 +1188,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintGetDocumentDataRequest {
-        context: context,
-        max_bytes: max_bytes,
+        context,
+        max_bytes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1282,7 +1282,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintStartPageRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1328,7 +1328,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintEndPageRequest {
-        cancel: cancel,
+        cancel,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1380,8 +1380,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintSelectInputRequest {
-        context: context,
-        event_mask: event_mask,
+        context,
+        event_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1427,7 +1427,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintInputSelectedRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1506,8 +1506,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintGetAttributesRequest {
-        context: context,
-        pool: pool,
+        context,
+        pool,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1612,9 +1612,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintGetOneAttributesRequest {
-        context: context,
-        pool: pool,
-        name: name,
+        context,
+        pool,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1721,11 +1721,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintSetAttributesRequest {
-        context: context,
-        string_len: string_len,
-        pool: pool,
-        rule: rule,
-        attributes: attributes,
+        context,
+        string_len,
+        pool,
+        rule,
+        attributes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1771,7 +1771,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintGetPageDimensionsRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1937,8 +1937,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintSetImageResolutionRequest {
-        context: context,
-        image_resolution: image_resolution,
+        context,
+        image_resolution,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2010,7 +2010,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PrintGetImageResolutionRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -403,11 +403,11 @@ impl TryFrom<u32> for Attr {
     }
 }
 
+/// Opcode for the PrintQueryVersion request
+pub const PRINT_QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintQueryVersionRequest;
 impl PrintQueryVersionRequest {
-    /// Opcode for the PrintQueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -418,7 +418,7 @@ impl PrintQueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_QUERY_VERSION_REQUEST,
             0,
             0,
         ];
@@ -466,14 +466,14 @@ impl TryFrom<&[u8]> for PrintQueryVersionReply {
     }
 }
 
+/// Opcode for the PrintGetPrinterList request
+pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrintGetPrinterListRequest<'input> {
     pub printer_name: &'input [String8],
     pub locale: &'input [String8],
 }
 impl<'input> PrintGetPrinterListRequest<'input> {
-    /// Opcode for the PrintGetPrinterList request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -488,7 +488,7 @@ impl<'input> PrintGetPrinterListRequest<'input> {
         let locale_len_bytes = locale_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_PRINTER_LIST_REQUEST,
             0,
             0,
             printer_name_len_bytes[0],
@@ -566,11 +566,11 @@ impl PrintGetPrinterListReply {
     }
 }
 
+/// Opcode for the PrintRehashPrinterList request
+pub const PRINT_REHASH_PRINTER_LIST_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintRehashPrinterListRequest;
 impl PrintRehashPrinterListRequest {
-    /// Opcode for the PrintRehashPrinterList request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -581,7 +581,7 @@ impl PrintRehashPrinterListRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_REHASH_PRINTER_LIST_REQUEST,
             0,
             0,
         ];
@@ -602,6 +602,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateContext request
+pub const CREATE_CONTEXT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateContextRequest<'input> {
     pub context_id: u32,
@@ -609,8 +611,6 @@ pub struct CreateContextRequest<'input> {
     pub locale: &'input [String8],
 }
 impl<'input> CreateContextRequest<'input> {
-    /// Opcode for the CreateContext request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -626,7 +626,7 @@ impl<'input> CreateContextRequest<'input> {
         let locale_len_bytes = locale_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_id_bytes[0],
@@ -667,13 +667,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintSetContext request
+pub const PRINT_SET_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintSetContextRequest {
     pub context: u32,
 }
 impl PrintSetContextRequest {
-    /// Opcode for the PrintSetContext request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -685,7 +685,7 @@ impl PrintSetContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_SET_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -712,11 +712,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintGetContext request
+pub const PRINT_GET_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintGetContextRequest;
 impl PrintGetContextRequest {
-    /// Opcode for the PrintGetContext request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -727,7 +727,7 @@ impl PrintGetContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -773,13 +773,13 @@ impl TryFrom<&[u8]> for PrintGetContextReply {
     }
 }
 
+/// Opcode for the PrintDestroyContext request
+pub const PRINT_DESTROY_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintDestroyContextRequest {
     pub context: u32,
 }
 impl PrintDestroyContextRequest {
-    /// Opcode for the PrintDestroyContext request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -791,7 +791,7 @@ impl PrintDestroyContextRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_DESTROY_CONTEXT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -818,11 +818,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintGetScreenOfContext request
+pub const PRINT_GET_SCREEN_OF_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintGetScreenOfContextRequest;
 impl PrintGetScreenOfContextRequest {
-    /// Opcode for the PrintGetScreenOfContext request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -833,7 +833,7 @@ impl PrintGetScreenOfContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_SCREEN_OF_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -879,13 +879,13 @@ impl TryFrom<&[u8]> for PrintGetScreenOfContextReply {
     }
 }
 
+/// Opcode for the PrintStartJob request
+pub const PRINT_START_JOB_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintStartJobRequest {
     pub output_mode: u8,
 }
 impl PrintStartJobRequest {
-    /// Opcode for the PrintStartJob request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -897,7 +897,7 @@ impl PrintStartJobRequest {
         let output_mode_bytes = self.output_mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_START_JOB_REQUEST,
             0,
             0,
             output_mode_bytes[0],
@@ -924,13 +924,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintEndJob request
+pub const PRINT_END_JOB_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintEndJobRequest {
     pub cancel: bool,
 }
 impl PrintEndJobRequest {
-    /// Opcode for the PrintEndJob request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -942,7 +942,7 @@ impl PrintEndJobRequest {
         let cancel_bytes = self.cancel.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_END_JOB_REQUEST,
             0,
             0,
             cancel_bytes[0],
@@ -969,13 +969,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintStartDoc request
+pub const PRINT_START_DOC_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintStartDocRequest {
     pub driver_mode: u8,
 }
 impl PrintStartDocRequest {
-    /// Opcode for the PrintStartDoc request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -987,7 +987,7 @@ impl PrintStartDocRequest {
         let driver_mode_bytes = self.driver_mode.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_START_DOC_REQUEST,
             0,
             0,
             driver_mode_bytes[0],
@@ -1014,13 +1014,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintEndDoc request
+pub const PRINT_END_DOC_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintEndDocRequest {
     pub cancel: bool,
 }
 impl PrintEndDocRequest {
-    /// Opcode for the PrintEndDoc request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1032,7 +1032,7 @@ impl PrintEndDocRequest {
         let cancel_bytes = self.cancel.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_END_DOC_REQUEST,
             0,
             0,
             cancel_bytes[0],
@@ -1059,6 +1059,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintPutDocumentData request
+pub const PRINT_PUT_DOCUMENT_DATA_REQUEST: u8 = 11;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrintPutDocumentDataRequest<'input> {
     pub drawable: xproto::Drawable,
@@ -1067,8 +1069,6 @@ pub struct PrintPutDocumentDataRequest<'input> {
     pub options: &'input [String8],
 }
 impl<'input> PrintPutDocumentDataRequest<'input> {
-    /// Opcode for the PrintPutDocumentData request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1086,7 +1086,7 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
         let len_options_bytes = len_options.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_PUT_DOCUMENT_DATA_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -1129,14 +1129,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintGetDocumentData request
+pub const PRINT_GET_DOCUMENT_DATA_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintGetDocumentDataRequest {
     pub context: Pcontext,
     pub max_bytes: u32,
 }
 impl PrintGetDocumentDataRequest {
-    /// Opcode for the PrintGetDocumentData request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1149,7 +1149,7 @@ impl PrintGetDocumentDataRequest {
         let max_bytes_bytes = self.max_bytes.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_DOCUMENT_DATA_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1228,13 +1228,13 @@ impl PrintGetDocumentDataReply {
     }
 }
 
+/// Opcode for the PrintStartPage request
+pub const PRINT_START_PAGE_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintStartPageRequest {
     pub window: xproto::Window,
 }
 impl PrintStartPageRequest {
-    /// Opcode for the PrintStartPage request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1246,7 +1246,7 @@ impl PrintStartPageRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_START_PAGE_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1273,13 +1273,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintEndPage request
+pub const PRINT_END_PAGE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintEndPageRequest {
     pub cancel: bool,
 }
 impl PrintEndPageRequest {
-    /// Opcode for the PrintEndPage request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1291,7 +1291,7 @@ impl PrintEndPageRequest {
         let cancel_bytes = self.cancel.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_END_PAGE_REQUEST,
             0,
             0,
             cancel_bytes[0],
@@ -1318,14 +1318,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintSelectInput request
+pub const PRINT_SELECT_INPUT_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintSelectInputRequest {
     pub context: Pcontext,
     pub event_mask: u32,
 }
 impl PrintSelectInputRequest {
-    /// Opcode for the PrintSelectInput request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1338,7 +1338,7 @@ impl PrintSelectInputRequest {
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_SELECT_INPUT_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1370,13 +1370,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintInputSelected request
+pub const PRINT_INPUT_SELECTED_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintInputSelectedRequest {
     pub context: Pcontext,
 }
 impl PrintInputSelectedRequest {
-    /// Opcode for the PrintInputSelected request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1388,7 +1388,7 @@ impl PrintInputSelectedRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_INPUT_SELECTED_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1442,14 +1442,14 @@ impl TryFrom<&[u8]> for PrintInputSelectedReply {
     }
 }
 
+/// Opcode for the PrintGetAttributes request
+pub const PRINT_GET_ATTRIBUTES_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintGetAttributesRequest {
     pub context: Pcontext,
     pub pool: u8,
 }
 impl PrintGetAttributesRequest {
-    /// Opcode for the PrintGetAttributes request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1462,7 +1462,7 @@ impl PrintGetAttributesRequest {
         let pool_bytes = self.pool.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_ATTRIBUTES_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1537,6 +1537,8 @@ impl PrintGetAttributesReply {
     }
 }
 
+/// Opcode for the PrintGetOneAttributes request
+pub const PRINT_GET_ONE_ATTRIBUTES_REQUEST: u8 = 19;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrintGetOneAttributesRequest<'input> {
     pub context: Pcontext,
@@ -1544,8 +1546,6 @@ pub struct PrintGetOneAttributesRequest<'input> {
     pub name: &'input [String8],
 }
 impl<'input> PrintGetOneAttributesRequest<'input> {
-    /// Opcode for the PrintGetOneAttributes request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1560,7 +1560,7 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
         let pool_bytes = self.pool.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_ONE_ATTRIBUTES_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1643,6 +1643,8 @@ impl PrintGetOneAttributesReply {
     }
 }
 
+/// Opcode for the PrintSetAttributes request
+pub const PRINT_SET_ATTRIBUTES_REQUEST: u8 = 18;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrintSetAttributesRequest<'input> {
     pub context: Pcontext,
@@ -1652,8 +1654,6 @@ pub struct PrintSetAttributesRequest<'input> {
     pub attributes: &'input [String8],
 }
 impl<'input> PrintSetAttributesRequest<'input> {
-    /// Opcode for the PrintSetAttributes request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1668,7 +1668,7 @@ impl<'input> PrintSetAttributesRequest<'input> {
         let rule_bytes = self.rule.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_SET_ATTRIBUTES_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1710,13 +1710,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PrintGetPageDimensions request
+pub const PRINT_GET_PAGE_DIMENSIONS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintGetPageDimensionsRequest {
     pub context: Pcontext,
 }
 impl PrintGetPageDimensionsRequest {
-    /// Opcode for the PrintGetPageDimensions request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1728,7 +1728,7 @@ impl PrintGetPageDimensionsRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_PAGE_DIMENSIONS_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1790,11 +1790,11 @@ impl TryFrom<&[u8]> for PrintGetPageDimensionsReply {
     }
 }
 
+/// Opcode for the PrintQueryScreens request
+pub const PRINT_QUERY_SCREENS_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintQueryScreensRequest;
 impl PrintQueryScreensRequest {
-    /// Opcode for the PrintQueryScreens request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1805,7 +1805,7 @@ impl PrintQueryScreensRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_QUERY_SCREENS_REQUEST,
             0,
             0,
         ];
@@ -1868,14 +1868,14 @@ impl PrintQueryScreensReply {
     }
 }
 
+/// Opcode for the PrintSetImageResolution request
+pub const PRINT_SET_IMAGE_RESOLUTION_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintSetImageResolutionRequest {
     pub context: Pcontext,
     pub image_resolution: u16,
 }
 impl PrintSetImageResolutionRequest {
-    /// Opcode for the PrintSetImageResolution request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1888,7 +1888,7 @@ impl PrintSetImageResolutionRequest {
         let image_resolution_bytes = self.image_resolution.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_SET_IMAGE_RESOLUTION_REQUEST,
             0,
             0,
             context_bytes[0],
@@ -1946,13 +1946,13 @@ impl TryFrom<&[u8]> for PrintSetImageResolutionReply {
     }
 }
 
+/// Opcode for the PrintGetImageResolution request
+pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrintGetImageResolutionRequest {
     pub context: Pcontext,
 }
 impl PrintGetImageResolutionRequest {
-    /// Opcode for the PrintGetImageResolution request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1964,7 +1964,7 @@ impl PrintGetImageResolutionRequest {
         let context_bytes = self.context.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PRINT_GET_IMAGE_RESOLUTION_REQUEST,
             0,
             0,
             context_bytes[0],

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -454,7 +454,7 @@ impl TryFrom<&[u8]> for PrintQueryVersionReply {
 
 /// Opcode for the PrintGetPrinterList request
 pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
-pub fn print_get_printer_list<'c, Conn>(conn: &'c Conn, printer_name: &[String8], locale: &[String8]) -> Result<Cookie<'c, Conn, PrintGetPrinterListReply>, ConnectionError>
+pub fn print_get_printer_list<'c, 'input, Conn>(conn: &'c Conn, printer_name: &'input [String8], locale: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetPrinterListReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -556,7 +556,7 @@ where
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
-pub fn create_context<'c, Conn>(conn: &'c Conn, context_id: u32, printer_name: &[String8], locale: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_context<'c, 'input, Conn>(conn: &'c Conn, context_id: u32, printer_name: &'input [String8], locale: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -855,7 +855,7 @@ where
 
 /// Opcode for the PrintPutDocumentData request
 pub const PRINT_PUT_DOCUMENT_DATA_REQUEST: u8 = 11;
-pub fn print_put_document_data<'c, Conn>(conn: &'c Conn, drawable: xproto::Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn print_put_document_data<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, data: &'input [u8], doc_format: &'input [String8], options: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1195,7 +1195,7 @@ impl PrintGetAttributesReply {
 
 /// Opcode for the PrintGetOneAttributes request
 pub const PRINT_GET_ONE_ATTRIBUTES_REQUEST: u8 = 19;
-pub fn print_get_one_attributes<'c, Conn>(conn: &'c Conn, context: Pcontext, pool: u8, name: &[String8]) -> Result<Cookie<'c, Conn, PrintGetOneAttributesReply>, ConnectionError>
+pub fn print_get_one_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, pool: u8, name: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetOneAttributesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1279,7 +1279,7 @@ impl PrintGetOneAttributesReply {
 
 /// Opcode for the PrintSetAttributes request
 pub const PRINT_SET_ATTRIBUTES_REQUEST: u8 = 18;
-pub fn print_set_attributes<'c, Conn>(conn: &'c Conn, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &[String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn print_set_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1853,7 +1853,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         print_query_version(self)
     }
-    fn xprint_print_get_printer_list<'c>(&'c self, printer_name: &[String8], locale: &[String8]) -> Result<Cookie<'c, Self, PrintGetPrinterListReply>, ConnectionError>
+    fn xprint_print_get_printer_list<'c, 'input>(&'c self, printer_name: &'input [String8], locale: &'input [String8]) -> Result<Cookie<'c, Self, PrintGetPrinterListReply>, ConnectionError>
     {
         print_get_printer_list(self, printer_name, locale)
     }
@@ -1861,7 +1861,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         print_rehash_printer_list(self)
     }
-    fn xprint_create_context<'c>(&'c self, context_id: u32, printer_name: &[String8], locale: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xprint_create_context<'c, 'input>(&'c self, context_id: u32, printer_name: &'input [String8], locale: &'input [String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_context(self, context_id, printer_name, locale)
     }
@@ -1897,7 +1897,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         print_end_doc(self, cancel)
     }
-    fn xprint_print_put_document_data<'c>(&'c self, drawable: xproto::Drawable, data: &[u8], doc_format: &[String8], options: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xprint_print_put_document_data<'c, 'input>(&'c self, drawable: xproto::Drawable, data: &'input [u8], doc_format: &'input [String8], options: &'input [String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         print_put_document_data(self, drawable, data, doc_format, options)
     }
@@ -1925,11 +1925,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         print_get_attributes(self, context, pool)
     }
-    fn xprint_print_get_one_attributes<'c>(&'c self, context: Pcontext, pool: u8, name: &[String8]) -> Result<Cookie<'c, Self, PrintGetOneAttributesReply>, ConnectionError>
+    fn xprint_print_get_one_attributes<'c, 'input>(&'c self, context: Pcontext, pool: u8, name: &'input [String8]) -> Result<Cookie<'c, Self, PrintGetOneAttributesReply>, ConnectionError>
     {
         print_get_one_attributes(self, context, pool, name)
     }
-    fn xprint_print_set_attributes<'c>(&'c self, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &[String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xprint_print_set_attributes<'c, 'input>(&'c self, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &'input [String8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         print_set_attributes(self, context, string_len, pool, rule, attributes)
     }

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -410,7 +409,7 @@ impl PrintQueryVersionRequest {
     /// Opcode for the PrintQueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -476,7 +475,7 @@ impl<'input> PrintGetPrinterListRequest<'input> {
     /// Opcode for the PrintGetPrinterList request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -509,7 +508,7 @@ impl<'input> PrintGetPrinterListRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.printer_name[..]).into(), (&self.locale[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.printer_name[..]).into(), (&self.locale[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn print_get_printer_list<'c, 'input, Conn>(conn: &'c Conn, printer_name: &'input [String8], locale: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetPrinterListReply>, ConnectionError>
@@ -573,7 +572,7 @@ impl PrintRehashPrinterListRequest {
     /// Opcode for the PrintRehashPrinterList request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -613,7 +612,7 @@ impl<'input> CreateContextRequest<'input> {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -651,7 +650,7 @@ impl<'input> CreateContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.printer_name[..]).into(), (&self.locale[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.printer_name[..]).into(), (&self.locale[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn create_context<'c, 'input, Conn>(conn: &'c Conn, context_id: u32, printer_name: &'input [String8], locale: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -676,7 +675,7 @@ impl PrintSetContextRequest {
     /// Opcode for the PrintSetContext request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -719,7 +718,7 @@ impl PrintGetContextRequest {
     /// Opcode for the PrintGetContext request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -782,7 +781,7 @@ impl PrintDestroyContextRequest {
     /// Opcode for the PrintDestroyContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -825,7 +824,7 @@ impl PrintGetScreenOfContextRequest {
     /// Opcode for the PrintGetScreenOfContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -888,7 +887,7 @@ impl PrintStartJobRequest {
     /// Opcode for the PrintStartJob request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -933,7 +932,7 @@ impl PrintEndJobRequest {
     /// Opcode for the PrintEndJob request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -978,7 +977,7 @@ impl PrintStartDocRequest {
     /// Opcode for the PrintStartDoc request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1023,7 +1022,7 @@ impl PrintEndDocRequest {
     /// Opcode for the PrintEndDoc request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1071,7 +1070,7 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
     /// Opcode for the PrintPutDocumentData request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1112,7 +1111,7 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), (&self.doc_format[..]).into(), (&self.options[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.data[..]).into(), (&self.doc_format[..]).into(), (&self.options[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn print_put_document_data<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, data: &'input [u8], doc_format: &'input [String8], options: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1139,7 +1138,7 @@ impl PrintGetDocumentDataRequest {
     /// Opcode for the PrintGetDocumentData request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1237,7 +1236,7 @@ impl PrintStartPageRequest {
     /// Opcode for the PrintStartPage request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1282,7 +1281,7 @@ impl PrintEndPageRequest {
     /// Opcode for the PrintEndPage request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1328,7 +1327,7 @@ impl PrintSelectInputRequest {
     /// Opcode for the PrintSelectInput request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1379,7 +1378,7 @@ impl PrintInputSelectedRequest {
     /// Opcode for the PrintInputSelected request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1452,7 +1451,7 @@ impl PrintGetAttributesRequest {
     /// Opcode for the PrintGetAttributes request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1548,7 +1547,7 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
     /// Opcode for the PrintGetOneAttributes request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1584,7 +1583,7 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn print_get_one_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, pool: u8, name: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetOneAttributesReply>, ConnectionError>
@@ -1656,7 +1655,7 @@ impl<'input> PrintSetAttributesRequest<'input> {
     /// Opcode for the PrintSetAttributes request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1692,7 +1691,7 @@ impl<'input> PrintSetAttributesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.attributes[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.attributes[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn print_set_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1719,7 +1718,7 @@ impl PrintGetPageDimensionsRequest {
     /// Opcode for the PrintGetPageDimensions request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1797,7 +1796,7 @@ impl PrintQueryScreensRequest {
     /// Opcode for the PrintQueryScreens request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1878,7 +1877,7 @@ impl PrintSetImageResolutionRequest {
     /// Opcode for the PrintSetImageResolution request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1955,7 +1954,7 @@ impl PrintGetImageResolutionRequest {
     /// Opcode for the PrintGetImageResolution request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -9981,7 +9981,7 @@ impl<'input> SendEventRequest<'input> {
 ///     free(event);
 /// }
 /// ```
-pub fn send_event<'c, 'input, Conn, A, B, C>(conn: &'c Conn, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn send_event<Conn, A, B, C>(conn: &Conn, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Window>,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -6049,7 +6049,7 @@ impl<'input> CreateWindowRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            CreateWindowRequest::opcode(),
+            Self::opcode(),
             depth_bytes[0],
             0,
             0,
@@ -6416,7 +6416,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            ChangeWindowAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -6567,7 +6567,7 @@ impl GetWindowAttributesRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            GetWindowAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -6719,7 +6719,7 @@ impl DestroyWindowRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            DestroyWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -6785,7 +6785,7 @@ impl DestroySubwindowsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            DestroySubwindowsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -6923,7 +6923,7 @@ impl ChangeSaveSetRequest {
         let mode_bytes = u8::from(self.mode).serialize();
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            ChangeSaveSetRequest::opcode(),
+            Self::opcode(),
             mode_bytes[0],
             0,
             0,
@@ -7028,7 +7028,7 @@ impl ReparentWindowRequest {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            ReparentWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -7150,7 +7150,7 @@ impl MapWindowRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            MapWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -7229,7 +7229,7 @@ impl MapSubwindowsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            MapSubwindowsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -7294,7 +7294,7 @@ impl UnmapWindowRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            UnmapWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -7359,7 +7359,7 @@ impl UnmapSubwindowsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            UnmapSubwindowsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -7717,7 +7717,7 @@ impl<'input> ConfigureWindowRequest<'input> {
         let value_mask = u16::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            ConfigureWindowRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -7909,7 +7909,7 @@ impl CirculateWindowRequest {
         let direction_bytes = u8::from(self.direction).serialize();
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            CirculateWindowRequest::opcode(),
+            Self::opcode(),
             direction_bytes[0],
             0,
             0,
@@ -8007,7 +8007,7 @@ impl GetGeometryRequest {
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
-            GetGeometryRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -8174,7 +8174,7 @@ impl QueryTreeRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            QueryTreeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -8354,7 +8354,7 @@ impl<'input> InternAtomRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            InternAtomRequest::opcode(),
+            Self::opcode(),
             only_if_exists_bytes[0],
             0,
             0,
@@ -8472,7 +8472,7 @@ impl GetAtomNameRequest {
         let length_so_far = 0;
         let atom_bytes = self.atom.serialize();
         let mut request0 = vec![
-            GetAtomNameRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -8695,7 +8695,7 @@ impl<'input> ChangePropertyRequest<'input> {
         let format_bytes = self.format.serialize();
         let data_len_bytes = self.data_len.serialize();
         let mut request0 = vec![
-            ChangePropertyRequest::opcode(),
+            Self::opcode(),
             mode_bytes[0],
             0,
             0,
@@ -8822,7 +8822,7 @@ impl DeletePropertyRequest {
         let window_bytes = self.window.serialize();
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
-            DeletePropertyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -9008,7 +9008,7 @@ impl GetPropertyRequest {
         let long_offset_bytes = self.long_offset.serialize();
         let long_length_bytes = self.long_length.serialize();
         let mut request0 = vec![
-            GetPropertyRequest::opcode(),
+            Self::opcode(),
             delete_bytes[0],
             0,
             0,
@@ -9352,7 +9352,7 @@ impl ListPropertiesRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            ListPropertiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -9471,7 +9471,7 @@ impl SetSelectionOwnerRequest {
         let selection_bytes = self.selection.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            SetSelectionOwnerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -9575,7 +9575,7 @@ impl GetSelectionOwnerRequest {
         let length_so_far = 0;
         let selection_bytes = self.selection.serialize();
         let mut request0 = vec![
-            GetSelectionOwnerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -9672,7 +9672,7 @@ impl ConvertSelectionRequest {
         let property_bytes = self.property.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            ConvertSelectionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -9888,7 +9888,7 @@ impl<'input> SendEventRequest<'input> {
         let destination_bytes = self.destination.serialize();
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
-            SendEventRequest::opcode(),
+            Self::opcode(),
             propagate_bytes[0],
             0,
             0,
@@ -10311,7 +10311,7 @@ impl GrabPointerRequest {
         let cursor_bytes = self.cursor.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            GrabPointerRequest::opcode(),
+            Self::opcode(),
             owner_events_bytes[0],
             0,
             0,
@@ -10505,7 +10505,7 @@ impl UngrabPointerRequest {
         let length_so_far = 0;
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            UngrabPointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -10739,7 +10739,7 @@ impl GrabButtonRequest {
         let button_bytes = u8::from(self.button).serialize();
         let modifiers_bytes = self.modifiers.serialize();
         let mut request0 = vec![
-            GrabButtonRequest::opcode(),
+            Self::opcode(),
             owner_events_bytes[0],
             0,
             0,
@@ -10886,7 +10886,7 @@ impl UngrabButtonRequest {
         let grab_window_bytes = self.grab_window.serialize();
         let modifiers_bytes = self.modifiers.serialize();
         let mut request0 = vec![
-            UngrabButtonRequest::opcode(),
+            Self::opcode(),
             button_bytes[0],
             0,
             0,
@@ -10942,7 +10942,7 @@ impl ChangeActivePointerGrabRequest {
         let time_bytes = self.time.serialize();
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
-            ChangeActivePointerGrabRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -11072,7 +11072,7 @@ impl GrabKeyboardRequest {
         let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
         let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
         let mut request0 = vec![
-            GrabKeyboardRequest::opcode(),
+            Self::opcode(),
             owner_events_bytes[0],
             0,
             0,
@@ -11217,7 +11217,7 @@ impl UngrabKeyboardRequest {
         let length_so_far = 0;
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            UngrabKeyboardRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -11392,7 +11392,7 @@ impl GrabKeyRequest {
         let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
         let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
         let mut request0 = vec![
-            GrabKeyRequest::opcode(),
+            Self::opcode(),
             owner_events_bytes[0],
             0,
             0,
@@ -11542,7 +11542,7 @@ impl UngrabKeyRequest {
         let grab_window_bytes = self.grab_window.serialize();
         let modifiers_bytes = self.modifiers.serialize();
         let mut request0 = vec![
-            UngrabKeyRequest::opcode(),
+            Self::opcode(),
             key_bytes[0],
             0,
             0,
@@ -11780,7 +11780,7 @@ impl AllowEventsRequest {
         let mode_bytes = u8::from(self.mode).serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            AllowEventsRequest::opcode(),
+            Self::opcode(),
             mode_bytes[0],
             0,
             0,
@@ -11842,7 +11842,7 @@ impl GrabServerRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GrabServerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -11877,7 +11877,7 @@ impl UngrabServerRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            UngrabServerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -11928,7 +11928,7 @@ impl QueryPointerRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            QueryPointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -12093,7 +12093,7 @@ impl GetMotionEventsRequest {
         let start_bytes = self.start.serialize();
         let stop_bytes = self.stop.serialize();
         let mut request0 = vec![
-            GetMotionEventsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -12199,7 +12199,7 @@ impl TranslateCoordinatesRequest {
         let src_x_bytes = self.src_x.serialize();
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
-            TranslateCoordinatesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -12330,7 +12330,7 @@ impl WarpPointerRequest {
         let dst_x_bytes = self.dst_x.serialize();
         let dst_y_bytes = self.dst_y.serialize();
         let mut request0 = vec![
-            WarpPointerRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -12549,7 +12549,7 @@ impl SetInputFocusRequest {
         let focus_bytes = self.focus.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            SetInputFocusRequest::opcode(),
+            Self::opcode(),
             revert_to_bytes[0],
             0,
             0,
@@ -12635,7 +12635,7 @@ impl GetInputFocusRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GetInputFocusRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -12697,7 +12697,7 @@ impl QueryKeymapRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            QueryKeymapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -12784,7 +12784,7 @@ impl<'input> OpenFontRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            OpenFontRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -12856,7 +12856,7 @@ impl CloseFontRequest {
         let length_so_far = 0;
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
-            CloseFontRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -13081,7 +13081,7 @@ impl QueryFontRequest {
         let length_so_far = 0;
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
-            QueryFontRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -13264,7 +13264,7 @@ impl<'input> QueryTextExtentsRequest<'input> {
         let odd_length_bytes = odd_length.serialize();
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
-            QueryTextExtentsRequest::opcode(),
+            Self::opcode(),
             odd_length_bytes[0],
             0,
             0,
@@ -13450,7 +13450,7 @@ impl<'input> ListFontsRequest<'input> {
         let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
         let pattern_len_bytes = pattern_len.serialize();
         let mut request0 = vec![
-            ListFontsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -13572,7 +13572,7 @@ impl<'input> ListFontsWithInfoRequest<'input> {
         let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
         let pattern_len_bytes = pattern_len.serialize();
         let mut request0 = vec![
-            ListFontsWithInfoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -13734,7 +13734,7 @@ impl<'input> SetFontPathRequest<'input> {
         let font_qty = u16::try_from(self.font.len()).expect("`font` has too many elements");
         let font_qty_bytes = font_qty.serialize();
         let mut request0 = vec![
-            SetFontPathRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -13779,7 +13779,7 @@ impl GetFontPathRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GetFontPathRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -13890,7 +13890,7 @@ impl CreatePixmapRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            CreatePixmapRequest::opcode(),
+            Self::opcode(),
             depth_bytes[0],
             0,
             0,
@@ -13981,7 +13981,7 @@ impl FreePixmapRequest {
         let length_so_far = 0;
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
-            FreePixmapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -15144,7 +15144,7 @@ impl<'input> CreateGCRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            CreateGCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -15576,7 +15576,7 @@ impl<'input> ChangeGCRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            ChangeGCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -15678,7 +15678,7 @@ impl CopyGCRequest {
         let dst_gc_bytes = self.dst_gc.serialize();
         let value_mask_bytes = self.value_mask.serialize();
         let mut request0 = vec![
-            CopyGCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -15739,7 +15739,7 @@ impl<'input> SetDashesRequest<'input> {
         let dashes_len = u16::try_from(self.dashes.len()).expect("`dashes` has too many elements");
         let dashes_len_bytes = dashes_len.serialize();
         let mut request0 = vec![
-            SetDashesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -15867,7 +15867,7 @@ impl<'input> SetClipRectanglesRequest<'input> {
         let clip_x_origin_bytes = self.clip_x_origin.serialize();
         let clip_y_origin_bytes = self.clip_y_origin.serialize();
         let mut request0 = vec![
-            SetClipRectanglesRequest::opcode(),
+            Self::opcode(),
             ordering_bytes[0],
             0,
             0,
@@ -15934,7 +15934,7 @@ impl FreeGCRequest {
         let length_so_far = 0;
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            FreeGCRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -15999,7 +15999,7 @@ impl ClearAreaRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            ClearAreaRequest::opcode(),
+            Self::opcode(),
             exposures_bytes[0],
             0,
             0,
@@ -16093,7 +16093,7 @@ impl CopyAreaRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            CopyAreaRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -16204,7 +16204,7 @@ impl CopyPlaneRequest {
         let height_bytes = self.height.serialize();
         let bit_plane_bytes = self.bit_plane.serialize();
         let mut request0 = vec![
-            CopyPlaneRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -16360,7 +16360,7 @@ impl<'input> PolyPointRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            PolyPointRequest::opcode(),
+            Self::opcode(),
             coordinate_mode_bytes[0],
             0,
             0,
@@ -16459,7 +16459,7 @@ impl<'input> PolyLineRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            PolyLineRequest::opcode(),
+            Self::opcode(),
             coordinate_mode_bytes[0],
             0,
             0,
@@ -16632,7 +16632,7 @@ impl<'input> PolySegmentRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            PolySegmentRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -16715,7 +16715,7 @@ impl<'input> PolyRectangleRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            PolyRectangleRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -16772,7 +16772,7 @@ impl<'input> PolyArcRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            PolyArcRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -16898,7 +16898,7 @@ impl<'input> FillPolyRequest<'input> {
         let shape_bytes = u8::from(self.shape).serialize();
         let coordinate_mode_bytes = u8::from(self.coordinate_mode).serialize();
         let mut request0 = vec![
-            FillPolyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -16986,7 +16986,7 @@ impl<'input> PolyFillRectangleRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            PolyFillRectangleRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -17068,7 +17068,7 @@ impl<'input> PolyFillArcRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            PolyFillArcRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -17204,7 +17204,7 @@ impl<'input> PutImageRequest<'input> {
         let left_pad_bytes = self.left_pad.serialize();
         let depth_bytes = self.depth.serialize();
         let mut request0 = vec![
-            PutImageRequest::opcode(),
+            Self::opcode(),
             format_bytes[0],
             0,
             0,
@@ -17288,7 +17288,7 @@ impl GetImageRequest {
         let height_bytes = self.height.serialize();
         let plane_mask_bytes = self.plane_mask.serialize();
         let mut request0 = vec![
-            GetImageRequest::opcode(),
+            Self::opcode(),
             format_bytes[0],
             0,
             0,
@@ -17402,7 +17402,7 @@ impl<'input> PolyText8Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            PolyText8Request::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -17468,7 +17468,7 @@ impl<'input> PolyText16Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            PolyText16Request::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -17570,7 +17570,7 @@ impl<'input> ImageText8Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            ImageText8Request::opcode(),
+            Self::opcode(),
             string_len_bytes[0],
             0,
             0,
@@ -17707,7 +17707,7 @@ impl<'input> ImageText16Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            ImageText16Request::opcode(),
+            Self::opcode(),
             string_len_bytes[0],
             0,
             0,
@@ -17878,7 +17878,7 @@ impl CreateColormapRequest {
         let window_bytes = self.window.serialize();
         let visual_bytes = self.visual.serialize();
         let mut request0 = vec![
-            CreateColormapRequest::opcode(),
+            Self::opcode(),
             alloc_bytes[0],
             0,
             0,
@@ -17933,7 +17933,7 @@ impl FreeColormapRequest {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            FreeColormapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -17979,7 +17979,7 @@ impl CopyColormapAndFreeRequest {
         let mid_bytes = self.mid.serialize();
         let src_cmap_bytes = self.src_cmap.serialize();
         let mut request0 = vec![
-            CopyColormapAndFreeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18028,7 +18028,7 @@ impl InstallColormapRequest {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            InstallColormapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18072,7 +18072,7 @@ impl UninstallColormapRequest {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            UninstallColormapRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18116,7 +18116,7 @@ impl ListInstalledColormapsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            ListInstalledColormapsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18226,7 +18226,7 @@ impl AllocColorRequest {
         let green_bytes = self.green.serialize();
         let blue_bytes = self.blue.serialize();
         let mut request0 = vec![
-            AllocColorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18334,7 +18334,7 @@ impl<'input> AllocNamedColorRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            AllocNamedColorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18429,7 +18429,7 @@ impl AllocColorCellsRequest {
         let colors_bytes = self.colors.serialize();
         let planes_bytes = self.planes.serialize();
         let mut request0 = vec![
-            AllocColorCellsRequest::opcode(),
+            Self::opcode(),
             contiguous_bytes[0],
             0,
             0,
@@ -18548,7 +18548,7 @@ impl AllocColorPlanesRequest {
         let greens_bytes = self.greens.serialize();
         let blues_bytes = self.blues.serialize();
         let mut request0 = vec![
-            AllocColorPlanesRequest::opcode(),
+            Self::opcode(),
             contiguous_bytes[0],
             0,
             0,
@@ -18657,7 +18657,7 @@ impl<'input> FreeColorsRequest<'input> {
         let cmap_bytes = self.cmap.serialize();
         let plane_mask_bytes = self.plane_mask.serialize();
         let mut request0 = vec![
-            FreeColorsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18838,7 +18838,7 @@ impl<'input> StoreColorsRequest<'input> {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            StoreColorsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -18894,7 +18894,7 @@ impl<'input> StoreNamedColorRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            StoreNamedColorRequest::opcode(),
+            Self::opcode(),
             flags_bytes[0],
             0,
             0,
@@ -19003,7 +19003,7 @@ impl<'input> QueryColorsRequest<'input> {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            QueryColorsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -19097,7 +19097,7 @@ impl<'input> LookupColorRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            LookupColorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -19263,7 +19263,7 @@ impl CreateCursorRequest {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            CreateCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -19455,7 +19455,7 @@ impl CreateGlyphCursorRequest {
         let back_green_bytes = self.back_green.serialize();
         let back_blue_bytes = self.back_blue.serialize();
         let mut request0 = vec![
-            CreateGlyphCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -19580,7 +19580,7 @@ impl FreeCursorRequest {
         let length_so_far = 0;
         let cursor_bytes = self.cursor.serialize();
         let mut request0 = vec![
-            FreeCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -19648,7 +19648,7 @@ impl RecolorCursorRequest {
         let back_green_bytes = self.back_green.serialize();
         let back_blue_bytes = self.back_blue.serialize();
         let mut request0 = vec![
-            RecolorCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -19781,7 +19781,7 @@ impl QueryBestSizeRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            QueryBestSizeRequest::opcode(),
+            Self::opcode(),
             class_bytes[0],
             0,
             0,
@@ -19882,7 +19882,7 @@ impl<'input> QueryExtensionRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            QueryExtensionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -19985,7 +19985,7 @@ impl ListExtensionsRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            ListExtensionsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -20069,7 +20069,7 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
         let first_keycode_bytes = self.first_keycode.serialize();
         let keysyms_per_keycode_bytes = self.keysyms_per_keycode.serialize();
         let mut request0 = vec![
-            ChangeKeyboardMappingRequest::opcode(),
+            Self::opcode(),
             keycode_count_bytes[0],
             0,
             0,
@@ -20123,7 +20123,7 @@ impl GetKeyboardMappingRequest {
         let first_keycode_bytes = self.first_keycode.serialize();
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
-            GetKeyboardMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -20549,7 +20549,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            ChangeKeyboardControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -20594,7 +20594,7 @@ impl GetKeyboardControlRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GetKeyboardControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -20671,7 +20671,7 @@ impl BellRequest {
         let length_so_far = 0;
         let percent_bytes = self.percent.serialize();
         let mut request0 = vec![
-            BellRequest::opcode(),
+            Self::opcode(),
             percent_bytes[0],
             0,
             0,
@@ -20719,7 +20719,7 @@ impl ChangePointerControlRequest {
         let do_acceleration_bytes = self.do_acceleration.serialize();
         let do_threshold_bytes = self.do_threshold.serialize();
         let mut request0 = vec![
-            ChangePointerControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -20768,7 +20768,7 @@ impl GetPointerControlRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GetPointerControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -20972,7 +20972,7 @@ impl SetScreenSaverRequest {
         let prefer_blanking_bytes = u8::from(self.prefer_blanking).serialize();
         let allow_exposures_bytes = u8::from(self.allow_exposures).serialize();
         let mut request0 = vec![
-            SetScreenSaverRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -21020,7 +21020,7 @@ impl GetScreenSaverRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GetScreenSaverRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -21238,7 +21238,7 @@ impl<'input> ChangeHostsRequest<'input> {
         let address_len = u16::try_from(self.address.len()).expect("`address` has too many elements");
         let address_len_bytes = address_len.serialize();
         let mut request0 = vec![
-            ChangeHostsRequest::opcode(),
+            Self::opcode(),
             mode_bytes[0],
             0,
             0,
@@ -21345,7 +21345,7 @@ impl ListHostsRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            ListHostsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -21497,7 +21497,7 @@ impl SetAccessControlRequest {
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
-            SetAccessControlRequest::opcode(),
+            Self::opcode(),
             mode_bytes[0],
             0,
             0,
@@ -21602,7 +21602,7 @@ impl SetCloseDownModeRequest {
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
-            SetCloseDownModeRequest::opcode(),
+            Self::opcode(),
             mode_bytes[0],
             0,
             0,
@@ -21720,7 +21720,7 @@ impl KillClientRequest {
         let length_so_far = 0;
         let resource_bytes = self.resource.serialize();
         let mut request0 = vec![
-            KillClientRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -21790,7 +21790,7 @@ impl<'input> RotatePropertiesRequest<'input> {
         let atoms_len_bytes = atoms_len.serialize();
         let delta_bytes = self.delta.serialize();
         let mut request0 = vec![
-            RotatePropertiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -21914,7 +21914,7 @@ impl ForceScreenSaverRequest {
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
-            ForceScreenSaverRequest::opcode(),
+            Self::opcode(),
             mode_bytes[0],
             0,
             0,
@@ -22020,7 +22020,7 @@ impl<'input> SetPointerMappingRequest<'input> {
         let map_len = u8::try_from(self.map.len()).expect("`map` has too many elements");
         let map_len_bytes = map_len.serialize();
         let mut request0 = vec![
-            SetPointerMappingRequest::opcode(),
+            Self::opcode(),
             map_len_bytes[0],
             0,
             0,
@@ -22085,7 +22085,7 @@ impl GetPointerMappingRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GetPointerMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -22247,7 +22247,7 @@ impl<'input> SetModifierMappingRequest<'input> {
         let keycodes_per_modifier = u8::try_from(self.keycodes.len() / 8).expect("`keycodes` has too many elements");
         let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
         let mut request0 = vec![
-            SetModifierMappingRequest::opcode(),
+            Self::opcode(),
             keycodes_per_modifier_bytes[0],
             0,
             0,
@@ -22312,7 +22312,7 @@ impl GetModifierMappingRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            GetModifierMappingRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,
@@ -22390,7 +22390,7 @@ impl NoOperationRequest {
     {
         let length_so_far = 0;
         let mut request0 = vec![
-            NoOperationRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             0,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -6152,17 +6152,17 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateWindowRequest {
-        depth: depth,
-        wid: wid,
-        parent: parent,
-        x: x,
-        y: y,
-        width: width,
-        height: height,
-        border_width: border_width,
-        class: class,
-        visual: visual,
-        value_list: value_list,
+        depth,
+        wid,
+        parent,
+        x,
+        y,
+        width,
+        height,
+        border_width,
+        class,
+        visual,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6466,8 +6466,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeWindowAttributesRequest {
-        window: window,
-        value_list: value_list,
+        window,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6600,7 +6600,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetWindowAttributesRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6762,7 +6762,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyWindowRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6806,7 +6806,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroySubwindowsRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6966,8 +6966,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeSaveSetRequest {
-        mode: mode,
-        window: window,
+        mode,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7089,10 +7089,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ReparentWindowRequest {
-        window: window,
-        parent: parent,
-        x: x,
-        y: y,
+        window,
+        parent,
+        x,
+        y,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7206,7 +7206,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = MapWindowRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7250,7 +7250,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = MapSubwindowsRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7336,7 +7336,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UnmapWindowRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7380,7 +7380,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UnmapSubwindowsRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7796,8 +7796,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ConfigureWindowRequest {
-        window: window,
-        value_list: value_list,
+        window,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7947,8 +7947,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CirculateWindowRequest {
-        direction: direction,
-        window: window,
+        direction,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8064,7 +8064,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetGeometryRequest {
-        drawable: drawable,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8232,7 +8232,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryTreeRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8423,8 +8423,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = InternAtomRequest {
-        only_if_exists: only_if_exists,
-        name: name,
+        only_if_exists,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8493,7 +8493,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetAtomNameRequest {
-        atom: atom,
+        atom,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8791,13 +8791,13 @@ where
     let property: Atom = property.into();
     let type_: Atom = type_.into();
     let request0 = ChangePropertyRequest {
-        mode: mode,
-        window: window,
-        property: property,
-        type_: type_,
-        format: format,
-        data_len: data_len,
-        data: data,
+        mode,
+        window,
+        property,
+        type_,
+        format,
+        data_len,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8847,8 +8847,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DeletePropertyRequest {
-        window: window,
-        property: property,
+        window,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9117,12 +9117,12 @@ where
     let property: Atom = property.into();
     let type_: Atom = type_.into();
     let request0 = GetPropertyRequest {
-        delete: delete,
-        window: window,
-        property: property,
-        type_: type_,
-        long_offset: long_offset,
-        long_length: long_length,
+        delete,
+        window,
+        property,
+        type_,
+        long_offset,
+        long_length,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9373,7 +9373,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListPropertiesRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9533,9 +9533,9 @@ where
     let owner: Window = owner.into();
     let time: Timestamp = time.into();
     let request0 = SetSelectionOwnerRequest {
-        owner: owner,
-        selection: selection,
-        time: time,
+        owner,
+        selection,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9613,7 +9613,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetSelectionOwnerRequest {
-        selection: selection,
+        selection,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9713,11 +9713,11 @@ where
     let property: Atom = property.into();
     let time: Timestamp = time.into();
     let request0 = ConvertSelectionRequest {
-        requestor: requestor,
-        selection: selection,
-        target: target,
-        property: property,
-        time: time,
+        requestor,
+        selection,
+        target,
+        property,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9994,10 +9994,10 @@ where
     let event: [u8; 32] = event.into();
     let event = &event;
     let request0 = SendEventRequest {
-        propagate: propagate,
-        destination: destination,
-        event_mask: event_mask,
-        event: event,
+        propagate,
+        destination,
+        event_mask,
+        event,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10427,14 +10427,14 @@ where
     let cursor: Cursor = cursor.into();
     let time: Timestamp = time.into();
     let request0 = GrabPointerRequest {
-        owner_events: owner_events,
-        grab_window: grab_window,
-        event_mask: event_mask,
-        pointer_mode: pointer_mode,
-        keyboard_mode: keyboard_mode,
-        confine_to: confine_to,
-        cursor: cursor,
-        time: time,
+        owner_events,
+        grab_window,
+        event_mask,
+        pointer_mode,
+        keyboard_mode,
+        confine_to,
+        cursor,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10551,7 +10551,7 @@ where
 {
     let time: Timestamp = time.into();
     let request0 = UngrabPointerRequest {
-        time: time,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10851,15 +10851,15 @@ where
     let cursor: Cursor = cursor.into();
     let modifiers: u16 = modifiers.into();
     let request0 = GrabButtonRequest {
-        owner_events: owner_events,
-        grab_window: grab_window,
-        event_mask: event_mask,
-        pointer_mode: pointer_mode,
-        keyboard_mode: keyboard_mode,
-        confine_to: confine_to,
-        cursor: cursor,
-        button: button,
-        modifiers: modifiers,
+        owner_events,
+        grab_window,
+        event_mask,
+        pointer_mode,
+        keyboard_mode,
+        confine_to,
+        cursor,
+        button,
+        modifiers,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10913,9 +10913,9 @@ where
 {
     let modifiers: u16 = modifiers.into();
     let request0 = UngrabButtonRequest {
-        button: button,
-        grab_window: grab_window,
-        modifiers: modifiers,
+        button,
+        grab_window,
+        modifiers,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10977,9 +10977,9 @@ where
     let time: Timestamp = time.into();
     let event_mask: u16 = event_mask.into();
     let request0 = ChangeActivePointerGrabRequest {
-        cursor: cursor,
-        time: time,
-        event_mask: event_mask,
+        cursor,
+        time,
+        event_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11165,11 +11165,11 @@ where
 {
     let time: Timestamp = time.into();
     let request0 = GrabKeyboardRequest {
-        owner_events: owner_events,
-        grab_window: grab_window,
-        time: time,
-        pointer_mode: pointer_mode,
-        keyboard_mode: keyboard_mode,
+        owner_events,
+        grab_window,
+        time,
+        pointer_mode,
+        keyboard_mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11240,7 +11240,7 @@ where
 {
     let time: Timestamp = time.into();
     let request0 = UngrabKeyboardRequest {
-        time: time,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11485,12 +11485,12 @@ where
     let modifiers: u16 = modifiers.into();
     let key: Keycode = key.into();
     let request0 = GrabKeyRequest {
-        owner_events: owner_events,
-        grab_window: grab_window,
-        modifiers: modifiers,
-        key: key,
-        pointer_mode: pointer_mode,
-        keyboard_mode: keyboard_mode,
+        owner_events,
+        grab_window,
+        modifiers,
+        key,
+        pointer_mode,
+        keyboard_mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11596,9 +11596,9 @@ where
     let key: Keycode = key.into();
     let modifiers: u16 = modifiers.into();
     let request0 = UngrabKeyRequest {
-        key: key,
-        grab_window: grab_window,
-        modifiers: modifiers,
+        key,
+        grab_window,
+        modifiers,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11821,8 +11821,8 @@ where
 {
     let time: Timestamp = time.into();
     let request0 = AllowEventsRequest {
-        mode: mode,
-        time: time,
+        mode,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11962,7 +11962,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryPointerRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12126,9 +12126,9 @@ where
     let start: Timestamp = start.into();
     let stop: Timestamp = stop.into();
     let request0 = GetMotionEventsRequest {
-        window: window,
-        start: start,
-        stop: stop,
+        window,
+        start,
+        stop,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12228,10 +12228,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = TranslateCoordinatesRequest {
-        src_window: src_window,
-        dst_window: dst_window,
-        src_x: src_x,
-        src_y: src_y,
+        src_window,
+        dst_window,
+        src_x,
+        src_y,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12403,14 +12403,14 @@ where
     let src_window: Window = src_window.into();
     let dst_window: Window = dst_window.into();
     let request0 = WarpPointerRequest {
-        src_window: src_window,
-        dst_window: dst_window,
-        src_x: src_x,
-        src_y: src_y,
-        src_width: src_width,
-        src_height: src_height,
-        dst_x: dst_x,
-        dst_y: dst_y,
+        src_window,
+        dst_window,
+        src_x,
+        src_y,
+        src_width,
+        src_height,
+        dst_x,
+        dst_y,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12613,9 +12613,9 @@ where
     let focus: Window = focus.into();
     let time: Timestamp = time.into();
     let request0 = SetInputFocusRequest {
-        revert_to: revert_to,
-        focus: focus,
-        time: time,
+        revert_to,
+        focus,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12832,8 +12832,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = OpenFontRequest {
-        fid: fid,
-        name: name,
+        fid,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12877,7 +12877,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CloseFontRequest {
-        font: font,
+        font,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13109,7 +13109,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryFontRequest {
-        font: font,
+        font,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13323,8 +13323,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryTextExtentsRequest {
-        font: font,
-        string: string,
+        font,
+        string,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13487,8 +13487,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListFontsRequest {
-        max_names: max_names,
-        pattern: pattern,
+        max_names,
+        pattern,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13609,8 +13609,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListFontsWithInfoRequest {
-        max_names: max_names,
-        pattern: pattern,
+        max_names,
+        pattern,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13759,7 +13759,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetFontPathRequest {
-        font: font,
+        font,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13942,11 +13942,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreatePixmapRequest {
-        depth: depth,
-        pid: pid,
-        drawable: drawable,
-        width: width,
-        height: height,
+        depth,
+        pid,
+        drawable,
+        width,
+        height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -14014,7 +14014,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreePixmapRequest {
-        pixmap: pixmap,
+        pixmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15200,9 +15200,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateGCRequest {
-        cid: cid,
-        drawable: drawable,
-        value_list: value_list,
+        cid,
+        drawable,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15650,8 +15650,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeGCRequest {
-        gc: gc,
-        value_list: value_list,
+        gc,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15709,9 +15709,9 @@ where
 {
     let value_mask: u32 = value_mask.into();
     let request0 = CopyGCRequest {
-        src_gc: src_gc,
-        dst_gc: dst_gc,
-        value_mask: value_mask,
+        src_gc,
+        dst_gc,
+        value_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15767,9 +15767,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDashesRequest {
-        gc: gc,
-        dash_offset: dash_offset,
-        dashes: dashes,
+        gc,
+        dash_offset,
+        dashes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15896,11 +15896,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetClipRectanglesRequest {
-        ordering: ordering,
-        gc: gc,
-        clip_x_origin: clip_x_origin,
-        clip_y_origin: clip_y_origin,
-        rectangles: rectangles,
+        ordering,
+        gc,
+        clip_x_origin,
+        clip_y_origin,
+        rectangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15966,7 +15966,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeGCRequest {
-        gc: gc,
+        gc,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16028,12 +16028,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ClearAreaRequest {
-        exposures: exposures,
-        window: window,
-        x: x,
-        y: y,
-        width: width,
-        height: height,
+        exposures,
+        window,
+        x,
+        y,
+        width,
+        height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16155,15 +16155,15 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CopyAreaRequest {
-        src_drawable: src_drawable,
-        dst_drawable: dst_drawable,
-        gc: gc,
-        src_x: src_x,
-        src_y: src_y,
-        dst_x: dst_x,
-        dst_y: dst_y,
-        width: width,
-        height: height,
+        src_drawable,
+        dst_drawable,
+        gc,
+        src_x,
+        src_y,
+        dst_x,
+        dst_y,
+        width,
+        height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16249,16 +16249,16 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CopyPlaneRequest {
-        src_drawable: src_drawable,
-        dst_drawable: dst_drawable,
-        gc: gc,
-        src_x: src_x,
-        src_y: src_y,
-        dst_x: dst_x,
-        dst_y: dst_y,
-        width: width,
-        height: height,
-        bit_plane: bit_plane,
+        src_drawable,
+        dst_drawable,
+        gc,
+        src_x,
+        src_y,
+        dst_x,
+        dst_y,
+        width,
+        height,
+        bit_plane,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16389,10 +16389,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyPointRequest {
-        coordinate_mode: coordinate_mode,
-        drawable: drawable,
-        gc: gc,
-        points: points,
+        coordinate_mode,
+        drawable,
+        gc,
+        points,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16527,10 +16527,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyLineRequest {
-        coordinate_mode: coordinate_mode,
-        drawable: drawable,
-        gc: gc,
-        points: points,
+        coordinate_mode,
+        drawable,
+        gc,
+        points,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16687,9 +16687,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolySegmentRequest {
-        drawable: drawable,
-        gc: gc,
-        segments: segments,
+        drawable,
+        gc,
+        segments,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16744,9 +16744,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyRectangleRequest {
-        drawable: drawable,
-        gc: gc,
-        rectangles: rectangles,
+        drawable,
+        gc,
+        rectangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16801,9 +16801,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyArcRequest {
-        drawable: drawable,
-        gc: gc,
-        arcs: arcs,
+        drawable,
+        gc,
+        arcs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16931,11 +16931,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FillPolyRequest {
-        drawable: drawable,
-        gc: gc,
-        shape: shape,
-        coordinate_mode: coordinate_mode,
-        points: points,
+        drawable,
+        gc,
+        shape,
+        coordinate_mode,
+        points,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17040,9 +17040,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyFillRectangleRequest {
-        drawable: drawable,
-        gc: gc,
-        rectangles: rectangles,
+        drawable,
+        gc,
+        rectangles,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17097,9 +17097,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyFillArcRequest {
-        drawable: drawable,
-        gc: gc,
-        arcs: arcs,
+        drawable,
+        gc,
+        arcs,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17244,16 +17244,16 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PutImageRequest {
-        format: format,
-        drawable: drawable,
-        gc: gc,
-        width: width,
-        height: height,
-        dst_x: dst_x,
-        dst_y: dst_y,
-        left_pad: left_pad,
-        depth: depth,
-        data: data,
+        format,
+        drawable,
+        gc,
+        width,
+        height,
+        dst_x,
+        dst_y,
+        left_pad,
+        depth,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17321,13 +17321,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetImageRequest {
-        format: format,
-        drawable: drawable,
-        x: x,
-        y: y,
-        width: width,
-        height: height,
-        plane_mask: plane_mask,
+        format,
+        drawable,
+        x,
+        y,
+        width,
+        height,
+        plane_mask,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17434,11 +17434,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyText8Request {
-        drawable: drawable,
-        gc: gc,
-        x: x,
-        y: y,
-        items: items,
+        drawable,
+        gc,
+        x,
+        y,
+        items,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17500,11 +17500,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PolyText16Request {
-        drawable: drawable,
-        gc: gc,
-        x: x,
-        y: y,
-        items: items,
+        drawable,
+        gc,
+        x,
+        y,
+        items,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17636,11 +17636,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ImageText8Request {
-        drawable: drawable,
-        gc: gc,
-        x: x,
-        y: y,
-        string: string,
+        drawable,
+        gc,
+        x,
+        y,
+        string,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17775,11 +17775,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ImageText16Request {
-        drawable: drawable,
-        gc: gc,
-        x: x,
-        y: y,
-        string: string,
+        drawable,
+        gc,
+        x,
+        y,
+        string,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17907,10 +17907,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateColormapRequest {
-        alloc: alloc,
-        mid: mid,
-        window: window,
-        visual: visual,
+        alloc,
+        mid,
+        window,
+        visual,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17954,7 +17954,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeColormapRequest {
-        cmap: cmap,
+        cmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18004,8 +18004,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CopyColormapAndFreeRequest {
-        mid: mid,
-        src_cmap: src_cmap,
+        mid,
+        src_cmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18049,7 +18049,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = InstallColormapRequest {
-        cmap: cmap,
+        cmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18093,7 +18093,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = UninstallColormapRequest {
-        cmap: cmap,
+        cmap,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18137,7 +18137,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListInstalledColormapsRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18273,10 +18273,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AllocColorRequest {
-        cmap: cmap,
-        red: red,
-        green: green,
-        blue: blue,
+        cmap,
+        red,
+        green,
+        blue,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18362,8 +18362,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AllocNamedColorRequest {
-        cmap: cmap,
-        name: name,
+        cmap,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18454,10 +18454,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AllocColorCellsRequest {
-        contiguous: contiguous,
-        cmap: cmap,
-        colors: colors,
-        planes: planes,
+        contiguous,
+        cmap,
+        colors,
+        planes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18577,12 +18577,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AllocColorPlanesRequest {
-        contiguous: contiguous,
-        cmap: cmap,
-        colors: colors,
-        reds: reds,
-        greens: greens,
-        blues: blues,
+        contiguous,
+        cmap,
+        colors,
+        reds,
+        greens,
+        blues,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18686,9 +18686,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeColorsRequest {
-        cmap: cmap,
-        plane_mask: plane_mask,
-        pixels: pixels,
+        cmap,
+        plane_mask,
+        pixels,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18863,8 +18863,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = StoreColorsRequest {
-        cmap: cmap,
-        items: items,
+        cmap,
+        items,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18928,10 +18928,10 @@ where
 {
     let flags: u8 = flags.into();
     let request0 = StoreNamedColorRequest {
-        flags: flags,
-        cmap: cmap,
-        pixel: pixel,
-        name: name,
+        flags,
+        cmap,
+        pixel,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19028,8 +19028,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryColorsRequest {
-        cmap: cmap,
-        pixels: pixels,
+        cmap,
+        pixels,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19125,8 +19125,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = LookupColorRequest {
-        cmap: cmap,
-        name: name,
+        cmap,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19310,17 +19310,17 @@ where
 {
     let mask: Pixmap = mask.into();
     let request0 = CreateCursorRequest {
-        cid: cid,
-        source: source,
-        mask: mask,
-        fore_red: fore_red,
-        fore_green: fore_green,
-        fore_blue: fore_blue,
-        back_red: back_red,
-        back_green: back_green,
-        back_blue: back_blue,
-        x: x,
-        y: y,
+        cid,
+        source,
+        mask,
+        fore_red,
+        fore_green,
+        fore_blue,
+        back_red,
+        back_green,
+        back_blue,
+        x,
+        y,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19535,17 +19535,17 @@ where
 {
     let mask_font: Font = mask_font.into();
     let request0 = CreateGlyphCursorRequest {
-        cid: cid,
-        source_font: source_font,
-        mask_font: mask_font,
-        source_char: source_char,
-        mask_char: mask_char,
-        fore_red: fore_red,
-        fore_green: fore_green,
-        fore_blue: fore_blue,
-        back_red: back_red,
-        back_green: back_green,
-        back_blue: back_blue,
+        cid,
+        source_font,
+        mask_font,
+        source_char,
+        mask_char,
+        fore_red,
+        fore_green,
+        fore_blue,
+        back_red,
+        back_green,
+        back_blue,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19613,7 +19613,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FreeCursorRequest {
-        cursor: cursor,
+        cursor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19681,13 +19681,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RecolorCursorRequest {
-        cursor: cursor,
-        fore_red: fore_red,
-        fore_green: fore_green,
-        fore_blue: fore_blue,
-        back_red: back_red,
-        back_green: back_green,
-        back_blue: back_blue,
+        cursor,
+        fore_red,
+        fore_green,
+        fore_blue,
+        back_red,
+        back_green,
+        back_blue,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19806,10 +19806,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryBestSizeRequest {
-        class: class,
-        drawable: drawable,
-        width: width,
-        height: height,
+        class,
+        drawable,
+        width,
+        height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19928,7 +19928,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryExtensionRequest {
-        name: name,
+        name,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -20095,10 +20095,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeKeyboardMappingRequest {
-        keycode_count: keycode_count,
-        first_keycode: first_keycode,
-        keysyms_per_keycode: keysyms_per_keycode,
-        keysyms: keysyms,
+        keycode_count,
+        first_keycode,
+        keysyms_per_keycode,
+        keysyms,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -20144,8 +20144,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetKeyboardMappingRequest {
-        first_keycode: first_keycode,
-        count: count,
+        first_keycode,
+        count,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -20574,7 +20574,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeKeyboardControlRequest {
-        value_list: value_list,
+        value_list,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -20688,7 +20688,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = BellRequest {
-        percent: percent,
+        percent,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -20744,11 +20744,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangePointerControlRequest {
-        acceleration_numerator: acceleration_numerator,
-        acceleration_denominator: acceleration_denominator,
-        threshold: threshold,
-        do_acceleration: do_acceleration,
-        do_threshold: do_threshold,
+        acceleration_numerator,
+        acceleration_denominator,
+        threshold,
+        do_acceleration,
+        do_threshold,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -20997,10 +20997,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetScreenSaverRequest {
-        timeout: timeout,
-        interval: interval,
-        prefer_blanking: prefer_blanking,
-        allow_exposures: allow_exposures,
+        timeout,
+        interval,
+        prefer_blanking,
+        allow_exposures,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -21262,9 +21262,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeHostsRequest {
-        mode: mode,
-        family: family,
-        address: address,
+        mode,
+        family,
+        address,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -21514,7 +21514,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetAccessControlRequest {
-        mode: mode,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -21619,7 +21619,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetCloseDownModeRequest {
-        mode: mode,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -21762,7 +21762,7 @@ where
 {
     let resource: u32 = resource.into();
     let request0 = KillClientRequest {
-        resource: resource,
+        resource,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -21819,9 +21819,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = RotatePropertiesRequest {
-        window: window,
-        delta: delta,
-        atoms: atoms,
+        window,
+        delta,
+        atoms,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -21931,7 +21931,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ForceScreenSaverRequest {
-        mode: mode,
+        mode,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -22040,7 +22040,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPointerMappingRequest {
-        map: map,
+        map,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -22267,7 +22267,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetModifierMappingRequest {
-        keycodes: keycodes,
+        keycodes,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -6013,7 +6013,7 @@ impl CreateWindowAux {
 /// * `xcb_generate_id`: function
 /// * `MapWindow`: request
 /// * `CreateNotify`: event
-pub fn create_window<'c, Conn>(conn: &'c Conn, depth: u8, wid: Window, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: WindowClass, visual: Visualid, value_list: &CreateWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_window<'c, 'input, Conn>(conn: &'c Conn, depth: u8, wid: Window, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: WindowClass, visual: Visualid, value_list: &'input CreateWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -6305,7 +6305,7 @@ impl ChangeWindowAttributesAux {
 /// * `Pixmap` - TODO: reasons?
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
-pub fn change_window_attributes<'c, Conn>(conn: &'c Conn, window: Window, value_list: &ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_window_attributes<'c, 'input, Conn>(conn: &'c Conn, window: Window, value_list: &'input ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -7241,7 +7241,7 @@ impl ConfigureWindowAux {
 ///     xcb_flush(c);
 /// }
 /// ```
-pub fn configure_window<'c, Conn>(conn: &'c Conn, window: Window, value_list: &ConfigureWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn configure_window<'c, 'input, Conn>(conn: &'c Conn, window: Window, value_list: &'input ConfigureWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -7658,7 +7658,7 @@ pub const INTERN_ATOM_REQUEST: u8 = 16;
 ///     }
 /// }
 /// ```
-pub fn intern_atom<'c, Conn>(conn: &'c Conn, only_if_exists: bool, name: &[u8]) -> Result<Cookie<'c, Conn, InternAtomReply>, ConnectionError>
+pub fn intern_atom<'c, 'input, Conn>(conn: &'c Conn, only_if_exists: bool, name: &'input [u8]) -> Result<Cookie<'c, Conn, InternAtomReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -7906,7 +7906,7 @@ pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 ///     xcb_flush(conn);
 /// }
 /// ```
-pub fn change_property<'c, Conn, A, B>(conn: &'c Conn, mode: PropMode, window: Window, property: A, type_: B, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_property<'c, 'input, Conn, A, B>(conn: &'c Conn, mode: PropMode, window: Window, property: A, type_: B, format: u8, data_len: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Atom>,
@@ -10729,7 +10729,7 @@ pub const OPEN_FONT_REQUEST: u8 = 45;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-pub fn open_font<'c, Conn>(conn: &'c Conn, fid: Font, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn open_font<'c, 'input, Conn>(conn: &'c Conn, fid: Font, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -11122,7 +11122,7 @@ pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
 ///
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Font` - The specified `font` does not exist.
-pub fn query_text_extents<'c, Conn>(conn: &'c Conn, font: Fontable, string: &[Char2b]) -> Result<Cookie<'c, Conn, QueryTextExtentsReply>, ConnectionError>
+pub fn query_text_extents<'c, 'input, Conn>(conn: &'c Conn, font: Fontable, string: &'input [Char2b]) -> Result<Cookie<'c, Conn, QueryTextExtentsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -11254,7 +11254,7 @@ pub const LIST_FONTS_REQUEST: u8 = 49;
 /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
-pub fn list_fonts<'c, Conn>(conn: &'c Conn, max_names: u16, pattern: &[u8]) -> Result<Cookie<'c, Conn, ListFontsReply>, ConnectionError>
+pub fn list_fonts<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pattern: &'input [u8]) -> Result<Cookie<'c, Conn, ListFontsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -11342,7 +11342,7 @@ pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
 /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
-pub fn list_fonts_with_info<'c, Conn>(conn: &'c Conn, max_names: u16, pattern: &[u8]) -> Result<ListFontsWithInfoCookie<'c, Conn>, ConnectionError>
+pub fn list_fonts_with_info<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pattern: &'input [u8]) -> Result<ListFontsWithInfoCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -11472,7 +11472,7 @@ impl ListFontsWithInfoReply {
 
 /// Opcode for the SetFontPath request
 pub const SET_FONT_PATH_REQUEST: u8 = 51;
-pub fn set_font_path<'c, Conn>(conn: &'c Conn, font: &[Str]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_font_path<'c, 'input, Conn>(conn: &'c Conn, font: &'input [Str]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -12763,7 +12763,7 @@ impl CreateGCAux {
 /// # See
 ///
 /// * `xcb_generate_id`: function
-pub fn create_gc<'c, Conn>(conn: &'c Conn, cid: Gcontext, drawable: Drawable, value_list: &CreateGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_gc<'c, 'input, Conn>(conn: &'c Conn, cid: Gcontext, drawable: Drawable, value_list: &'input CreateGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13151,7 +13151,7 @@ impl ChangeGCAux {
 ///     xcb_flush(conn);
 /// }
 /// ```
-pub fn change_gc<'c, Conn>(conn: &'c Conn, gc: Gcontext, value_list: &ChangeGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_gc<'c, 'input, Conn>(conn: &'c Conn, gc: Gcontext, value_list: &'input ChangeGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13223,7 +13223,7 @@ where
 
 /// Opcode for the SetDashes request
 pub const SET_DASHES_REQUEST: u8 = 58;
-pub fn set_dashes<'c, Conn>(conn: &'c Conn, gc: Gcontext, dash_offset: u16, dashes: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_dashes<'c, 'input, Conn>(conn: &'c Conn, gc: Gcontext, dash_offset: u16, dashes: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13326,7 +13326,7 @@ impl TryFrom<u32> for ClipOrdering {
 
 /// Opcode for the SetClipRectangles request
 pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
-pub fn set_clip_rectangles<'c, Conn>(conn: &'c Conn, ordering: ClipOrdering, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, ordering: ClipOrdering, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13642,7 +13642,7 @@ impl TryFrom<u32> for CoordMode {
 
 /// Opcode for the PolyPoint request
 pub const POLY_POINT_REQUEST: u8 = 64;
-pub fn poly_point<'c, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_point<'c, 'input, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13716,7 +13716,7 @@ pub const POLY_LINE_REQUEST: u8 = 65;
 ///     xcb_flush(conn);
 /// }
 /// ```
-pub fn poly_line<'c, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_line<'c, 'input, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13827,7 +13827,7 @@ pub const POLY_SEGMENT_REQUEST: u8 = 66;
 /// * `Drawable` - The specified `drawable` does not exist.
 /// * `GContext` - The specified `gc` does not exist.
 /// * `Match` - TODO: reasons?
-pub fn poly_segment<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, segments: &[Segment]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_segment<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, segments: &'input [Segment]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13861,7 +13861,7 @@ where
 
 /// Opcode for the PolyRectangle request
 pub const POLY_RECTANGLE_REQUEST: u8 = 67;
-pub fn poly_rectangle<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_rectangle<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13895,7 +13895,7 @@ where
 
 /// Opcode for the PolyArc request
 pub const POLY_ARC_REQUEST: u8 = 68;
-pub fn poly_arc<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -13994,7 +13994,7 @@ impl TryFrom<u32> for PolyShape {
 
 /// Opcode for the FillPoly request
 pub const FILL_POLY_REQUEST: u8 = 69;
-pub fn fill_poly<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, shape: PolyShape, coordinate_mode: CoordMode, points: &[Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn fill_poly<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, shape: PolyShape, coordinate_mode: CoordMode, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14059,7 +14059,7 @@ pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - TODO: reasons?
-pub fn poly_fill_rectangle<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_fill_rectangle<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14093,7 +14093,7 @@ where
 
 /// Opcode for the PolyFillArc request
 pub const POLY_FILL_ARC_REQUEST: u8 = 71;
-pub fn poly_fill_arc<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_fill_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14192,7 +14192,7 @@ impl TryFrom<u32> for ImageFormat {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 72;
-pub fn put_image<'c, Conn>(conn: &'c Conn, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14332,7 +14332,7 @@ impl GetImageReply {
 
 /// Opcode for the PolyText8 request
 pub const POLY_TEXT8_REQUEST: u8 = 74;
-pub fn poly_text8<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_text8<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14371,7 +14371,7 @@ where
 
 /// Opcode for the PolyText16 request
 pub const POLY_TEXT16_REQUEST: u8 = 75;
-pub fn poly_text16<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn poly_text16<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14444,7 +14444,7 @@ pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 /// # See
 ///
 /// * `ImageText16`: request
-pub fn image_text8<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn image_text8<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14520,7 +14520,7 @@ pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 /// # See
 ///
 /// * `ImageText8`: request
-pub fn image_text16<'c, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[Char2b]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn image_text16<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &'input [Char2b]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -14926,7 +14926,7 @@ impl TryFrom<&[u8]> for AllocColorReply {
 
 /// Opcode for the AllocNamedColor request
 pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
-pub fn alloc_named_color<'c, Conn>(conn: &'c Conn, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
+pub fn alloc_named_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -15174,7 +15174,7 @@ impl AllocColorPlanesReply {
 
 /// Opcode for the FreeColors request
 pub const FREE_COLORS_REQUEST: u8 = 88;
-pub fn free_colors<'c, Conn>(conn: &'c Conn, cmap: Colormap, plane_mask: u32, pixels: &[u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn free_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, plane_mask: u32, pixels: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -15334,7 +15334,7 @@ impl Serialize for Coloritem {
 
 /// Opcode for the StoreColors request
 pub const STORE_COLORS_REQUEST: u8 = 89;
-pub fn store_colors<'c, Conn>(conn: &'c Conn, cmap: Colormap, items: &[Coloritem]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn store_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, items: &'input [Coloritem]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -15363,7 +15363,7 @@ where
 
 /// Opcode for the StoreNamedColor request
 pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
-pub fn store_named_color<'c, Conn, A>(conn: &'c Conn, flags: A, cmap: Colormap, pixel: u32, name: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn store_named_color<'c, 'input, Conn, A>(conn: &'c Conn, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
@@ -15453,7 +15453,7 @@ impl Serialize for Rgb {
 
 /// Opcode for the QueryColors request
 pub const QUERY_COLORS_REQUEST: u8 = 91;
-pub fn query_colors<'c, Conn>(conn: &'c Conn, cmap: Colormap, pixels: &[u32]) -> Result<Cookie<'c, Conn, QueryColorsReply>, ConnectionError>
+pub fn query_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, pixels: &'input [u32]) -> Result<Cookie<'c, Conn, QueryColorsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -15524,7 +15524,7 @@ impl QueryColorsReply {
 
 /// Opcode for the LookupColor request
 pub const LOOKUP_COLOR_REQUEST: u8 = 92;
-pub fn lookup_color<'c, Conn>(conn: &'c Conn, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
+pub fn lookup_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -16092,7 +16092,7 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 ///
 /// * `xdpyinfo`: program
 /// * `xcb_get_extension_data`: function
-pub fn query_extension<'c, Conn>(conn: &'c Conn, name: &[u8]) -> Result<Cookie<'c, Conn, QueryExtensionReply>, ConnectionError>
+pub fn query_extension<'c, 'input, Conn>(conn: &'c Conn, name: &'input [u8]) -> Result<Cookie<'c, Conn, QueryExtensionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -16219,7 +16219,7 @@ impl ListExtensionsReply {
 
 /// Opcode for the ChangeKeyboardMapping request
 pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
-pub fn change_keyboard_mapping<'c, Conn>(conn: &'c Conn, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &[Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_keyboard_mapping<'c, 'input, Conn>(conn: &'c Conn, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &'input [Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -16657,7 +16657,7 @@ impl ChangeKeyboardControlAux {
     }
 }
 
-pub fn change_keyboard_control<'c, Conn>(conn: &'c Conn, value_list: &ChangeKeyboardControlAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_keyboard_control<'c, 'input, Conn>(conn: &'c Conn, value_list: &'input ChangeKeyboardControlAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -17207,7 +17207,7 @@ impl TryFrom<u32> for Family {
 
 /// Opcode for the ChangeHosts request
 pub const CHANGE_HOSTS_REQUEST: u8 = 109;
-pub fn change_hosts<'c, Conn>(conn: &'c Conn, mode: HostMode, family: Family, address: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn change_hosts<'c, 'input, Conn>(conn: &'c Conn, mode: HostMode, family: Family, address: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -17645,7 +17645,7 @@ where
 
 /// Opcode for the RotateProperties request
 pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
-pub fn rotate_properties<'c, Conn>(conn: &'c Conn, window: Window, delta: i16, atoms: &[Atom]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn rotate_properties<'c, 'input, Conn>(conn: &'c Conn, window: Window, delta: i16, atoms: &'input [Atom]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -17837,7 +17837,7 @@ impl TryFrom<u32> for MappingStatus {
 
 /// Opcode for the SetPointerMapping request
 pub const SET_POINTER_MAPPING_REQUEST: u8 = 116;
-pub fn set_pointer_mapping<'c, Conn>(conn: &'c Conn, map: &[u8]) -> Result<Cookie<'c, Conn, SetPointerMappingReply>, ConnectionError>
+pub fn set_pointer_mapping<'c, 'input, Conn>(conn: &'c Conn, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetPointerMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -18029,7 +18029,7 @@ impl TryFrom<u32> for MapIndex {
 
 /// Opcode for the SetModifierMapping request
 pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
-pub fn set_modifier_mapping<'c, Conn>(conn: &'c Conn, keycodes: &[Keycode]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>
+pub fn set_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, keycodes: &'input [Keycode]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -18217,7 +18217,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `xcb_generate_id`: function
     /// * `MapWindow`: request
     /// * `CreateNotify`: event
-    fn create_window<'c>(&'c self, depth: u8, wid: Window, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: WindowClass, visual: Visualid, value_list: &CreateWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn create_window<'c, 'input>(&'c self, depth: u8, wid: Window, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: WindowClass, visual: Visualid, value_list: &'input CreateWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_window(self, depth, wid, parent, x, y, width, height, border_width, class, visual, value_list)
     }
@@ -18242,7 +18242,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Pixmap` - TODO: reasons?
     /// * `Value` - TODO: reasons?
     /// * `Window` - The specified `window` does not exist.
-    fn change_window_attributes<'c>(&'c self, window: Window, value_list: &ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_window_attributes<'c, 'input>(&'c self, window: Window, value_list: &'input ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_window_attributes(self, window, value_list)
     }
@@ -18476,7 +18476,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(c);
     /// }
     /// ```
-    fn configure_window<'c>(&'c self, window: Window, value_list: &ConfigureWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn configure_window<'c, 'input>(&'c self, window: Window, value_list: &'input ConfigureWindowAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         configure_window(self, window, value_list)
     }
@@ -18627,7 +18627,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     }
     /// }
     /// ```
-    fn intern_atom<'c>(&'c self, only_if_exists: bool, name: &[u8]) -> Result<Cookie<'c, Self, InternAtomReply>, ConnectionError>
+    fn intern_atom<'c, 'input>(&'c self, only_if_exists: bool, name: &'input [u8]) -> Result<Cookie<'c, Self, InternAtomReply>, ConnectionError>
     {
         intern_atom(self, only_if_exists, name)
     }
@@ -18686,7 +18686,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(conn);
     /// }
     /// ```
-    fn change_property<'c, A, B>(&'c self, mode: PropMode, window: Window, property: A, type_: B, format: u8, data_len: u32, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_property<'c, 'input, A, B>(&'c self, mode: PropMode, window: Window, property: A, type_: B, format: u8, data_len: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<Atom>,
         B: Into<Atom>,
@@ -19462,7 +19462,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * `xcb_generate_id`: function
-    fn open_font<'c>(&'c self, fid: Font, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn open_font<'c, 'input>(&'c self, fid: Font, name: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         open_font(self, fid, name)
     }
@@ -19515,7 +19515,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `GContext` - The specified graphics context does not exist.
     /// * `Font` - The specified `font` does not exist.
-    fn query_text_extents<'c>(&'c self, font: Fontable, string: &[Char2b]) -> Result<Cookie<'c, Self, QueryTextExtentsReply>, ConnectionError>
+    fn query_text_extents<'c, 'input>(&'c self, font: Fontable, string: &'input [Char2b]) -> Result<Cookie<'c, Self, QueryTextExtentsReply>, ConnectionError>
     {
         query_text_extents(self, font, string)
     }
@@ -19532,7 +19532,7 @@ pub trait ConnectionExt: RequestConnection {
     /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
     /// not matter.
     /// * `max_names` - The maximum number of fonts to be returned.
-    fn list_fonts<'c>(&'c self, max_names: u16, pattern: &[u8]) -> Result<Cookie<'c, Self, ListFontsReply>, ConnectionError>
+    fn list_fonts<'c, 'input>(&'c self, max_names: u16, pattern: &'input [u8]) -> Result<Cookie<'c, Self, ListFontsReply>, ConnectionError>
     {
         list_fonts(self, max_names, pattern)
     }
@@ -19549,11 +19549,11 @@ pub trait ConnectionExt: RequestConnection {
     /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
     /// not matter.
     /// * `max_names` - The maximum number of fonts to be returned.
-    fn list_fonts_with_info<'c>(&'c self, max_names: u16, pattern: &[u8]) -> Result<ListFontsWithInfoCookie<'c, Self>, ConnectionError>
+    fn list_fonts_with_info<'c, 'input>(&'c self, max_names: u16, pattern: &'input [u8]) -> Result<ListFontsWithInfoCookie<'c, Self>, ConnectionError>
     {
         list_fonts_with_info(self, max_names, pattern)
     }
-    fn set_font_path<'c>(&'c self, font: &[Str]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn set_font_path<'c, 'input>(&'c self, font: &'input [Str]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_font_path(self, font)
     }
@@ -19627,7 +19627,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * `xcb_generate_id`: function
-    fn create_gc<'c>(&'c self, cid: Gcontext, drawable: Drawable, value_list: &CreateGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn create_gc<'c, 'input>(&'c self, cid: Gcontext, drawable: Drawable, value_list: &'input CreateGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_gc(self, cid, drawable, value_list)
     }
@@ -19676,7 +19676,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(conn);
     /// }
     /// ```
-    fn change_gc<'c>(&'c self, gc: Gcontext, value_list: &ChangeGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_gc<'c, 'input>(&'c self, gc: Gcontext, value_list: &'input ChangeGCAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_gc(self, gc, value_list)
     }
@@ -19686,11 +19686,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         copy_gc(self, src_gc, dst_gc, value_mask)
     }
-    fn set_dashes<'c>(&'c self, gc: Gcontext, dash_offset: u16, dashes: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn set_dashes<'c, 'input>(&'c self, gc: Gcontext, dash_offset: u16, dashes: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_dashes(self, gc, dash_offset, dashes)
     }
-    fn set_clip_rectangles<'c>(&'c self, ordering: ClipOrdering, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn set_clip_rectangles<'c, 'input>(&'c self, ordering: ClipOrdering, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_clip_rectangles(self, ordering, gc, clip_x_origin, clip_y_origin, rectangles)
     }
@@ -19742,7 +19742,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         copy_plane(self, src_drawable, dst_drawable, gc, src_x, src_y, dst_x, dst_y, width, height, bit_plane)
     }
-    fn poly_point<'c>(&'c self, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_point<'c, 'input>(&'c self, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &'input [Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_point(self, coordinate_mode, drawable, gc, points)
     }
@@ -19785,7 +19785,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     xcb_flush(conn);
     /// }
     /// ```
-    fn poly_line<'c>(&'c self, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_line<'c, 'input>(&'c self, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &'input [Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_line(self, coordinate_mode, drawable, gc, points)
     }
@@ -19815,19 +19815,19 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Drawable` - The specified `drawable` does not exist.
     /// * `GContext` - The specified `gc` does not exist.
     /// * `Match` - TODO: reasons?
-    fn poly_segment<'c>(&'c self, drawable: Drawable, gc: Gcontext, segments: &[Segment]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_segment<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, segments: &'input [Segment]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_segment(self, drawable, gc, segments)
     }
-    fn poly_rectangle<'c>(&'c self, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_rectangle<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_rectangle(self, drawable, gc, rectangles)
     }
-    fn poly_arc<'c>(&'c self, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_arc<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_arc(self, drawable, gc, arcs)
     }
-    fn fill_poly<'c>(&'c self, drawable: Drawable, gc: Gcontext, shape: PolyShape, coordinate_mode: CoordMode, points: &[Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn fill_poly<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, shape: PolyShape, coordinate_mode: CoordMode, points: &'input [Point]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         fill_poly(self, drawable, gc, shape, coordinate_mode, points)
     }
@@ -19856,15 +19856,15 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
     /// * `GContext` - The specified graphics context does not exist.
     /// * `Match` - TODO: reasons?
-    fn poly_fill_rectangle<'c>(&'c self, drawable: Drawable, gc: Gcontext, rectangles: &[Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_fill_rectangle<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_fill_rectangle(self, drawable, gc, rectangles)
     }
-    fn poly_fill_arc<'c>(&'c self, drawable: Drawable, gc: Gcontext, arcs: &[Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_fill_arc<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_fill_arc(self, drawable, gc, arcs)
     }
-    fn put_image<'c>(&'c self, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn put_image<'c, 'input>(&'c self, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         put_image(self, format, drawable, gc, width, height, dst_x, dst_y, left_pad, depth, data)
     }
@@ -19872,11 +19872,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_image(self, format, drawable, x, y, width, height, plane_mask)
     }
-    fn poly_text8<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_text8<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_text8(self, drawable, gc, x, y, items)
     }
-    fn poly_text16<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn poly_text16<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         poly_text16(self, drawable, gc, x, y, items)
     }
@@ -19914,7 +19914,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * `ImageText16`: request
-    fn image_text8<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn image_text8<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         image_text8(self, drawable, gc, x, y, string)
     }
@@ -19953,7 +19953,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * `ImageText8`: request
-    fn image_text16<'c>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &[Char2b]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn image_text16<'c, 'input>(&'c self, drawable: Drawable, gc: Gcontext, x: i16, y: i16, string: &'input [Char2b]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         image_text16(self, drawable, gc, x, y, string)
     }
@@ -20003,7 +20003,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         alloc_color(self, cmap, red, green, blue)
     }
-    fn alloc_named_color<'c>(&'c self, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Self, AllocNamedColorReply>, ConnectionError>
+    fn alloc_named_color<'c, 'input>(&'c self, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Self, AllocNamedColorReply>, ConnectionError>
     {
         alloc_named_color(self, cmap, name)
     }
@@ -20015,25 +20015,25 @@ pub trait ConnectionExt: RequestConnection {
     {
         alloc_color_planes(self, contiguous, cmap, colors, reds, greens, blues)
     }
-    fn free_colors<'c>(&'c self, cmap: Colormap, plane_mask: u32, pixels: &[u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn free_colors<'c, 'input>(&'c self, cmap: Colormap, plane_mask: u32, pixels: &'input [u32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         free_colors(self, cmap, plane_mask, pixels)
     }
-    fn store_colors<'c>(&'c self, cmap: Colormap, items: &[Coloritem]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn store_colors<'c, 'input>(&'c self, cmap: Colormap, items: &'input [Coloritem]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         store_colors(self, cmap, items)
     }
-    fn store_named_color<'c, A>(&'c self, flags: A, cmap: Colormap, pixel: u32, name: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn store_named_color<'c, 'input, A>(&'c self, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u8>,
     {
         store_named_color(self, flags, cmap, pixel, name)
     }
-    fn query_colors<'c>(&'c self, cmap: Colormap, pixels: &[u32]) -> Result<Cookie<'c, Self, QueryColorsReply>, ConnectionError>
+    fn query_colors<'c, 'input>(&'c self, cmap: Colormap, pixels: &'input [u32]) -> Result<Cookie<'c, Self, QueryColorsReply>, ConnectionError>
     {
         query_colors(self, cmap, pixels)
     }
-    fn lookup_color<'c>(&'c self, cmap: Colormap, name: &[u8]) -> Result<Cookie<'c, Self, LookupColorReply>, ConnectionError>
+    fn lookup_color<'c, 'input>(&'c self, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Self, LookupColorReply>, ConnectionError>
     {
         lookup_color(self, cmap, name)
     }
@@ -20128,7 +20128,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `xdpyinfo`: program
     /// * `xcb_get_extension_data`: function
-    fn query_extension<'c>(&'c self, name: &[u8]) -> Result<Cookie<'c, Self, QueryExtensionReply>, ConnectionError>
+    fn query_extension<'c, 'input>(&'c self, name: &'input [u8]) -> Result<Cookie<'c, Self, QueryExtensionReply>, ConnectionError>
     {
         query_extension(self, name)
     }
@@ -20136,7 +20136,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         list_extensions(self)
     }
-    fn change_keyboard_mapping<'c>(&'c self, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &[Keysym]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_keyboard_mapping<'c, 'input>(&'c self, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &'input [Keysym]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_keyboard_mapping(self, keycode_count, first_keycode, keysyms_per_keycode, keysyms)
     }
@@ -20144,7 +20144,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_keyboard_mapping(self, first_keycode, count)
     }
-    fn change_keyboard_control<'c>(&'c self, value_list: &ChangeKeyboardControlAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_keyboard_control<'c, 'input>(&'c self, value_list: &'input ChangeKeyboardControlAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_keyboard_control(self, value_list)
     }
@@ -20172,7 +20172,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_screen_saver(self)
     }
-    fn change_hosts<'c>(&'c self, mode: HostMode, family: Family, address: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn change_hosts<'c, 'input>(&'c self, mode: HostMode, family: Family, address: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         change_hosts(self, mode, family, address)
     }
@@ -20213,7 +20213,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         kill_client(self, resource)
     }
-    fn rotate_properties<'c>(&'c self, window: Window, delta: i16, atoms: &[Atom]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn rotate_properties<'c, 'input>(&'c self, window: Window, delta: i16, atoms: &'input [Atom]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         rotate_properties(self, window, delta, atoms)
     }
@@ -20221,7 +20221,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         force_screen_saver(self, mode)
     }
-    fn set_pointer_mapping<'c>(&'c self, map: &[u8]) -> Result<Cookie<'c, Self, SetPointerMappingReply>, ConnectionError>
+    fn set_pointer_mapping<'c, 'input>(&'c self, map: &'input [u8]) -> Result<Cookie<'c, Self, SetPointerMappingReply>, ConnectionError>
     {
         set_pointer_mapping(self, map)
     }
@@ -20229,7 +20229,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_pointer_mapping(self)
     }
-    fn set_modifier_mapping<'c>(&'c self, keycodes: &[Keycode]) -> Result<Cookie<'c, Self, SetModifierMappingReply>, ConnectionError>
+    fn set_modifier_mapping<'c, 'input>(&'c self, keycodes: &'input [Keycode]) -> Result<Cookie<'c, Self, SetModifierMappingReply>, ConnectionError>
     {
         set_modifier_mapping(self, keycodes)
     }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -23163,7 +23163,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     free(event);
     /// }
     /// ```
-    fn send_event<'c, 'input, A, B, C>(&'c self, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn send_event<A, B, C>(&self, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<Window>,
         B: Into<u32>,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -5750,8 +5751,6 @@ impl Gravity {
     }
 }
 
-/// Opcode for the CreateWindow request
-pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// Auxiliary and optional information for the `create_window` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreateWindowAux {
@@ -6013,70 +6012,163 @@ impl CreateWindowAux {
 /// * `xcb_generate_id`: function
 /// * `MapWindow`: request
 /// * `CreateNotify`: event
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateWindowRequest<'input> {
+    pub depth: u8,
+    pub wid: Window,
+    pub parent: Window,
+    pub x: i16,
+    pub y: i16,
+    pub width: u16,
+    pub height: u16,
+    pub border_width: u16,
+    pub class: WindowClass,
+    pub visual: Visualid,
+    pub value_list: &'input CreateWindowAux,
+}
+impl<'input> CreateWindowRequest<'input> {
+    /// Opcode for the CreateWindow request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let depth_bytes = self.depth.serialize();
+        let wid_bytes = self.wid.serialize();
+        let parent_bytes = self.parent.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let border_width_bytes = self.border_width.serialize();
+        let class_bytes = u16::from(self.class).serialize();
+        let visual_bytes = self.visual.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            CreateWindowRequest::opcode(),
+            depth_bytes[0],
+            0,
+            0,
+            wid_bytes[0],
+            wid_bytes[1],
+            wid_bytes[2],
+            wid_bytes[3],
+            parent_bytes[0],
+            parent_bytes[1],
+            parent_bytes[2],
+            parent_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            border_width_bytes[0],
+            border_width_bytes[1],
+            class_bytes[0],
+            class_bytes[1],
+            visual_bytes[0],
+            visual_bytes[1],
+            visual_bytes[2],
+            visual_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
+/// Creates a window.
+///
+/// Creates an unmapped window as child of the specified `parent` window. A
+/// CreateNotify event will be generated. The new window is placed on top in the
+/// stacking order with respect to siblings.
+///
+/// The coordinate system has the X axis horizontal and the Y axis vertical with
+/// the origin [0, 0] at the upper-left corner. Coordinates are integral, in terms
+/// of pixels, and coincide with pixel centers. Each window and pixmap has its own
+/// coordinate system. For a window, the origin is inside the border at the inside,
+/// upper-left corner.
+///
+/// The created window is not yet displayed (mapped), call `xcb_map_window` to
+/// display it.
+///
+/// The created window will initially use the same cursor as its parent.
+///
+/// # Fields
+///
+/// * `wid` - The ID with which you will refer to the new window, created by
+/// `xcb_generate_id`.
+/// * `depth` - Specifies the new window's depth (TODO: what unit?).
+///
+/// The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
+/// `parent` window.
+/// * `visual` - Specifies the id for the new window's visual.
+///
+/// The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
+/// `parent` window.
+/// * `class` -
+/// * `parent` - The parent window of the new window.
+/// * `border_width` - TODO:
+///
+/// Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
+/// * `x` - The X coordinate of the new window.
+/// * `y` - The Y coordinate of the new window.
+/// * `width` - The width of the new window.
+/// * `height` - The height of the new window.
+///
+/// # Errors
+///
+/// * `Colormap` - TODO: reasons?
+/// * `Match` - TODO: reasons?
+/// * `Cursor` - TODO: reasons?
+/// * `Pixmap` - TODO: reasons?
+/// * `Value` - TODO: reasons?
+/// * `Window` - TODO: reasons?
+/// * `Alloc` - The X server could not allocate the requested resources (no memory?).
+///
+/// # See
+///
+/// * `xcb_generate_id`: function
+/// * `MapWindow`: request
+/// * `CreateNotify`: event
 pub fn create_window<'c, 'input, Conn>(conn: &'c Conn, depth: u8, wid: Window, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: WindowClass, visual: Visualid, value_list: &'input CreateWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let depth_bytes = depth.serialize();
-    let wid_bytes = wid.serialize();
-    let parent_bytes = parent.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let border_width_bytes = border_width.serialize();
-    let class_bytes = u16::from(class).serialize();
-    let visual_bytes = visual.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        CREATE_WINDOW_REQUEST,
-        depth_bytes[0],
-        0,
-        0,
-        wid_bytes[0],
-        wid_bytes[1],
-        wid_bytes[2],
-        wid_bytes[3],
-        parent_bytes[0],
-        parent_bytes[1],
-        parent_bytes[2],
-        parent_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        border_width_bytes[0],
-        border_width_bytes[1],
-        class_bytes[0],
-        class_bytes[1],
-        visual_bytes[0],
-        visual_bytes[1],
-        visual_bytes[2],
-        visual_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateWindowRequest {
+        depth: depth,
+        wid: wid,
+        parent: parent,
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+        border_width: border_width,
+        class: class,
+        visual: visual,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangeWindowAttributes request
-pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// Auxiliary and optional information for the `change_window_attributes` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangeWindowAttributesAux {
@@ -6305,37 +6397,81 @@ impl ChangeWindowAttributesAux {
 /// * `Pixmap` - TODO: reasons?
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeWindowAttributesRequest<'input> {
+    pub window: Window,
+    pub value_list: &'input ChangeWindowAttributesAux,
+}
+impl<'input> ChangeWindowAttributesRequest<'input> {
+    /// Opcode for the ChangeWindowAttributes request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            ChangeWindowAttributesRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
+/// change window attributes.
+///
+/// Changes the attributes specified by `value_mask` for the specified `window`.
+///
+/// # Fields
+///
+/// * `window` - The window to change.
+/// * `value_mask` -
+/// * `value_list` - Values for each of the attributes specified in the bitmask `value_mask`. The
+/// order has to correspond to the order of possible `value_mask` bits. See the
+/// example.
+///
+/// # Errors
+///
+/// * `Access` - TODO: reasons?
+/// * `Colormap` - TODO: reasons?
+/// * `Cursor` - TODO: reasons?
+/// * `Match` - TODO: reasons?
+/// * `Pixmap` - TODO: reasons?
+/// * `Value` - TODO: reasons?
+/// * `Window` - The specified `window` does not exist.
 pub fn change_window_attributes<'c, 'input, Conn>(conn: &'c Conn, window: Window, value_list: &'input ChangeWindowAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        CHANGE_WINDOW_ATTRIBUTES_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeWindowAttributesRequest {
+        window: window,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6403,8 +6539,50 @@ impl TryFrom<u32> for MapState {
     }
 }
 
-/// Opcode for the GetWindowAttributes request
-pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
+/// Gets window attributes.
+///
+/// Gets the current attributes for the specified `window`.
+///
+/// # Fields
+///
+/// * `window` - The window to get the attributes from.
+///
+/// # Errors
+///
+/// * `Window` - The specified `window` does not exist.
+/// * `Drawable` - TODO: reasons?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetWindowAttributesRequest {
+    pub window: Window,
+}
+impl GetWindowAttributesRequest {
+    /// Opcode for the GetWindowAttributes request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            GetWindowAttributesRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Gets window attributes.
 ///
 /// Gets the current attributes for the specified `window`.
@@ -6421,23 +6599,12 @@ pub fn get_window_attributes<Conn>(conn: &Conn, window: Window) -> Result<Cookie
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        GET_WINDOW_ATTRIBUTES_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetWindowAttributesRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -6514,8 +6681,60 @@ impl TryFrom<&[u8]> for GetWindowAttributesReply {
     }
 }
 
-/// Opcode for the DestroyWindow request
-pub const DESTROY_WINDOW_REQUEST: u8 = 4;
+/// Destroys a window.
+///
+/// Destroys the specified window and all of its subwindows. A DestroyNotify event
+/// is generated for each destroyed window (a DestroyNotify event is first generated
+/// for any given window's inferiors). If the window was mapped, it will be
+/// automatically unmapped before destroying.
+///
+/// Calling DestroyWindow on the root window will do nothing.
+///
+/// # Fields
+///
+/// * `window` - The window to destroy.
+///
+/// # Errors
+///
+/// * `Window` - The specified window does not exist.
+///
+/// # See
+///
+/// * `DestroyNotify`: event
+/// * `MapWindow`: request
+/// * `UnmapWindow`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroyWindowRequest {
+    pub window: Window,
+}
+impl DestroyWindowRequest {
+    /// Opcode for the DestroyWindow request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            DestroyWindowRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Destroys a window.
 ///
 /// Destroys the specified window and all of its subwindows. A DestroyNotify event
@@ -6542,48 +6761,56 @@ pub fn destroy_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        DESTROY_WINDOW_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroyWindowRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DestroySubwindows request
-pub const DESTROY_SUBWINDOWS_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroySubwindowsRequest {
+    pub window: Window,
+}
+impl DestroySubwindowsRequest {
+    /// Opcode for the DestroySubwindows request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            DestroySubwindowsRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        DESTROY_SUBWINDOWS_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroySubwindowsRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6656,8 +6883,62 @@ impl TryFrom<u32> for SetMode {
     }
 }
 
-/// Opcode for the ChangeSaveSet request
-pub const CHANGE_SAVE_SET_REQUEST: u8 = 6;
+/// Changes a client's save set.
+///
+/// TODO: explain what the save set is for.
+///
+/// This function either adds or removes the specified window to the client's (your
+/// application's) save set.
+///
+/// # Fields
+///
+/// * `mode` - Insert to add the specified window to the save set or Delete to delete it from the save set.
+/// * `window` - The window to add or delete to/from your save set.
+///
+/// # Errors
+///
+/// * `Match` - You created the specified window. This does not make sense, you can only add
+/// windows created by other clients to your save set.
+/// * `Value` - You specified an invalid mode.
+/// * `Window` - The specified window does not exist.
+///
+/// # See
+///
+/// * `ReparentWindow`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeSaveSetRequest {
+    pub mode: SetMode,
+    pub window: Window,
+}
+impl ChangeSaveSetRequest {
+    /// Opcode for the ChangeSaveSet request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mode_bytes = u8::from(self.mode).serialize();
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            ChangeSaveSetRequest::opcode(),
+            mode_bytes[0],
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Changes a client's save set.
 ///
 /// TODO: explain what the save set is for.
@@ -6684,28 +6965,93 @@ pub fn change_save_set<Conn>(conn: &Conn, mode: SetMode, window: Window) -> Resu
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mode_bytes = u8::from(mode).serialize();
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        CHANGE_SAVE_SET_REQUEST,
-        mode_bytes[0],
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ChangeSaveSetRequest {
+        mode: mode,
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ReparentWindow request
-pub const REPARENT_WINDOW_REQUEST: u8 = 7;
+/// Reparents a window.
+///
+/// Makes the specified window a child of the specified parent window. If the
+/// window is mapped, it will automatically be unmapped before reparenting and
+/// re-mapped after reparenting. The window is placed in the stacking order on top
+/// with respect to sibling windows.
+///
+/// After reparenting, a ReparentNotify event is generated.
+///
+/// # Fields
+///
+/// * `window` - The window to reparent.
+/// * `parent` - The new parent of the window.
+/// * `x` - The X position of the window within its new parent.
+/// * `y` - The Y position of the window within its new parent.
+///
+/// # Errors
+///
+/// * `Match` - The new parent window is not on the same screen as the old parent window.
+/// 
+/// The new parent window is the specified window or an inferior of the specified window.
+/// 
+/// The new parent is InputOnly and the window is not.
+/// 
+/// The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
+/// * `Window` - The specified window does not exist.
+///
+/// # See
+///
+/// * `ReparentNotify`: event
+/// * `MapWindow`: request
+/// * `UnmapWindow`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReparentWindowRequest {
+    pub window: Window,
+    pub parent: Window,
+    pub x: i16,
+    pub y: i16,
+}
+impl ReparentWindowRequest {
+    /// Opcode for the ReparentWindow request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let parent_bytes = self.parent.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mut request0 = vec![
+            ReparentWindowRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            parent_bytes[0],
+            parent_bytes[1],
+            parent_bytes[2],
+            parent_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Reparents a window.
 ///
 /// Makes the specified window a child of the specified parent window. If the
@@ -6742,38 +7088,84 @@ pub fn reparent_window<Conn>(conn: &Conn, window: Window, parent: Window, x: i16
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let parent_bytes = parent.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mut request0 = [
-        REPARENT_WINDOW_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        parent_bytes[0],
-        parent_bytes[1],
-        parent_bytes[2],
-        parent_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ReparentWindowRequest {
+        window: window,
+        parent: parent,
+        x: x,
+        y: y,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the MapWindow request
-pub const MAP_WINDOW_REQUEST: u8 = 8;
+/// Makes a window visible.
+///
+/// Maps the specified window. This means making the window visible (as long as its
+/// parent is visible).
+///
+/// This MapWindow request will be translated to a MapRequest request if a window
+/// manager is running. The window manager then decides to either map the window or
+/// not. Set the override-redirect window attribute to true if you want to bypass
+/// this mechanism.
+///
+/// If the window manager decides to map the window (or if no window manager is
+/// running), a MapNotify event is generated.
+///
+/// If the window becomes viewable and no earlier contents for it are remembered,
+/// the X server tiles the window with its background. If the window's background
+/// is undefined, the existing screen contents are not altered, and the X server
+/// generates zero or more Expose events.
+///
+/// If the window type is InputOutput, an Expose event will be generated when the
+/// window becomes visible. The normal response to an Expose event should be to
+/// repaint the window.
+///
+/// # Fields
+///
+/// * `window` - The window to make visible.
+///
+/// # Errors
+///
+/// * `Match` - The specified window does not exist.
+///
+/// # See
+///
+/// * `MapNotify`: event
+/// * `Expose`: event
+/// * `UnmapWindow`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MapWindowRequest {
+    pub window: Window,
+}
+impl MapWindowRequest {
+    /// Opcode for the MapWindow request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            MapWindowRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Makes a window visible.
 ///
 /// Maps the specified window. This means making the window visible (as long as its
@@ -6813,52 +7205,111 @@ pub fn map_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Co
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        MAP_WINDOW_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = MapWindowRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the MapSubwindows request
-pub const MAP_SUBWINDOWS_REQUEST: u8 = 9;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MapSubwindowsRequest {
+    pub window: Window,
+}
+impl MapSubwindowsRequest {
+    /// Opcode for the MapSubwindows request
+    pub const fn opcode() -> u8 { 9 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            MapSubwindowsRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn map_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        MAP_SUBWINDOWS_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = MapSubwindowsRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UnmapWindow request
-pub const UNMAP_WINDOW_REQUEST: u8 = 10;
+/// Makes a window invisible.
+///
+/// Unmaps the specified window. This means making the window invisible (and all
+/// its child windows).
+///
+/// Unmapping a window leads to the `UnmapNotify` event being generated. Also,
+/// `Expose` events are generated for formerly obscured windows.
+///
+/// # Fields
+///
+/// * `window` - The window to make invisible.
+///
+/// # Errors
+///
+/// * `Window` - The specified window does not exist.
+///
+/// # See
+///
+/// * `UnmapNotify`: event
+/// * `Expose`: event
+/// * `MapWindow`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnmapWindowRequest {
+    pub window: Window,
+}
+impl UnmapWindowRequest {
+    /// Opcode for the UnmapWindow request
+    pub const fn opcode() -> u8 { 10 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            UnmapWindowRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Makes a window invisible.
 ///
 /// Unmaps the specified window. This means making the window invisible (and all
@@ -6884,48 +7335,56 @@ pub fn unmap_window<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, 
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        UNMAP_WINDOW_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UnmapWindowRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UnmapSubwindows request
-pub const UNMAP_SUBWINDOWS_REQUEST: u8 = 11;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnmapSubwindowsRequest {
+    pub window: Window,
+}
+impl UnmapSubwindowsRequest {
+    /// Opcode for the UnmapSubwindows request
+    pub const fn opcode() -> u8 { 11 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            UnmapSubwindowsRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn unmap_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        UNMAP_SUBWINDOWS_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UnmapSubwindowsRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7078,8 +7537,6 @@ impl TryFrom<u32> for StackMode {
     }
 }
 
-/// Opcode for the ConfigureWindow request
-pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 /// Auxiliary and optional information for the `configure_window` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ConfigureWindowAux {
@@ -7241,37 +7698,110 @@ impl ConfigureWindowAux {
 ///     xcb_flush(c);
 /// }
 /// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConfigureWindowRequest<'input> {
+    pub window: Window,
+    pub value_list: &'input ConfigureWindowAux,
+}
+impl<'input> ConfigureWindowRequest<'input> {
+    /// Opcode for the ConfigureWindow request
+    pub const fn opcode() -> u8 { 12 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let value_mask = u16::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            ConfigureWindowRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
+/// Configures window attributes.
+///
+/// Configures a window's size, position, border width and stacking order.
+///
+/// # Fields
+///
+/// * `window` - The window to configure.
+/// * `value_mask` - Bitmask of attributes to change.
+/// * `value_list` - New values, corresponding to the attributes in value_mask. The order has to
+/// correspond to the order of possible `value_mask` bits. See the example.
+///
+/// # Errors
+///
+/// * `Match` - You specified a Sibling without also specifying StackMode or the window is not
+/// actually a Sibling.
+/// * `Window` - The specified window does not exist. TODO: any other reason?
+/// * `Value` - TODO: reasons?
+///
+/// # See
+///
+/// * `MapNotify`: event
+/// * `Expose`: event
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Configures the given window to the left upper corner
+///  * with a size of 1024x768 pixels.
+///  *
+///  */
+/// void my_example(xcb_connection_t *c, xcb_window_t window) {
+///     uint16_t mask = 0;
+///
+///     mask |= XCB_CONFIG_WINDOW_X;
+///     mask |= XCB_CONFIG_WINDOW_Y;
+///     mask |= XCB_CONFIG_WINDOW_WIDTH;
+///     mask |= XCB_CONFIG_WINDOW_HEIGHT;
+///
+///     const uint32_t values[] = {
+///         0,    /* x */
+///         0,    /* y */
+///         1024, /* width */
+///         768   /* height */
+///     };
+///
+///     xcb_configure_window(c, window, mask, values);
+///     xcb_flush(c);
+/// }
+/// ```
 pub fn configure_window<'c, 'input, Conn>(conn: &'c Conn, window: Window, value_list: &'input ConfigureWindowAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let value_mask = u16::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        CONFIGURE_WINDOW_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ConfigureWindowRequest {
+        window: window,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7344,8 +7874,57 @@ impl TryFrom<u32> for Circulate {
     }
 }
 
-/// Opcode for the CirculateWindow request
-pub const CIRCULATE_WINDOW_REQUEST: u8 = 13;
+/// Change window stacking order.
+///
+/// If `direction` is `XCB_CIRCULATE_RAISE_LOWEST`, the lowest mapped child (if
+/// any) will be raised to the top of the stack.
+///
+/// If `direction` is `XCB_CIRCULATE_LOWER_HIGHEST`, the highest mapped child will
+/// be lowered to the bottom of the stack.
+///
+/// # Fields
+///
+/// * `direction` -
+/// * `window` - The window to raise/lower (depending on `direction`).
+///
+/// # Errors
+///
+/// * `Window` - The specified `window` does not exist.
+/// * `Value` - The specified `direction` is invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CirculateWindowRequest {
+    pub direction: Circulate,
+    pub window: Window,
+}
+impl CirculateWindowRequest {
+    /// Opcode for the CirculateWindow request
+    pub const fn opcode() -> u8 { 13 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let direction_bytes = u8::from(self.direction).serialize();
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            CirculateWindowRequest::opcode(),
+            direction_bytes[0],
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Change window stacking order.
 ///
 /// If `direction` is `XCB_CIRCULATE_RAISE_LOWEST`, the lowest mapped child (if
@@ -7367,28 +7946,83 @@ pub fn circulate_window<Conn>(conn: &Conn, direction: Circulate, window: Window)
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let direction_bytes = u8::from(direction).serialize();
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        CIRCULATE_WINDOW_REQUEST,
-        direction_bytes[0],
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CirculateWindowRequest {
+        direction: direction,
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetGeometry request
-pub const GET_GEOMETRY_REQUEST: u8 = 14;
+/// Get current window geometry.
+///
+/// Gets the current geometry of the specified drawable (either `Window` or `Pixmap`).
+///
+/// # Fields
+///
+/// * `drawable` - The drawable (`Window` or `Pixmap`) of which the geometry will be received.
+///
+/// # Errors
+///
+/// * `Drawable` - TODO: reasons?
+/// * `Window` - TODO: reasons?
+///
+/// # See
+///
+/// * `xwininfo`: program
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Displays the x and y position of the given window.
+///  *
+///  */
+/// void my_example(xcb_connection_t *c, xcb_window_t window) {
+///     xcb_get_geometry_cookie_t cookie;
+///     xcb_get_geometry_reply_t *reply;
+///
+///     cookie = xcb_get_geometry(c, window);
+///     /* ... do other work here if possible ... */
+///     if ((reply = xcb_get_geometry_reply(c, cookie, NULL))) {
+///         printf("This window is at %d, %d\\n", reply->x, reply->y);
+///     }
+///     free(reply);
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetGeometryRequest {
+    pub drawable: Drawable,
+}
+impl GetGeometryRequest {
+    /// Opcode for the GetGeometry request
+    pub const fn opcode() -> u8 { 14 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let mut request0 = vec![
+            GetGeometryRequest::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Get current window geometry.
 ///
 /// Gets the current geometry of the specified drawable (either `Window` or `Pixmap`).
@@ -7429,23 +8063,12 @@ pub fn get_geometry<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, 
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let mut request0 = [
-        GET_GEOMETRY_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetGeometryRequest {
+        drawable: drawable,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -7498,8 +8121,75 @@ impl TryFrom<&[u8]> for GetGeometryReply {
     }
 }
 
-/// Opcode for the QueryTree request
-pub const QUERY_TREE_REQUEST: u8 = 15;
+/// query the window tree.
+///
+/// Gets the root window ID, parent window ID and list of children windows for the
+/// specified `window`. The children are listed in bottom-to-top stacking order.
+///
+/// # Fields
+///
+/// * `window` - The `window` to query.
+///
+/// # See
+///
+/// * `xwininfo`: program
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Displays the root, parent and children of the specified window.
+///  *
+///  */
+/// void my_example(xcb_connection_t *conn, xcb_window_t window) {
+///     xcb_query_tree_cookie_t cookie;
+///     xcb_query_tree_reply_t *reply;
+///
+///     cookie = xcb_query_tree(conn, window);
+///     if ((reply = xcb_query_tree_reply(conn, cookie, NULL))) {
+///         printf("root = 0x%08x\\n", reply->root);
+///         printf("parent = 0x%08x\\n", reply->parent);
+///
+///         xcb_window_t *children = xcb_query_tree_children(reply);
+///         for (int i = 0; i < xcb_query_tree_children_length(reply); i++)
+///             printf("child window = 0x%08x\\n", children[i]);
+///
+///         free(reply);
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryTreeRequest {
+    pub window: Window,
+}
+impl QueryTreeRequest {
+    /// Opcode for the QueryTree request
+    pub const fn opcode() -> u8 { 15 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            QueryTreeRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// query the window tree.
 ///
 /// Gets the root window ID, parent window ID and list of children windows for the
@@ -7541,23 +8231,12 @@ pub fn query_tree<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, 
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        QUERY_TREE_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryTreeRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -7611,8 +8290,89 @@ impl QueryTreeReply {
     }
 }
 
-/// Opcode for the InternAtom request
-pub const INTERN_ATOM_REQUEST: u8 = 16;
+/// Get atom identifier by name.
+///
+/// Retrieves the identifier (xcb_atom_t TODO) for the atom with the specified
+/// name. Atoms are used in protocols like EWMH, for example to store window titles
+/// (`_NET_WM_NAME` atom) as property of a window.
+///
+/// If `only_if_exists` is 0, the atom will be created if it does not already exist.
+/// If `only_if_exists` is 1, `XCB_ATOM_NONE` will be returned if the atom does
+/// not yet exist.
+///
+/// # Fields
+///
+/// * `name_len` - The length of the following `name`.
+/// * `name` - The name of the atom.
+/// * `only_if_exists` - Return a valid atom id only if the atom already exists.
+///
+/// # Errors
+///
+/// * `Alloc` - TODO: reasons?
+/// * `Value` - A value other than 0 or 1 was specified for `only_if_exists`.
+///
+/// # See
+///
+/// * `xlsatoms`: program
+/// * `GetAtomName`: request
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Resolves the _NET_WM_NAME atom.
+///  *
+///  */
+/// void my_example(xcb_connection_t *c) {
+///     xcb_intern_atom_cookie_t cookie;
+///     xcb_intern_atom_reply_t *reply;
+///
+///     cookie = xcb_intern_atom(c, 0, strlen("_NET_WM_NAME"), "_NET_WM_NAME");
+///     /* ... do other work here if possible ... */
+///     if ((reply = xcb_intern_atom_reply(c, cookie, NULL))) {
+///         printf("The _NET_WM_NAME atom has ID %u\n", reply->atom);
+///         free(reply);
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InternAtomRequest<'input> {
+    pub only_if_exists: bool,
+    pub name: &'input [u8],
+}
+impl<'input> InternAtomRequest<'input> {
+    /// Opcode for the InternAtom request
+    pub const fn opcode() -> u8 { 16 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let only_if_exists_bytes = self.only_if_exists.serialize();
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        let name_len_bytes = name_len.serialize();
+        let mut request0 = vec![
+            InternAtomRequest::opcode(),
+            only_if_exists_bytes[0],
+            0,
+            0,
+            name_len_bytes[0],
+            name_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// Get atom identifier by name.
 ///
 /// Retrieves the identifier (xcb_atom_t TODO) for the atom with the specified
@@ -7662,28 +8422,13 @@ pub fn intern_atom<'c, 'input, Conn>(conn: &'c Conn, only_if_exists: bool, name:
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let only_if_exists_bytes = only_if_exists.serialize();
-    let name_len = u16::try_from(name.len()).expect("`name` has too many elements");
-    let name_len_bytes = name_len.serialize();
-    let mut request0 = [
-        INTERN_ATOM_REQUEST,
-        only_if_exists_bytes[0],
-        0,
-        0,
-        name_len_bytes[0],
-        name_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = InternAtomRequest {
+        only_if_exists: only_if_exists,
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7711,29 +8456,48 @@ impl TryFrom<&[u8]> for InternAtomReply {
     }
 }
 
-/// Opcode for the GetAtomName request
-pub const GET_ATOM_NAME_REQUEST: u8 = 17;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetAtomNameRequest {
+    pub atom: Atom,
+}
+impl GetAtomNameRequest {
+    /// Opcode for the GetAtomName request
+    pub const fn opcode() -> u8 { 17 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let atom_bytes = self.atom.serialize();
+        let mut request0 = vec![
+            GetAtomNameRequest::opcode(),
+            0,
+            0,
+            0,
+            atom_bytes[0],
+            atom_bytes[1],
+            atom_bytes[2],
+            atom_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_atom_name<Conn>(conn: &Conn, atom: Atom) -> Result<Cookie<'_, Conn, GetAtomNameReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let atom_bytes = atom.serialize();
-    let mut request0 = [
-        GET_ATOM_NAME_REQUEST,
-        0,
-        0,
-        0,
-        atom_bytes[0],
-        atom_bytes[1],
-        atom_bytes[2],
-        atom_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetAtomNameRequest {
+        atom: atom,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7853,8 +8617,120 @@ impl TryFrom<u32> for PropMode {
     }
 }
 
-/// Opcode for the ChangeProperty request
-pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
+/// Changes a window property.
+///
+/// Sets or updates a property on the specified `window`. Properties are for
+/// example the window title (`WM_NAME`) or its minimum size (`WM_NORMAL_HINTS`).
+/// Protocols such as EWMH also use properties - for example EWMH defines the
+/// window title, encoded as UTF-8 string, in the `_NET_WM_NAME` property.
+///
+/// # Fields
+///
+/// * `window` - The window whose property you want to change.
+/// * `mode` -
+/// * `property` - The property you want to change (an atom).
+/// * `type` - The type of the property you want to change (an atom).
+/// * `format` - Specifies whether the data should be viewed as a list of 8-bit, 16-bit or
+/// 32-bit quantities. Possible values are 8, 16 and 32. This information allows
+/// the X server to correctly perform byte-swap operations as necessary.
+/// * `data_len` - Specifies the number of elements (see `format`).
+/// * `data` - The property data.
+///
+/// # Errors
+///
+/// * `Match` - TODO: reasons?
+/// * `Value` - TODO: reasons?
+/// * `Window` - The specified `window` does not exist.
+/// * `Atom` - `property` or `type` do not refer to a valid atom.
+/// * `Alloc` - The X server could not store the property (no memory?).
+///
+/// # See
+///
+/// * `InternAtom`: request
+/// * `xprop`: program
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Sets the WM_NAME property of the window to "XCB Example".
+///  *
+///  */
+/// void my_example(xcb_connection_t *conn, xcb_window_t window) {
+///     xcb_change_property(conn,
+///         XCB_PROP_MODE_REPLACE,
+///         window,
+///         XCB_ATOM_WM_NAME,
+///         XCB_ATOM_STRING,
+///         8,
+///         strlen("XCB Example"),
+///         "XCB Example");
+///     xcb_flush(conn);
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangePropertyRequest<'input> {
+    pub mode: PropMode,
+    pub window: Window,
+    pub property: Atom,
+    pub type_: Atom,
+    pub format: u8,
+    pub data_len: u32,
+    pub data: &'input [u8],
+}
+impl<'input> ChangePropertyRequest<'input> {
+    /// Opcode for the ChangeProperty request
+    pub const fn opcode() -> u8 { 18 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mode_bytes = u8::from(self.mode).serialize();
+        let window_bytes = self.window.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let format_bytes = self.format.serialize();
+        let data_len_bytes = self.data_len.serialize();
+        let mut request0 = vec![
+            ChangePropertyRequest::opcode(),
+            mode_bytes[0],
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            format_bytes[0],
+            0,
+            0,
+            0,
+            data_len_bytes[0],
+            data_len_bytes[1],
+            data_len_bytes[2],
+            data_len_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(self.data.len(), usize::try_from(self.data_len.checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
+        let length_so_far = length_so_far + (&self.data[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// Changes a window property.
 ///
 /// Sets or updates a property on the specified `window`. Properties are for
@@ -7914,78 +8790,69 @@ where
 {
     let property: Atom = property.into();
     let type_: Atom = type_.into();
-    let length_so_far = 0;
-    let mode_bytes = u8::from(mode).serialize();
-    let window_bytes = window.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let format_bytes = format.serialize();
-    let data_len_bytes = data_len.serialize();
-    let mut request0 = [
-        CHANGE_PROPERTY_REQUEST,
-        mode_bytes[0],
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        format_bytes[0],
-        0,
-        0,
-        0,
-        data_len_bytes[0],
-        data_len_bytes[1],
-        data_len_bytes[2],
-        data_len_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(data.len(), usize::try_from(data_len.checked_mul(u32::from(format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
-    let length_so_far = length_so_far + data.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(data), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangePropertyRequest {
+        mode: mode,
+        window: window,
+        property: property,
+        type_: type_,
+        format: format,
+        data_len: data_len,
+        data: data,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the DeleteProperty request
-pub const DELETE_PROPERTY_REQUEST: u8 = 19;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeletePropertyRequest {
+    pub window: Window,
+    pub property: Atom,
+}
+impl DeletePropertyRequest {
+    /// Opcode for the DeleteProperty request
+    pub const fn opcode() -> u8 { 19 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let property_bytes = self.property.serialize();
+        let mut request0 = vec![
+            DeletePropertyRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn delete_property<Conn>(conn: &Conn, window: Window, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let property_bytes = property.serialize();
-    let mut request0 = [
-        DELETE_PROPERTY_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DeletePropertyRequest {
+        window: window,
+        property: property,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8047,8 +8914,132 @@ impl TryFrom<u32> for GetPropertyType {
     }
 }
 
-/// Opcode for the GetProperty request
-pub const GET_PROPERTY_REQUEST: u8 = 20;
+/// Gets a window property.
+///
+/// Gets the specified `property` from the specified `window`. Properties are for
+/// example the window title (`WM_NAME`) or its minimum size (`WM_NORMAL_HINTS`).
+/// Protocols such as EWMH also use properties - for example EWMH defines the
+/// window title, encoded as UTF-8 string, in the `_NET_WM_NAME` property.
+///
+/// TODO: talk about `type`
+///
+/// TODO: talk about `delete`
+///
+/// TODO: talk about the offset/length thing. what's a valid use case?
+///
+/// # Fields
+///
+/// * `window` - The window whose property you want to get.
+/// * `delete` - Whether the property should actually be deleted. For deleting a property, the
+/// specified `type` has to match the actual property type.
+/// * `property` - The property you want to get (an atom).
+/// * `type` - The type of the property you want to get (an atom).
+/// * `long_offset` - Specifies the offset (in 32-bit multiples) in the specified property where the
+/// data is to be retrieved.
+/// * `long_length` - Specifies how many 32-bit multiples of data should be retrieved (e.g. if you
+/// set `long_length` to 4, you will receive 16 bytes of data).
+///
+/// # Errors
+///
+/// * `Window` - The specified `window` does not exist.
+/// * `Atom` - `property` or `type` do not refer to a valid atom.
+/// * `Value` - The specified `long_offset` is beyond the actual property length (e.g. the
+/// property has a length of 3 bytes and you are setting `long_offset` to 1,
+/// resulting in a byte offset of 4).
+///
+/// # See
+///
+/// * `InternAtom`: request
+/// * `xprop`: program
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Prints the WM_NAME property of the window.
+///  *
+///  */
+/// void my_example(xcb_connection_t *c, xcb_window_t window) {
+///     xcb_get_property_cookie_t cookie;
+///     xcb_get_property_reply_t *reply;
+///
+///     /* These atoms are predefined in the X11 protocol. */
+///     xcb_atom_t property = XCB_ATOM_WM_NAME;
+///     xcb_atom_t type = XCB_ATOM_STRING;
+///
+///     // TODO: a reasonable long_length for WM_NAME?
+///     cookie = xcb_get_property(c, 0, window, property, type, 0, 0);
+///     if ((reply = xcb_get_property_reply(c, cookie, NULL))) {
+///         int len = xcb_get_property_value_length(reply);
+///         if (len == 0) {
+///             printf("TODO\\n");
+///             free(reply);
+///             return;
+///         }
+///         printf("WM_NAME is %.*s\\n", len,
+///                (char*)xcb_get_property_value(reply));
+///     }
+///     free(reply);
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetPropertyRequest {
+    pub delete: bool,
+    pub window: Window,
+    pub property: Atom,
+    pub type_: Atom,
+    pub long_offset: u32,
+    pub long_length: u32,
+}
+impl GetPropertyRequest {
+    /// Opcode for the GetProperty request
+    pub const fn opcode() -> u8 { 20 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let delete_bytes = self.delete.serialize();
+        let window_bytes = self.window.serialize();
+        let property_bytes = self.property.serialize();
+        let type_bytes = self.type_.serialize();
+        let long_offset_bytes = self.long_offset.serialize();
+        let long_length_bytes = self.long_length.serialize();
+        let mut request0 = vec![
+            GetPropertyRequest::opcode(),
+            delete_bytes[0],
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            long_offset_bytes[0],
+            long_offset_bytes[1],
+            long_offset_bytes[2],
+            long_offset_bytes[3],
+            long_length_bytes[0],
+            long_length_bytes[1],
+            long_length_bytes[2],
+            long_length_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Gets a window property.
 ///
 /// Gets the specified `property` from the specified `window`. Properties are for
@@ -8125,44 +9116,17 @@ where
 {
     let property: Atom = property.into();
     let type_: Atom = type_.into();
-    let length_so_far = 0;
-    let delete_bytes = delete.serialize();
-    let window_bytes = window.serialize();
-    let property_bytes = property.serialize();
-    let type_bytes = type_.serialize();
-    let long_offset_bytes = long_offset.serialize();
-    let long_length_bytes = long_length.serialize();
-    let mut request0 = [
-        GET_PROPERTY_REQUEST,
-        delete_bytes[0],
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        type_bytes[0],
-        type_bytes[1],
-        type_bytes[2],
-        type_bytes[3],
-        long_offset_bytes[0],
-        long_offset_bytes[1],
-        long_offset_bytes[2],
-        long_offset_bytes[3],
-        long_length_bytes[0],
-        long_length_bytes[1],
-        long_length_bytes[2],
-        long_length_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetPropertyRequest {
+        delete: delete,
+        window: window,
+        property: property,
+        type_: type_,
+        long_offset: long_offset,
+        long_length: long_length,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 impl GetPropertyReply {
     /// Iterate over the contained value if its format is 8.
@@ -8372,29 +9336,48 @@ impl TryFrom<&[u8]> for GetPropertyReply {
     }
 }
 
-/// Opcode for the ListProperties request
-pub const LIST_PROPERTIES_REQUEST: u8 = 21;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListPropertiesRequest {
+    pub window: Window,
+}
+impl ListPropertiesRequest {
+    /// Opcode for the ListProperties request
+    pub const fn opcode() -> u8 { 21 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            ListPropertiesRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_properties<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        LIST_PROPERTIES_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListPropertiesRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8439,8 +9422,79 @@ impl ListPropertiesReply {
     }
 }
 
-/// Opcode for the SetSelectionOwner request
-pub const SET_SELECTION_OWNER_REQUEST: u8 = 22;
+/// Sets the owner of a selection.
+///
+/// Makes `window` the owner of the selection `selection` and updates the
+/// last-change time of the specified selection.
+///
+/// TODO: briefly explain what a selection is.
+///
+/// # Fields
+///
+/// * `selection` - The selection.
+/// * `owner` - The new owner of the selection.
+///
+/// The special value `XCB_NONE` means that the selection will have no owner.
+/// * `time` - Timestamp to avoid race conditions when running X over the network.
+///
+/// The selection will not be changed if `time` is earlier than the current
+/// last-change time of the `selection` or is later than the current X server time.
+/// Otherwise, the last-change time is set to the specified time.
+///
+/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
+/// time.
+///
+/// # Errors
+///
+/// * `Atom` - `selection` does not refer to a valid atom.
+///
+/// # See
+///
+/// * `SetSelectionOwner`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetSelectionOwnerRequest {
+    pub owner: Window,
+    pub selection: Atom,
+    pub time: Timestamp,
+}
+impl SetSelectionOwnerRequest {
+    /// Opcode for the SetSelectionOwner request
+    pub const fn opcode() -> u8 { 22 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let owner_bytes = self.owner.serialize();
+        let selection_bytes = self.selection.serialize();
+        let time_bytes = self.time.serialize();
+        let mut request0 = vec![
+            SetSelectionOwnerRequest::opcode(),
+            0,
+            0,
+            0,
+            owner_bytes[0],
+            owner_bytes[1],
+            owner_bytes[2],
+            owner_bytes[3],
+            selection_bytes[0],
+            selection_bytes[1],
+            selection_bytes[2],
+            selection_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Sets the owner of a selection.
 ///
 /// Makes `window` the owner of the selection `selection` and updates the
@@ -8478,37 +9532,65 @@ where
 {
     let owner: Window = owner.into();
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let owner_bytes = owner.serialize();
-    let selection_bytes = selection.serialize();
-    let time_bytes = time.serialize();
-    let mut request0 = [
-        SET_SELECTION_OWNER_REQUEST,
-        0,
-        0,
-        0,
-        owner_bytes[0],
-        owner_bytes[1],
-        owner_bytes[2],
-        owner_bytes[3],
-        selection_bytes[0],
-        selection_bytes[1],
-        selection_bytes[2],
-        selection_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetSelectionOwnerRequest {
+        owner: owner,
+        selection: selection,
+        time: time,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetSelectionOwner request
-pub const GET_SELECTION_OWNER_REQUEST: u8 = 23;
+/// Gets the owner of a selection.
+///
+/// Gets the owner of the specified selection.
+///
+/// TODO: briefly explain what a selection is.
+///
+/// # Fields
+///
+/// * `selection` - The selection.
+///
+/// # Errors
+///
+/// * `Atom` - `selection` does not refer to a valid atom.
+///
+/// # See
+///
+/// * `SetSelectionOwner`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetSelectionOwnerRequest {
+    pub selection: Atom,
+}
+impl GetSelectionOwnerRequest {
+    /// Opcode for the GetSelectionOwner request
+    pub const fn opcode() -> u8 { 23 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let selection_bytes = self.selection.serialize();
+        let mut request0 = vec![
+            GetSelectionOwnerRequest::opcode(),
+            0,
+            0,
+            0,
+            selection_bytes[0],
+            selection_bytes[1],
+            selection_bytes[2],
+            selection_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Gets the owner of a selection.
 ///
 /// Gets the owner of the specified selection.
@@ -8530,23 +9612,12 @@ pub fn get_selection_owner<Conn>(conn: &Conn, selection: Atom) -> Result<Cookie<
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let selection_bytes = selection.serialize();
-    let mut request0 = [
-        GET_SELECTION_OWNER_REQUEST,
-        0,
-        0,
-        0,
-        selection_bytes[0],
-        selection_bytes[1],
-        selection_bytes[2],
-        selection_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetSelectionOwnerRequest {
+        selection: selection,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -8577,8 +9648,62 @@ impl TryFrom<&[u8]> for GetSelectionOwnerReply {
     }
 }
 
-/// Opcode for the ConvertSelection request
-pub const CONVERT_SELECTION_REQUEST: u8 = 24;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConvertSelectionRequest {
+    pub requestor: Window,
+    pub selection: Atom,
+    pub target: Atom,
+    pub property: Atom,
+    pub time: Timestamp,
+}
+impl ConvertSelectionRequest {
+    /// Opcode for the ConvertSelection request
+    pub const fn opcode() -> u8 { 24 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let requestor_bytes = self.requestor.serialize();
+        let selection_bytes = self.selection.serialize();
+        let target_bytes = self.target.serialize();
+        let property_bytes = self.property.serialize();
+        let time_bytes = self.time.serialize();
+        let mut request0 = vec![
+            ConvertSelectionRequest::opcode(),
+            0,
+            0,
+            0,
+            requestor_bytes[0],
+            requestor_bytes[1],
+            requestor_bytes[2],
+            requestor_bytes[3],
+            selection_bytes[0],
+            selection_bytes[1],
+            selection_bytes[2],
+            selection_bytes[3],
+            target_bytes[0],
+            target_bytes[1],
+            target_bytes[2],
+            target_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn convert_selection<Conn, A, B>(conn: &Conn, requestor: Window, selection: Atom, target: Atom, property: A, time: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8587,43 +9712,16 @@ where
 {
     let property: Atom = property.into();
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let requestor_bytes = requestor.serialize();
-    let selection_bytes = selection.serialize();
-    let target_bytes = target.serialize();
-    let property_bytes = property.serialize();
-    let time_bytes = time.serialize();
-    let mut request0 = [
-        CONVERT_SELECTION_REQUEST,
-        0,
-        0,
-        0,
-        requestor_bytes[0],
-        requestor_bytes[1],
-        requestor_bytes[2],
-        requestor_bytes[3],
-        selection_bytes[0],
-        selection_bytes[1],
-        selection_bytes[2],
-        selection_bytes[3],
-        target_bytes[0],
-        target_bytes[1],
-        target_bytes[2],
-        target_bytes[3],
-        property_bytes[0],
-        property_bytes[1],
-        property_bytes[2],
-        property_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ConvertSelectionRequest {
+        requestor: requestor,
+        selection: selection,
+        target: target,
+        property: property,
+        time: time,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8696,8 +9794,6 @@ impl TryFrom<u32> for SendEventDest {
     }
 }
 
-/// Opcode for the SendEvent request
-pub const SEND_EVENT_REQUEST: u8 = 25;
 /// send an event.
 ///
 /// Identifies the `destination` window, determines which clients should receive
@@ -8771,7 +9867,122 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 ///     free(event);
 /// }
 /// ```
-pub fn send_event<Conn, A, B, C>(conn: &Conn, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SendEventRequest<'input> {
+    pub propagate: bool,
+    pub destination: Window,
+    pub event_mask: u32,
+    pub event: &'input [u8; 32],
+}
+impl<'input> SendEventRequest<'input> {
+    /// Opcode for the SendEvent request
+    pub const fn opcode() -> u8 { 25 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let propagate_bytes = self.propagate.serialize();
+        let destination_bytes = self.destination.serialize();
+        let event_mask_bytes = self.event_mask.serialize();
+        let mut request0 = vec![
+            SendEventRequest::opcode(),
+            propagate_bytes[0],
+            0,
+            0,
+            destination_bytes[0],
+            destination_bytes[1],
+            destination_bytes[2],
+            destination_bytes[3],
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            event_mask_bytes[2],
+            event_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.event[..]).len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.event[..]).into()], vec![]))
+    }
+}
+/// send an event.
+///
+/// Identifies the `destination` window, determines which clients should receive
+/// the specified event and ignores any active grabs.
+///
+/// The `event` must be one of the core events or an event defined by an extension,
+/// so that the X server can correctly byte-swap the contents as necessary. The
+/// contents of `event` are otherwise unaltered and unchecked except for the
+/// `send_event` field which is forced to 'true'.
+///
+/// # Fields
+///
+/// * `destination` - The window to send this event to. Every client which selects any event within
+/// `event_mask` on `destination` will get the event.
+///
+/// The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
+/// that contains the mouse pointer.
+///
+/// The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
+/// has the keyboard focus.
+/// * `event_mask` - Event_mask for determining which clients should receive the specified event.
+/// See `destination` and `propagate`.
+/// * `propagate` - If `propagate` is true and no clients have selected any event on `destination`,
+/// the destination is replaced with the closest ancestor of `destination` for
+/// which some client has selected a type in `event_mask` and for which no
+/// intervening window has that type in its do-not-propagate-mask. If no such
+/// window exists or if the window is an ancestor of the focus window and
+/// `InputFocus` was originally specified as the destination, the event is not sent
+/// to any clients. Otherwise, the event is reported to every client selecting on
+/// the final destination any of the types specified in `event_mask`.
+/// * `event` - The event to send to the specified `destination`.
+///
+/// # Errors
+///
+/// * `Window` - The specified `destination` window does not exist.
+/// * `Value` - The given `event` is neither a core event nor an event defined by an extension.
+///
+/// # See
+///
+/// * `ConfigureNotify`: event
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Tell the given window that it was configured to a size of 800x600 pixels.
+///  *
+///  */
+/// void my_example(xcb_connection_t *conn, xcb_window_t window) {
+///     /* Every X11 event is 32 bytes long. Therefore, XCB will copy 32 bytes.
+///      * In order to properly initialize these bytes, we allocate 32 bytes even
+///      * though we only need less for an xcb_configure_notify_event_t */
+///     xcb_configure_notify_event_t *event = calloc(32, 1);
+///
+///     event->event = window;
+///     event->window = window;
+///     event->response_type = XCB_CONFIGURE_NOTIFY;
+///
+///     event->x = 0;
+///     event->y = 0;
+///     event->width = 800;
+///     event->height = 600;
+///
+///     event->border_width = 0;
+///     event->above_sibling = XCB_NONE;
+///     event->override_redirect = false;
+///
+///     xcb_send_event(conn, false, window, XCB_EVENT_MASK_STRUCTURE_NOTIFY,
+///                    (char*)event);
+///     xcb_flush(conn);
+///     free(event);
+/// }
+/// ```
+pub fn send_event<'c, 'input, Conn, A, B, C>(conn: &'c Conn, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Window>,
@@ -8781,30 +9992,16 @@ where
     let destination: Window = destination.into();
     let event_mask: u32 = event_mask.into();
     let event: [u8; 32] = event.into();
-    let length_so_far = 0;
-    let propagate_bytes = propagate.serialize();
-    let destination_bytes = destination.serialize();
-    let event_mask_bytes = event_mask.serialize();
-    let mut request0 = [
-        SEND_EVENT_REQUEST,
-        propagate_bytes[0],
-        0,
-        0,
-        destination_bytes[0],
-        destination_bytes[1],
-        destination_bytes[2],
-        destination_bytes[3],
-        event_mask_bytes[0],
-        event_mask_bytes[1],
-        event_mask_bytes[2],
-        event_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + event.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&event)], vec![])?)
+    let event = &event;
+    let request0 = SendEventRequest {
+        propagate: propagate,
+        destination: destination,
+        event_mask: event_mask,
+        event: event,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -9013,8 +10210,139 @@ impl TryFrom<u32> for CursorEnum {
     }
 }
 
-/// Opcode for the GrabPointer request
-pub const GRAB_POINTER_REQUEST: u8 = 26;
+/// Grab the pointer.
+///
+/// Actively grabs control of the pointer. Further pointer events are reported only to the grabbing client. Overrides any active pointer grab by this client.
+///
+/// # Fields
+///
+/// * `event_mask` - Specifies which pointer events are reported to the client.
+///
+/// TODO: which values?
+/// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
+/// move the pointer out of that window).
+///
+/// The special value `XCB_NONE` means don't confine the pointer.
+/// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
+/// cursor.
+/// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
+/// reported to the `grab_window`.
+/// * `grab_window` - Specifies the window on which the pointer should be grabbed.
+/// * `time` - The time argument allows you to avoid certain circumstances that come up if
+/// applications take a long time to respond or if there are long network delays.
+/// Consider a situation where you have two applications, both of which normally
+/// grab the pointer when clicked on. If both applications specify the timestamp
+/// from the event, the second application may wake up faster and successfully grab
+/// the pointer before the first application. The first application then will get
+/// an indication that the other application grabbed the pointer before its request
+/// was processed.
+///
+/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
+/// time.
+/// * `pointer_mode` -
+/// * `keyboard_mode` -
+///
+/// # Errors
+///
+/// * `Value` - TODO: reasons?
+/// * `Window` - The specified `window` does not exist.
+///
+/// # See
+///
+/// * `GrabKeyboard`: request
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Grabs the pointer actively
+///  *
+///  */
+/// void my_example(xcb_connection_t *conn, xcb_screen_t *screen, xcb_cursor_t cursor) {
+///     xcb_grab_pointer_cookie_t cookie;
+///     xcb_grab_pointer_reply_t *reply;
+///
+///     cookie = xcb_grab_pointer(
+///         conn,
+///         false,               /* get all pointer events specified by the following mask */
+///         screen->root,        /* grab the root window */
+///         XCB_NONE,            /* which events to let through */
+///         XCB_GRAB_MODE_ASYNC, /* pointer events should continue as normal */
+///         XCB_GRAB_MODE_ASYNC, /* keyboard mode */
+///         XCB_NONE,            /* confine_to = in which window should the cursor stay */
+///         cursor,              /* we change the cursor to whatever the user wanted */
+///         XCB_CURRENT_TIME
+///     );
+///
+///     if ((reply = xcb_grab_pointer_reply(conn, cookie, NULL))) {
+///         if (reply->status == XCB_GRAB_STATUS_SUCCESS)
+///             printf("successfully grabbed the pointer\\n");
+///         free(preply);
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GrabPointerRequest {
+    pub owner_events: bool,
+    pub grab_window: Window,
+    pub event_mask: u16,
+    pub pointer_mode: GrabMode,
+    pub keyboard_mode: GrabMode,
+    pub confine_to: Window,
+    pub cursor: Cursor,
+    pub time: Timestamp,
+}
+impl GrabPointerRequest {
+    /// Opcode for the GrabPointer request
+    pub const fn opcode() -> u8 { 26 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let owner_events_bytes = self.owner_events.serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let event_mask_bytes = self.event_mask.serialize();
+        let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
+        let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
+        let confine_to_bytes = self.confine_to.serialize();
+        let cursor_bytes = self.cursor.serialize();
+        let time_bytes = self.time.serialize();
+        let mut request0 = vec![
+            GrabPointerRequest::opcode(),
+            owner_events_bytes[0],
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            pointer_mode_bytes[0],
+            keyboard_mode_bytes[0],
+            confine_to_bytes[0],
+            confine_to_bytes[1],
+            confine_to_bytes[2],
+            confine_to_bytes[3],
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Grab the pointer.
 ///
 /// Actively grabs control of the pointer. Further pointer events are reported only to the grabbing client. Overrides any active pointer grab by this client.
@@ -9098,46 +10426,19 @@ where
     let confine_to: Window = confine_to.into();
     let cursor: Cursor = cursor.into();
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let owner_events_bytes = owner_events.serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let event_mask_bytes = event_mask.serialize();
-    let pointer_mode_bytes = u8::from(pointer_mode).serialize();
-    let keyboard_mode_bytes = u8::from(keyboard_mode).serialize();
-    let confine_to_bytes = confine_to.serialize();
-    let cursor_bytes = cursor.serialize();
-    let time_bytes = time.serialize();
-    let mut request0 = [
-        GRAB_POINTER_REQUEST,
-        owner_events_bytes[0],
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        event_mask_bytes[0],
-        event_mask_bytes[1],
-        pointer_mode_bytes[0],
-        keyboard_mode_bytes[0],
-        confine_to_bytes[0],
-        confine_to_bytes[1],
-        confine_to_bytes[2],
-        confine_to_bytes[3],
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GrabPointerRequest {
+        owner_events: owner_events,
+        grab_window: grab_window,
+        event_mask: event_mask,
+        pointer_mode: pointer_mode,
+        keyboard_mode: keyboard_mode,
+        confine_to: confine_to,
+        cursor: cursor,
+        time: time,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9165,8 +10466,61 @@ impl TryFrom<&[u8]> for GrabPointerReply {
     }
 }
 
-/// Opcode for the UngrabPointer request
-pub const UNGRAB_POINTER_REQUEST: u8 = 27;
+/// release the pointer.
+///
+/// Releases the pointer and any queued events if you actively grabbed the pointer
+/// before using `xcb_grab_pointer`, `xcb_grab_button` or within a normal button
+/// press.
+///
+/// EnterNotify and LeaveNotify events are generated.
+///
+/// # Fields
+///
+/// * `time` - Timestamp to avoid race conditions when running X over the network.
+///
+/// The pointer will not be released if `time` is earlier than the
+/// last-pointer-grab time or later than the current X server time.
+/// * `name_len` - Length (in bytes) of `name`.
+/// * `name` - A pattern describing an X core font.
+///
+/// # See
+///
+/// * `GrabPointer`: request
+/// * `GrabButton`: request
+/// * `EnterNotify`: event
+/// * `LeaveNotify`: event
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabPointerRequest {
+    pub time: Timestamp,
+}
+impl UngrabPointerRequest {
+    /// Opcode for the UngrabPointer request
+    pub const fn opcode() -> u8 { 27 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let time_bytes = self.time.serialize();
+        let mut request0 = vec![
+            UngrabPointerRequest::opcode(),
+            0,
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// release the pointer.
 ///
 /// Releases the pointer and any queued events if you actively grabbed the pointer
@@ -9196,23 +10550,12 @@ where
     A: Into<Timestamp>,
 {
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let time_bytes = time.serialize();
-    let mut request0 = [
-        UNGRAB_POINTER_REQUEST,
-        0,
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabPointerRequest {
+        time: time,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -9297,8 +10640,137 @@ impl TryFrom<u32> for ButtonIndex {
     }
 }
 
-/// Opcode for the GrabButton request
-pub const GRAB_BUTTON_REQUEST: u8 = 28;
+/// Grab pointer button(s).
+///
+/// This request establishes a passive grab. The pointer is actively grabbed as
+/// described in GrabPointer, the last-pointer-grab time is set to the time at
+/// which the button was pressed (as transmitted in the ButtonPress event), and the
+/// ButtonPress event is reported if all of the following conditions are true:
+///
+/// The pointer is not grabbed and the specified button is logically pressed when
+/// the specified modifier keys are logically down, and no other buttons or
+/// modifier keys are logically down.
+///
+/// The grab-window contains the pointer.
+///
+/// The confine-to window (if any) is viewable.
+///
+/// A passive grab on the same button/key combination does not exist on any
+/// ancestor of grab-window.
+///
+/// The interpretation of the remaining arguments is the same as for GrabPointer.
+/// The active grab is terminated automatically when the logical state of the
+/// pointer has all buttons released, independent of the logical state of modifier
+/// keys. Note that the logical state of a device (as seen by means of the
+/// protocol) may lag the physical state if device event processing is frozen. This
+/// request overrides all previous passive grabs by the same client on the same
+/// button/key combinations on the same window. A modifier of AnyModifier is
+/// equivalent to issuing the request for all possible modifier combinations
+/// (including the combination of no modifiers). It is not required that all
+/// specified modifiers have currently assigned keycodes. A button of AnyButton is
+/// equivalent to issuing the request for all possible buttons. Otherwise, it is
+/// not required that the button specified currently be assigned to a physical
+/// button.
+///
+/// An Access error is generated if some other client has already issued a
+/// GrabButton request with the same button/key combination on the same window.
+/// When using AnyModifier or AnyButton, the request fails completely (no grabs are
+/// established), and an Access error is generated if there is a conflicting grab
+/// for any combination. The request has no effect on an active grab.
+///
+/// # Fields
+///
+/// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
+/// reported to the `grab_window`.
+/// * `grab_window` - Specifies the window on which the pointer should be grabbed.
+/// * `event_mask` - Specifies which pointer events are reported to the client.
+///
+/// TODO: which values?
+/// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
+/// move the pointer out of that window).
+///
+/// The special value `XCB_NONE` means don't confine the pointer.
+/// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
+/// cursor.
+/// * `modifiers` - The modifiers to grab.
+///
+/// Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
+/// possible modifier combinations.
+/// * `pointer_mode` -
+/// * `keyboard_mode` -
+/// * `button` -
+///
+/// # Errors
+///
+/// * `Access` - Another client has already issued a GrabButton with the same button/key
+/// combination on the same window.
+/// * `Value` - TODO: reasons?
+/// * `Cursor` - The specified `cursor` does not exist.
+/// * `Window` - The specified `window` does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GrabButtonRequest {
+    pub owner_events: bool,
+    pub grab_window: Window,
+    pub event_mask: u16,
+    pub pointer_mode: GrabMode,
+    pub keyboard_mode: GrabMode,
+    pub confine_to: Window,
+    pub cursor: Cursor,
+    pub button: ButtonIndex,
+    pub modifiers: u16,
+}
+impl GrabButtonRequest {
+    /// Opcode for the GrabButton request
+    pub const fn opcode() -> u8 { 28 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let owner_events_bytes = self.owner_events.serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let event_mask_bytes = self.event_mask.serialize();
+        let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
+        let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
+        let confine_to_bytes = self.confine_to.serialize();
+        let cursor_bytes = self.cursor.serialize();
+        let button_bytes = u8::from(self.button).serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let mut request0 = vec![
+            GrabButtonRequest::opcode(),
+            owner_events_bytes[0],
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            pointer_mode_bytes[0],
+            keyboard_mode_bytes[0],
+            confine_to_bytes[0],
+            confine_to_bytes[1],
+            confine_to_bytes[2],
+            confine_to_bytes[3],
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+            button_bytes[0],
+            0,
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Grab pointer button(s).
 ///
 /// This request establishes a passive grab. The pointer is actively grabbed as
@@ -9378,84 +10850,122 @@ where
     let confine_to: Window = confine_to.into();
     let cursor: Cursor = cursor.into();
     let modifiers: u16 = modifiers.into();
-    let length_so_far = 0;
-    let owner_events_bytes = owner_events.serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let event_mask_bytes = event_mask.serialize();
-    let pointer_mode_bytes = u8::from(pointer_mode).serialize();
-    let keyboard_mode_bytes = u8::from(keyboard_mode).serialize();
-    let confine_to_bytes = confine_to.serialize();
-    let cursor_bytes = cursor.serialize();
-    let button_bytes = u8::from(button).serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let mut request0 = [
-        GRAB_BUTTON_REQUEST,
-        owner_events_bytes[0],
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        event_mask_bytes[0],
-        event_mask_bytes[1],
-        pointer_mode_bytes[0],
-        keyboard_mode_bytes[0],
-        confine_to_bytes[0],
-        confine_to_bytes[1],
-        confine_to_bytes[2],
-        confine_to_bytes[3],
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-        button_bytes[0],
-        0,
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GrabButtonRequest {
+        owner_events: owner_events,
+        grab_window: grab_window,
+        event_mask: event_mask,
+        pointer_mode: pointer_mode,
+        keyboard_mode: keyboard_mode,
+        confine_to: confine_to,
+        cursor: cursor,
+        button: button,
+        modifiers: modifiers,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UngrabButton request
-pub const UNGRAB_BUTTON_REQUEST: u8 = 29;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabButtonRequest {
+    pub button: ButtonIndex,
+    pub grab_window: Window,
+    pub modifiers: u16,
+}
+impl UngrabButtonRequest {
+    /// Opcode for the UngrabButton request
+    pub const fn opcode() -> u8 { 29 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let button_bytes = u8::from(self.button).serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let mut request0 = vec![
+            UngrabButtonRequest::opcode(),
+            button_bytes[0],
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn ungrab_button<Conn, A>(conn: &Conn, button: ButtonIndex, grab_window: Window, modifiers: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u16>,
 {
     let modifiers: u16 = modifiers.into();
-    let length_so_far = 0;
-    let button_bytes = u8::from(button).serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let mut request0 = [
-        UNGRAB_BUTTON_REQUEST,
-        button_bytes[0],
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabButtonRequest {
+        button: button,
+        grab_window: grab_window,
+        modifiers: modifiers,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangeActivePointerGrab request
-pub const CHANGE_ACTIVE_POINTER_GRAB_REQUEST: u8 = 30;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeActivePointerGrabRequest {
+    pub cursor: Cursor,
+    pub time: Timestamp,
+    pub event_mask: u16,
+}
+impl ChangeActivePointerGrabRequest {
+    /// Opcode for the ChangeActivePointerGrab request
+    pub const fn opcode() -> u8 { 30 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cursor_bytes = self.cursor.serialize();
+        let time_bytes = self.time.serialize();
+        let event_mask_bytes = self.event_mask.serialize();
+        let mut request0 = vec![
+            ChangeActivePointerGrabRequest::opcode(),
+            0,
+            0,
+            0,
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn change_active_pointer_grab<Conn, A, B, C>(conn: &Conn, cursor: A, time: B, event_mask: C) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9466,37 +10976,126 @@ where
     let cursor: Cursor = cursor.into();
     let time: Timestamp = time.into();
     let event_mask: u16 = event_mask.into();
-    let length_so_far = 0;
-    let cursor_bytes = cursor.serialize();
-    let time_bytes = time.serialize();
-    let event_mask_bytes = event_mask.serialize();
-    let mut request0 = [
-        CHANGE_ACTIVE_POINTER_GRAB_REQUEST,
-        0,
-        0,
-        0,
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        event_mask_bytes[0],
-        event_mask_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ChangeActivePointerGrabRequest {
+        cursor: cursor,
+        time: time,
+        event_mask: event_mask,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GrabKeyboard request
-pub const GRAB_KEYBOARD_REQUEST: u8 = 31;
+/// Grab the keyboard.
+///
+/// Actively grabs control of the keyboard and generates FocusIn and FocusOut
+/// events. Further key events are reported only to the grabbing client.
+///
+/// Any active keyboard grab by this client is overridden. If the keyboard is
+/// actively grabbed by some other client, `AlreadyGrabbed` is returned. If
+/// `grab_window` is not viewable, `GrabNotViewable` is returned. If the keyboard
+/// is frozen by an active grab of another client, `GrabFrozen` is returned. If the
+/// specified `time` is earlier than the last-keyboard-grab time or later than the
+/// current X server time, `GrabInvalidTime` is returned. Otherwise, the
+/// last-keyboard-grab time is set to the specified time.
+///
+/// # Fields
+///
+/// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
+/// reported to the `grab_window`.
+/// * `grab_window` - Specifies the window on which the pointer should be grabbed.
+/// * `time` - Timestamp to avoid race conditions when running X over the network.
+///
+/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
+/// time.
+/// * `pointer_mode` -
+/// * `keyboard_mode` -
+///
+/// # Errors
+///
+/// * `Value` - TODO: reasons?
+/// * `Window` - The specified `window` does not exist.
+///
+/// # See
+///
+/// * `GrabPointer`: request
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Grabs the keyboard actively
+///  *
+///  */
+/// void my_example(xcb_connection_t *conn, xcb_screen_t *screen) {
+///     xcb_grab_keyboard_cookie_t cookie;
+///     xcb_grab_keyboard_reply_t *reply;
+///
+///     cookie = xcb_grab_keyboard(
+///         conn,
+///         true,                /* report events */
+///         screen->root,        /* grab the root window */
+///         XCB_CURRENT_TIME,
+///         XCB_GRAB_MODE_ASYNC, /* process events as normal, do not require sync */
+///         XCB_GRAB_MODE_ASYNC
+///     );
+///
+///     if ((reply = xcb_grab_keyboard_reply(conn, cookie, NULL))) {
+///         if (reply->status == XCB_GRAB_STATUS_SUCCESS)
+///             printf("successfully grabbed the keyboard\\n");
+///
+///         free(reply);
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GrabKeyboardRequest {
+    pub owner_events: bool,
+    pub grab_window: Window,
+    pub time: Timestamp,
+    pub pointer_mode: GrabMode,
+    pub keyboard_mode: GrabMode,
+}
+impl GrabKeyboardRequest {
+    /// Opcode for the GrabKeyboard request
+    pub const fn opcode() -> u8 { 31 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let owner_events_bytes = self.owner_events.serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let time_bytes = self.time.serialize();
+        let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
+        let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
+        let mut request0 = vec![
+            GrabKeyboardRequest::opcode(),
+            owner_events_bytes[0],
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            pointer_mode_bytes[0],
+            keyboard_mode_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Grab the keyboard.
 ///
 /// Actively grabs control of the keyboard and generates FocusIn and FocusOut
@@ -9565,35 +11164,16 @@ where
     A: Into<Timestamp>,
 {
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let owner_events_bytes = owner_events.serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let time_bytes = time.serialize();
-    let pointer_mode_bytes = u8::from(pointer_mode).serialize();
-    let keyboard_mode_bytes = u8::from(keyboard_mode).serialize();
-    let mut request0 = [
-        GRAB_KEYBOARD_REQUEST,
-        owner_events_bytes[0],
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        pointer_mode_bytes[0],
-        keyboard_mode_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GrabKeyboardRequest {
+        owner_events: owner_events,
+        grab_window: grab_window,
+        time: time,
+        pointer_mode: pointer_mode,
+        keyboard_mode: keyboard_mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9621,31 +11201,50 @@ impl TryFrom<&[u8]> for GrabKeyboardReply {
     }
 }
 
-/// Opcode for the UngrabKeyboard request
-pub const UNGRAB_KEYBOARD_REQUEST: u8 = 32;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabKeyboardRequest {
+    pub time: Timestamp,
+}
+impl UngrabKeyboardRequest {
+    /// Opcode for the UngrabKeyboard request
+    pub const fn opcode() -> u8 { 32 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let time_bytes = self.time.serialize();
+        let mut request0 = vec![
+            UngrabKeyboardRequest::opcode(),
+            0,
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn ungrab_keyboard<Conn, A>(conn: &Conn, time: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Timestamp>,
 {
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let time_bytes = time.serialize();
-    let mut request0 = [
-        UNGRAB_KEYBOARD_REQUEST,
-        0,
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabKeyboardRequest {
+        time: time,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9707,8 +11306,116 @@ impl TryFrom<u32> for Grab {
     }
 }
 
-/// Opcode for the GrabKey request
-pub const GRAB_KEY_REQUEST: u8 = 33;
+/// Grab keyboard key(s).
+///
+/// Establishes a passive grab on the keyboard. In the future, the keyboard is
+/// actively grabbed (as for `GrabKeyboard`), the last-keyboard-grab time is set to
+/// the time at which the key was pressed (as transmitted in the KeyPress event),
+/// and the KeyPress event is reported if all of the following conditions are true:
+///
+/// The keyboard is not grabbed and the specified key (which can itself be a
+/// modifier key) is logically pressed when the specified modifier keys are
+/// logically down, and no other modifier keys are logically down.
+///
+/// Either the grab_window is an ancestor of (or is) the focus window, or the
+/// grab_window is a descendant of the focus window and contains the pointer.
+///
+/// A passive grab on the same key combination does not exist on any ancestor of
+/// grab_window.
+///
+/// The interpretation of the remaining arguments is as for XGrabKeyboard.  The active grab is terminated
+/// automatically when the logical state of the keyboard has the specified key released (independent of the
+/// logical state of the modifier keys), at which point a KeyRelease event is reported to the grabbing window.
+///
+/// Note that the logical state of a device (as seen by client applications) may lag the physical state if
+/// device event processing is frozen.
+///
+/// A modifiers argument of AnyModifier is equivalent to issuing the request for all possible modifier combinations (including the combination of no modifiers).  It is not required that all modifiers specified
+/// have currently assigned KeyCodes.  A keycode argument of AnyKey is equivalent to issuing the request for
+/// all possible KeyCodes.  Otherwise, the specified keycode must be in the range specified by min_keycode
+/// and max_keycode in the connection setup, or a BadValue error results.
+///
+/// If some other client has issued a XGrabKey with the same key combination on the same window, a BadAccess
+/// error results.  When using AnyModifier or AnyKey, the request fails completely, and a BadAccess error
+/// results (no grabs are established) if there is a conflicting grab for any combination.
+///
+/// # Fields
+///
+/// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
+/// reported to the `grab_window`.
+/// * `grab_window` - Specifies the window on which the pointer should be grabbed.
+/// * `key` - The keycode of the key to grab.
+///
+/// The special value `XCB_GRAB_ANY` means grab any key.
+/// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
+/// cursor.
+/// * `modifiers` - The modifiers to grab.
+///
+/// Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
+/// possible modifier combinations.
+/// * `pointer_mode` -
+/// * `keyboard_mode` -
+///
+/// # Errors
+///
+/// * `Access` - Another client has already issued a GrabKey with the same button/key
+/// combination on the same window.
+/// * `Value` - TODO: reasons?
+/// * `Window` - The specified `window` does not exist.
+///
+/// # See
+///
+/// * `GrabKeyboard`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GrabKeyRequest {
+    pub owner_events: bool,
+    pub grab_window: Window,
+    pub modifiers: u16,
+    pub key: Keycode,
+    pub pointer_mode: GrabMode,
+    pub keyboard_mode: GrabMode,
+}
+impl GrabKeyRequest {
+    /// Opcode for the GrabKey request
+    pub const fn opcode() -> u8 { 33 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let owner_events_bytes = self.owner_events.serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let key_bytes = self.key.serialize();
+        let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
+        let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
+        let mut request0 = vec![
+            GrabKeyRequest::opcode(),
+            owner_events_bytes[0],
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+            key_bytes[0],
+            pointer_mode_bytes[0],
+            keyboard_mode_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Grab keyboard key(s).
 ///
 /// Establishes a passive grab on the keyboard. In the future, the keyboard is
@@ -9777,40 +11484,84 @@ where
 {
     let modifiers: u16 = modifiers.into();
     let key: Keycode = key.into();
-    let length_so_far = 0;
-    let owner_events_bytes = owner_events.serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let key_bytes = key.serialize();
-    let pointer_mode_bytes = u8::from(pointer_mode).serialize();
-    let keyboard_mode_bytes = u8::from(keyboard_mode).serialize();
-    let mut request0 = [
-        GRAB_KEY_REQUEST,
-        owner_events_bytes[0],
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-        key_bytes[0],
-        pointer_mode_bytes[0],
-        keyboard_mode_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GrabKeyRequest {
+        owner_events: owner_events,
+        grab_window: grab_window,
+        modifiers: modifiers,
+        key: key,
+        pointer_mode: pointer_mode,
+        keyboard_mode: keyboard_mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UngrabKey request
-pub const UNGRAB_KEY_REQUEST: u8 = 34;
+/// release a key combination.
+///
+/// Releases the key combination on `grab_window` if you grabbed it using
+/// `xcb_grab_key` before.
+///
+/// # Fields
+///
+/// * `key` - The keycode of the specified key combination.
+///
+/// Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
+/// * `grab_window` - The window on which the grabbed key combination will be released.
+/// * `modifiers` - The modifiers of the specified key combination.
+///
+/// Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
+/// with every possible modifier combination.
+///
+/// # Errors
+///
+/// * `Window` - The specified `grab_window` does not exist.
+/// * `Value` - TODO: reasons?
+///
+/// # See
+///
+/// * `GrabKey`: request
+/// * `xev`: program
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabKeyRequest {
+    pub key: Keycode,
+    pub grab_window: Window,
+    pub modifiers: u16,
+}
+impl UngrabKeyRequest {
+    /// Opcode for the UngrabKey request
+    pub const fn opcode() -> u8 { 34 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let key_bytes = self.key.serialize();
+        let grab_window_bytes = self.grab_window.serialize();
+        let modifiers_bytes = self.modifiers.serialize();
+        let mut request0 = vec![
+            UngrabKeyRequest::opcode(),
+            key_bytes[0],
+            0,
+            0,
+            grab_window_bytes[0],
+            grab_window_bytes[1],
+            grab_window_bytes[2],
+            grab_window_bytes[3],
+            modifiers_bytes[0],
+            modifiers_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// release a key combination.
 ///
 /// Releases the key combination on `grab_window` if you grabbed it using
@@ -9844,29 +11595,14 @@ where
 {
     let key: Keycode = key.into();
     let modifiers: u16 = modifiers.into();
-    let length_so_far = 0;
-    let key_bytes = key.serialize();
-    let grab_window_bytes = grab_window.serialize();
-    let modifiers_bytes = modifiers.serialize();
-    let mut request0 = [
-        UNGRAB_KEY_REQUEST,
-        key_bytes[0],
-        0,
-        0,
-        grab_window_bytes[0],
-        grab_window_bytes[1],
-        grab_window_bytes[2],
-        grab_window_bytes[3],
-        modifiers_bytes[0],
-        modifiers_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabKeyRequest {
+        key: key,
+        grab_window: grab_window,
+        modifiers: modifiers,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -10008,8 +11744,58 @@ impl TryFrom<u32> for Allow {
     }
 }
 
-/// Opcode for the AllowEvents request
-pub const ALLOW_EVENTS_REQUEST: u8 = 35;
+/// release queued events.
+///
+/// Releases queued events if the client has caused a device (pointer/keyboard) to
+/// freeze due to grabbing it actively. This request has no effect if `time` is
+/// earlier than the last-grab time of the most recent active grab for this client
+/// or if `time` is later than the current X server time.
+///
+/// # Fields
+///
+/// * `mode` -
+/// * `time` - Timestamp to avoid race conditions when running X over the network.
+///
+/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
+/// time.
+///
+/// # Errors
+///
+/// * `Value` - You specified an invalid `mode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllowEventsRequest {
+    pub mode: Allow,
+    pub time: Timestamp,
+}
+impl AllowEventsRequest {
+    /// Opcode for the AllowEvents request
+    pub const fn opcode() -> u8 { 35 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mode_bytes = u8::from(self.mode).serialize();
+        let time_bytes = self.time.serialize();
+        let mut request0 = vec![
+            AllowEventsRequest::opcode(),
+            mode_bytes[0],
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// release queued events.
 ///
 /// Releases queued events if the client has caused a device (pointer/keyboard) to
@@ -10034,68 +11820,130 @@ where
     A: Into<Timestamp>,
 {
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let mode_bytes = u8::from(mode).serialize();
-    let time_bytes = time.serialize();
-    let mut request0 = [
-        ALLOW_EVENTS_REQUEST,
-        mode_bytes[0],
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = AllowEventsRequest {
+        mode: mode,
+        time: time,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GrabServer request
-pub const GRAB_SERVER_REQUEST: u8 = 36;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GrabServerRequest;
+impl GrabServerRequest {
+    /// Opcode for the GrabServer request
+    pub const fn opcode() -> u8 { 36 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GrabServerRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn grab_server<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GRAB_SERVER_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GrabServerRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UngrabServer request
-pub const UNGRAB_SERVER_REQUEST: u8 = 37;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UngrabServerRequest;
+impl UngrabServerRequest {
+    /// Opcode for the UngrabServer request
+    pub const fn opcode() -> u8 { 37 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            UngrabServerRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn ungrab_server<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        UNGRAB_SERVER_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UngrabServerRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the QueryPointer request
-pub const QUERY_POINTER_REQUEST: u8 = 38;
+/// get pointer coordinates.
+///
+/// Gets the root window the pointer is logically on and the pointer coordinates
+/// relative to the root window's origin.
+///
+/// # Fields
+///
+/// * `window` - A window to check if the pointer is on the same screen as `window` (see the
+/// `same_screen` field in the reply).
+///
+/// # Errors
+///
+/// * `Window` - The specified `window` does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryPointerRequest {
+    pub window: Window,
+}
+impl QueryPointerRequest {
+    /// Opcode for the QueryPointer request
+    pub const fn opcode() -> u8 { 38 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            QueryPointerRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// get pointer coordinates.
 ///
 /// Gets the root window the pointer is logically on and the pointer coordinates
@@ -10113,23 +11961,12 @@ pub fn query_pointer<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Con
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        QUERY_POINTER_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryPointerRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -10236,8 +12073,50 @@ impl Serialize for Timecoord {
     }
 }
 
-/// Opcode for the GetMotionEvents request
-pub const GET_MOTION_EVENTS_REQUEST: u8 = 39;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetMotionEventsRequest {
+    pub window: Window,
+    pub start: Timestamp,
+    pub stop: Timestamp,
+}
+impl GetMotionEventsRequest {
+    /// Opcode for the GetMotionEvents request
+    pub const fn opcode() -> u8 { 39 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let start_bytes = self.start.serialize();
+        let stop_bytes = self.stop.serialize();
+        let mut request0 = vec![
+            GetMotionEventsRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            start_bytes[0],
+            start_bytes[1],
+            start_bytes[2],
+            start_bytes[3],
+            stop_bytes[0],
+            stop_bytes[1],
+            stop_bytes[2],
+            stop_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_motion_events<Conn, A, B>(conn: &Conn, window: Window, start: A, stop: B) -> Result<Cookie<'_, Conn, GetMotionEventsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10246,33 +12125,14 @@ where
 {
     let start: Timestamp = start.into();
     let stop: Timestamp = stop.into();
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let start_bytes = start.serialize();
-    let stop_bytes = stop.serialize();
-    let mut request0 = [
-        GET_MOTION_EVENTS_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        start_bytes[0],
-        start_bytes[1],
-        start_bytes[2],
-        start_bytes[3],
-        stop_bytes[0],
-        stop_bytes[1],
-        stop_bytes[2],
-        stop_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetMotionEventsRequest {
+        window: window,
+        start: start,
+        stop: stop,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10317,40 +12177,65 @@ impl GetMotionEventsReply {
     }
 }
 
-/// Opcode for the TranslateCoordinates request
-pub const TRANSLATE_COORDINATES_REQUEST: u8 = 40;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TranslateCoordinatesRequest {
+    pub src_window: Window,
+    pub dst_window: Window,
+    pub src_x: i16,
+    pub src_y: i16,
+}
+impl TranslateCoordinatesRequest {
+    /// Opcode for the TranslateCoordinates request
+    pub const fn opcode() -> u8 { 40 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let src_window_bytes = self.src_window.serialize();
+        let dst_window_bytes = self.dst_window.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let mut request0 = vec![
+            TranslateCoordinatesRequest::opcode(),
+            0,
+            0,
+            0,
+            src_window_bytes[0],
+            src_window_bytes[1],
+            src_window_bytes[2],
+            src_window_bytes[3],
+            dst_window_bytes[0],
+            dst_window_bytes[1],
+            dst_window_bytes[2],
+            dst_window_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn translate_coordinates<Conn>(conn: &Conn, src_window: Window, dst_window: Window, src_x: i16, src_y: i16) -> Result<Cookie<'_, Conn, TranslateCoordinatesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let src_window_bytes = src_window.serialize();
-    let dst_window_bytes = dst_window.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let mut request0 = [
-        TRANSLATE_COORDINATES_REQUEST,
-        0,
-        0,
-        0,
-        src_window_bytes[0],
-        src_window_bytes[1],
-        src_window_bytes[2],
-        src_window_bytes[3],
-        dst_window_bytes[0],
-        dst_window_bytes[1],
-        dst_window_bytes[2],
-        dst_window_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = TranslateCoordinatesRequest {
+        src_window: src_window,
+        dst_window: dst_window,
+        src_x: src_x,
+        src_y: src_y,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10383,8 +12268,100 @@ impl TryFrom<&[u8]> for TranslateCoordinatesReply {
     }
 }
 
-/// Opcode for the WarpPointer request
-pub const WARP_POINTER_REQUEST: u8 = 41;
+/// move mouse pointer.
+///
+/// Moves the mouse pointer to the specified position.
+///
+/// If `src_window` is not `XCB_NONE` (TODO), the move will only take place if the
+/// pointer is inside `src_window` and within the rectangle specified by (`src_x`,
+/// `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
+/// `src_window`.
+///
+/// If `dst_window` is not `XCB_NONE` (TODO), the pointer will be moved to the
+/// offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
+/// `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
+/// relative to the current position of the pointer.
+///
+/// # Fields
+///
+/// * `src_window` - If `src_window` is not `XCB_NONE` (TODO), the move will only take place if the
+/// pointer is inside `src_window` and within the rectangle specified by (`src_x`,
+/// `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
+/// `src_window`.
+/// * `dst_window` - If `dst_window` is not `XCB_NONE` (TODO), the pointer will be moved to the
+/// offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
+/// `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
+/// relative to the current position of the pointer.
+///
+/// # Errors
+///
+/// * `Window` - TODO: reasons?
+///
+/// # See
+///
+/// * `SetInputFocus`: request
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WarpPointerRequest {
+    pub src_window: Window,
+    pub dst_window: Window,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub src_width: u16,
+    pub src_height: u16,
+    pub dst_x: i16,
+    pub dst_y: i16,
+}
+impl WarpPointerRequest {
+    /// Opcode for the WarpPointer request
+    pub const fn opcode() -> u8 { 41 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let src_window_bytes = self.src_window.serialize();
+        let dst_window_bytes = self.dst_window.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let src_width_bytes = self.src_width.serialize();
+        let src_height_bytes = self.src_height.serialize();
+        let dst_x_bytes = self.dst_x.serialize();
+        let dst_y_bytes = self.dst_y.serialize();
+        let mut request0 = vec![
+            WarpPointerRequest::opcode(),
+            0,
+            0,
+            0,
+            src_window_bytes[0],
+            src_window_bytes[1],
+            src_window_bytes[2],
+            src_window_bytes[3],
+            dst_window_bytes[0],
+            dst_window_bytes[1],
+            dst_window_bytes[2],
+            dst_window_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+            src_width_bytes[0],
+            src_width_bytes[1],
+            src_height_bytes[0],
+            src_height_bytes[1],
+            dst_x_bytes[0],
+            dst_x_bytes[1],
+            dst_y_bytes[0],
+            dst_y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// move mouse pointer.
 ///
 /// Moves the mouse pointer to the specified position.
@@ -10425,46 +12402,19 @@ where
 {
     let src_window: Window = src_window.into();
     let dst_window: Window = dst_window.into();
-    let length_so_far = 0;
-    let src_window_bytes = src_window.serialize();
-    let dst_window_bytes = dst_window.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let src_width_bytes = src_width.serialize();
-    let src_height_bytes = src_height.serialize();
-    let dst_x_bytes = dst_x.serialize();
-    let dst_y_bytes = dst_y.serialize();
-    let mut request0 = [
-        WARP_POINTER_REQUEST,
-        0,
-        0,
-        0,
-        src_window_bytes[0],
-        src_window_bytes[1],
-        src_window_bytes[2],
-        src_window_bytes[3],
-        dst_window_bytes[0],
-        dst_window_bytes[1],
-        dst_window_bytes[2],
-        dst_window_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-        src_width_bytes[0],
-        src_width_bytes[1],
-        src_height_bytes[0],
-        src_height_bytes[1],
-        dst_x_bytes[0],
-        dst_x_bytes[1],
-        dst_y_bytes[0],
-        dst_y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = WarpPointerRequest {
+        src_window: src_window,
+        dst_window: dst_window,
+        src_x: src_x,
+        src_y: src_y,
+        src_width: src_width,
+        src_height: src_height,
+        dst_x: dst_x,
+        dst_y: dst_y,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -10544,8 +12494,81 @@ impl TryFrom<u32> for InputFocus {
     }
 }
 
-/// Opcode for the SetInputFocus request
-pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
+/// Sets input focus.
+///
+/// Changes the input focus and the last-focus-change time. If the specified `time`
+/// is earlier than the current last-focus-change time, the request is ignored (to
+/// avoid race conditions when running X over the network).
+///
+/// A FocusIn and FocusOut event is generated when focus is changed.
+///
+/// # Fields
+///
+/// * `focus` - The window to focus. All keyboard events will be reported to this window. The
+/// window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
+///
+/// If `focus` is `XCB_NONE` (TODO), all keyboard events are
+/// discarded until a new focus window is set.
+///
+/// If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
+/// screen on which the pointer is on currently.
+/// * `time` - Timestamp to avoid race conditions when running X over the network.
+///
+/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
+/// time.
+/// * `revert_to` - Specifies what happens when the `focus` window becomes unviewable (if `focus`
+/// is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
+///
+/// # Errors
+///
+/// * `Window` - The specified `focus` window does not exist.
+/// * `Match` - The specified `focus` window is not viewable.
+/// * `Value` - TODO: Reasons?
+///
+/// # See
+///
+/// * `FocusIn`: event
+/// * `FocusOut`: event
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetInputFocusRequest {
+    pub revert_to: InputFocus,
+    pub focus: Window,
+    pub time: Timestamp,
+}
+impl SetInputFocusRequest {
+    /// Opcode for the SetInputFocus request
+    pub const fn opcode() -> u8 { 42 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let revert_to_bytes = u8::from(self.revert_to).serialize();
+        let focus_bytes = self.focus.serialize();
+        let time_bytes = self.time.serialize();
+        let mut request0 = vec![
+            SetInputFocusRequest::opcode(),
+            revert_to_bytes[0],
+            0,
+            0,
+            focus_bytes[0],
+            focus_bytes[1],
+            focus_bytes[2],
+            focus_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Sets input focus.
 ///
 /// Changes the input focus and the last-focus-change time. If the specified `time`
@@ -10589,49 +12612,49 @@ where
 {
     let focus: Window = focus.into();
     let time: Timestamp = time.into();
-    let length_so_far = 0;
-    let revert_to_bytes = u8::from(revert_to).serialize();
-    let focus_bytes = focus.serialize();
-    let time_bytes = time.serialize();
-    let mut request0 = [
-        SET_INPUT_FOCUS_REQUEST,
-        revert_to_bytes[0],
-        0,
-        0,
-        focus_bytes[0],
-        focus_bytes[1],
-        focus_bytes[2],
-        focus_bytes[3],
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetInputFocusRequest {
+        revert_to: revert_to,
+        focus: focus,
+        time: time,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetInputFocus request
-pub const GET_INPUT_FOCUS_REQUEST: u8 = 43;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetInputFocusRequest;
+impl GetInputFocusRequest {
+    /// Opcode for the GetInputFocus request
+    pub const fn opcode() -> u8 { 43 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GetInputFocusRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_input_focus<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetInputFocusReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GET_INPUT_FOCUS_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetInputFocusRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10661,24 +12684,39 @@ impl TryFrom<&[u8]> for GetInputFocusReply {
     }
 }
 
-/// Opcode for the QueryKeymap request
-pub const QUERY_KEYMAP_REQUEST: u8 = 44;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryKeymapRequest;
+impl QueryKeymapRequest {
+    /// Opcode for the QueryKeymap request
+    pub const fn opcode() -> u8 { 44 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            QueryKeymapRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_keymap<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryKeymapReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        QUERY_KEYMAP_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryKeymapRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10707,8 +12745,68 @@ impl TryFrom<&[u8]> for QueryKeymapReply {
     }
 }
 
-/// Opcode for the OpenFont request
-pub const OPEN_FONT_REQUEST: u8 = 45;
+/// opens a font.
+///
+/// Opens any X core font matching the given `name` (for example "-misc-fixed-*").
+///
+/// Note that X core fonts are deprecated (but still supported) in favor of
+/// client-side rendering using Xft.
+///
+/// # Fields
+///
+/// * `fid` - The ID with which you will refer to the font, created by `xcb_generate_id`.
+/// * `name_len` - Length (in bytes) of `name`.
+/// * `name` - A pattern describing an X core font.
+///
+/// # Errors
+///
+/// * `Name` - No font matches the given `name`.
+///
+/// # See
+///
+/// * `xcb_generate_id`: function
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenFontRequest<'input> {
+    pub fid: Font,
+    pub name: &'input [u8],
+}
+impl<'input> OpenFontRequest<'input> {
+    /// Opcode for the OpenFont request
+    pub const fn opcode() -> u8 { 45 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let fid_bytes = self.fid.serialize();
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        let name_len_bytes = name_len.serialize();
+        let mut request0 = vec![
+            OpenFontRequest::opcode(),
+            0,
+            0,
+            0,
+            fid_bytes[0],
+            fid_bytes[1],
+            fid_bytes[2],
+            fid_bytes[3],
+            name_len_bytes[0],
+            name_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// opens a font.
 ///
 /// Opens any X core font matching the given `name` (for example "-misc-fixed-*").
@@ -10733,57 +12831,57 @@ pub fn open_font<'c, 'input, Conn>(conn: &'c Conn, fid: Font, name: &'input [u8]
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let fid_bytes = fid.serialize();
-    let name_len = u16::try_from(name.len()).expect("`name` has too many elements");
-    let name_len_bytes = name_len.serialize();
-    let mut request0 = [
-        OPEN_FONT_REQUEST,
-        0,
-        0,
-        0,
-        fid_bytes[0],
-        fid_bytes[1],
-        fid_bytes[2],
-        fid_bytes[3],
-        name_len_bytes[0],
-        name_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = OpenFontRequest {
+        fid: fid,
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CloseFont request
-pub const CLOSE_FONT_REQUEST: u8 = 46;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CloseFontRequest {
+    pub font: Font,
+}
+impl CloseFontRequest {
+    /// Opcode for the CloseFont request
+    pub const fn opcode() -> u8 { 46 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let font_bytes = self.font.serialize();
+        let mut request0 = vec![
+            CloseFontRequest::opcode(),
+            0,
+            0,
+            0,
+            font_bytes[0],
+            font_bytes[1],
+            font_bytes[2],
+            font_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn close_font<Conn>(conn: &Conn, font: Font) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let font_bytes = font.serialize();
-    let mut request0 = [
-        CLOSE_FONT_REQUEST,
-        0,
-        0,
-        0,
-        font_bytes[0],
-        font_bytes[1],
-        font_bytes[2],
-        font_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CloseFontRequest {
+        font: font,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10960,8 +13058,45 @@ impl Serialize for Charinfo {
     }
 }
 
-/// Opcode for the QueryFont request
-pub const QUERY_FONT_REQUEST: u8 = 47;
+/// query font metrics.
+///
+/// Queries information associated with the font.
+///
+/// # Fields
+///
+/// * `font` - The fontable (Font or Graphics Context) to query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryFontRequest {
+    pub font: Fontable,
+}
+impl QueryFontRequest {
+    /// Opcode for the QueryFont request
+    pub const fn opcode() -> u8 { 47 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let font_bytes = self.font.serialize();
+        let mut request0 = vec![
+            QueryFontRequest::opcode(),
+            0,
+            0,
+            0,
+            font_bytes[0],
+            font_bytes[1],
+            font_bytes[2],
+            font_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// query font metrics.
 ///
 /// Queries information associated with the font.
@@ -10973,23 +13108,12 @@ pub fn query_font<Conn>(conn: &Conn, font: Fontable) -> Result<Cookie<'_, Conn, 
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let font_bytes = font.serialize();
-    let mut request0 = [
-        QUERY_FONT_REQUEST,
-        0,
-        0,
-        0,
-        font_bytes[0],
-        font_bytes[1],
-        font_bytes[2],
-        font_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryFontRequest {
+        font: font,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -11086,8 +13210,80 @@ impl QueryFontReply {
     }
 }
 
-/// Opcode for the QueryTextExtents request
-pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
+/// get text extents.
+///
+/// Query text extents from the X11 server. This request returns the bounding box
+/// of the specified 16-bit character string in the specified `font` or the font
+/// contained in the specified graphics context.
+///
+/// `font_ascent` is set to the maximum of the ascent metrics of all characters in
+/// the string. `font_descent` is set to the maximum of the descent metrics.
+/// `overall_width` is set to the sum of the character-width metrics of all
+/// characters in the string. For each character in the string, let W be the sum of
+/// the character-width metrics of all characters preceding it in the string. Let L
+/// be the left-side-bearing metric of the character plus W. Let R be the
+/// right-side-bearing metric of the character plus W. The lbearing member is set
+/// to the minimum L of all characters in the string. The rbearing member is set to
+/// the maximum R.
+///
+/// For fonts defined with linear indexing rather than 2-byte matrix indexing, each
+/// `xcb_char2b_t` structure is interpreted as a 16-bit number with byte1 as the
+/// most significant byte. If the font has no defined default character, undefined
+/// characters in the string are taken to have all zero metrics.
+///
+/// Characters with all zero metrics are ignored. If the font has no defined
+/// default_char, the undefined characters in the string are also ignored.
+///
+/// # Fields
+///
+/// * `font` - The `font` to calculate text extents in. You can also pass a graphics context.
+/// * `string_len` - The number of characters in `string`.
+/// * `string` - The text to get text extents for.
+///
+/// # Errors
+///
+/// * `GContext` - The specified graphics context does not exist.
+/// * `Font` - The specified `font` does not exist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryTextExtentsRequest<'input> {
+    pub font: Fontable,
+    pub string: &'input [Char2b],
+}
+impl<'input> QueryTextExtentsRequest<'input> {
+    /// Opcode for the QueryTextExtents request
+    pub const fn opcode() -> u8 { 48 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let string_len = u32::try_from(self.string.len()).unwrap();
+        let length_so_far = 0;
+        let odd_length = (string_len & 1u32) != 0;
+        let odd_length_bytes = odd_length.serialize();
+        let font_bytes = self.font.serialize();
+        let mut request0 = vec![
+            QueryTextExtentsRequest::opcode(),
+            odd_length_bytes[0],
+            0,
+            0,
+            font_bytes[0],
+            font_bytes[1],
+            font_bytes[2],
+            font_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let string_bytes = self.string.serialize();
+        let length_so_far = length_so_far + string_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), string_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// get text extents.
 ///
 /// Query text extents from the X11 server. This request returns the bounding box
@@ -11126,30 +13322,13 @@ pub fn query_text_extents<'c, 'input, Conn>(conn: &'c Conn, font: Fontable, stri
 where
     Conn: RequestConnection + ?Sized,
 {
-    let string_len = u32::try_from(string.len()).unwrap();
-    let length_so_far = 0;
-    let odd_length = (string_len & 1u32) != 0;
-    let odd_length_bytes = odd_length.serialize();
-    let font_bytes = font.serialize();
-    let mut request0 = [
-        QUERY_TEXT_EXTENTS_REQUEST,
-        odd_length_bytes[0],
-        0,
-        0,
-        font_bytes[0],
-        font_bytes[1],
-        font_bytes[2],
-        font_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let string_bytes = string.serialize();
-    let length_so_far = length_so_far + string_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&string_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = QueryTextExtentsRequest {
+        font: font,
+        string: string,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -11239,8 +13418,57 @@ impl Str {
     }
 }
 
-/// Opcode for the ListFonts request
-pub const LIST_FONTS_REQUEST: u8 = 49;
+/// get matching font names.
+///
+/// Gets a list of available font names which match the given `pattern`.
+///
+/// # Fields
+///
+/// * `pattern_len` - The length (in bytes) of `pattern`.
+/// * `pattern` - A font pattern, for example "-misc-fixed-*".
+///
+/// The asterisk (*) is a wildcard for any number of characters. The question mark
+/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
+/// not matter.
+/// * `max_names` - The maximum number of fonts to be returned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListFontsRequest<'input> {
+    pub max_names: u16,
+    pub pattern: &'input [u8],
+}
+impl<'input> ListFontsRequest<'input> {
+    /// Opcode for the ListFonts request
+    pub const fn opcode() -> u8 { 49 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let max_names_bytes = self.max_names.serialize();
+        let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
+        let pattern_len_bytes = pattern_len.serialize();
+        let mut request0 = vec![
+            ListFontsRequest::opcode(),
+            0,
+            0,
+            0,
+            max_names_bytes[0],
+            max_names_bytes[1],
+            pattern_len_bytes[0],
+            pattern_len_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.pattern[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.pattern[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// get matching font names.
 ///
 /// Gets a list of available font names which match the given `pattern`.
@@ -11258,28 +13486,13 @@ pub fn list_fonts<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pattern: &'i
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let max_names_bytes = max_names.serialize();
-    let pattern_len = u16::try_from(pattern.len()).expect("`pattern` has too many elements");
-    let pattern_len_bytes = pattern_len.serialize();
-    let mut request0 = [
-        LIST_FONTS_REQUEST,
-        0,
-        0,
-        0,
-        max_names_bytes[0],
-        max_names_bytes[1],
-        pattern_len_bytes[0],
-        pattern_len_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + pattern.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(pattern), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ListFontsRequest {
+        max_names: max_names,
+        pattern: pattern,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -11327,8 +13540,57 @@ impl ListFontsReply {
     }
 }
 
-/// Opcode for the ListFontsWithInfo request
-pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
+/// get matching font names and information.
+///
+/// Gets a list of available font names which match the given `pattern`.
+///
+/// # Fields
+///
+/// * `pattern_len` - The length (in bytes) of `pattern`.
+/// * `pattern` - A font pattern, for example "-misc-fixed-*".
+///
+/// The asterisk (*) is a wildcard for any number of characters. The question mark
+/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
+/// not matter.
+/// * `max_names` - The maximum number of fonts to be returned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListFontsWithInfoRequest<'input> {
+    pub max_names: u16,
+    pub pattern: &'input [u8],
+}
+impl<'input> ListFontsWithInfoRequest<'input> {
+    /// Opcode for the ListFontsWithInfo request
+    pub const fn opcode() -> u8 { 50 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let max_names_bytes = self.max_names.serialize();
+        let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
+        let pattern_len_bytes = pattern_len.serialize();
+        let mut request0 = vec![
+            ListFontsWithInfoRequest::opcode(),
+            0,
+            0,
+            0,
+            max_names_bytes[0],
+            max_names_bytes[1],
+            pattern_len_bytes[0],
+            pattern_len_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.pattern[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.pattern[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// get matching font names and information.
 ///
 /// Gets a list of available font names which match the given `pattern`.
@@ -11346,28 +13608,13 @@ pub fn list_fonts_with_info<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pa
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let max_names_bytes = max_names.serialize();
-    let pattern_len = u16::try_from(pattern.len()).expect("`pattern` has too many elements");
-    let pattern_len_bytes = pattern_len.serialize();
-    let mut request0 = [
-        LIST_FONTS_WITH_INFO_REQUEST,
-        0,
-        0,
-        0,
-        max_names_bytes[0],
-        max_names_bytes[1],
-        pattern_len_bytes[0],
-        pattern_len_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + pattern.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(ListFontsWithInfoCookie::new(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(pattern), IoSlice::new(&padding0)], vec![])?))
+    let request0 = ListFontsWithInfoRequest {
+        max_names: max_names,
+        pattern: pattern,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(ListFontsWithInfoCookie::new(conn.send_request_with_reply(&slices, fds)?))
 }
 
 /// # Fields
@@ -11470,54 +13717,88 @@ impl ListFontsWithInfoReply {
     }
 }
 
-/// Opcode for the SetFontPath request
-pub const SET_FONT_PATH_REQUEST: u8 = 51;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetFontPathRequest<'input> {
+    pub font: &'input [Str],
+}
+impl<'input> SetFontPathRequest<'input> {
+    /// Opcode for the SetFontPath request
+    pub const fn opcode() -> u8 { 51 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let font_qty = u16::try_from(self.font.len()).expect("`font` has too many elements");
+        let font_qty_bytes = font_qty.serialize();
+        let mut request0 = vec![
+            SetFontPathRequest::opcode(),
+            0,
+            0,
+            0,
+            font_qty_bytes[0],
+            font_qty_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let font_bytes = self.font.serialize();
+        let length_so_far = length_so_far + font_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), font_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_font_path<'c, 'input, Conn>(conn: &'c Conn, font: &'input [Str]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let font_qty = u16::try_from(font.len()).expect("`font` has too many elements");
-    let font_qty_bytes = font_qty.serialize();
-    let mut request0 = [
-        SET_FONT_PATH_REQUEST,
-        0,
-        0,
-        0,
-        font_qty_bytes[0],
-        font_qty_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let font_bytes = font.serialize();
-    let length_so_far = length_so_far + font_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&font_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetFontPathRequest {
+        font: font,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetFontPath request
-pub const GET_FONT_PATH_REQUEST: u8 = 52;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetFontPathRequest;
+impl GetFontPathRequest {
+    /// Opcode for the GetFontPath request
+    pub const fn opcode() -> u8 { 52 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GetFontPathRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_font_path<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetFontPathReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GET_FONT_PATH_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetFontPathRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11562,8 +13843,77 @@ impl GetFontPathReply {
     }
 }
 
-/// Opcode for the CreatePixmap request
-pub const CREATE_PIXMAP_REQUEST: u8 = 53;
+/// Creates a pixmap.
+///
+/// Creates a pixmap. The pixmap can only be used on the same screen as `drawable`
+/// is on and only with drawables of the same `depth`.
+///
+/// # Fields
+///
+/// * `depth` - TODO
+/// * `pid` - The ID with which you will refer to the new pixmap, created by
+/// `xcb_generate_id`.
+/// * `drawable` - Drawable to get the screen from.
+/// * `width` - The width of the new pixmap.
+/// * `height` - The height of the new pixmap.
+///
+/// # Errors
+///
+/// * `Value` - TODO: reasons?
+/// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
+/// * `Alloc` - The X server could not allocate the requested resources (no memory?).
+///
+/// # See
+///
+/// * `xcb_generate_id`: function
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreatePixmapRequest {
+    pub depth: u8,
+    pub pid: Pixmap,
+    pub drawable: Drawable,
+    pub width: u16,
+    pub height: u16,
+}
+impl CreatePixmapRequest {
+    /// Opcode for the CreatePixmap request
+    pub const fn opcode() -> u8 { 53 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let depth_bytes = self.depth.serialize();
+        let pid_bytes = self.pid.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mut request0 = vec![
+            CreatePixmapRequest::opcode(),
+            depth_bytes[0],
+            0,
+            0,
+            pid_bytes[0],
+            pid_bytes[1],
+            pid_bytes[2],
+            pid_bytes[3],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Creates a pixmap.
 ///
 /// Creates a pixmap. The pixmap can only be used on the same screen as `drawable`
@@ -11591,39 +13941,62 @@ pub fn create_pixmap<Conn>(conn: &Conn, depth: u8, pid: Pixmap, drawable: Drawab
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let depth_bytes = depth.serialize();
-    let pid_bytes = pid.serialize();
-    let drawable_bytes = drawable.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let mut request0 = [
-        CREATE_PIXMAP_REQUEST,
-        depth_bytes[0],
-        0,
-        0,
-        pid_bytes[0],
-        pid_bytes[1],
-        pid_bytes[2],
-        pid_bytes[3],
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreatePixmapRequest {
+        depth: depth,
+        pid: pid,
+        drawable: drawable,
+        width: width,
+        height: height,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FreePixmap request
-pub const FREE_PIXMAP_REQUEST: u8 = 54;
+/// Destroys a pixmap.
+///
+/// Deletes the association between the pixmap ID and the pixmap. The pixmap
+/// storage will be freed when there are no more references to it.
+///
+/// # Fields
+///
+/// * `pixmap` - The pixmap to destroy.
+///
+/// # Errors
+///
+/// * `Pixmap` - The specified pixmap does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FreePixmapRequest {
+    pub pixmap: Pixmap,
+}
+impl FreePixmapRequest {
+    /// Opcode for the FreePixmap request
+    pub const fn opcode() -> u8 { 54 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let pixmap_bytes = self.pixmap.serialize();
+        let mut request0 = vec![
+            FreePixmapRequest::opcode(),
+            0,
+            0,
+            0,
+            pixmap_bytes[0],
+            pixmap_bytes[1],
+            pixmap_bytes[2],
+            pixmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Destroys a pixmap.
 ///
 /// Deletes the association between the pixmap ID and the pixmap. The pixmap
@@ -11640,23 +14013,12 @@ pub fn free_pixmap<Conn>(conn: &Conn, pixmap: Pixmap) -> Result<VoidCookie<'_, C
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let pixmap_bytes = pixmap.serialize();
-    let mut request0 = [
-        FREE_PIXMAP_REQUEST,
-        0,
-        0,
-        0,
-        pixmap_bytes[0],
-        pixmap_bytes[1],
-        pixmap_bytes[2],
-        pixmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FreePixmapRequest {
+        pixmap: pixmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -12435,8 +14797,6 @@ impl TryFrom<u32> for ArcMode {
     }
 }
 
-/// Opcode for the CreateGC request
-pub const CREATE_GC_REQUEST: u8 = 55;
 /// Auxiliary and optional information for the `create_gc` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CreateGCAux {
@@ -12763,46 +15123,92 @@ impl CreateGCAux {
 /// # See
 ///
 /// * `xcb_generate_id`: function
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateGCRequest<'input> {
+    pub cid: Gcontext,
+    pub drawable: Drawable,
+    pub value_list: &'input CreateGCAux,
+}
+impl<'input> CreateGCRequest<'input> {
+    /// Opcode for the CreateGC request
+    pub const fn opcode() -> u8 { 55 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cid_bytes = self.cid.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            CreateGCRequest::opcode(),
+            0,
+            0,
+            0,
+            cid_bytes[0],
+            cid_bytes[1],
+            cid_bytes[2],
+            cid_bytes[3],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
+/// Creates a graphics context.
+///
+/// Creates a graphics context. The graphics context can be used with any drawable
+/// that has the same root and depth as the specified drawable.
+///
+/// # Fields
+///
+/// * `cid` - The ID with which you will refer to the graphics context, created by
+/// `xcb_generate_id`.
+/// * `drawable` - Drawable to get the root/depth from.
+///
+/// # Errors
+///
+/// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
+/// * `Match` - TODO: reasons?
+/// * `Font` - TODO: reasons?
+/// * `Pixmap` - TODO: reasons?
+/// * `Value` - TODO: reasons?
+/// * `Alloc` - The X server could not allocate the requested resources (no memory?).
+///
+/// # See
+///
+/// * `xcb_generate_id`: function
 pub fn create_gc<'c, 'input, Conn>(conn: &'c Conn, cid: Gcontext, drawable: Drawable, value_list: &'input CreateGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cid_bytes = cid.serialize();
-    let drawable_bytes = drawable.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        CREATE_GC_REQUEST,
-        0,
-        0,
-        0,
-        cid_bytes[0],
-        cid_bytes[1],
-        cid_bytes[2],
-        cid_bytes[3],
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = CreateGCRequest {
+        cid: cid,
+        drawable: drawable,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangeGC request
-pub const CHANGE_GC_REQUEST: u8 = 56;
 /// Auxiliary and optional information for the `change_gc` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangeGCAux {
@@ -13151,109 +15557,223 @@ impl ChangeGCAux {
 ///     xcb_flush(conn);
 /// }
 /// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeGCRequest<'input> {
+    pub gc: Gcontext,
+    pub value_list: &'input ChangeGCAux,
+}
+impl<'input> ChangeGCRequest<'input> {
+    /// Opcode for the ChangeGC request
+    pub const fn opcode() -> u8 { 56 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let gc_bytes = self.gc.serialize();
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            ChangeGCRequest::opcode(),
+            0,
+            0,
+            0,
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
+/// change graphics context components.
+///
+/// Changes the components specified by `value_mask` for the specified graphics context.
+///
+/// # Fields
+///
+/// * `gc` - The graphics context to change.
+/// * `value_mask` -
+/// * `value_list` - Values for each of the components specified in the bitmask `value_mask`. The
+/// order has to correspond to the order of possible `value_mask` bits. See the
+/// example.
+///
+/// # Errors
+///
+/// * `Font` - TODO: reasons?
+/// * `GContext` - TODO: reasons?
+/// * `Match` - TODO: reasons?
+/// * `Pixmap` - TODO: reasons?
+/// * `Value` - TODO: reasons?
+/// * `Alloc` - The X server could not allocate the requested resources (no memory?).
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Changes the foreground color component of the specified graphics context.
+///  *
+///  */
+/// void my_example(xcb_connection_t *conn, xcb_gcontext_t gc, uint32_t fg, uint32_t bg) {
+///     /* C99 allows us to use a compact way of changing a single component: */
+///     xcb_change_gc(conn, gc, XCB_GC_FOREGROUND, (uint32_t[]){ fg });
+///
+///     /* The more explicit way. Beware that the order of values is important! */
+///     uint32_t mask = 0;
+///     mask |= XCB_GC_FOREGROUND;
+///     mask |= XCB_GC_BACKGROUND;
+///
+///     uint32_t values[] = {
+///         fg,
+///         bg
+///     };
+///     xcb_change_gc(conn, gc, mask, values);
+///     xcb_flush(conn);
+/// }
+/// ```
 pub fn change_gc<'c, 'input, Conn>(conn: &'c Conn, gc: Gcontext, value_list: &'input ChangeGCAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let gc_bytes = gc.serialize();
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        CHANGE_GC_REQUEST,
-        0,
-        0,
-        0,
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeGCRequest {
+        gc: gc,
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CopyGC request
-pub const COPY_GC_REQUEST: u8 = 57;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CopyGCRequest {
+    pub src_gc: Gcontext,
+    pub dst_gc: Gcontext,
+    pub value_mask: u32,
+}
+impl CopyGCRequest {
+    /// Opcode for the CopyGC request
+    pub const fn opcode() -> u8 { 57 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let src_gc_bytes = self.src_gc.serialize();
+        let dst_gc_bytes = self.dst_gc.serialize();
+        let value_mask_bytes = self.value_mask.serialize();
+        let mut request0 = vec![
+            CopyGCRequest::opcode(),
+            0,
+            0,
+            0,
+            src_gc_bytes[0],
+            src_gc_bytes[1],
+            src_gc_bytes[2],
+            src_gc_bytes[3],
+            dst_gc_bytes[0],
+            dst_gc_bytes[1],
+            dst_gc_bytes[2],
+            dst_gc_bytes[3],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn copy_gc<Conn, A>(conn: &Conn, src_gc: Gcontext, dst_gc: Gcontext, value_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u32>,
 {
     let value_mask: u32 = value_mask.into();
-    let length_so_far = 0;
-    let src_gc_bytes = src_gc.serialize();
-    let dst_gc_bytes = dst_gc.serialize();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        COPY_GC_REQUEST,
-        0,
-        0,
-        0,
-        src_gc_bytes[0],
-        src_gc_bytes[1],
-        src_gc_bytes[2],
-        src_gc_bytes[3],
-        dst_gc_bytes[0],
-        dst_gc_bytes[1],
-        dst_gc_bytes[2],
-        dst_gc_bytes[3],
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CopyGCRequest {
+        src_gc: src_gc,
+        dst_gc: dst_gc,
+        value_mask: value_mask,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the SetDashes request
-pub const SET_DASHES_REQUEST: u8 = 58;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetDashesRequest<'input> {
+    pub gc: Gcontext,
+    pub dash_offset: u16,
+    pub dashes: &'input [u8],
+}
+impl<'input> SetDashesRequest<'input> {
+    /// Opcode for the SetDashes request
+    pub const fn opcode() -> u8 { 58 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let gc_bytes = self.gc.serialize();
+        let dash_offset_bytes = self.dash_offset.serialize();
+        let dashes_len = u16::try_from(self.dashes.len()).expect("`dashes` has too many elements");
+        let dashes_len_bytes = dashes_len.serialize();
+        let mut request0 = vec![
+            SetDashesRequest::opcode(),
+            0,
+            0,
+            0,
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            dash_offset_bytes[0],
+            dash_offset_bytes[1],
+            dashes_len_bytes[0],
+            dashes_len_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.dashes[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.dashes[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_dashes<'c, 'input, Conn>(conn: &'c Conn, gc: Gcontext, dash_offset: u16, dashes: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let gc_bytes = gc.serialize();
-    let dash_offset_bytes = dash_offset.serialize();
-    let dashes_len = u16::try_from(dashes.len()).expect("`dashes` has too many elements");
-    let dashes_len_bytes = dashes_len.serialize();
-    let mut request0 = [
-        SET_DASHES_REQUEST,
-        0,
-        0,
-        0,
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        dash_offset_bytes[0],
-        dash_offset_bytes[1],
-        dashes_len_bytes[0],
-        dashes_len_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + dashes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(dashes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetDashesRequest {
+        gc: gc,
+        dash_offset: dash_offset,
+        dashes: dashes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13324,44 +15844,112 @@ impl TryFrom<u32> for ClipOrdering {
     }
 }
 
-/// Opcode for the SetClipRectangles request
-pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetClipRectanglesRequest<'input> {
+    pub ordering: ClipOrdering,
+    pub gc: Gcontext,
+    pub clip_x_origin: i16,
+    pub clip_y_origin: i16,
+    pub rectangles: &'input [Rectangle],
+}
+impl<'input> SetClipRectanglesRequest<'input> {
+    /// Opcode for the SetClipRectangles request
+    pub const fn opcode() -> u8 { 59 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let ordering_bytes = u8::from(self.ordering).serialize();
+        let gc_bytes = self.gc.serialize();
+        let clip_x_origin_bytes = self.clip_x_origin.serialize();
+        let clip_y_origin_bytes = self.clip_y_origin.serialize();
+        let mut request0 = vec![
+            SetClipRectanglesRequest::opcode(),
+            ordering_bytes[0],
+            0,
+            0,
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            clip_x_origin_bytes[0],
+            clip_x_origin_bytes[1],
+            clip_y_origin_bytes[0],
+            clip_y_origin_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let rectangles_bytes = self.rectangles.serialize();
+        let length_so_far = length_so_far + rectangles_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, ordering: ClipOrdering, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let ordering_bytes = u8::from(ordering).serialize();
-    let gc_bytes = gc.serialize();
-    let clip_x_origin_bytes = clip_x_origin.serialize();
-    let clip_y_origin_bytes = clip_y_origin.serialize();
-    let mut request0 = [
-        SET_CLIP_RECTANGLES_REQUEST,
-        ordering_bytes[0],
-        0,
-        0,
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        clip_x_origin_bytes[0],
-        clip_x_origin_bytes[1],
-        clip_y_origin_bytes[0],
-        clip_y_origin_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let rectangles_bytes = rectangles.serialize();
-    let length_so_far = length_so_far + rectangles_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&rectangles_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetClipRectanglesRequest {
+        ordering: ordering,
+        gc: gc,
+        clip_x_origin: clip_x_origin,
+        clip_y_origin: clip_y_origin,
+        rectangles: rectangles,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FreeGC request
-pub const FREE_GC_REQUEST: u8 = 60;
+/// Destroys a graphics context.
+///
+/// Destroys the specified `gc` and all associated storage.
+///
+/// # Fields
+///
+/// * `gc` - The graphics context to destroy.
+///
+/// # Errors
+///
+/// * `GContext` - The specified graphics context does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FreeGCRequest {
+    pub gc: Gcontext,
+}
+impl FreeGCRequest {
+    /// Opcode for the FreeGC request
+    pub const fn opcode() -> u8 { 60 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            FreeGCRequest::opcode(),
+            0,
+            0,
+            0,
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Destroys a graphics context.
 ///
 /// Destroys the specified `gc` and all associated storage.
@@ -13377,65 +15965,170 @@ pub fn free_gc<Conn>(conn: &Conn, gc: Gcontext) -> Result<VoidCookie<'_, Conn>, 
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        FREE_GC_REQUEST,
-        0,
-        0,
-        0,
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FreeGCRequest {
+        gc: gc,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ClearArea request
-pub const CLEAR_AREA_REQUEST: u8 = 61;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClearAreaRequest {
+    pub exposures: bool,
+    pub window: Window,
+    pub x: i16,
+    pub y: i16,
+    pub width: u16,
+    pub height: u16,
+}
+impl ClearAreaRequest {
+    /// Opcode for the ClearArea request
+    pub const fn opcode() -> u8 { 61 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let exposures_bytes = self.exposures.serialize();
+        let window_bytes = self.window.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mut request0 = vec![
+            ClearAreaRequest::opcode(),
+            exposures_bytes[0],
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn clear_area<Conn>(conn: &Conn, exposures: bool, window: Window, x: i16, y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let exposures_bytes = exposures.serialize();
-    let window_bytes = window.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let mut request0 = [
-        CLEAR_AREA_REQUEST,
-        exposures_bytes[0],
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ClearAreaRequest {
+        exposures: exposures,
+        window: window,
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CopyArea request
-pub const COPY_AREA_REQUEST: u8 = 62;
+/// copy areas.
+///
+/// Copies the specified rectangle from `src_drawable` to `dst_drawable`.
+///
+/// # Fields
+///
+/// * `dst_drawable` - The destination drawable (Window or Pixmap).
+/// * `src_drawable` - The source drawable (Window or Pixmap).
+/// * `gc` - The graphics context to use.
+/// * `src_x` - The source X coordinate.
+/// * `src_y` - The source Y coordinate.
+/// * `dst_x` - The destination X coordinate.
+/// * `dst_y` - The destination Y coordinate.
+/// * `width` - The width of the area to copy (in pixels).
+/// * `height` - The height of the area to copy (in pixels).
+///
+/// # Errors
+///
+/// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
+/// * `GContext` - The specified graphics context does not exist.
+/// * `Match` - `src_drawable` has a different root or depth than `dst_drawable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CopyAreaRequest {
+    pub src_drawable: Drawable,
+    pub dst_drawable: Drawable,
+    pub gc: Gcontext,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub dst_x: i16,
+    pub dst_y: i16,
+    pub width: u16,
+    pub height: u16,
+}
+impl CopyAreaRequest {
+    /// Opcode for the CopyArea request
+    pub const fn opcode() -> u8 { 62 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let src_drawable_bytes = self.src_drawable.serialize();
+        let dst_drawable_bytes = self.dst_drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let dst_x_bytes = self.dst_x.serialize();
+        let dst_y_bytes = self.dst_y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mut request0 = vec![
+            CopyAreaRequest::opcode(),
+            0,
+            0,
+            0,
+            src_drawable_bytes[0],
+            src_drawable_bytes[1],
+            src_drawable_bytes[2],
+            src_drawable_bytes[3],
+            dst_drawable_bytes[0],
+            dst_drawable_bytes[1],
+            dst_drawable_bytes[2],
+            dst_drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+            dst_x_bytes[0],
+            dst_x_bytes[1],
+            dst_y_bytes[0],
+            dst_y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// copy areas.
 ///
 /// Copies the specified rectangle from `src_drawable` to `dst_drawable`.
@@ -13461,109 +16154,115 @@ pub fn copy_area<Conn>(conn: &Conn, src_drawable: Drawable, dst_drawable: Drawab
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let src_drawable_bytes = src_drawable.serialize();
-    let dst_drawable_bytes = dst_drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let dst_x_bytes = dst_x.serialize();
-    let dst_y_bytes = dst_y.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let mut request0 = [
-        COPY_AREA_REQUEST,
-        0,
-        0,
-        0,
-        src_drawable_bytes[0],
-        src_drawable_bytes[1],
-        src_drawable_bytes[2],
-        src_drawable_bytes[3],
-        dst_drawable_bytes[0],
-        dst_drawable_bytes[1],
-        dst_drawable_bytes[2],
-        dst_drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-        dst_x_bytes[0],
-        dst_x_bytes[1],
-        dst_y_bytes[0],
-        dst_y_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CopyAreaRequest {
+        src_drawable: src_drawable,
+        dst_drawable: dst_drawable,
+        gc: gc,
+        src_x: src_x,
+        src_y: src_y,
+        dst_x: dst_x,
+        dst_y: dst_y,
+        width: width,
+        height: height,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CopyPlane request
-pub const COPY_PLANE_REQUEST: u8 = 63;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CopyPlaneRequest {
+    pub src_drawable: Drawable,
+    pub dst_drawable: Drawable,
+    pub gc: Gcontext,
+    pub src_x: i16,
+    pub src_y: i16,
+    pub dst_x: i16,
+    pub dst_y: i16,
+    pub width: u16,
+    pub height: u16,
+    pub bit_plane: u32,
+}
+impl CopyPlaneRequest {
+    /// Opcode for the CopyPlane request
+    pub const fn opcode() -> u8 { 63 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let src_drawable_bytes = self.src_drawable.serialize();
+        let dst_drawable_bytes = self.dst_drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let src_x_bytes = self.src_x.serialize();
+        let src_y_bytes = self.src_y.serialize();
+        let dst_x_bytes = self.dst_x.serialize();
+        let dst_y_bytes = self.dst_y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let bit_plane_bytes = self.bit_plane.serialize();
+        let mut request0 = vec![
+            CopyPlaneRequest::opcode(),
+            0,
+            0,
+            0,
+            src_drawable_bytes[0],
+            src_drawable_bytes[1],
+            src_drawable_bytes[2],
+            src_drawable_bytes[3],
+            dst_drawable_bytes[0],
+            dst_drawable_bytes[1],
+            dst_drawable_bytes[2],
+            dst_drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            src_x_bytes[0],
+            src_x_bytes[1],
+            src_y_bytes[0],
+            src_y_bytes[1],
+            dst_x_bytes[0],
+            dst_x_bytes[1],
+            dst_y_bytes[0],
+            dst_y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            bit_plane_bytes[0],
+            bit_plane_bytes[1],
+            bit_plane_bytes[2],
+            bit_plane_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn copy_plane<Conn>(conn: &Conn, src_drawable: Drawable, dst_drawable: Drawable, gc: Gcontext, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16, bit_plane: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let src_drawable_bytes = src_drawable.serialize();
-    let dst_drawable_bytes = dst_drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let src_x_bytes = src_x.serialize();
-    let src_y_bytes = src_y.serialize();
-    let dst_x_bytes = dst_x.serialize();
-    let dst_y_bytes = dst_y.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let bit_plane_bytes = bit_plane.serialize();
-    let mut request0 = [
-        COPY_PLANE_REQUEST,
-        0,
-        0,
-        0,
-        src_drawable_bytes[0],
-        src_drawable_bytes[1],
-        src_drawable_bytes[2],
-        src_drawable_bytes[3],
-        dst_drawable_bytes[0],
-        dst_drawable_bytes[1],
-        dst_drawable_bytes[2],
-        dst_drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        src_x_bytes[0],
-        src_x_bytes[1],
-        src_y_bytes[0],
-        src_y_bytes[1],
-        dst_x_bytes[0],
-        dst_x_bytes[1],
-        dst_y_bytes[0],
-        dst_y_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        bit_plane_bytes[0],
-        bit_plane_bytes[1],
-        bit_plane_bytes[2],
-        bit_plane_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CopyPlaneRequest {
+        src_drawable: src_drawable,
+        dst_drawable: dst_drawable,
+        gc: gc,
+        src_x: src_x,
+        src_y: src_y,
+        dst_x: dst_x,
+        dst_y: dst_y,
+        width: width,
+        height: height,
+        bit_plane: bit_plane,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -13640,43 +16339,150 @@ impl TryFrom<u32> for CoordMode {
     }
 }
 
-/// Opcode for the PolyPoint request
-pub const POLY_POINT_REQUEST: u8 = 64;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyPointRequest<'input> {
+    pub coordinate_mode: CoordMode,
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub points: &'input [Point],
+}
+impl<'input> PolyPointRequest<'input> {
+    /// Opcode for the PolyPoint request
+    pub const fn opcode() -> u8 { 64 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let coordinate_mode_bytes = u8::from(self.coordinate_mode).serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            PolyPointRequest::opcode(),
+            coordinate_mode_bytes[0],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let points_bytes = self.points.serialize();
+        let length_so_far = length_so_far + points_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn poly_point<'c, 'input, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let coordinate_mode_bytes = u8::from(coordinate_mode).serialize();
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        POLY_POINT_REQUEST,
-        coordinate_mode_bytes[0],
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let points_bytes = points.serialize();
-    let length_so_far = length_so_far + points_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&points_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyPointRequest {
+        coordinate_mode: coordinate_mode,
+        drawable: drawable,
+        gc: gc,
+        points: points,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the PolyLine request
-pub const POLY_LINE_REQUEST: u8 = 65;
+/// draw lines.
+///
+/// Draws `points_len`-1 lines between each pair of points (point[i], point[i+1])
+/// in the `points` array. The lines are drawn in the order listed in the array.
+/// They join correctly at all intermediate points, and if the first and last
+/// points coincide, the first and last lines also join correctly. For any given
+/// line, a pixel is not drawn more than once. If thin (zero line-width) lines
+/// intersect, the intersecting pixels are drawn multiple times. If wide lines
+/// intersect, the intersecting pixels are drawn only once, as though the entire
+/// request were a single, filled shape.
+///
+/// # Fields
+///
+/// * `drawable` - The drawable to draw the line(s) on.
+/// * `gc` - The graphics context to use.
+/// * `points_len` - The number of `xcb_point_t` structures in `points`.
+/// * `points` - An array of points.
+/// * `coordinate_mode` -
+///
+/// # Errors
+///
+/// * `Drawable` - TODO: reasons?
+/// * `GContext` - TODO: reasons?
+/// * `Match` - TODO: reasons?
+/// * `Value` - TODO: reasons?
+///
+/// # Example
+///
+/// ```text
+/// /*
+///  * Draw a straight line.
+///  *
+///  */
+/// void my_example(xcb_connection_t *conn, xcb_drawable_t drawable, xcb_gcontext_t gc) {
+///     xcb_poly_line(conn, XCB_COORD_MODE_ORIGIN, drawable, gc, 2,
+///                   (xcb_point_t[]) { {10, 10}, {100, 10} });
+///     xcb_flush(conn);
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyLineRequest<'input> {
+    pub coordinate_mode: CoordMode,
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub points: &'input [Point],
+}
+impl<'input> PolyLineRequest<'input> {
+    /// Opcode for the PolyLine request
+    pub const fn opcode() -> u8 { 65 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let coordinate_mode_bytes = u8::from(self.coordinate_mode).serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            PolyLineRequest::opcode(),
+            coordinate_mode_bytes[0],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let points_bytes = self.points.serialize();
+        let length_so_far = length_so_far + points_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// draw lines.
 ///
 /// Draws `points_len`-1 lines between each pair of points (point[i], point[i+1])
@@ -13720,33 +16526,15 @@ pub fn poly_line<'c, 'input, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, d
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let coordinate_mode_bytes = u8::from(coordinate_mode).serialize();
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        POLY_LINE_REQUEST,
-        coordinate_mode_bytes[0],
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let points_bytes = points.serialize();
-    let length_so_far = length_so_far + points_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&points_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyLineRequest {
+        coordinate_mode: coordinate_mode,
+        drawable: drawable,
+        gc: gc,
+        points: points,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13799,8 +16587,75 @@ impl Serialize for Segment {
     }
 }
 
-/// Opcode for the PolySegment request
-pub const POLY_SEGMENT_REQUEST: u8 = 66;
+/// draw lines.
+///
+/// Draws multiple, unconnected lines. For each segment, a line is drawn between
+/// (x1, y1) and (x2, y2). The lines are drawn in the order listed in the array of
+/// `xcb_segment_t` structures and does not perform joining at coincident
+/// endpoints. For any given line, a pixel is not drawn more than once. If lines
+/// intersect, the intersecting pixels are drawn multiple times.
+///
+/// TODO: include the xcb_segment_t data structure
+///
+/// TODO: an example
+///
+/// # Fields
+///
+/// * `drawable` - A drawable (Window or Pixmap) to draw on.
+/// * `gc` - The graphics context to use.
+///
+/// TODO: document which attributes of a gc are used
+/// * `segments_len` - The number of `xcb_segment_t` structures in `segments`.
+/// * `segments` - An array of `xcb_segment_t` structures.
+///
+/// # Errors
+///
+/// * `Drawable` - The specified `drawable` does not exist.
+/// * `GContext` - The specified `gc` does not exist.
+/// * `Match` - TODO: reasons?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolySegmentRequest<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub segments: &'input [Segment],
+}
+impl<'input> PolySegmentRequest<'input> {
+    /// Opcode for the PolySegment request
+    pub const fn opcode() -> u8 { 66 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            PolySegmentRequest::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let segments_bytes = self.segments.serialize();
+        let length_so_far = length_so_far + segments_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), segments_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// draw lines.
 ///
 /// Draws multiple, unconnected lines. For each segment, a line is drawn between
@@ -13831,100 +16686,128 @@ pub fn poly_segment<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gc
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        POLY_SEGMENT_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let segments_bytes = segments.serialize();
-    let length_so_far = length_so_far + segments_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&segments_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolySegmentRequest {
+        drawable: drawable,
+        gc: gc,
+        segments: segments,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the PolyRectangle request
-pub const POLY_RECTANGLE_REQUEST: u8 = 67;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyRectangleRequest<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub rectangles: &'input [Rectangle],
+}
+impl<'input> PolyRectangleRequest<'input> {
+    /// Opcode for the PolyRectangle request
+    pub const fn opcode() -> u8 { 67 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            PolyRectangleRequest::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let rectangles_bytes = self.rectangles.serialize();
+        let length_so_far = length_so_far + rectangles_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn poly_rectangle<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        POLY_RECTANGLE_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let rectangles_bytes = rectangles.serialize();
-    let length_so_far = length_so_far + rectangles_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&rectangles_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyRectangleRequest {
+        drawable: drawable,
+        gc: gc,
+        rectangles: rectangles,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the PolyArc request
-pub const POLY_ARC_REQUEST: u8 = 68;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyArcRequest<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub arcs: &'input [Arc],
+}
+impl<'input> PolyArcRequest<'input> {
+    /// Opcode for the PolyArc request
+    pub const fn opcode() -> u8 { 68 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            PolyArcRequest::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let arcs_bytes = self.arcs.serialize();
+        let length_so_far = length_so_far + arcs_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), arcs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn poly_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        POLY_ARC_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let arcs_bytes = arcs.serialize();
-    let length_so_far = length_so_far + arcs_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&arcs_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyArcRequest {
+        drawable: drawable,
+        gc: gc,
+        arcs: arcs,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13992,48 +16875,141 @@ impl TryFrom<u32> for PolyShape {
     }
 }
 
-/// Opcode for the FillPoly request
-pub const FILL_POLY_REQUEST: u8 = 69;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FillPolyRequest<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub shape: PolyShape,
+    pub coordinate_mode: CoordMode,
+    pub points: &'input [Point],
+}
+impl<'input> FillPolyRequest<'input> {
+    /// Opcode for the FillPoly request
+    pub const fn opcode() -> u8 { 69 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let shape_bytes = u8::from(self.shape).serialize();
+        let coordinate_mode_bytes = u8::from(self.coordinate_mode).serialize();
+        let mut request0 = vec![
+            FillPolyRequest::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            shape_bytes[0],
+            coordinate_mode_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let points_bytes = self.points.serialize();
+        let length_so_far = length_so_far + points_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn fill_poly<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, shape: PolyShape, coordinate_mode: CoordMode, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let shape_bytes = u8::from(shape).serialize();
-    let coordinate_mode_bytes = u8::from(coordinate_mode).serialize();
-    let mut request0 = [
-        FILL_POLY_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        shape_bytes[0],
-        coordinate_mode_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let points_bytes = points.serialize();
-    let length_so_far = length_so_far + points_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&points_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = FillPolyRequest {
+        drawable: drawable,
+        gc: gc,
+        shape: shape,
+        coordinate_mode: coordinate_mode,
+        points: points,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the PolyFillRectangle request
-pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
+/// Fills rectangles.
+///
+/// Fills the specified rectangle(s) in the order listed in the array. For any
+/// given rectangle, each pixel is not drawn more than once. If rectangles
+/// intersect, the intersecting pixels are drawn multiple times.
+///
+/// # Fields
+///
+/// * `drawable` - The drawable (Window or Pixmap) to draw on.
+/// * `gc` - The graphics context to use.
+///
+/// The following graphics context components are used: function, plane-mask,
+/// fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///
+/// The following graphics context mode-dependent components are used:
+/// foreground, background, tile, stipple, tile-stipple-x-origin, and
+/// tile-stipple-y-origin.
+/// * `rectangles_len` - The number of `xcb_rectangle_t` structures in `rectangles`.
+/// * `rectangles` - The rectangles to fill.
+///
+/// # Errors
+///
+/// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
+/// * `GContext` - The specified graphics context does not exist.
+/// * `Match` - TODO: reasons?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyFillRectangleRequest<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub rectangles: &'input [Rectangle],
+}
+impl<'input> PolyFillRectangleRequest<'input> {
+    /// Opcode for the PolyFillRectangle request
+    pub const fn opcode() -> u8 { 70 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            PolyFillRectangleRequest::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let rectangles_bytes = self.rectangles.serialize();
+        let length_so_far = length_so_far + rectangles_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// Fills rectangles.
 ///
 /// Fills the specified rectangle(s) in the order listed in the array. For any
@@ -14063,66 +17039,71 @@ pub fn poly_fill_rectangle<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable,
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        POLY_FILL_RECTANGLE_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let rectangles_bytes = rectangles.serialize();
-    let length_so_far = length_so_far + rectangles_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&rectangles_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyFillRectangleRequest {
+        drawable: drawable,
+        gc: gc,
+        rectangles: rectangles,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the PolyFillArc request
-pub const POLY_FILL_ARC_REQUEST: u8 = 71;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyFillArcRequest<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub arcs: &'input [Arc],
+}
+impl<'input> PolyFillArcRequest<'input> {
+    /// Opcode for the PolyFillArc request
+    pub const fn opcode() -> u8 { 71 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let mut request0 = vec![
+            PolyFillArcRequest::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let arcs_bytes = self.arcs.serialize();
+        let length_so_far = length_so_far + arcs_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), arcs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn poly_fill_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let mut request0 = [
-        POLY_FILL_ARC_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let arcs_bytes = arcs.serialize();
-    let length_so_far = length_so_far + arcs_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&arcs_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyFillArcRequest {
+        drawable: drawable,
+        gc: gc,
+        arcs: arcs,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14190,99 +17171,167 @@ impl TryFrom<u32> for ImageFormat {
     }
 }
 
-/// Opcode for the PutImage request
-pub const PUT_IMAGE_REQUEST: u8 = 72;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PutImageRequest<'input> {
+    pub format: ImageFormat,
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub width: u16,
+    pub height: u16,
+    pub dst_x: i16,
+    pub dst_y: i16,
+    pub left_pad: u8,
+    pub depth: u8,
+    pub data: &'input [u8],
+}
+impl<'input> PutImageRequest<'input> {
+    /// Opcode for the PutImage request
+    pub const fn opcode() -> u8 { 72 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let format_bytes = u8::from(self.format).serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let dst_x_bytes = self.dst_x.serialize();
+        let dst_y_bytes = self.dst_y.serialize();
+        let left_pad_bytes = self.left_pad.serialize();
+        let depth_bytes = self.depth.serialize();
+        let mut request0 = vec![
+            PutImageRequest::opcode(),
+            format_bytes[0],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            dst_x_bytes[0],
+            dst_x_bytes[1],
+            dst_y_bytes[0],
+            dst_y_bytes[1],
+            left_pad_bytes[0],
+            depth_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.data[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let format_bytes = u8::from(format).serialize();
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let dst_x_bytes = dst_x.serialize();
-    let dst_y_bytes = dst_y.serialize();
-    let left_pad_bytes = left_pad.serialize();
-    let depth_bytes = depth.serialize();
-    let mut request0 = [
-        PUT_IMAGE_REQUEST,
-        format_bytes[0],
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        dst_x_bytes[0],
-        dst_x_bytes[1],
-        dst_y_bytes[0],
-        dst_y_bytes[1],
-        left_pad_bytes[0],
-        depth_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + data.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(data), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PutImageRequest {
+        format: format,
+        drawable: drawable,
+        gc: gc,
+        width: width,
+        height: height,
+        dst_x: dst_x,
+        dst_y: dst_y,
+        left_pad: left_pad,
+        depth: depth,
+        data: data,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetImage request
-pub const GET_IMAGE_REQUEST: u8 = 73;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetImageRequest {
+    pub format: ImageFormat,
+    pub drawable: Drawable,
+    pub x: i16,
+    pub y: i16,
+    pub width: u16,
+    pub height: u16,
+    pub plane_mask: u32,
+}
+impl GetImageRequest {
+    /// Opcode for the GetImage request
+    pub const fn opcode() -> u8 { 73 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let format_bytes = u8::from(self.format).serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let plane_mask_bytes = self.plane_mask.serialize();
+        let mut request0 = vec![
+            GetImageRequest::opcode(),
+            format_bytes[0],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            plane_mask_bytes[0],
+            plane_mask_bytes[1],
+            plane_mask_bytes[2],
+            plane_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_image<Conn>(conn: &Conn, format: ImageFormat, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, plane_mask: u32) -> Result<Cookie<'_, Conn, GetImageReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let format_bytes = u8::from(format).serialize();
-    let drawable_bytes = drawable.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let plane_mask_bytes = plane_mask.serialize();
-    let mut request0 = [
-        GET_IMAGE_REQUEST,
-        format_bytes[0],
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        plane_mask_bytes[0],
-        plane_mask_bytes[1],
-        plane_mask_bytes[2],
-        plane_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetImageRequest {
+        format: format,
+        drawable: drawable,
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+        plane_mask: plane_mask,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14330,86 +17379,224 @@ impl GetImageReply {
     }
 }
 
-/// Opcode for the PolyText8 request
-pub const POLY_TEXT8_REQUEST: u8 = 74;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyText8Request<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub x: i16,
+    pub y: i16,
+    pub items: &'input [u8],
+}
+impl<'input> PolyText8Request<'input> {
+    /// Opcode for the PolyText8 request
+    pub const fn opcode() -> u8 { 74 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mut request0 = vec![
+            PolyText8Request::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.items[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.items[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn poly_text8<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mut request0 = [
-        POLY_TEXT8_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + items.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(items), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyText8Request {
+        drawable: drawable,
+        gc: gc,
+        x: x,
+        y: y,
+        items: items,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the PolyText16 request
-pub const POLY_TEXT16_REQUEST: u8 = 75;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolyText16Request<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub x: i16,
+    pub y: i16,
+    pub items: &'input [u8],
+}
+impl<'input> PolyText16Request<'input> {
+    /// Opcode for the PolyText16 request
+    pub const fn opcode() -> u8 { 75 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mut request0 = vec![
+            PolyText16Request::opcode(),
+            0,
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.items[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.items[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn poly_text16<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mut request0 = [
-        POLY_TEXT16_REQUEST,
-        0,
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + items.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(items), IoSlice::new(&padding0)], vec![])?)
+    let request0 = PolyText16Request {
+        drawable: drawable,
+        gc: gc,
+        x: x,
+        y: y,
+        items: items,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ImageText8 request
-pub const IMAGE_TEXT8_REQUEST: u8 = 76;
+/// Draws text.
+///
+/// Fills the destination rectangle with the background pixel from `gc`, then
+/// paints the text with the foreground pixel from `gc`. The upper-left corner of
+/// the filled rectangle is at [x, y - font-ascent]. The width is overall-width,
+/// the height is font-ascent + font-descent. The overall-width, font-ascent and
+/// font-descent are as returned by `xcb_query_text_extents` (TODO).
+///
+/// Note that using X core fonts is deprecated (but still supported) in favor of
+/// client-side rendering using Xft.
+///
+/// # Fields
+///
+/// * `drawable` - The drawable (Window or Pixmap) to draw text on.
+/// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
+/// using 8 bits!
+/// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
+/// type of `string_len`.
+/// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
+/// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
+/// * `gc` - The graphics context to use.
+///
+/// The following graphics context components are used: plane-mask, foreground,
+/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///
+/// # Errors
+///
+/// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
+/// * `GContext` - The specified graphics context does not exist.
+/// * `Match` - TODO: reasons?
+///
+/// # See
+///
+/// * `ImageText16`: request
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageText8Request<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub x: i16,
+    pub y: i16,
+    pub string: &'input [u8],
+}
+impl<'input> ImageText8Request<'input> {
+    /// Opcode for the ImageText8 request
+    pub const fn opcode() -> u8 { 76 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let string_len = u8::try_from(self.string.len()).expect("`string` has too many elements");
+        let string_len_bytes = string_len.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mut request0 = vec![
+            ImageText8Request::opcode(),
+            string_len_bytes[0],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.string[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.string[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// Draws text.
 ///
 /// Fills the destination rectangle with the background pixel from `gc`, then
@@ -14448,43 +17635,106 @@ pub fn image_text8<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gco
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let string_len = u8::try_from(string.len()).expect("`string` has too many elements");
-    let string_len_bytes = string_len.serialize();
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mut request0 = [
-        IMAGE_TEXT8_REQUEST,
-        string_len_bytes[0],
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + string.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(string), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ImageText8Request {
+        drawable: drawable,
+        gc: gc,
+        x: x,
+        y: y,
+        string: string,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ImageText16 request
-pub const IMAGE_TEXT16_REQUEST: u8 = 77;
+/// Draws text.
+///
+/// Fills the destination rectangle with the background pixel from `gc`, then
+/// paints the text with the foreground pixel from `gc`. The upper-left corner of
+/// the filled rectangle is at [x, y - font-ascent]. The width is overall-width,
+/// the height is font-ascent + font-descent. The overall-width, font-ascent and
+/// font-descent are as returned by `xcb_query_text_extents` (TODO).
+///
+/// Note that using X core fonts is deprecated (but still supported) in favor of
+/// client-side rendering using Xft.
+///
+/// # Fields
+///
+/// * `drawable` - The drawable (Window or Pixmap) to draw text on.
+/// * `string_len` - The length of the `string` in characters. Note that this parameter limited by
+/// 255 due to using 8 bits!
+/// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
+/// type of `string_len`. Every character uses 2 bytes (hence the 16 in this
+/// request's name).
+/// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
+/// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
+/// * `gc` - The graphics context to use.
+///
+/// The following graphics context components are used: plane-mask, foreground,
+/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///
+/// # Errors
+///
+/// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
+/// * `GContext` - The specified graphics context does not exist.
+/// * `Match` - TODO: reasons?
+///
+/// # See
+///
+/// * `ImageText8`: request
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageText16Request<'input> {
+    pub drawable: Drawable,
+    pub gc: Gcontext,
+    pub x: i16,
+    pub y: i16,
+    pub string: &'input [Char2b],
+}
+impl<'input> ImageText16Request<'input> {
+    /// Opcode for the ImageText16 request
+    pub const fn opcode() -> u8 { 77 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let string_len = u8::try_from(self.string.len()).expect("`string` has too many elements");
+        let string_len_bytes = string_len.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let gc_bytes = self.gc.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mut request0 = vec![
+            ImageText16Request::opcode(),
+            string_len_bytes[0],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            gc_bytes[0],
+            gc_bytes[1],
+            gc_bytes[2],
+            gc_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let string_bytes = self.string.serialize();
+        let length_so_far = length_so_far + string_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), string_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// Draws text.
 ///
 /// Fills the destination rectangle with the background pixel from `gc`, then
@@ -14524,40 +17774,16 @@ pub fn image_text16<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gc
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let string_len = u8::try_from(string.len()).expect("`string` has too many elements");
-    let string_len_bytes = string_len.serialize();
-    let drawable_bytes = drawable.serialize();
-    let gc_bytes = gc.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mut request0 = [
-        IMAGE_TEXT16_REQUEST,
-        string_len_bytes[0],
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        gc_bytes[0],
-        gc_bytes[1],
-        gc_bytes[2],
-        gc_bytes[3],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let string_bytes = string.serialize();
-    let length_so_far = length_so_far + string_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&string_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ImageText16Request {
+        drawable: drawable,
+        gc: gc,
+        x: x,
+        y: y,
+        string: string,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14630,170 +17856,292 @@ impl TryFrom<u32> for ColormapAlloc {
     }
 }
 
-/// Opcode for the CreateColormap request
-pub const CREATE_COLORMAP_REQUEST: u8 = 78;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateColormapRequest {
+    pub alloc: ColormapAlloc,
+    pub mid: Colormap,
+    pub window: Window,
+    pub visual: Visualid,
+}
+impl CreateColormapRequest {
+    /// Opcode for the CreateColormap request
+    pub const fn opcode() -> u8 { 78 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let alloc_bytes = u8::from(self.alloc).serialize();
+        let mid_bytes = self.mid.serialize();
+        let window_bytes = self.window.serialize();
+        let visual_bytes = self.visual.serialize();
+        let mut request0 = vec![
+            CreateColormapRequest::opcode(),
+            alloc_bytes[0],
+            0,
+            0,
+            mid_bytes[0],
+            mid_bytes[1],
+            mid_bytes[2],
+            mid_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            visual_bytes[0],
+            visual_bytes[1],
+            visual_bytes[2],
+            visual_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_colormap<Conn>(conn: &Conn, alloc: ColormapAlloc, mid: Colormap, window: Window, visual: Visualid) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let alloc_bytes = u8::from(alloc).serialize();
-    let mid_bytes = mid.serialize();
-    let window_bytes = window.serialize();
-    let visual_bytes = visual.serialize();
-    let mut request0 = [
-        CREATE_COLORMAP_REQUEST,
-        alloc_bytes[0],
-        0,
-        0,
-        mid_bytes[0],
-        mid_bytes[1],
-        mid_bytes[2],
-        mid_bytes[3],
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        visual_bytes[0],
-        visual_bytes[1],
-        visual_bytes[2],
-        visual_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateColormapRequest {
+        alloc: alloc,
+        mid: mid,
+        window: window,
+        visual: visual,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FreeColormap request
-pub const FREE_COLORMAP_REQUEST: u8 = 79;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FreeColormapRequest {
+    pub cmap: Colormap,
+}
+impl FreeColormapRequest {
+    /// Opcode for the FreeColormap request
+    pub const fn opcode() -> u8 { 79 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let mut request0 = vec![
+            FreeColormapRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn free_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let mut request0 = [
-        FREE_COLORMAP_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FreeColormapRequest {
+        cmap: cmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CopyColormapAndFree request
-pub const COPY_COLORMAP_AND_FREE_REQUEST: u8 = 80;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CopyColormapAndFreeRequest {
+    pub mid: Colormap,
+    pub src_cmap: Colormap,
+}
+impl CopyColormapAndFreeRequest {
+    /// Opcode for the CopyColormapAndFree request
+    pub const fn opcode() -> u8 { 80 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mid_bytes = self.mid.serialize();
+        let src_cmap_bytes = self.src_cmap.serialize();
+        let mut request0 = vec![
+            CopyColormapAndFreeRequest::opcode(),
+            0,
+            0,
+            0,
+            mid_bytes[0],
+            mid_bytes[1],
+            mid_bytes[2],
+            mid_bytes[3],
+            src_cmap_bytes[0],
+            src_cmap_bytes[1],
+            src_cmap_bytes[2],
+            src_cmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn copy_colormap_and_free<Conn>(conn: &Conn, mid: Colormap, src_cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mid_bytes = mid.serialize();
-    let src_cmap_bytes = src_cmap.serialize();
-    let mut request0 = [
-        COPY_COLORMAP_AND_FREE_REQUEST,
-        0,
-        0,
-        0,
-        mid_bytes[0],
-        mid_bytes[1],
-        mid_bytes[2],
-        mid_bytes[3],
-        src_cmap_bytes[0],
-        src_cmap_bytes[1],
-        src_cmap_bytes[2],
-        src_cmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CopyColormapAndFreeRequest {
+        mid: mid,
+        src_cmap: src_cmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the InstallColormap request
-pub const INSTALL_COLORMAP_REQUEST: u8 = 81;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InstallColormapRequest {
+    pub cmap: Colormap,
+}
+impl InstallColormapRequest {
+    /// Opcode for the InstallColormap request
+    pub const fn opcode() -> u8 { 81 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let mut request0 = vec![
+            InstallColormapRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn install_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let mut request0 = [
-        INSTALL_COLORMAP_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = InstallColormapRequest {
+        cmap: cmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the UninstallColormap request
-pub const UNINSTALL_COLORMAP_REQUEST: u8 = 82;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UninstallColormapRequest {
+    pub cmap: Colormap,
+}
+impl UninstallColormapRequest {
+    /// Opcode for the UninstallColormap request
+    pub const fn opcode() -> u8 { 82 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let mut request0 = vec![
+            UninstallColormapRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn uninstall_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let mut request0 = [
-        UNINSTALL_COLORMAP_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = UninstallColormapRequest {
+        cmap: cmap,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ListInstalledColormaps request
-pub const LIST_INSTALLED_COLORMAPS_REQUEST: u8 = 83;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListInstalledColormapsRequest {
+    pub window: Window,
+}
+impl ListInstalledColormapsRequest {
+    /// Opcode for the ListInstalledColormaps request
+    pub const fn opcode() -> u8 { 83 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let mut request0 = vec![
+            ListInstalledColormapsRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_installed_colormaps<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListInstalledColormapsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let mut request0 = [
-        LIST_INSTALLED_COLORMAPS_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListInstalledColormapsRequest {
+        window: window,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14838,8 +18186,70 @@ impl ListInstalledColormapsReply {
     }
 }
 
-/// Opcode for the AllocColor request
-pub const ALLOC_COLOR_REQUEST: u8 = 84;
+/// Allocate a color.
+///
+/// Allocates a read-only colormap entry corresponding to the closest RGB value
+/// supported by the hardware. If you are using TrueColor, you can take a shortcut
+/// and directly calculate the color pixel value to avoid the round trip. But, for
+/// example, on 16-bit color setups (VNC), you can easily get the closest supported
+/// RGB value to the RGB value you are specifying.
+///
+/// # Fields
+///
+/// * `cmap` - TODO
+/// * `red` - The red value of your color.
+/// * `green` - The green value of your color.
+/// * `blue` - The blue value of your color.
+///
+/// # Errors
+///
+/// * `Colormap` - The specified colormap `cmap` does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocColorRequest {
+    pub cmap: Colormap,
+    pub red: u16,
+    pub green: u16,
+    pub blue: u16,
+}
+impl AllocColorRequest {
+    /// Opcode for the AllocColor request
+    pub const fn opcode() -> u8 { 84 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let red_bytes = self.red.serialize();
+        let green_bytes = self.green.serialize();
+        let blue_bytes = self.blue.serialize();
+        let mut request0 = vec![
+            AllocColorRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+            red_bytes[0],
+            red_bytes[1],
+            green_bytes[0],
+            green_bytes[1],
+            blue_bytes[0],
+            blue_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Allocate a color.
 ///
 /// Allocates a read-only colormap entry corresponding to the closest RGB value
@@ -14862,34 +18272,15 @@ pub fn alloc_color<Conn>(conn: &Conn, cmap: Colormap, red: u16, green: u16, blue
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let red_bytes = red.serialize();
-    let green_bytes = green.serialize();
-    let blue_bytes = blue.serialize();
-    let mut request0 = [
-        ALLOC_COLOR_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-        red_bytes[0],
-        red_bytes[1],
-        green_bytes[0],
-        green_bytes[1],
-        blue_bytes[0],
-        blue_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = AllocColorRequest {
+        cmap: cmap,
+        red: red,
+        green: green,
+        blue: blue,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14924,38 +18315,59 @@ impl TryFrom<&[u8]> for AllocColorReply {
     }
 }
 
-/// Opcode for the AllocNamedColor request
-pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllocNamedColorRequest<'input> {
+    pub cmap: Colormap,
+    pub name: &'input [u8],
+}
+impl<'input> AllocNamedColorRequest<'input> {
+    /// Opcode for the AllocNamedColor request
+    pub const fn opcode() -> u8 { 85 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        let name_len_bytes = name_len.serialize();
+        let mut request0 = vec![
+            AllocNamedColorRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+            name_len_bytes[0],
+            name_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn alloc_named_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let name_len = u16::try_from(name.len()).expect("`name` has too many elements");
-    let name_len_bytes = name_len.serialize();
-    let mut request0 = [
-        ALLOC_NAMED_COLOR_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-        name_len_bytes[0],
-        name_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = AllocNamedColorRequest {
+        cmap: cmap,
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14995,36 +18407,61 @@ impl TryFrom<&[u8]> for AllocNamedColorReply {
     }
 }
 
-/// Opcode for the AllocColorCells request
-pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocColorCellsRequest {
+    pub contiguous: bool,
+    pub cmap: Colormap,
+    pub colors: u16,
+    pub planes: u16,
+}
+impl AllocColorCellsRequest {
+    /// Opcode for the AllocColorCells request
+    pub const fn opcode() -> u8 { 86 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let contiguous_bytes = self.contiguous.serialize();
+        let cmap_bytes = self.cmap.serialize();
+        let colors_bytes = self.colors.serialize();
+        let planes_bytes = self.planes.serialize();
+        let mut request0 = vec![
+            AllocColorCellsRequest::opcode(),
+            contiguous_bytes[0],
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+            colors_bytes[0],
+            colors_bytes[1],
+            planes_bytes[0],
+            planes_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn alloc_color_cells<Conn>(conn: &Conn, contiguous: bool, cmap: Colormap, colors: u16, planes: u16) -> Result<Cookie<'_, Conn, AllocColorCellsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let contiguous_bytes = contiguous.serialize();
-    let cmap_bytes = cmap.serialize();
-    let colors_bytes = colors.serialize();
-    let planes_bytes = planes.serialize();
-    let mut request0 = [
-        ALLOC_COLOR_CELLS_REQUEST,
-        contiguous_bytes[0],
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-        colors_bytes[0],
-        colors_bytes[1],
-        planes_bytes[0],
-        planes_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = AllocColorCellsRequest {
+        contiguous: contiguous,
+        cmap: cmap,
+        colors: colors,
+        planes: planes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15085,42 +18522,71 @@ impl AllocColorCellsReply {
     }
 }
 
-/// Opcode for the AllocColorPlanes request
-pub const ALLOC_COLOR_PLANES_REQUEST: u8 = 87;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocColorPlanesRequest {
+    pub contiguous: bool,
+    pub cmap: Colormap,
+    pub colors: u16,
+    pub reds: u16,
+    pub greens: u16,
+    pub blues: u16,
+}
+impl AllocColorPlanesRequest {
+    /// Opcode for the AllocColorPlanes request
+    pub const fn opcode() -> u8 { 87 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let contiguous_bytes = self.contiguous.serialize();
+        let cmap_bytes = self.cmap.serialize();
+        let colors_bytes = self.colors.serialize();
+        let reds_bytes = self.reds.serialize();
+        let greens_bytes = self.greens.serialize();
+        let blues_bytes = self.blues.serialize();
+        let mut request0 = vec![
+            AllocColorPlanesRequest::opcode(),
+            contiguous_bytes[0],
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+            colors_bytes[0],
+            colors_bytes[1],
+            reds_bytes[0],
+            reds_bytes[1],
+            greens_bytes[0],
+            greens_bytes[1],
+            blues_bytes[0],
+            blues_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn alloc_color_planes<Conn>(conn: &Conn, contiguous: bool, cmap: Colormap, colors: u16, reds: u16, greens: u16, blues: u16) -> Result<Cookie<'_, Conn, AllocColorPlanesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let contiguous_bytes = contiguous.serialize();
-    let cmap_bytes = cmap.serialize();
-    let colors_bytes = colors.serialize();
-    let reds_bytes = reds.serialize();
-    let greens_bytes = greens.serialize();
-    let blues_bytes = blues.serialize();
-    let mut request0 = [
-        ALLOC_COLOR_PLANES_REQUEST,
-        contiguous_bytes[0],
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-        colors_bytes[0],
-        colors_bytes[1],
-        reds_bytes[0],
-        reds_bytes[1],
-        greens_bytes[0],
-        greens_bytes[1],
-        blues_bytes[0],
-        blues_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = AllocColorPlanesRequest {
+        contiguous: contiguous,
+        cmap: cmap,
+        colors: colors,
+        reds: reds,
+        greens: greens,
+        blues: blues,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15172,38 +18638,61 @@ impl AllocColorPlanesReply {
     }
 }
 
-/// Opcode for the FreeColors request
-pub const FREE_COLORS_REQUEST: u8 = 88;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FreeColorsRequest<'input> {
+    pub cmap: Colormap,
+    pub plane_mask: u32,
+    pub pixels: &'input [u32],
+}
+impl<'input> FreeColorsRequest<'input> {
+    /// Opcode for the FreeColors request
+    pub const fn opcode() -> u8 { 88 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let plane_mask_bytes = self.plane_mask.serialize();
+        let mut request0 = vec![
+            FreeColorsRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+            plane_mask_bytes[0],
+            plane_mask_bytes[1],
+            plane_mask_bytes[2],
+            plane_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let pixels_bytes = self.pixels.serialize();
+        let length_so_far = length_so_far + pixels_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), pixels_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn free_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, plane_mask: u32, pixels: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let plane_mask_bytes = plane_mask.serialize();
-    let mut request0 = [
-        FREE_COLORS_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-        plane_mask_bytes[0],
-        plane_mask_bytes[1],
-        plane_mask_bytes[2],
-        plane_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let pixels_bytes = pixels.serialize();
-    let length_so_far = length_so_far + pixels_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&pixels_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = FreeColorsRequest {
+        cmap: cmap,
+        plane_mask: plane_mask,
+        pixels: pixels,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15332,75 +18821,121 @@ impl Serialize for Coloritem {
     }
 }
 
-/// Opcode for the StoreColors request
-pub const STORE_COLORS_REQUEST: u8 = 89;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreColorsRequest<'input> {
+    pub cmap: Colormap,
+    pub items: &'input [Coloritem],
+}
+impl<'input> StoreColorsRequest<'input> {
+    /// Opcode for the StoreColors request
+    pub const fn opcode() -> u8 { 89 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let mut request0 = vec![
+            StoreColorsRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let items_bytes = self.items.serialize();
+        let length_so_far = length_so_far + items_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), items_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn store_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, items: &'input [Coloritem]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let mut request0 = [
-        STORE_COLORS_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let items_bytes = items.serialize();
-    let length_so_far = length_so_far + items_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&items_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = StoreColorsRequest {
+        cmap: cmap,
+        items: items,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the StoreNamedColor request
-pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreNamedColorRequest<'input> {
+    pub flags: u8,
+    pub cmap: Colormap,
+    pub pixel: u32,
+    pub name: &'input [u8],
+}
+impl<'input> StoreNamedColorRequest<'input> {
+    /// Opcode for the StoreNamedColor request
+    pub const fn opcode() -> u8 { 90 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let flags_bytes = self.flags.serialize();
+        let cmap_bytes = self.cmap.serialize();
+        let pixel_bytes = self.pixel.serialize();
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        let name_len_bytes = name_len.serialize();
+        let mut request0 = vec![
+            StoreNamedColorRequest::opcode(),
+            flags_bytes[0],
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+            pixel_bytes[0],
+            pixel_bytes[1],
+            pixel_bytes[2],
+            pixel_bytes[3],
+            name_len_bytes[0],
+            name_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn store_named_color<'c, 'input, Conn, A>(conn: &'c Conn, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
 {
     let flags: u8 = flags.into();
-    let length_so_far = 0;
-    let flags_bytes = flags.serialize();
-    let cmap_bytes = cmap.serialize();
-    let pixel_bytes = pixel.serialize();
-    let name_len = u16::try_from(name.len()).expect("`name` has too many elements");
-    let name_len_bytes = name_len.serialize();
-    let mut request0 = [
-        STORE_NAMED_COLOR_REQUEST,
-        flags_bytes[0],
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-        pixel_bytes[0],
-        pixel_bytes[1],
-        pixel_bytes[2],
-        pixel_bytes[3],
-        name_len_bytes[0],
-        name_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = StoreNamedColorRequest {
+        flags: flags,
+        cmap: cmap,
+        pixel: pixel,
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15451,33 +18986,54 @@ impl Serialize for Rgb {
     }
 }
 
-/// Opcode for the QueryColors request
-pub const QUERY_COLORS_REQUEST: u8 = 91;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryColorsRequest<'input> {
+    pub cmap: Colormap,
+    pub pixels: &'input [u32],
+}
+impl<'input> QueryColorsRequest<'input> {
+    /// Opcode for the QueryColors request
+    pub const fn opcode() -> u8 { 91 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let mut request0 = vec![
+            QueryColorsRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let pixels_bytes = self.pixels.serialize();
+        let length_so_far = length_so_far + pixels_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), pixels_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn query_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, pixels: &'input [u32]) -> Result<Cookie<'c, Conn, QueryColorsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let mut request0 = [
-        QUERY_COLORS_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let pixels_bytes = pixels.serialize();
-    let length_so_far = length_so_far + pixels_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(&pixels_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = QueryColorsRequest {
+        cmap: cmap,
+        pixels: pixels,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15522,38 +19078,59 @@ impl QueryColorsReply {
     }
 }
 
-/// Opcode for the LookupColor request
-pub const LOOKUP_COLOR_REQUEST: u8 = 92;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupColorRequest<'input> {
+    pub cmap: Colormap,
+    pub name: &'input [u8],
+}
+impl<'input> LookupColorRequest<'input> {
+    /// Opcode for the LookupColor request
+    pub const fn opcode() -> u8 { 92 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cmap_bytes = self.cmap.serialize();
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        let name_len_bytes = name_len.serialize();
+        let mut request0 = vec![
+            LookupColorRequest::opcode(),
+            0,
+            0,
+            0,
+            cmap_bytes[0],
+            cmap_bytes[1],
+            cmap_bytes[2],
+            cmap_bytes[3],
+            name_len_bytes[0],
+            name_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn lookup_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cmap_bytes = cmap.serialize();
-    let name_len = u16::try_from(name.len()).expect("`name` has too many elements");
-    let name_len_bytes = name_len.serialize();
-    let mut request0 = [
-        LOOKUP_COLOR_REQUEST,
-        0,
-        0,
-        0,
-        cmap_bytes[0],
-        cmap_bytes[1],
-        cmap_bytes[2],
-        cmap_bytes[3],
-        name_len_bytes[0],
-        name_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = LookupColorRequest {
+        cmap: cmap,
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15650,65 +19227,104 @@ impl TryFrom<u32> for PixmapEnum {
     }
 }
 
-/// Opcode for the CreateCursor request
-pub const CREATE_CURSOR_REQUEST: u8 = 93;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateCursorRequest {
+    pub cid: Cursor,
+    pub source: Pixmap,
+    pub mask: Pixmap,
+    pub fore_red: u16,
+    pub fore_green: u16,
+    pub fore_blue: u16,
+    pub back_red: u16,
+    pub back_green: u16,
+    pub back_blue: u16,
+    pub x: u16,
+    pub y: u16,
+}
+impl CreateCursorRequest {
+    /// Opcode for the CreateCursor request
+    pub const fn opcode() -> u8 { 93 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cid_bytes = self.cid.serialize();
+        let source_bytes = self.source.serialize();
+        let mask_bytes = self.mask.serialize();
+        let fore_red_bytes = self.fore_red.serialize();
+        let fore_green_bytes = self.fore_green.serialize();
+        let fore_blue_bytes = self.fore_blue.serialize();
+        let back_red_bytes = self.back_red.serialize();
+        let back_green_bytes = self.back_green.serialize();
+        let back_blue_bytes = self.back_blue.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let mut request0 = vec![
+            CreateCursorRequest::opcode(),
+            0,
+            0,
+            0,
+            cid_bytes[0],
+            cid_bytes[1],
+            cid_bytes[2],
+            cid_bytes[3],
+            source_bytes[0],
+            source_bytes[1],
+            source_bytes[2],
+            source_bytes[3],
+            mask_bytes[0],
+            mask_bytes[1],
+            mask_bytes[2],
+            mask_bytes[3],
+            fore_red_bytes[0],
+            fore_red_bytes[1],
+            fore_green_bytes[0],
+            fore_green_bytes[1],
+            fore_blue_bytes[0],
+            fore_blue_bytes[1],
+            back_red_bytes[0],
+            back_red_bytes[1],
+            back_green_bytes[0],
+            back_green_bytes[1],
+            back_blue_bytes[0],
+            back_blue_bytes[1],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_cursor<Conn, A>(conn: &Conn, cid: Cursor, source: Pixmap, mask: A, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Pixmap>,
 {
     let mask: Pixmap = mask.into();
-    let length_so_far = 0;
-    let cid_bytes = cid.serialize();
-    let source_bytes = source.serialize();
-    let mask_bytes = mask.serialize();
-    let fore_red_bytes = fore_red.serialize();
-    let fore_green_bytes = fore_green.serialize();
-    let fore_blue_bytes = fore_blue.serialize();
-    let back_red_bytes = back_red.serialize();
-    let back_green_bytes = back_green.serialize();
-    let back_blue_bytes = back_blue.serialize();
-    let x_bytes = x.serialize();
-    let y_bytes = y.serialize();
-    let mut request0 = [
-        CREATE_CURSOR_REQUEST,
-        0,
-        0,
-        0,
-        cid_bytes[0],
-        cid_bytes[1],
-        cid_bytes[2],
-        cid_bytes[3],
-        source_bytes[0],
-        source_bytes[1],
-        source_bytes[2],
-        source_bytes[3],
-        mask_bytes[0],
-        mask_bytes[1],
-        mask_bytes[2],
-        mask_bytes[3],
-        fore_red_bytes[0],
-        fore_red_bytes[1],
-        fore_green_bytes[0],
-        fore_green_bytes[1],
-        fore_blue_bytes[0],
-        fore_blue_bytes[1],
-        back_red_bytes[0],
-        back_red_bytes[1],
-        back_green_bytes[0],
-        back_green_bytes[1],
-        back_blue_bytes[0],
-        back_blue_bytes[1],
-        x_bytes[0],
-        x_bytes[1],
-        y_bytes[0],
-        y_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateCursorRequest {
+        cid: cid,
+        source: source,
+        mask: mask,
+        fore_red: fore_red,
+        fore_green: fore_green,
+        fore_blue: fore_blue,
+        back_red: back_red,
+        back_green: back_green,
+        back_blue: back_blue,
+        x: x,
+        y: y,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15770,8 +19386,115 @@ impl TryFrom<u32> for FontEnum {
     }
 }
 
-/// Opcode for the CreateGlyphCursor request
-pub const CREATE_GLYPH_CURSOR_REQUEST: u8 = 94;
+/// create cursor.
+///
+/// Creates a cursor from a font glyph. X provides a set of standard cursor shapes
+/// in a special font named cursor. Applications are encouraged to use this
+/// interface for their cursors because the font can be customized for the
+/// individual display type.
+///
+/// All pixels which are set to 1 in the source will use the foreground color (as
+/// specified by `fore_red`, `fore_green` and `fore_blue`). All pixels set to 0
+/// will use the background color (as specified by `back_red`, `back_green` and
+/// `back_blue`).
+///
+/// # Fields
+///
+/// * `cid` - The ID with which you will refer to the cursor, created by `xcb_generate_id`.
+/// * `source_font` - In which font to look for the cursor glyph.
+/// * `mask_font` - In which font to look for the mask glyph.
+/// * `source_char` - The glyph of `source_font` to use.
+/// * `mask_char` - The glyph of `mask_font` to use as a mask: Pixels which are set to 1 define
+/// which source pixels are displayed. All pixels which are set to 0 are not
+/// displayed.
+/// * `fore_red` - The red value of the foreground color.
+/// * `fore_green` - The green value of the foreground color.
+/// * `fore_blue` - The blue value of the foreground color.
+/// * `back_red` - The red value of the background color.
+/// * `back_green` - The green value of the background color.
+/// * `back_blue` - The blue value of the background color.
+///
+/// # Errors
+///
+/// * `Alloc` - The X server could not allocate the requested resources (no memory?).
+/// * `Font` - The specified `source_font` or `mask_font` does not exist.
+/// * `Value` - Either `source_char` or `mask_char` are not defined in `source_font` or `mask_font`, respectively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateGlyphCursorRequest {
+    pub cid: Cursor,
+    pub source_font: Font,
+    pub mask_font: Font,
+    pub source_char: u16,
+    pub mask_char: u16,
+    pub fore_red: u16,
+    pub fore_green: u16,
+    pub fore_blue: u16,
+    pub back_red: u16,
+    pub back_green: u16,
+    pub back_blue: u16,
+}
+impl CreateGlyphCursorRequest {
+    /// Opcode for the CreateGlyphCursor request
+    pub const fn opcode() -> u8 { 94 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cid_bytes = self.cid.serialize();
+        let source_font_bytes = self.source_font.serialize();
+        let mask_font_bytes = self.mask_font.serialize();
+        let source_char_bytes = self.source_char.serialize();
+        let mask_char_bytes = self.mask_char.serialize();
+        let fore_red_bytes = self.fore_red.serialize();
+        let fore_green_bytes = self.fore_green.serialize();
+        let fore_blue_bytes = self.fore_blue.serialize();
+        let back_red_bytes = self.back_red.serialize();
+        let back_green_bytes = self.back_green.serialize();
+        let back_blue_bytes = self.back_blue.serialize();
+        let mut request0 = vec![
+            CreateGlyphCursorRequest::opcode(),
+            0,
+            0,
+            0,
+            cid_bytes[0],
+            cid_bytes[1],
+            cid_bytes[2],
+            cid_bytes[3],
+            source_font_bytes[0],
+            source_font_bytes[1],
+            source_font_bytes[2],
+            source_font_bytes[3],
+            mask_font_bytes[0],
+            mask_font_bytes[1],
+            mask_font_bytes[2],
+            mask_font_bytes[3],
+            source_char_bytes[0],
+            source_char_bytes[1],
+            mask_char_bytes[0],
+            mask_char_bytes[1],
+            fore_red_bytes[0],
+            fore_red_bytes[1],
+            fore_green_bytes[0],
+            fore_green_bytes[1],
+            fore_blue_bytes[0],
+            fore_blue_bytes[1],
+            back_red_bytes[0],
+            back_red_bytes[1],
+            back_green_bytes[0],
+            back_green_bytes[1],
+            back_blue_bytes[0],
+            back_blue_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// create cursor.
 ///
 /// Creates a cursor from a font glyph. X provides a set of standard cursor shapes
@@ -15811,61 +19534,68 @@ where
     A: Into<Font>,
 {
     let mask_font: Font = mask_font.into();
-    let length_so_far = 0;
-    let cid_bytes = cid.serialize();
-    let source_font_bytes = source_font.serialize();
-    let mask_font_bytes = mask_font.serialize();
-    let source_char_bytes = source_char.serialize();
-    let mask_char_bytes = mask_char.serialize();
-    let fore_red_bytes = fore_red.serialize();
-    let fore_green_bytes = fore_green.serialize();
-    let fore_blue_bytes = fore_blue.serialize();
-    let back_red_bytes = back_red.serialize();
-    let back_green_bytes = back_green.serialize();
-    let back_blue_bytes = back_blue.serialize();
-    let mut request0 = [
-        CREATE_GLYPH_CURSOR_REQUEST,
-        0,
-        0,
-        0,
-        cid_bytes[0],
-        cid_bytes[1],
-        cid_bytes[2],
-        cid_bytes[3],
-        source_font_bytes[0],
-        source_font_bytes[1],
-        source_font_bytes[2],
-        source_font_bytes[3],
-        mask_font_bytes[0],
-        mask_font_bytes[1],
-        mask_font_bytes[2],
-        mask_font_bytes[3],
-        source_char_bytes[0],
-        source_char_bytes[1],
-        mask_char_bytes[0],
-        mask_char_bytes[1],
-        fore_red_bytes[0],
-        fore_red_bytes[1],
-        fore_green_bytes[0],
-        fore_green_bytes[1],
-        fore_blue_bytes[0],
-        fore_blue_bytes[1],
-        back_red_bytes[0],
-        back_red_bytes[1],
-        back_green_bytes[0],
-        back_green_bytes[1],
-        back_blue_bytes[0],
-        back_blue_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateGlyphCursorRequest {
+        cid: cid,
+        source_font: source_font,
+        mask_font: mask_font,
+        source_char: source_char,
+        mask_char: mask_char,
+        fore_red: fore_red,
+        fore_green: fore_green,
+        fore_blue: fore_blue,
+        back_red: back_red,
+        back_green: back_green,
+        back_blue: back_blue,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the FreeCursor request
-pub const FREE_CURSOR_REQUEST: u8 = 95;
+/// Deletes a cursor.
+///
+/// Deletes the association between the cursor resource ID and the specified
+/// cursor. The cursor is freed when no other resource references it.
+///
+/// # Fields
+///
+/// * `cursor` - The cursor to destroy.
+///
+/// # Errors
+///
+/// * `Cursor` - The specified cursor does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FreeCursorRequest {
+    pub cursor: Cursor,
+}
+impl FreeCursorRequest {
+    /// Opcode for the FreeCursor request
+    pub const fn opcode() -> u8 { 95 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cursor_bytes = self.cursor.serialize();
+        let mut request0 = vec![
+            FreeCursorRequest::opcode(),
+            0,
+            0,
+            0,
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// Deletes a cursor.
 ///
 /// Deletes the association between the cursor resource ID and the specified
@@ -15882,66 +19612,86 @@ pub fn free_cursor<Conn>(conn: &Conn, cursor: Cursor) -> Result<VoidCookie<'_, C
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cursor_bytes = cursor.serialize();
-    let mut request0 = [
-        FREE_CURSOR_REQUEST,
-        0,
-        0,
-        0,
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FreeCursorRequest {
+        cursor: cursor,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the RecolorCursor request
-pub const RECOLOR_CURSOR_REQUEST: u8 = 96;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecolorCursorRequest {
+    pub cursor: Cursor,
+    pub fore_red: u16,
+    pub fore_green: u16,
+    pub fore_blue: u16,
+    pub back_red: u16,
+    pub back_green: u16,
+    pub back_blue: u16,
+}
+impl RecolorCursorRequest {
+    /// Opcode for the RecolorCursor request
+    pub const fn opcode() -> u8 { 96 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let cursor_bytes = self.cursor.serialize();
+        let fore_red_bytes = self.fore_red.serialize();
+        let fore_green_bytes = self.fore_green.serialize();
+        let fore_blue_bytes = self.fore_blue.serialize();
+        let back_red_bytes = self.back_red.serialize();
+        let back_green_bytes = self.back_green.serialize();
+        let back_blue_bytes = self.back_blue.serialize();
+        let mut request0 = vec![
+            RecolorCursorRequest::opcode(),
+            0,
+            0,
+            0,
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+            fore_red_bytes[0],
+            fore_red_bytes[1],
+            fore_green_bytes[0],
+            fore_green_bytes[1],
+            fore_blue_bytes[0],
+            fore_blue_bytes[1],
+            back_red_bytes[0],
+            back_red_bytes[1],
+            back_green_bytes[0],
+            back_green_bytes[1],
+            back_blue_bytes[0],
+            back_blue_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn recolor_cursor<Conn>(conn: &Conn, cursor: Cursor, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let cursor_bytes = cursor.serialize();
-    let fore_red_bytes = fore_red.serialize();
-    let fore_green_bytes = fore_green.serialize();
-    let fore_blue_bytes = fore_blue.serialize();
-    let back_red_bytes = back_red.serialize();
-    let back_green_bytes = back_green.serialize();
-    let back_blue_bytes = back_blue.serialize();
-    let mut request0 = [
-        RECOLOR_CURSOR_REQUEST,
-        0,
-        0,
-        0,
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-        fore_red_bytes[0],
-        fore_red_bytes[1],
-        fore_green_bytes[0],
-        fore_green_bytes[1],
-        fore_blue_bytes[0],
-        fore_blue_bytes[1],
-        back_red_bytes[0],
-        back_red_bytes[1],
-        back_green_bytes[0],
-        back_green_bytes[1],
-        back_blue_bytes[0],
-        back_blue_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = RecolorCursorRequest {
+        cursor: cursor,
+        fore_red: fore_red,
+        fore_green: fore_green,
+        fore_blue: fore_blue,
+        back_red: back_red,
+        back_green: back_green,
+        back_blue: back_blue,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16009,36 +19759,61 @@ impl TryFrom<u32> for QueryShapeOf {
     }
 }
 
-/// Opcode for the QueryBestSize request
-pub const QUERY_BEST_SIZE_REQUEST: u8 = 97;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryBestSizeRequest {
+    pub class: QueryShapeOf,
+    pub drawable: Drawable,
+    pub width: u16,
+    pub height: u16,
+}
+impl QueryBestSizeRequest {
+    /// Opcode for the QueryBestSize request
+    pub const fn opcode() -> u8 { 97 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let class_bytes = u8::from(self.class).serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mut request0 = vec![
+            QueryBestSizeRequest::opcode(),
+            class_bytes[0],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_best_size<Conn>(conn: &Conn, class: QueryShapeOf, drawable: Drawable, width: u16, height: u16) -> Result<Cookie<'_, Conn, QueryBestSizeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let class_bytes = u8::from(class).serialize();
-    let drawable_bytes = drawable.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let mut request0 = [
-        QUERY_BEST_SIZE_REQUEST,
-        class_bytes[0],
-        0,
-        0,
-        drawable_bytes[0],
-        drawable_bytes[1],
-        drawable_bytes[2],
-        drawable_bytes[3],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryBestSizeRequest {
+        class: class,
+        drawable: drawable,
+        width: width,
+        height: height,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16068,8 +19843,64 @@ impl TryFrom<&[u8]> for QueryBestSizeReply {
     }
 }
 
-/// Opcode for the QueryExtension request
-pub const QUERY_EXTENSION_REQUEST: u8 = 98;
+/// check if extension is present.
+///
+/// Determines if the specified extension is present on this X11 server.
+///
+/// Every extension has a unique `major_opcode` to identify requests, the minor
+/// opcodes and request formats are extension-specific. If the extension provides
+/// events and errors, the `first_event` and `first_error` fields in the reply are
+/// set accordingly.
+///
+/// There should rarely be a need to use this request directly, XCB provides the
+/// `xcb_get_extension_data` function instead.
+///
+/// # Fields
+///
+/// * `name_len` - The length of `name` in bytes.
+/// * `name` - The name of the extension to query, for example "RANDR". This is case
+/// sensitive!
+///
+/// # See
+///
+/// * `xdpyinfo`: program
+/// * `xcb_get_extension_data`: function
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryExtensionRequest<'input> {
+    pub name: &'input [u8],
+}
+impl<'input> QueryExtensionRequest<'input> {
+    /// Opcode for the QueryExtension request
+    pub const fn opcode() -> u8 { 98 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        let name_len_bytes = name_len.serialize();
+        let mut request0 = vec![
+            QueryExtensionRequest::opcode(),
+            0,
+            0,
+            0,
+            name_len_bytes[0],
+            name_len_bytes[1],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.name[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 /// check if extension is present.
 ///
 /// Determines if the specified extension is present on this X11 server.
@@ -16096,27 +19927,12 @@ pub fn query_extension<'c, 'input, Conn>(conn: &'c Conn, name: &'input [u8]) -> 
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let name_len = u16::try_from(name.len()).expect("`name` has too many elements");
-    let name_len_bytes = name_len.serialize();
-    let mut request0 = [
-        QUERY_EXTENSION_REQUEST,
-        0,
-        0,
-        0,
-        name_len_bytes[0],
-        name_len_bytes[1],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + name.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(name), IoSlice::new(&padding0)], vec![])?)
+    let request0 = QueryExtensionRequest {
+        name: name,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 /// # Fields
@@ -16156,24 +19972,39 @@ impl TryFrom<&[u8]> for QueryExtensionReply {
     }
 }
 
-/// Opcode for the ListExtensions request
-pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListExtensionsRequest;
+impl ListExtensionsRequest {
+    /// Opcode for the ListExtensions request
+    pub const fn opcode() -> u8 { 99 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            ListExtensionsRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_extensions<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListExtensionsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        LIST_EXTENSIONS_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListExtensionsRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16217,62 +20048,108 @@ impl ListExtensionsReply {
     }
 }
 
-/// Opcode for the ChangeKeyboardMapping request
-pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeKeyboardMappingRequest<'input> {
+    pub keycode_count: u8,
+    pub first_keycode: Keycode,
+    pub keysyms_per_keycode: u8,
+    pub keysyms: &'input [Keysym],
+}
+impl<'input> ChangeKeyboardMappingRequest<'input> {
+    /// Opcode for the ChangeKeyboardMapping request
+    pub const fn opcode() -> u8 { 100 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let keycode_count_bytes = self.keycode_count.serialize();
+        let first_keycode_bytes = self.first_keycode.serialize();
+        let keysyms_per_keycode_bytes = self.keysyms_per_keycode.serialize();
+        let mut request0 = vec![
+            ChangeKeyboardMappingRequest::opcode(),
+            keycode_count_bytes[0],
+            0,
+            0,
+            first_keycode_bytes[0],
+            keysyms_per_keycode_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(self.keysyms.len(), usize::try_from(u32::from(self.keycode_count).checked_mul(u32::from(self.keysyms_per_keycode)).unwrap()).unwrap(), "`keysyms` has an incorrect length");
+        let keysyms_bytes = self.keysyms.serialize();
+        let length_so_far = length_so_far + keysyms_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), keysyms_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_keyboard_mapping<'c, 'input, Conn>(conn: &'c Conn, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &'input [Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let keycode_count_bytes = keycode_count.serialize();
-    let first_keycode_bytes = first_keycode.serialize();
-    let keysyms_per_keycode_bytes = keysyms_per_keycode.serialize();
-    let mut request0 = [
-        CHANGE_KEYBOARD_MAPPING_REQUEST,
-        keycode_count_bytes[0],
-        0,
-        0,
-        first_keycode_bytes[0],
-        keysyms_per_keycode_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(keysyms.len(), usize::try_from(u32::from(keycode_count).checked_mul(u32::from(keysyms_per_keycode)).unwrap()).unwrap(), "`keysyms` has an incorrect length");
-    let keysyms_bytes = keysyms.serialize();
-    let length_so_far = length_so_far + keysyms_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&keysyms_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeKeyboardMappingRequest {
+        keycode_count: keycode_count,
+        first_keycode: first_keycode,
+        keysyms_per_keycode: keysyms_per_keycode,
+        keysyms: keysyms,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetKeyboardMapping request
-pub const GET_KEYBOARD_MAPPING_REQUEST: u8 = 101;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetKeyboardMappingRequest {
+    pub first_keycode: Keycode,
+    pub count: u8,
+}
+impl GetKeyboardMappingRequest {
+    /// Opcode for the GetKeyboardMapping request
+    pub const fn opcode() -> u8 { 101 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let first_keycode_bytes = self.first_keycode.serialize();
+        let count_bytes = self.count.serialize();
+        let mut request0 = vec![
+            GetKeyboardMappingRequest::opcode(),
+            0,
+            0,
+            0,
+            first_keycode_bytes[0],
+            count_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_keyboard_mapping<Conn>(conn: &Conn, first_keycode: Keycode, count: u8) -> Result<Cookie<'_, Conn, GetKeyboardMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let first_keycode_bytes = first_keycode.serialize();
-    let count_bytes = count.serialize();
-    let mut request0 = [
-        GET_KEYBOARD_MAPPING_REQUEST,
-        0,
-        0,
-        0,
-        first_keycode_bytes[0],
-        count_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetKeyboardMappingRequest {
+        first_keycode: first_keycode,
+        count: count,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16532,8 +20409,6 @@ impl TryFrom<u32> for AutoRepeatMode {
     }
 }
 
-/// Opcode for the ChangeKeyboardControl request
-pub const CHANGE_KEYBOARD_CONTROL_REQUEST: u8 = 102;
 /// Auxiliary and optional information for the `change_keyboard_control` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ChangeKeyboardControlAux {
@@ -16657,52 +20532,88 @@ impl ChangeKeyboardControlAux {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeKeyboardControlRequest<'input> {
+    pub value_list: &'input ChangeKeyboardControlAux,
+}
+impl<'input> ChangeKeyboardControlRequest<'input> {
+    /// Opcode for the ChangeKeyboardControl request
+    pub const fn opcode() -> u8 { 102 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask_bytes = value_mask.serialize();
+        let mut request0 = vec![
+            ChangeKeyboardControlRequest::opcode(),
+            0,
+            0,
+            0,
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+            value_mask_bytes[2],
+            value_mask_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let value_list_bytes = self.value_list.serialize(value_mask);
+        let length_so_far = length_so_far + value_list_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_keyboard_control<'c, 'input, Conn>(conn: &'c Conn, value_list: &'input ChangeKeyboardControlAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let value_mask = u32::try_from(value_list.switch_expr()).unwrap();
-    let value_mask_bytes = value_mask.serialize();
-    let mut request0 = [
-        CHANGE_KEYBOARD_CONTROL_REQUEST,
-        0,
-        0,
-        0,
-        value_mask_bytes[0],
-        value_mask_bytes[1],
-        value_mask_bytes[2],
-        value_mask_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let value_list_bytes = value_list.serialize(value_mask);
-    let length_so_far = length_so_far + value_list_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&value_list_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeKeyboardControlRequest {
+        value_list: value_list,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetKeyboardControl request
-pub const GET_KEYBOARD_CONTROL_REQUEST: u8 = 103;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetKeyboardControlRequest;
+impl GetKeyboardControlRequest {
+    /// Opcode for the GetKeyboardControl request
+    pub const fn opcode() -> u8 { 103 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GetKeyboardControlRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_keyboard_control<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetKeyboardControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GET_KEYBOARD_CONTROL_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetKeyboardControlRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16744,78 +20655,139 @@ impl TryFrom<&[u8]> for GetKeyboardControlReply {
     }
 }
 
-/// Opcode for the Bell request
-pub const BELL_REQUEST: u8 = 104;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BellRequest {
+    pub percent: i8,
+}
+impl BellRequest {
+    /// Opcode for the Bell request
+    pub const fn opcode() -> u8 { 104 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let percent_bytes = self.percent.serialize();
+        let mut request0 = vec![
+            BellRequest::opcode(),
+            percent_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn bell<Conn>(conn: &Conn, percent: i8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let percent_bytes = percent.serialize();
-    let mut request0 = [
-        BELL_REQUEST,
-        percent_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = BellRequest {
+        percent: percent,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ChangePointerControl request
-pub const CHANGE_POINTER_CONTROL_REQUEST: u8 = 105;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangePointerControlRequest {
+    pub acceleration_numerator: i16,
+    pub acceleration_denominator: i16,
+    pub threshold: i16,
+    pub do_acceleration: bool,
+    pub do_threshold: bool,
+}
+impl ChangePointerControlRequest {
+    /// Opcode for the ChangePointerControl request
+    pub const fn opcode() -> u8 { 105 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let acceleration_numerator_bytes = self.acceleration_numerator.serialize();
+        let acceleration_denominator_bytes = self.acceleration_denominator.serialize();
+        let threshold_bytes = self.threshold.serialize();
+        let do_acceleration_bytes = self.do_acceleration.serialize();
+        let do_threshold_bytes = self.do_threshold.serialize();
+        let mut request0 = vec![
+            ChangePointerControlRequest::opcode(),
+            0,
+            0,
+            0,
+            acceleration_numerator_bytes[0],
+            acceleration_numerator_bytes[1],
+            acceleration_denominator_bytes[0],
+            acceleration_denominator_bytes[1],
+            threshold_bytes[0],
+            threshold_bytes[1],
+            do_acceleration_bytes[0],
+            do_threshold_bytes[0],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn change_pointer_control<Conn>(conn: &Conn, acceleration_numerator: i16, acceleration_denominator: i16, threshold: i16, do_acceleration: bool, do_threshold: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let acceleration_numerator_bytes = acceleration_numerator.serialize();
-    let acceleration_denominator_bytes = acceleration_denominator.serialize();
-    let threshold_bytes = threshold.serialize();
-    let do_acceleration_bytes = do_acceleration.serialize();
-    let do_threshold_bytes = do_threshold.serialize();
-    let mut request0 = [
-        CHANGE_POINTER_CONTROL_REQUEST,
-        0,
-        0,
-        0,
-        acceleration_numerator_bytes[0],
-        acceleration_numerator_bytes[1],
-        acceleration_denominator_bytes[0],
-        acceleration_denominator_bytes[1],
-        threshold_bytes[0],
-        threshold_bytes[1],
-        do_acceleration_bytes[0],
-        do_threshold_bytes[0],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ChangePointerControlRequest {
+        acceleration_numerator: acceleration_numerator,
+        acceleration_denominator: acceleration_denominator,
+        threshold: threshold,
+        do_acceleration: do_acceleration,
+        do_threshold: do_threshold,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetPointerControl request
-pub const GET_POINTER_CONTROL_REQUEST: u8 = 106;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetPointerControlRequest;
+impl GetPointerControlRequest {
+    /// Opcode for the GetPointerControl request
+    pub const fn opcode() -> u8 { 106 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GetPointerControlRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_pointer_control<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetPointerControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GET_POINTER_CONTROL_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetPointerControlRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16978,56 +20950,96 @@ impl TryFrom<u32> for Exposures {
     }
 }
 
-/// Opcode for the SetScreenSaver request
-pub const SET_SCREEN_SAVER_REQUEST: u8 = 107;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetScreenSaverRequest {
+    pub timeout: i16,
+    pub interval: i16,
+    pub prefer_blanking: Blanking,
+    pub allow_exposures: Exposures,
+}
+impl SetScreenSaverRequest {
+    /// Opcode for the SetScreenSaver request
+    pub const fn opcode() -> u8 { 107 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let timeout_bytes = self.timeout.serialize();
+        let interval_bytes = self.interval.serialize();
+        let prefer_blanking_bytes = u8::from(self.prefer_blanking).serialize();
+        let allow_exposures_bytes = u8::from(self.allow_exposures).serialize();
+        let mut request0 = vec![
+            SetScreenSaverRequest::opcode(),
+            0,
+            0,
+            0,
+            timeout_bytes[0],
+            timeout_bytes[1],
+            interval_bytes[0],
+            interval_bytes[1],
+            prefer_blanking_bytes[0],
+            allow_exposures_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_screen_saver<Conn>(conn: &Conn, timeout: i16, interval: i16, prefer_blanking: Blanking, allow_exposures: Exposures) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let timeout_bytes = timeout.serialize();
-    let interval_bytes = interval.serialize();
-    let prefer_blanking_bytes = u8::from(prefer_blanking).serialize();
-    let allow_exposures_bytes = u8::from(allow_exposures).serialize();
-    let mut request0 = [
-        SET_SCREEN_SAVER_REQUEST,
-        0,
-        0,
-        0,
-        timeout_bytes[0],
-        timeout_bytes[1],
-        interval_bytes[0],
-        interval_bytes[1],
-        prefer_blanking_bytes[0],
-        allow_exposures_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetScreenSaverRequest {
+        timeout: timeout,
+        interval: interval,
+        prefer_blanking: prefer_blanking,
+        allow_exposures: allow_exposures,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GetScreenSaver request
-pub const GET_SCREEN_SAVER_REQUEST: u8 = 108;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetScreenSaverRequest;
+impl GetScreenSaverRequest {
+    /// Opcode for the GetScreenSaver request
+    pub const fn opcode() -> u8 { 108 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GetScreenSaverRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_screen_saver<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetScreenSaverReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GET_SCREEN_SAVER_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetScreenSaverRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17205,35 +21217,58 @@ impl TryFrom<u32> for Family {
     }
 }
 
-/// Opcode for the ChangeHosts request
-pub const CHANGE_HOSTS_REQUEST: u8 = 109;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeHostsRequest<'input> {
+    pub mode: HostMode,
+    pub family: Family,
+    pub address: &'input [u8],
+}
+impl<'input> ChangeHostsRequest<'input> {
+    /// Opcode for the ChangeHosts request
+    pub const fn opcode() -> u8 { 109 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mode_bytes = u8::from(self.mode).serialize();
+        let family_bytes = u8::from(self.family).serialize();
+        let address_len = u16::try_from(self.address.len()).expect("`address` has too many elements");
+        let address_len_bytes = address_len.serialize();
+        let mut request0 = vec![
+            ChangeHostsRequest::opcode(),
+            mode_bytes[0],
+            0,
+            0,
+            family_bytes[0],
+            0,
+            address_len_bytes[0],
+            address_len_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.address[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.address[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn change_hosts<'c, 'input, Conn>(conn: &'c Conn, mode: HostMode, family: Family, address: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mode_bytes = u8::from(mode).serialize();
-    let family_bytes = u8::from(family).serialize();
-    let address_len = u16::try_from(address.len()).expect("`address` has too many elements");
-    let address_len_bytes = address_len.serialize();
-    let mut request0 = [
-        CHANGE_HOSTS_REQUEST,
-        mode_bytes[0],
-        0,
-        0,
-        family_bytes[0],
-        0,
-        address_len_bytes[0],
-        address_len_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + address.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(address), IoSlice::new(&padding0)], vec![])?)
+    let request0 = ChangeHostsRequest {
+        mode: mode,
+        family: family,
+        address: address,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17297,24 +21332,39 @@ impl Host {
     }
 }
 
-/// Opcode for the ListHosts request
-pub const LIST_HOSTS_REQUEST: u8 = 110;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListHostsRequest;
+impl ListHostsRequest {
+    /// Opcode for the ListHosts request
+    pub const fn opcode() -> u8 { 110 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            ListHostsRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_hosts<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListHostsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        LIST_HOSTS_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListHostsRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17431,25 +21481,44 @@ impl TryFrom<u32> for AccessControl {
     }
 }
 
-/// Opcode for the SetAccessControl request
-pub const SET_ACCESS_CONTROL_REQUEST: u8 = 111;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetAccessControlRequest {
+    pub mode: AccessControl,
+}
+impl SetAccessControlRequest {
+    /// Opcode for the SetAccessControl request
+    pub const fn opcode() -> u8 { 111 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mode_bytes = u8::from(self.mode).serialize();
+        let mut request0 = vec![
+            SetAccessControlRequest::opcode(),
+            mode_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_access_control<Conn>(conn: &Conn, mode: AccessControl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mode_bytes = u8::from(mode).serialize();
-    let mut request0 = [
-        SET_ACCESS_CONTROL_REQUEST,
-        mode_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetAccessControlRequest {
+        mode: mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17517,25 +21586,44 @@ impl TryFrom<u32> for CloseDown {
     }
 }
 
-/// Opcode for the SetCloseDownMode request
-pub const SET_CLOSE_DOWN_MODE_REQUEST: u8 = 112;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetCloseDownModeRequest {
+    pub mode: CloseDown,
+}
+impl SetCloseDownModeRequest {
+    /// Opcode for the SetCloseDownMode request
+    pub const fn opcode() -> u8 { 112 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mode_bytes = u8::from(self.mode).serialize();
+        let mut request0 = vec![
+            SetCloseDownModeRequest::opcode(),
+            mode_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn set_close_down_mode<Conn>(conn: &Conn, mode: CloseDown) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mode_bytes = u8::from(mode).serialize();
-    let mut request0 = [
-        SET_CLOSE_DOWN_MODE_REQUEST,
-        mode_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = SetCloseDownModeRequest {
+        mode: mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17597,8 +21685,57 @@ impl TryFrom<u32> for Kill {
     }
 }
 
-/// Opcode for the KillClient request
-pub const KILL_CLIENT_REQUEST: u8 = 113;
+/// kills a client.
+///
+/// Forces a close down of the client that created the specified `resource`.
+///
+/// # Fields
+///
+/// * `resource` - Any resource belonging to the client (for example a Window), used to identify
+/// the client connection.
+///
+/// The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
+/// that have terminated in `RetainTemporary` (TODO) are destroyed.
+///
+/// # Errors
+///
+/// * `Value` - The specified `resource` does not exist.
+///
+/// # See
+///
+/// * `xkill`: program
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KillClientRequest {
+    pub resource: u32,
+}
+impl KillClientRequest {
+    /// Opcode for the KillClient request
+    pub const fn opcode() -> u8 { 113 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let resource_bytes = self.resource.serialize();
+        let mut request0 = vec![
+            KillClientRequest::opcode(),
+            0,
+            0,
+            0,
+            resource_bytes[0],
+            resource_bytes[1],
+            resource_bytes[2],
+            resource_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 /// kills a client.
 ///
 /// Forces a close down of the client that created the specified `resource`.
@@ -17624,59 +21761,71 @@ where
     A: Into<u32>,
 {
     let resource: u32 = resource.into();
-    let length_so_far = 0;
-    let resource_bytes = resource.serialize();
-    let mut request0 = [
-        KILL_CLIENT_REQUEST,
-        0,
-        0,
-        0,
-        resource_bytes[0],
-        resource_bytes[1],
-        resource_bytes[2],
-        resource_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = KillClientRequest {
+        resource: resource,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the RotateProperties request
-pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RotatePropertiesRequest<'input> {
+    pub window: Window,
+    pub delta: i16,
+    pub atoms: &'input [Atom],
+}
+impl<'input> RotatePropertiesRequest<'input> {
+    /// Opcode for the RotateProperties request
+    pub const fn opcode() -> u8 { 114 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let atoms_len = u16::try_from(self.atoms.len()).expect("`atoms` has too many elements");
+        let atoms_len_bytes = atoms_len.serialize();
+        let delta_bytes = self.delta.serialize();
+        let mut request0 = vec![
+            RotatePropertiesRequest::opcode(),
+            0,
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            atoms_len_bytes[0],
+            atoms_len_bytes[1],
+            delta_bytes[0],
+            delta_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let atoms_bytes = self.atoms.serialize();
+        let length_so_far = length_so_far + atoms_bytes.len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), atoms_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn rotate_properties<'c, 'input, Conn>(conn: &'c Conn, window: Window, delta: i16, atoms: &'input [Atom]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let atoms_len = u16::try_from(atoms.len()).expect("`atoms` has too many elements");
-    let atoms_len_bytes = atoms_len.serialize();
-    let delta_bytes = delta.serialize();
-    let mut request0 = [
-        ROTATE_PROPERTIES_REQUEST,
-        0,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        atoms_len_bytes[0],
-        atoms_len_bytes[1],
-        delta_bytes[0],
-        delta_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let atoms_bytes = atoms.serialize();
-    let length_so_far = length_so_far + atoms_bytes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0), IoSlice::new(&atoms_bytes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = RotatePropertiesRequest {
+        window: window,
+        delta: delta,
+        atoms: atoms,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17749,25 +21898,44 @@ impl TryFrom<u32> for ScreenSaver {
     }
 }
 
-/// Opcode for the ForceScreenSaver request
-pub const FORCE_SCREEN_SAVER_REQUEST: u8 = 115;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ForceScreenSaverRequest {
+    pub mode: ScreenSaver,
+}
+impl ForceScreenSaverRequest {
+    /// Opcode for the ForceScreenSaver request
+    pub const fn opcode() -> u8 { 115 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mode_bytes = u8::from(self.mode).serialize();
+        let mut request0 = vec![
+            ForceScreenSaverRequest::opcode(),
+            mode_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn force_screen_saver<Conn>(conn: &Conn, mode: ScreenSaver) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mode_bytes = u8::from(mode).serialize();
-    let mut request0 = [
-        FORCE_SCREEN_SAVER_REQUEST,
-        mode_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ForceScreenSaverRequest {
+        mode: mode,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17835,29 +22003,48 @@ impl TryFrom<u32> for MappingStatus {
     }
 }
 
-/// Opcode for the SetPointerMapping request
-pub const SET_POINTER_MAPPING_REQUEST: u8 = 116;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetPointerMappingRequest<'input> {
+    pub map: &'input [u8],
+}
+impl<'input> SetPointerMappingRequest<'input> {
+    /// Opcode for the SetPointerMapping request
+    pub const fn opcode() -> u8 { 116 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let map_len = u8::try_from(self.map.len()).expect("`map` has too many elements");
+        let map_len_bytes = map_len.serialize();
+        let mut request0 = vec![
+            SetPointerMappingRequest::opcode(),
+            map_len_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.map[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.map[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_pointer_mapping<'c, 'input, Conn>(conn: &'c Conn, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetPointerMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let map_len = u8::try_from(map.len()).expect("`map` has too many elements");
-    let map_len_bytes = map_len.serialize();
-    let mut request0 = [
-        SET_POINTER_MAPPING_REQUEST,
-        map_len_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + map.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(map), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetPointerMappingRequest {
+        map: map,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17885,24 +22072,39 @@ impl TryFrom<&[u8]> for SetPointerMappingReply {
     }
 }
 
-/// Opcode for the GetPointerMapping request
-pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetPointerMappingRequest;
+impl GetPointerMappingRequest {
+    /// Opcode for the GetPointerMapping request
+    pub const fn opcode() -> u8 { 117 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GetPointerMappingRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_pointer_mapping<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetPointerMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GET_POINTER_MAPPING_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetPointerMappingRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18027,30 +22229,49 @@ impl TryFrom<u32> for MapIndex {
     }
 }
 
-/// Opcode for the SetModifierMapping request
-pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetModifierMappingRequest<'input> {
+    pub keycodes: &'input [Keycode],
+}
+impl<'input> SetModifierMappingRequest<'input> {
+    /// Opcode for the SetModifierMapping request
+    pub const fn opcode() -> u8 { 118 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        assert_eq!(self.keycodes.len() % 8, 0, "`keycodes` has an incorrect length, must be a multiple of 8");
+        let keycodes_per_modifier = u8::try_from(self.keycodes.len() / 8).expect("`keycodes` has too many elements");
+        let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
+        let mut request0 = vec![
+            SetModifierMappingRequest::opcode(),
+            keycodes_per_modifier_bytes[0],
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        let length_so_far = length_so_far + (&self.keycodes[..]).len();
+        let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
+        let length_so_far = length_so_far + padding0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into(), (&self.keycodes[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+    }
+}
 pub fn set_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, keycodes: &'input [Keycode]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    assert_eq!(keycodes.len() % 8, 0, "`keycodes` has an incorrect length, must be a multiple of 8");
-    let keycodes_per_modifier = u8::try_from(keycodes.len() / 8).expect("`keycodes` has too many elements");
-    let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
-    let mut request0 = [
-        SET_MODIFIER_MAPPING_REQUEST,
-        keycodes_per_modifier_bytes[0],
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    let length_so_far = length_so_far + keycodes.len();
-    let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
-    let length_so_far = length_so_far + padding0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0), IoSlice::new(keycodes), IoSlice::new(&padding0)], vec![])?)
+    let request0 = SetModifierMappingRequest {
+        keycodes: keycodes,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18078,24 +22299,39 @@ impl TryFrom<&[u8]> for SetModifierMappingReply {
     }
 }
 
-/// Opcode for the GetModifierMapping request
-pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetModifierMappingRequest;
+impl GetModifierMappingRequest {
+    /// Opcode for the GetModifierMapping request
+    pub const fn opcode() -> u8 { 119 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            GetModifierMappingRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_modifier_mapping<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        GET_MODIFIER_MAPPING_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetModifierMappingRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18141,24 +22377,39 @@ impl GetModifierMappingReply {
     }
 }
 
-/// Opcode for the NoOperation request
-pub const NO_OPERATION_REQUEST: u8 = 127;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NoOperationRequest;
+impl NoOperationRequest {
+    /// Opcode for the NoOperation request
+    pub const fn opcode() -> u8 { 127 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let length_so_far = 0;
+        let mut request0 = vec![
+            NoOperationRequest::opcode(),
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn no_operation<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let length_so_far = 0;
-    let mut request0 = [
-        NO_OPERATION_REQUEST,
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = NoOperationRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Extension trait defining the requests of this extension.
@@ -18913,7 +23164,7 @@ pub trait ConnectionExt: RequestConnection {
     ///     free(event);
     /// }
     /// ```
-    fn send_event<A, B, C>(&self, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn send_event<'c, 'input, A, B, C>(&'c self, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<Window>,
         B: Into<u32>,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -13,7 +13,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -22,7 +21,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::cookie::ListFontsWithInfoCookie;
@@ -6030,7 +6029,7 @@ impl<'input> CreateWindowRequest<'input> {
     /// Opcode for the CreateWindow request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6090,7 +6089,7 @@ impl<'input> CreateWindowRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// Creates a window.
@@ -6406,7 +6405,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
     /// Opcode for the ChangeWindowAttributes request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6437,7 +6436,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// change window attributes.
@@ -6559,7 +6558,7 @@ impl GetWindowAttributesRequest {
     /// Opcode for the GetWindowAttributes request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6711,7 +6710,7 @@ impl DestroyWindowRequest {
     /// Opcode for the DestroyWindow request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6777,7 +6776,7 @@ impl DestroySubwindowsRequest {
     /// Opcode for the DestroySubwindows request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -6914,7 +6913,7 @@ impl ChangeSaveSetRequest {
     /// Opcode for the ChangeSaveSet request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7017,7 +7016,7 @@ impl ReparentWindowRequest {
     /// Opcode for the ReparentWindow request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7142,7 +7141,7 @@ impl MapWindowRequest {
     /// Opcode for the MapWindow request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7221,7 +7220,7 @@ impl MapSubwindowsRequest {
     /// Opcode for the MapSubwindows request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7286,7 +7285,7 @@ impl UnmapWindowRequest {
     /// Opcode for the UnmapWindow request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7351,7 +7350,7 @@ impl UnmapSubwindowsRequest {
     /// Opcode for the UnmapSubwindows request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7707,7 +7706,7 @@ impl<'input> ConfigureWindowRequest<'input> {
     /// Opcode for the ConfigureWindow request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7738,7 +7737,7 @@ impl<'input> ConfigureWindowRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// Configures window attributes.
@@ -7900,7 +7899,7 @@ impl CirculateWindowRequest {
     /// Opcode for the CirculateWindow request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -7999,7 +7998,7 @@ impl GetGeometryRequest {
     /// Opcode for the GetGeometry request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8166,7 +8165,7 @@ impl QueryTreeRequest {
     /// Opcode for the QueryTree request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8344,7 +8343,7 @@ impl<'input> InternAtomRequest<'input> {
     /// Opcode for the InternAtom request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8370,7 +8369,7 @@ impl<'input> InternAtomRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 /// Get atom identifier by name.
@@ -8464,7 +8463,7 @@ impl GetAtomNameRequest {
     /// Opcode for the GetAtomName request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8682,7 +8681,7 @@ impl<'input> ChangePropertyRequest<'input> {
     /// Opcode for the ChangeProperty request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8728,7 +8727,7 @@ impl<'input> ChangePropertyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
     }
 }
 /// Changes a window property.
@@ -8813,7 +8812,7 @@ impl DeletePropertyRequest {
     /// Opcode for the DeleteProperty request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -8995,7 +8994,7 @@ impl GetPropertyRequest {
     /// Opcode for the GetProperty request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9344,7 +9343,7 @@ impl ListPropertiesRequest {
     /// Opcode for the ListProperties request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9461,7 +9460,7 @@ impl SetSelectionOwnerRequest {
     /// Opcode for the SetSelectionOwner request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9567,7 +9566,7 @@ impl GetSelectionOwnerRequest {
     /// Opcode for the GetSelectionOwner request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9660,7 +9659,7 @@ impl ConvertSelectionRequest {
     /// Opcode for the ConvertSelection request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -9878,7 +9877,7 @@ impl<'input> SendEventRequest<'input> {
     /// Opcode for the SendEvent request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10296,7 +10295,7 @@ impl GrabPointerRequest {
     /// Opcode for the GrabPointer request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10497,7 +10496,7 @@ impl UngrabPointerRequest {
     /// Opcode for the UngrabPointer request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10723,7 +10722,7 @@ impl GrabButtonRequest {
     /// Opcode for the GrabButton request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10876,7 +10875,7 @@ impl UngrabButtonRequest {
     /// Opcode for the UngrabButton request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -10932,7 +10931,7 @@ impl ChangeActivePointerGrabRequest {
     /// Opcode for the ChangeActivePointerGrab request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11060,7 +11059,7 @@ impl GrabKeyboardRequest {
     /// Opcode for the GrabKeyboard request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11209,7 +11208,7 @@ impl UngrabKeyboardRequest {
     /// Opcode for the UngrabKeyboard request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11379,7 +11378,7 @@ impl GrabKeyRequest {
     /// Opcode for the GrabKey request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11532,7 +11531,7 @@ impl UngrabKeyRequest {
     /// Opcode for the UngrabKey request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11771,7 +11770,7 @@ impl AllowEventsRequest {
     /// Opcode for the AllowEvents request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11835,7 +11834,7 @@ impl GrabServerRequest {
     /// Opcode for the GrabServer request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11870,7 +11869,7 @@ impl UngrabServerRequest {
     /// Opcode for the UngrabServer request
     pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -11920,7 +11919,7 @@ impl QueryPointerRequest {
     /// Opcode for the QueryPointer request
     pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12083,7 +12082,7 @@ impl GetMotionEventsRequest {
     /// Opcode for the GetMotionEvents request
     pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12188,7 +12187,7 @@ impl TranslateCoordinatesRequest {
     /// Opcode for the TranslateCoordinates request
     pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12315,7 +12314,7 @@ impl WarpPointerRequest {
     /// Opcode for the WarpPointer request
     pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12539,7 +12538,7 @@ impl SetInputFocusRequest {
     /// Opcode for the SetInputFocus request
     pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12628,7 +12627,7 @@ impl GetInputFocusRequest {
     /// Opcode for the GetInputFocus request
     pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12690,7 +12689,7 @@ impl QueryKeymapRequest {
     /// Opcode for the QueryKeymap request
     pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12774,7 +12773,7 @@ impl<'input> OpenFontRequest<'input> {
     /// Opcode for the OpenFont request
     pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -12804,7 +12803,7 @@ impl<'input> OpenFontRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 /// opens a font.
@@ -12848,7 +12847,7 @@ impl CloseFontRequest {
     /// Opcode for the CloseFont request
     pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13073,7 +13072,7 @@ impl QueryFontRequest {
     /// Opcode for the QueryFont request
     pub const fn opcode() -> u8 { 47 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13253,7 +13252,7 @@ impl<'input> QueryTextExtentsRequest<'input> {
     /// Opcode for the QueryTextExtents request
     pub const fn opcode() -> u8 { 48 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13281,7 +13280,7 @@ impl<'input> QueryTextExtentsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), string_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), string_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// get text extents.
@@ -13440,7 +13439,7 @@ impl<'input> ListFontsRequest<'input> {
     /// Opcode for the ListFonts request
     pub const fn opcode() -> u8 { 49 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13466,7 +13465,7 @@ impl<'input> ListFontsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.pattern[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.pattern[..]).into(), padding0.into()], vec![]))
     }
 }
 /// get matching font names.
@@ -13562,7 +13561,7 @@ impl<'input> ListFontsWithInfoRequest<'input> {
     /// Opcode for the ListFontsWithInfo request
     pub const fn opcode() -> u8 { 50 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13588,7 +13587,7 @@ impl<'input> ListFontsWithInfoRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.pattern[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.pattern[..]).into(), padding0.into()], vec![]))
     }
 }
 /// get matching font names and information.
@@ -13725,7 +13724,7 @@ impl<'input> SetFontPathRequest<'input> {
     /// Opcode for the SetFontPath request
     pub const fn opcode() -> u8 { 51 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13751,7 +13750,7 @@ impl<'input> SetFontPathRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), font_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), font_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_font_path<'c, 'input, Conn>(conn: &'c Conn, font: &'input [Str]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -13772,7 +13771,7 @@ impl GetFontPathRequest {
     /// Opcode for the GetFontPath request
     pub const fn opcode() -> u8 { 52 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13878,7 +13877,7 @@ impl CreatePixmapRequest {
     /// Opcode for the CreatePixmap request
     pub const fn opcode() -> u8 { 53 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -13973,7 +13972,7 @@ impl FreePixmapRequest {
     /// Opcode for the FreePixmap request
     pub const fn opcode() -> u8 { 54 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15133,7 +15132,7 @@ impl<'input> CreateGCRequest<'input> {
     /// Opcode for the CreateGC request
     pub const fn opcode() -> u8 { 55 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15169,7 +15168,7 @@ impl<'input> CreateGCRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// Creates a graphics context.
@@ -15566,7 +15565,7 @@ impl<'input> ChangeGCRequest<'input> {
     /// Opcode for the ChangeGC request
     pub const fn opcode() -> u8 { 56 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15597,7 +15596,7 @@ impl<'input> ChangeGCRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// change graphics context components.
@@ -15668,7 +15667,7 @@ impl CopyGCRequest {
     /// Opcode for the CopyGC request
     pub const fn opcode() -> u8 { 57 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15728,7 +15727,7 @@ impl<'input> SetDashesRequest<'input> {
     /// Opcode for the SetDashes request
     pub const fn opcode() -> u8 { 58 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15759,7 +15758,7 @@ impl<'input> SetDashesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.dashes[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.dashes[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_dashes<'c, 'input, Conn>(conn: &'c Conn, gc: Gcontext, dash_offset: u16, dashes: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -15856,7 +15855,7 @@ impl<'input> SetClipRectanglesRequest<'input> {
     /// Opcode for the SetClipRectangles request
     pub const fn opcode() -> u8 { 59 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15888,7 +15887,7 @@ impl<'input> SetClipRectanglesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rectangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, ordering: ClipOrdering, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -15926,7 +15925,7 @@ impl FreeGCRequest {
     /// Opcode for the FreeGC request
     pub const fn opcode() -> u8 { 60 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -15986,7 +15985,7 @@ impl ClearAreaRequest {
     /// Opcode for the ClearArea request
     pub const fn opcode() -> u8 { 61 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16077,7 +16076,7 @@ impl CopyAreaRequest {
     /// Opcode for the CopyArea request
     pub const fn opcode() -> u8 { 62 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16187,7 +16186,7 @@ impl CopyPlaneRequest {
     /// Opcode for the CopyPlane request
     pub const fn opcode() -> u8 { 63 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16350,7 +16349,7 @@ impl<'input> PolyPointRequest<'input> {
     /// Opcode for the PolyPoint request
     pub const fn opcode() -> u8 { 64 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16381,7 +16380,7 @@ impl<'input> PolyPointRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), points_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_point<'c, 'input, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -16449,7 +16448,7 @@ impl<'input> PolyLineRequest<'input> {
     /// Opcode for the PolyLine request
     pub const fn opcode() -> u8 { 65 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16480,7 +16479,7 @@ impl<'input> PolyLineRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), points_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// draw lines.
@@ -16623,7 +16622,7 @@ impl<'input> PolySegmentRequest<'input> {
     /// Opcode for the PolySegment request
     pub const fn opcode() -> u8 { 66 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16653,7 +16652,7 @@ impl<'input> PolySegmentRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), segments_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), segments_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// draw lines.
@@ -16706,7 +16705,7 @@ impl<'input> PolyRectangleRequest<'input> {
     /// Opcode for the PolyRectangle request
     pub const fn opcode() -> u8 { 67 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16736,7 +16735,7 @@ impl<'input> PolyRectangleRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rectangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_rectangle<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -16763,7 +16762,7 @@ impl<'input> PolyArcRequest<'input> {
     /// Opcode for the PolyArc request
     pub const fn opcode() -> u8 { 68 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16793,7 +16792,7 @@ impl<'input> PolyArcRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), arcs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), arcs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -16887,7 +16886,7 @@ impl<'input> FillPolyRequest<'input> {
     /// Opcode for the FillPoly request
     pub const fn opcode() -> u8 { 69 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -16923,7 +16922,7 @@ impl<'input> FillPolyRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), points_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), points_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn fill_poly<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, shape: PolyShape, coordinate_mode: CoordMode, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -16977,7 +16976,7 @@ impl<'input> PolyFillRectangleRequest<'input> {
     /// Opcode for the PolyFillRectangle request
     pub const fn opcode() -> u8 { 70 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17007,7 +17006,7 @@ impl<'input> PolyFillRectangleRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), rectangles_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), rectangles_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// Fills rectangles.
@@ -17059,7 +17058,7 @@ impl<'input> PolyFillArcRequest<'input> {
     /// Opcode for the PolyFillArc request
     pub const fn opcode() -> u8 { 71 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17089,7 +17088,7 @@ impl<'input> PolyFillArcRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), arcs_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), arcs_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_fill_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -17188,7 +17187,7 @@ impl<'input> PutImageRequest<'input> {
     /// Opcode for the PutImage request
     pub const fn opcode() -> u8 { 72 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17236,7 +17235,7 @@ impl<'input> PutImageRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -17274,7 +17273,7 @@ impl GetImageRequest {
     /// Opcode for the GetImage request
     pub const fn opcode() -> u8 { 73 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17391,7 +17390,7 @@ impl<'input> PolyText8Request<'input> {
     /// Opcode for the PolyText8 request
     pub const fn opcode() -> u8 { 74 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17426,7 +17425,7 @@ impl<'input> PolyText8Request<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.items[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.items[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_text8<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -17457,7 +17456,7 @@ impl<'input> PolyText16Request<'input> {
     /// Opcode for the PolyText16 request
     pub const fn opcode() -> u8 { 75 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17492,7 +17491,7 @@ impl<'input> PolyText16Request<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.items[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.items[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_text16<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -17557,7 +17556,7 @@ impl<'input> ImageText8Request<'input> {
     /// Opcode for the ImageText8 request
     pub const fn opcode() -> u8 { 76 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17594,7 +17593,7 @@ impl<'input> ImageText8Request<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.string[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.string[..]).into(), padding0.into()], vec![]))
     }
 }
 /// Draws text.
@@ -17694,7 +17693,7 @@ impl<'input> ImageText16Request<'input> {
     /// Opcode for the ImageText16 request
     pub const fn opcode() -> u8 { 77 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17732,7 +17731,7 @@ impl<'input> ImageText16Request<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), string_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), string_bytes.into(), padding0.into()], vec![]))
     }
 }
 /// Draws text.
@@ -17867,7 +17866,7 @@ impl CreateColormapRequest {
     /// Opcode for the CreateColormap request
     pub const fn opcode() -> u8 { 78 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17925,7 +17924,7 @@ impl FreeColormapRequest {
     /// Opcode for the FreeColormap request
     pub const fn opcode() -> u8 { 79 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -17970,7 +17969,7 @@ impl CopyColormapAndFreeRequest {
     /// Opcode for the CopyColormapAndFree request
     pub const fn opcode() -> u8 { 80 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18020,7 +18019,7 @@ impl InstallColormapRequest {
     /// Opcode for the InstallColormap request
     pub const fn opcode() -> u8 { 81 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18064,7 +18063,7 @@ impl UninstallColormapRequest {
     /// Opcode for the UninstallColormap request
     pub const fn opcode() -> u8 { 82 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18108,7 +18107,7 @@ impl ListInstalledColormapsRequest {
     /// Opcode for the ListInstalledColormaps request
     pub const fn opcode() -> u8 { 83 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18215,7 +18214,7 @@ impl AllocColorRequest {
     /// Opcode for the AllocColor request
     pub const fn opcode() -> u8 { 84 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18324,7 +18323,7 @@ impl<'input> AllocNamedColorRequest<'input> {
     /// Opcode for the AllocNamedColor request
     pub const fn opcode() -> u8 { 85 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18354,7 +18353,7 @@ impl<'input> AllocNamedColorRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn alloc_named_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
@@ -18418,7 +18417,7 @@ impl AllocColorCellsRequest {
     /// Opcode for the AllocColorCells request
     pub const fn opcode() -> u8 { 86 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18535,7 +18534,7 @@ impl AllocColorPlanesRequest {
     /// Opcode for the AllocColorPlanes request
     pub const fn opcode() -> u8 { 87 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18648,7 +18647,7 @@ impl<'input> FreeColorsRequest<'input> {
     /// Opcode for the FreeColors request
     pub const fn opcode() -> u8 { 88 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18678,7 +18677,7 @@ impl<'input> FreeColorsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), pixels_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), pixels_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn free_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, plane_mask: u32, pixels: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -18830,7 +18829,7 @@ impl<'input> StoreColorsRequest<'input> {
     /// Opcode for the StoreColors request
     pub const fn opcode() -> u8 { 89 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18855,7 +18854,7 @@ impl<'input> StoreColorsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), items_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), items_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn store_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, items: &'input [Coloritem]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -18882,7 +18881,7 @@ impl<'input> StoreNamedColorRequest<'input> {
     /// Opcode for the StoreNamedColor request
     pub const fn opcode() -> u8 { 90 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -18918,7 +18917,7 @@ impl<'input> StoreNamedColorRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn store_named_color<'c, 'input, Conn, A>(conn: &'c Conn, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -18995,7 +18994,7 @@ impl<'input> QueryColorsRequest<'input> {
     /// Opcode for the QueryColors request
     pub const fn opcode() -> u8 { 91 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19020,7 +19019,7 @@ impl<'input> QueryColorsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), pixels_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), pixels_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn query_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, pixels: &'input [u32]) -> Result<Cookie<'c, Conn, QueryColorsReply>, ConnectionError>
@@ -19087,7 +19086,7 @@ impl<'input> LookupColorRequest<'input> {
     /// Opcode for the LookupColor request
     pub const fn opcode() -> u8 { 92 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19117,7 +19116,7 @@ impl<'input> LookupColorRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn lookup_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
@@ -19245,7 +19244,7 @@ impl CreateCursorRequest {
     /// Opcode for the CreateCursor request
     pub const fn opcode() -> u8 { 93 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19437,7 +19436,7 @@ impl CreateGlyphCursorRequest {
     /// Opcode for the CreateGlyphCursor request
     pub const fn opcode() -> u8 { 94 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19572,7 +19571,7 @@ impl FreeCursorRequest {
     /// Opcode for the FreeCursor request
     pub const fn opcode() -> u8 { 95 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19634,7 +19633,7 @@ impl RecolorCursorRequest {
     /// Opcode for the RecolorCursor request
     pub const fn opcode() -> u8 { 96 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19770,7 +19769,7 @@ impl QueryBestSizeRequest {
     /// Opcode for the QueryBestSize request
     pub const fn opcode() -> u8 { 97 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19873,7 +19872,7 @@ impl<'input> QueryExtensionRequest<'input> {
     /// Opcode for the QueryExtension request
     pub const fn opcode() -> u8 { 98 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -19898,7 +19897,7 @@ impl<'input> QueryExtensionRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
     }
 }
 /// check if extension is present.
@@ -19978,7 +19977,7 @@ impl ListExtensionsRequest {
     /// Opcode for the ListExtensions request
     pub const fn opcode() -> u8 { 99 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20059,7 +20058,7 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
     /// Opcode for the ChangeKeyboardMapping request
     pub const fn opcode() -> u8 { 100 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20087,7 +20086,7 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), keysyms_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), keysyms_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_keyboard_mapping<'c, 'input, Conn>(conn: &'c Conn, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &'input [Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -20114,7 +20113,7 @@ impl GetKeyboardMappingRequest {
     /// Opcode for the GetKeyboardMapping request
     pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20540,7 +20539,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
     /// Opcode for the ChangeKeyboardControl request
     pub const fn opcode() -> u8 { 102 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20566,7 +20565,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), value_list_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), value_list_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_keyboard_control<'c, 'input, Conn>(conn: &'c Conn, value_list: &'input ChangeKeyboardControlAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -20587,7 +20586,7 @@ impl GetKeyboardControlRequest {
     /// Opcode for the GetKeyboardControl request
     pub const fn opcode() -> u8 { 103 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20663,7 +20662,7 @@ impl BellRequest {
     /// Opcode for the Bell request
     pub const fn opcode() -> u8 { 104 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20707,7 +20706,7 @@ impl ChangePointerControlRequest {
     /// Opcode for the ChangePointerControl request
     pub const fn opcode() -> u8 { 105 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20761,7 +20760,7 @@ impl GetPointerControlRequest {
     /// Opcode for the GetPointerControl request
     pub const fn opcode() -> u8 { 106 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -20961,7 +20960,7 @@ impl SetScreenSaverRequest {
     /// Opcode for the SetScreenSaver request
     pub const fn opcode() -> u8 { 107 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21013,7 +21012,7 @@ impl GetScreenSaverRequest {
     /// Opcode for the GetScreenSaver request
     pub const fn opcode() -> u8 { 108 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21227,7 +21226,7 @@ impl<'input> ChangeHostsRequest<'input> {
     /// Opcode for the ChangeHosts request
     pub const fn opcode() -> u8 { 109 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21254,7 +21253,7 @@ impl<'input> ChangeHostsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.address[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.address[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn change_hosts<'c, 'input, Conn>(conn: &'c Conn, mode: HostMode, family: Family, address: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -21338,7 +21337,7 @@ impl ListHostsRequest {
     /// Opcode for the ListHosts request
     pub const fn opcode() -> u8 { 110 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21489,7 +21488,7 @@ impl SetAccessControlRequest {
     /// Opcode for the SetAccessControl request
     pub const fn opcode() -> u8 { 111 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21594,7 +21593,7 @@ impl SetCloseDownModeRequest {
     /// Opcode for the SetCloseDownMode request
     pub const fn opcode() -> u8 { 112 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21712,7 +21711,7 @@ impl KillClientRequest {
     /// Opcode for the KillClient request
     pub const fn opcode() -> u8 { 113 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21779,7 +21778,7 @@ impl<'input> RotatePropertiesRequest<'input> {
     /// Opcode for the RotateProperties request
     pub const fn opcode() -> u8 { 114 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -21811,7 +21810,7 @@ impl<'input> RotatePropertiesRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), atoms_bytes.into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), atoms_bytes.into(), padding0.into()], vec![]))
     }
 }
 pub fn rotate_properties<'c, 'input, Conn>(conn: &'c Conn, window: Window, delta: i16, atoms: &'input [Atom]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -21906,7 +21905,7 @@ impl ForceScreenSaverRequest {
     /// Opcode for the ForceScreenSaver request
     pub const fn opcode() -> u8 { 115 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -22011,7 +22010,7 @@ impl<'input> SetPointerMappingRequest<'input> {
     /// Opcode for the SetPointerMapping request
     pub const fn opcode() -> u8 { 116 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -22032,7 +22031,7 @@ impl<'input> SetPointerMappingRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.map[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.map[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_pointer_mapping<'c, 'input, Conn>(conn: &'c Conn, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetPointerMappingReply>, ConnectionError>
@@ -22078,7 +22077,7 @@ impl GetPointerMappingRequest {
     /// Opcode for the GetPointerMapping request
     pub const fn opcode() -> u8 { 117 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -22237,7 +22236,7 @@ impl<'input> SetModifierMappingRequest<'input> {
     /// Opcode for the SetModifierMapping request
     pub const fn opcode() -> u8 { 118 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -22259,7 +22258,7 @@ impl<'input> SetModifierMappingRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.keycodes[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.keycodes[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, keycodes: &'input [Keycode]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>
@@ -22305,7 +22304,7 @@ impl GetModifierMappingRequest {
     /// Opcode for the GetModifierMapping request
     pub const fn opcode() -> u8 { 119 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -22383,7 +22382,7 @@ impl NoOperationRequest {
     /// Opcode for the NoOperation request
     pub const fn opcode() -> u8 { 127 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -5957,6 +5957,8 @@ impl CreateWindowAux {
     }
 }
 
+/// Opcode for the CreateWindow request
+pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// Creates a window.
 ///
 /// Creates an unmapped window as child of the specified `parent` window. A
@@ -6026,8 +6028,6 @@ pub struct CreateWindowRequest<'input> {
     pub value_list: &'input CreateWindowAux,
 }
 impl<'input> CreateWindowRequest<'input> {
-    /// Opcode for the CreateWindow request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6048,7 +6048,7 @@ impl<'input> CreateWindowRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CREATE_WINDOW_REQUEST,
             depth_bytes[0],
             0,
             0,
@@ -6375,6 +6375,8 @@ impl ChangeWindowAttributesAux {
     }
 }
 
+/// Opcode for the ChangeWindowAttributes request
+pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// change window attributes.
 ///
 /// Changes the attributes specified by `value_mask` for the specified `window`.
@@ -6402,8 +6404,6 @@ pub struct ChangeWindowAttributesRequest<'input> {
     pub value_list: &'input ChangeWindowAttributesAux,
 }
 impl<'input> ChangeWindowAttributesRequest<'input> {
-    /// Opcode for the ChangeWindowAttributes request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6415,7 +6415,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_WINDOW_ATTRIBUTES_REQUEST,
             0,
             0,
             0,
@@ -6538,6 +6538,8 @@ impl TryFrom<u32> for MapState {
     }
 }
 
+/// Opcode for the GetWindowAttributes request
+pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
 /// Gets window attributes.
 ///
 /// Gets the current attributes for the specified `window`.
@@ -6555,8 +6557,6 @@ pub struct GetWindowAttributesRequest {
     pub window: Window,
 }
 impl GetWindowAttributesRequest {
-    /// Opcode for the GetWindowAttributes request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6566,7 +6566,7 @@ impl GetWindowAttributesRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_WINDOW_ATTRIBUTES_REQUEST,
             0,
             0,
             0,
@@ -6680,6 +6680,8 @@ impl TryFrom<&[u8]> for GetWindowAttributesReply {
     }
 }
 
+/// Opcode for the DestroyWindow request
+pub const DESTROY_WINDOW_REQUEST: u8 = 4;
 /// Destroys a window.
 ///
 /// Destroys the specified window and all of its subwindows. A DestroyNotify event
@@ -6707,8 +6709,6 @@ pub struct DestroyWindowRequest {
     pub window: Window,
 }
 impl DestroyWindowRequest {
-    /// Opcode for the DestroyWindow request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6718,7 +6718,7 @@ impl DestroyWindowRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            DESTROY_WINDOW_REQUEST,
             0,
             0,
             0,
@@ -6768,13 +6768,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DestroySubwindows request
+pub const DESTROY_SUBWINDOWS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroySubwindowsRequest {
     pub window: Window,
 }
 impl DestroySubwindowsRequest {
-    /// Opcode for the DestroySubwindows request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6784,7 +6784,7 @@ impl DestroySubwindowsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            DESTROY_SUBWINDOWS_REQUEST,
             0,
             0,
             0,
@@ -6882,6 +6882,8 @@ impl TryFrom<u32> for SetMode {
     }
 }
 
+/// Opcode for the ChangeSaveSet request
+pub const CHANGE_SAVE_SET_REQUEST: u8 = 6;
 /// Changes a client's save set.
 ///
 /// TODO: explain what the save set is for.
@@ -6910,8 +6912,6 @@ pub struct ChangeSaveSetRequest {
     pub window: Window,
 }
 impl ChangeSaveSetRequest {
-    /// Opcode for the ChangeSaveSet request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -6922,7 +6922,7 @@ impl ChangeSaveSetRequest {
         let mode_bytes = u8::from(self.mode).serialize();
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_SAVE_SET_REQUEST,
             mode_bytes[0],
             0,
             0,
@@ -6973,6 +6973,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ReparentWindow request
+pub const REPARENT_WINDOW_REQUEST: u8 = 7;
 /// Reparents a window.
 ///
 /// Makes the specified window a child of the specified parent window. If the
@@ -7013,8 +7015,6 @@ pub struct ReparentWindowRequest {
     pub y: i16,
 }
 impl ReparentWindowRequest {
-    /// Opcode for the ReparentWindow request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7027,7 +7027,7 @@ impl ReparentWindowRequest {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            REPARENT_WINDOW_REQUEST,
             0,
             0,
             0,
@@ -7098,6 +7098,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the MapWindow request
+pub const MAP_WINDOW_REQUEST: u8 = 8;
 /// Makes a window visible.
 ///
 /// Maps the specified window. This means making the window visible (as long as its
@@ -7138,8 +7140,6 @@ pub struct MapWindowRequest {
     pub window: Window,
 }
 impl MapWindowRequest {
-    /// Opcode for the MapWindow request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7149,7 +7149,7 @@ impl MapWindowRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            MAP_WINDOW_REQUEST,
             0,
             0,
             0,
@@ -7212,13 +7212,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the MapSubwindows request
+pub const MAP_SUBWINDOWS_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MapSubwindowsRequest {
     pub window: Window,
 }
 impl MapSubwindowsRequest {
-    /// Opcode for the MapSubwindows request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7228,7 +7228,7 @@ impl MapSubwindowsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            MAP_SUBWINDOWS_REQUEST,
             0,
             0,
             0,
@@ -7256,6 +7256,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UnmapWindow request
+pub const UNMAP_WINDOW_REQUEST: u8 = 10;
 /// Makes a window invisible.
 ///
 /// Unmaps the specified window. This means making the window invisible (and all
@@ -7282,8 +7284,6 @@ pub struct UnmapWindowRequest {
     pub window: Window,
 }
 impl UnmapWindowRequest {
-    /// Opcode for the UnmapWindow request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7293,7 +7293,7 @@ impl UnmapWindowRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            UNMAP_WINDOW_REQUEST,
             0,
             0,
             0,
@@ -7342,13 +7342,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UnmapSubwindows request
+pub const UNMAP_SUBWINDOWS_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnmapSubwindowsRequest {
     pub window: Window,
 }
 impl UnmapSubwindowsRequest {
-    /// Opcode for the UnmapSubwindows request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7358,7 +7358,7 @@ impl UnmapSubwindowsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            UNMAP_SUBWINDOWS_REQUEST,
             0,
             0,
             0,
@@ -7647,6 +7647,8 @@ impl ConfigureWindowAux {
     }
 }
 
+/// Opcode for the ConfigureWindow request
+pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 /// Configures window attributes.
 ///
 /// Configures a window's size, position, border width and stacking order.
@@ -7703,8 +7705,6 @@ pub struct ConfigureWindowRequest<'input> {
     pub value_list: &'input ConfigureWindowAux,
 }
 impl<'input> ConfigureWindowRequest<'input> {
-    /// Opcode for the ConfigureWindow request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7716,7 +7716,7 @@ impl<'input> ConfigureWindowRequest<'input> {
         let value_mask = u16::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CONFIGURE_WINDOW_REQUEST,
             0,
             0,
             0,
@@ -7873,6 +7873,8 @@ impl TryFrom<u32> for Circulate {
     }
 }
 
+/// Opcode for the CirculateWindow request
+pub const CIRCULATE_WINDOW_REQUEST: u8 = 13;
 /// Change window stacking order.
 ///
 /// If `direction` is `XCB_CIRCULATE_RAISE_LOWEST`, the lowest mapped child (if
@@ -7896,8 +7898,6 @@ pub struct CirculateWindowRequest {
     pub window: Window,
 }
 impl CirculateWindowRequest {
-    /// Opcode for the CirculateWindow request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -7908,7 +7908,7 @@ impl CirculateWindowRequest {
         let direction_bytes = u8::from(self.direction).serialize();
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CIRCULATE_WINDOW_REQUEST,
             direction_bytes[0],
             0,
             0,
@@ -7954,6 +7954,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetGeometry request
+pub const GET_GEOMETRY_REQUEST: u8 = 14;
 /// Get current window geometry.
 ///
 /// Gets the current geometry of the specified drawable (either `Window` or `Pixmap`).
@@ -7995,8 +7997,6 @@ pub struct GetGeometryRequest {
     pub drawable: Drawable,
 }
 impl GetGeometryRequest {
-    /// Opcode for the GetGeometry request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8006,7 +8006,7 @@ impl GetGeometryRequest {
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_GEOMETRY_REQUEST,
             0,
             0,
             0,
@@ -8120,6 +8120,8 @@ impl TryFrom<&[u8]> for GetGeometryReply {
     }
 }
 
+/// Opcode for the QueryTree request
+pub const QUERY_TREE_REQUEST: u8 = 15;
 /// query the window tree.
 ///
 /// Gets the root window ID, parent window ID and list of children windows for the
@@ -8162,8 +8164,6 @@ pub struct QueryTreeRequest {
     pub window: Window,
 }
 impl QueryTreeRequest {
-    /// Opcode for the QueryTree request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8173,7 +8173,7 @@ impl QueryTreeRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_TREE_REQUEST,
             0,
             0,
             0,
@@ -8289,6 +8289,8 @@ impl QueryTreeReply {
     }
 }
 
+/// Opcode for the InternAtom request
+pub const INTERN_ATOM_REQUEST: u8 = 16;
 /// Get atom identifier by name.
 ///
 /// Retrieves the identifier (xcb_atom_t TODO) for the atom with the specified
@@ -8340,8 +8342,6 @@ pub struct InternAtomRequest<'input> {
     pub name: &'input [u8],
 }
 impl<'input> InternAtomRequest<'input> {
-    /// Opcode for the InternAtom request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8353,7 +8353,7 @@ impl<'input> InternAtomRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            INTERN_ATOM_REQUEST,
             only_if_exists_bytes[0],
             0,
             0,
@@ -8455,13 +8455,13 @@ impl TryFrom<&[u8]> for InternAtomReply {
     }
 }
 
+/// Opcode for the GetAtomName request
+pub const GET_ATOM_NAME_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetAtomNameRequest {
     pub atom: Atom,
 }
 impl GetAtomNameRequest {
-    /// Opcode for the GetAtomName request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8471,7 +8471,7 @@ impl GetAtomNameRequest {
         let length_so_far = 0;
         let atom_bytes = self.atom.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_ATOM_NAME_REQUEST,
             0,
             0,
             0,
@@ -8616,6 +8616,8 @@ impl TryFrom<u32> for PropMode {
     }
 }
 
+/// Opcode for the ChangeProperty request
+pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 /// Changes a window property.
 ///
 /// Sets or updates a property on the specified `window`. Properties are for
@@ -8678,8 +8680,6 @@ pub struct ChangePropertyRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> ChangePropertyRequest<'input> {
-    /// Opcode for the ChangeProperty request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8694,7 +8694,7 @@ impl<'input> ChangePropertyRequest<'input> {
         let format_bytes = self.format.serialize();
         let data_len_bytes = self.data_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_PROPERTY_REQUEST,
             mode_bytes[0],
             0,
             0,
@@ -8803,14 +8803,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the DeleteProperty request
+pub const DELETE_PROPERTY_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeletePropertyRequest {
     pub window: Window,
     pub property: Atom,
 }
 impl DeletePropertyRequest {
-    /// Opcode for the DeleteProperty request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -8821,7 +8821,7 @@ impl DeletePropertyRequest {
         let window_bytes = self.window.serialize();
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            DELETE_PROPERTY_REQUEST,
             0,
             0,
             0,
@@ -8913,6 +8913,8 @@ impl TryFrom<u32> for GetPropertyType {
     }
 }
 
+/// Opcode for the GetProperty request
+pub const GET_PROPERTY_REQUEST: u8 = 20;
 /// Gets a window property.
 ///
 /// Gets the specified `property` from the specified `window`. Properties are for
@@ -8991,8 +8993,6 @@ pub struct GetPropertyRequest {
     pub long_length: u32,
 }
 impl GetPropertyRequest {
-    /// Opcode for the GetProperty request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9007,7 +9007,7 @@ impl GetPropertyRequest {
         let long_offset_bytes = self.long_offset.serialize();
         let long_length_bytes = self.long_length.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_PROPERTY_REQUEST,
             delete_bytes[0],
             0,
             0,
@@ -9335,13 +9335,13 @@ impl TryFrom<&[u8]> for GetPropertyReply {
     }
 }
 
+/// Opcode for the ListProperties request
+pub const LIST_PROPERTIES_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListPropertiesRequest {
     pub window: Window,
 }
 impl ListPropertiesRequest {
-    /// Opcode for the ListProperties request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9351,7 +9351,7 @@ impl ListPropertiesRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            LIST_PROPERTIES_REQUEST,
             0,
             0,
             0,
@@ -9421,6 +9421,8 @@ impl ListPropertiesReply {
     }
 }
 
+/// Opcode for the SetSelectionOwner request
+pub const SET_SELECTION_OWNER_REQUEST: u8 = 22;
 /// Sets the owner of a selection.
 ///
 /// Makes `window` the owner of the selection `selection` and updates the
@@ -9457,8 +9459,6 @@ pub struct SetSelectionOwnerRequest {
     pub time: Timestamp,
 }
 impl SetSelectionOwnerRequest {
-    /// Opcode for the SetSelectionOwner request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9470,7 +9470,7 @@ impl SetSelectionOwnerRequest {
         let selection_bytes = self.selection.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_SELECTION_OWNER_REQUEST,
             0,
             0,
             0,
@@ -9541,6 +9541,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetSelectionOwner request
+pub const GET_SELECTION_OWNER_REQUEST: u8 = 23;
 /// Gets the owner of a selection.
 ///
 /// Gets the owner of the specified selection.
@@ -9563,8 +9565,6 @@ pub struct GetSelectionOwnerRequest {
     pub selection: Atom,
 }
 impl GetSelectionOwnerRequest {
-    /// Opcode for the GetSelectionOwner request
-    pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9574,7 +9574,7 @@ impl GetSelectionOwnerRequest {
         let length_so_far = 0;
         let selection_bytes = self.selection.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_SELECTION_OWNER_REQUEST,
             0,
             0,
             0,
@@ -9647,6 +9647,8 @@ impl TryFrom<&[u8]> for GetSelectionOwnerReply {
     }
 }
 
+/// Opcode for the ConvertSelection request
+pub const CONVERT_SELECTION_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConvertSelectionRequest {
     pub requestor: Window,
@@ -9656,8 +9658,6 @@ pub struct ConvertSelectionRequest {
     pub time: Timestamp,
 }
 impl ConvertSelectionRequest {
-    /// Opcode for the ConvertSelection request
-    pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9671,7 +9671,7 @@ impl ConvertSelectionRequest {
         let property_bytes = self.property.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CONVERT_SELECTION_REQUEST,
             0,
             0,
             0,
@@ -9793,6 +9793,8 @@ impl TryFrom<u32> for SendEventDest {
     }
 }
 
+/// Opcode for the SendEvent request
+pub const SEND_EVENT_REQUEST: u8 = 25;
 /// send an event.
 ///
 /// Identifies the `destination` window, determines which clients should receive
@@ -9874,8 +9876,6 @@ pub struct SendEventRequest<'input> {
     pub event: &'input [u8; 32],
 }
 impl<'input> SendEventRequest<'input> {
-    /// Opcode for the SendEvent request
-    pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -9887,7 +9887,7 @@ impl<'input> SendEventRequest<'input> {
         let destination_bytes = self.destination.serialize();
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SEND_EVENT_REQUEST,
             propagate_bytes[0],
             0,
             0,
@@ -10209,6 +10209,8 @@ impl TryFrom<u32> for CursorEnum {
     }
 }
 
+/// Opcode for the GrabPointer request
+pub const GRAB_POINTER_REQUEST: u8 = 26;
 /// Grab the pointer.
 ///
 /// Actively grabs control of the pointer. Further pointer events are reported only to the grabbing client. Overrides any active pointer grab by this client.
@@ -10292,8 +10294,6 @@ pub struct GrabPointerRequest {
     pub time: Timestamp,
 }
 impl GrabPointerRequest {
-    /// Opcode for the GrabPointer request
-    pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10310,7 +10310,7 @@ impl GrabPointerRequest {
         let cursor_bytes = self.cursor.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GRAB_POINTER_REQUEST,
             owner_events_bytes[0],
             0,
             0,
@@ -10465,6 +10465,8 @@ impl TryFrom<&[u8]> for GrabPointerReply {
     }
 }
 
+/// Opcode for the UngrabPointer request
+pub const UNGRAB_POINTER_REQUEST: u8 = 27;
 /// release the pointer.
 ///
 /// Releases the pointer and any queued events if you actively grabbed the pointer
@@ -10493,8 +10495,6 @@ pub struct UngrabPointerRequest {
     pub time: Timestamp,
 }
 impl UngrabPointerRequest {
-    /// Opcode for the UngrabPointer request
-    pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10504,7 +10504,7 @@ impl UngrabPointerRequest {
         let length_so_far = 0;
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            UNGRAB_POINTER_REQUEST,
             0,
             0,
             0,
@@ -10639,6 +10639,8 @@ impl TryFrom<u32> for ButtonIndex {
     }
 }
 
+/// Opcode for the GrabButton request
+pub const GRAB_BUTTON_REQUEST: u8 = 28;
 /// Grab pointer button(s).
 ///
 /// This request establishes a passive grab. The pointer is actively grabbed as
@@ -10719,8 +10721,6 @@ pub struct GrabButtonRequest {
     pub modifiers: u16,
 }
 impl GrabButtonRequest {
-    /// Opcode for the GrabButton request
-    pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10738,7 +10738,7 @@ impl GrabButtonRequest {
         let button_bytes = u8::from(self.button).serialize();
         let modifiers_bytes = self.modifiers.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GRAB_BUTTON_REQUEST,
             owner_events_bytes[0],
             0,
             0,
@@ -10865,6 +10865,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UngrabButton request
+pub const UNGRAB_BUTTON_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UngrabButtonRequest {
     pub button: ButtonIndex,
@@ -10872,8 +10874,6 @@ pub struct UngrabButtonRequest {
     pub modifiers: u16,
 }
 impl UngrabButtonRequest {
-    /// Opcode for the UngrabButton request
-    pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10885,7 +10885,7 @@ impl UngrabButtonRequest {
         let grab_window_bytes = self.grab_window.serialize();
         let modifiers_bytes = self.modifiers.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            UNGRAB_BUTTON_REQUEST,
             button_bytes[0],
             0,
             0,
@@ -10921,6 +10921,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ChangeActivePointerGrab request
+pub const CHANGE_ACTIVE_POINTER_GRAB_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeActivePointerGrabRequest {
     pub cursor: Cursor,
@@ -10928,8 +10930,6 @@ pub struct ChangeActivePointerGrabRequest {
     pub event_mask: u16,
 }
 impl ChangeActivePointerGrabRequest {
-    /// Opcode for the ChangeActivePointerGrab request
-    pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -10941,7 +10941,7 @@ impl ChangeActivePointerGrabRequest {
         let time_bytes = self.time.serialize();
         let event_mask_bytes = self.event_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_ACTIVE_POINTER_GRAB_REQUEST,
             0,
             0,
             0,
@@ -10985,6 +10985,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GrabKeyboard request
+pub const GRAB_KEYBOARD_REQUEST: u8 = 31;
 /// Grab the keyboard.
 ///
 /// Actively grabs control of the keyboard and generates FocusIn and FocusOut
@@ -11056,8 +11058,6 @@ pub struct GrabKeyboardRequest {
     pub keyboard_mode: GrabMode,
 }
 impl GrabKeyboardRequest {
-    /// Opcode for the GrabKeyboard request
-    pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11071,7 +11071,7 @@ impl GrabKeyboardRequest {
         let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
         let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GRAB_KEYBOARD_REQUEST,
             owner_events_bytes[0],
             0,
             0,
@@ -11200,13 +11200,13 @@ impl TryFrom<&[u8]> for GrabKeyboardReply {
     }
 }
 
+/// Opcode for the UngrabKeyboard request
+pub const UNGRAB_KEYBOARD_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UngrabKeyboardRequest {
     pub time: Timestamp,
 }
 impl UngrabKeyboardRequest {
-    /// Opcode for the UngrabKeyboard request
-    pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11216,7 +11216,7 @@ impl UngrabKeyboardRequest {
         let length_so_far = 0;
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            UNGRAB_KEYBOARD_REQUEST,
             0,
             0,
             0,
@@ -11305,6 +11305,8 @@ impl TryFrom<u32> for Grab {
     }
 }
 
+/// Opcode for the GrabKey request
+pub const GRAB_KEY_REQUEST: u8 = 33;
 /// Grab keyboard key(s).
 ///
 /// Establishes a passive grab on the keyboard. In the future, the keyboard is
@@ -11375,8 +11377,6 @@ pub struct GrabKeyRequest {
     pub keyboard_mode: GrabMode,
 }
 impl GrabKeyRequest {
-    /// Opcode for the GrabKey request
-    pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11391,7 +11391,7 @@ impl GrabKeyRequest {
         let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
         let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GRAB_KEY_REQUEST,
             owner_events_bytes[0],
             0,
             0,
@@ -11496,6 +11496,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UngrabKey request
+pub const UNGRAB_KEY_REQUEST: u8 = 34;
 /// release a key combination.
 ///
 /// Releases the key combination on `grab_window` if you grabbed it using
@@ -11528,8 +11530,6 @@ pub struct UngrabKeyRequest {
     pub modifiers: u16,
 }
 impl UngrabKeyRequest {
-    /// Opcode for the UngrabKey request
-    pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11541,7 +11541,7 @@ impl UngrabKeyRequest {
         let grab_window_bytes = self.grab_window.serialize();
         let modifiers_bytes = self.modifiers.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            UNGRAB_KEY_REQUEST,
             key_bytes[0],
             0,
             0,
@@ -11743,6 +11743,8 @@ impl TryFrom<u32> for Allow {
     }
 }
 
+/// Opcode for the AllowEvents request
+pub const ALLOW_EVENTS_REQUEST: u8 = 35;
 /// release queued events.
 ///
 /// Releases queued events if the client has caused a device (pointer/keyboard) to
@@ -11767,8 +11769,6 @@ pub struct AllowEventsRequest {
     pub time: Timestamp,
 }
 impl AllowEventsRequest {
-    /// Opcode for the AllowEvents request
-    pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11779,7 +11779,7 @@ impl AllowEventsRequest {
         let mode_bytes = u8::from(self.mode).serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            ALLOW_EVENTS_REQUEST,
             mode_bytes[0],
             0,
             0,
@@ -11828,11 +11828,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GrabServer request
+pub const GRAB_SERVER_REQUEST: u8 = 36;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrabServerRequest;
 impl GrabServerRequest {
-    /// Opcode for the GrabServer request
-    pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11841,7 +11841,7 @@ impl GrabServerRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GRAB_SERVER_REQUEST,
             0,
             0,
             0,
@@ -11863,11 +11863,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UngrabServer request
+pub const UNGRAB_SERVER_REQUEST: u8 = 37;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UngrabServerRequest;
 impl UngrabServerRequest {
-    /// Opcode for the UngrabServer request
-    pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11876,7 +11876,7 @@ impl UngrabServerRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            UNGRAB_SERVER_REQUEST,
             0,
             0,
             0,
@@ -11898,6 +11898,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryPointer request
+pub const QUERY_POINTER_REQUEST: u8 = 38;
 /// get pointer coordinates.
 ///
 /// Gets the root window the pointer is logically on and the pointer coordinates
@@ -11916,8 +11918,6 @@ pub struct QueryPointerRequest {
     pub window: Window,
 }
 impl QueryPointerRequest {
-    /// Opcode for the QueryPointer request
-    pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -11927,7 +11927,7 @@ impl QueryPointerRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_POINTER_REQUEST,
             0,
             0,
             0,
@@ -12072,6 +12072,8 @@ impl Serialize for Timecoord {
     }
 }
 
+/// Opcode for the GetMotionEvents request
+pub const GET_MOTION_EVENTS_REQUEST: u8 = 39;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetMotionEventsRequest {
     pub window: Window,
@@ -12079,8 +12081,6 @@ pub struct GetMotionEventsRequest {
     pub stop: Timestamp,
 }
 impl GetMotionEventsRequest {
-    /// Opcode for the GetMotionEvents request
-    pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12092,7 +12092,7 @@ impl GetMotionEventsRequest {
         let start_bytes = self.start.serialize();
         let stop_bytes = self.stop.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_MOTION_EVENTS_REQUEST,
             0,
             0,
             0,
@@ -12176,6 +12176,8 @@ impl GetMotionEventsReply {
     }
 }
 
+/// Opcode for the TranslateCoordinates request
+pub const TRANSLATE_COORDINATES_REQUEST: u8 = 40;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TranslateCoordinatesRequest {
     pub src_window: Window,
@@ -12184,8 +12186,6 @@ pub struct TranslateCoordinatesRequest {
     pub src_y: i16,
 }
 impl TranslateCoordinatesRequest {
-    /// Opcode for the TranslateCoordinates request
-    pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12198,7 +12198,7 @@ impl TranslateCoordinatesRequest {
         let src_x_bytes = self.src_x.serialize();
         let src_y_bytes = self.src_y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            TRANSLATE_COORDINATES_REQUEST,
             0,
             0,
             0,
@@ -12267,6 +12267,8 @@ impl TryFrom<&[u8]> for TranslateCoordinatesReply {
     }
 }
 
+/// Opcode for the WarpPointer request
+pub const WARP_POINTER_REQUEST: u8 = 41;
 /// move mouse pointer.
 ///
 /// Moves the mouse pointer to the specified position.
@@ -12311,8 +12313,6 @@ pub struct WarpPointerRequest {
     pub dst_y: i16,
 }
 impl WarpPointerRequest {
-    /// Opcode for the WarpPointer request
-    pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12329,7 +12329,7 @@ impl WarpPointerRequest {
         let dst_x_bytes = self.dst_x.serialize();
         let dst_y_bytes = self.dst_y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            WARP_POINTER_REQUEST,
             0,
             0,
             0,
@@ -12493,6 +12493,8 @@ impl TryFrom<u32> for InputFocus {
     }
 }
 
+/// Opcode for the SetInputFocus request
+pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
 /// Sets input focus.
 ///
 /// Changes the input focus and the last-focus-change time. If the specified `time`
@@ -12535,8 +12537,6 @@ pub struct SetInputFocusRequest {
     pub time: Timestamp,
 }
 impl SetInputFocusRequest {
-    /// Opcode for the SetInputFocus request
-    pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12548,7 +12548,7 @@ impl SetInputFocusRequest {
         let focus_bytes = self.focus.serialize();
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_INPUT_FOCUS_REQUEST,
             revert_to_bytes[0],
             0,
             0,
@@ -12621,11 +12621,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetInputFocus request
+pub const GET_INPUT_FOCUS_REQUEST: u8 = 43;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetInputFocusRequest;
 impl GetInputFocusRequest {
-    /// Opcode for the GetInputFocus request
-    pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12634,7 +12634,7 @@ impl GetInputFocusRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GET_INPUT_FOCUS_REQUEST,
             0,
             0,
             0,
@@ -12683,11 +12683,11 @@ impl TryFrom<&[u8]> for GetInputFocusReply {
     }
 }
 
+/// Opcode for the QueryKeymap request
+pub const QUERY_KEYMAP_REQUEST: u8 = 44;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryKeymapRequest;
 impl QueryKeymapRequest {
-    /// Opcode for the QueryKeymap request
-    pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12696,7 +12696,7 @@ impl QueryKeymapRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_KEYMAP_REQUEST,
             0,
             0,
             0,
@@ -12744,6 +12744,8 @@ impl TryFrom<&[u8]> for QueryKeymapReply {
     }
 }
 
+/// Opcode for the OpenFont request
+pub const OPEN_FONT_REQUEST: u8 = 45;
 /// opens a font.
 ///
 /// Opens any X core font matching the given `name` (for example "-misc-fixed-*").
@@ -12770,8 +12772,6 @@ pub struct OpenFontRequest<'input> {
     pub name: &'input [u8],
 }
 impl<'input> OpenFontRequest<'input> {
-    /// Opcode for the OpenFont request
-    pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12783,7 +12783,7 @@ impl<'input> OpenFontRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            OPEN_FONT_REQUEST,
             0,
             0,
             0,
@@ -12839,13 +12839,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CloseFont request
+pub const CLOSE_FONT_REQUEST: u8 = 46;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CloseFontRequest {
     pub font: Font,
 }
 impl CloseFontRequest {
-    /// Opcode for the CloseFont request
-    pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -12855,7 +12855,7 @@ impl CloseFontRequest {
         let length_so_far = 0;
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CLOSE_FONT_REQUEST,
             0,
             0,
             0,
@@ -13057,6 +13057,8 @@ impl Serialize for Charinfo {
     }
 }
 
+/// Opcode for the QueryFont request
+pub const QUERY_FONT_REQUEST: u8 = 47;
 /// query font metrics.
 ///
 /// Queries information associated with the font.
@@ -13069,8 +13071,6 @@ pub struct QueryFontRequest {
     pub font: Fontable,
 }
 impl QueryFontRequest {
-    /// Opcode for the QueryFont request
-    pub const fn opcode() -> u8 { 47 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13080,7 +13080,7 @@ impl QueryFontRequest {
         let length_so_far = 0;
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_FONT_REQUEST,
             0,
             0,
             0,
@@ -13209,6 +13209,8 @@ impl QueryFontReply {
     }
 }
 
+/// Opcode for the QueryTextExtents request
+pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
 /// get text extents.
 ///
 /// Query text extents from the X11 server. This request returns the bounding box
@@ -13249,8 +13251,6 @@ pub struct QueryTextExtentsRequest<'input> {
     pub string: &'input [Char2b],
 }
 impl<'input> QueryTextExtentsRequest<'input> {
-    /// Opcode for the QueryTextExtents request
-    pub const fn opcode() -> u8 { 48 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13263,7 +13263,7 @@ impl<'input> QueryTextExtentsRequest<'input> {
         let odd_length_bytes = odd_length.serialize();
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_TEXT_EXTENTS_REQUEST,
             odd_length_bytes[0],
             0,
             0,
@@ -13417,6 +13417,8 @@ impl Str {
     }
 }
 
+/// Opcode for the ListFonts request
+pub const LIST_FONTS_REQUEST: u8 = 49;
 /// get matching font names.
 ///
 /// Gets a list of available font names which match the given `pattern`.
@@ -13436,8 +13438,6 @@ pub struct ListFontsRequest<'input> {
     pub pattern: &'input [u8],
 }
 impl<'input> ListFontsRequest<'input> {
-    /// Opcode for the ListFonts request
-    pub const fn opcode() -> u8 { 49 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13449,7 +13449,7 @@ impl<'input> ListFontsRequest<'input> {
         let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
         let pattern_len_bytes = pattern_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            LIST_FONTS_REQUEST,
             0,
             0,
             0,
@@ -13539,6 +13539,8 @@ impl ListFontsReply {
     }
 }
 
+/// Opcode for the ListFontsWithInfo request
+pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
 /// get matching font names and information.
 ///
 /// Gets a list of available font names which match the given `pattern`.
@@ -13558,8 +13560,6 @@ pub struct ListFontsWithInfoRequest<'input> {
     pub pattern: &'input [u8],
 }
 impl<'input> ListFontsWithInfoRequest<'input> {
-    /// Opcode for the ListFontsWithInfo request
-    pub const fn opcode() -> u8 { 50 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13571,7 +13571,7 @@ impl<'input> ListFontsWithInfoRequest<'input> {
         let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
         let pattern_len_bytes = pattern_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            LIST_FONTS_WITH_INFO_REQUEST,
             0,
             0,
             0,
@@ -13716,13 +13716,13 @@ impl ListFontsWithInfoReply {
     }
 }
 
+/// Opcode for the SetFontPath request
+pub const SET_FONT_PATH_REQUEST: u8 = 51;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetFontPathRequest<'input> {
     pub font: &'input [Str],
 }
 impl<'input> SetFontPathRequest<'input> {
-    /// Opcode for the SetFontPath request
-    pub const fn opcode() -> u8 { 51 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13733,7 +13733,7 @@ impl<'input> SetFontPathRequest<'input> {
         let font_qty = u16::try_from(self.font.len()).expect("`font` has too many elements");
         let font_qty_bytes = font_qty.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_FONT_PATH_REQUEST,
             0,
             0,
             0,
@@ -13765,11 +13765,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetFontPath request
+pub const GET_FONT_PATH_REQUEST: u8 = 52;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetFontPathRequest;
 impl GetFontPathRequest {
-    /// Opcode for the GetFontPath request
-    pub const fn opcode() -> u8 { 52 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13778,7 +13778,7 @@ impl GetFontPathRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GET_FONT_PATH_REQUEST,
             0,
             0,
             0,
@@ -13842,6 +13842,8 @@ impl GetFontPathReply {
     }
 }
 
+/// Opcode for the CreatePixmap request
+pub const CREATE_PIXMAP_REQUEST: u8 = 53;
 /// Creates a pixmap.
 ///
 /// Creates a pixmap. The pixmap can only be used on the same screen as `drawable`
@@ -13874,8 +13876,6 @@ pub struct CreatePixmapRequest {
     pub height: u16,
 }
 impl CreatePixmapRequest {
-    /// Opcode for the CreatePixmap request
-    pub const fn opcode() -> u8 { 53 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13889,7 +13889,7 @@ impl CreatePixmapRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CREATE_PIXMAP_REQUEST,
             depth_bytes[0],
             0,
             0,
@@ -13952,6 +13952,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreePixmap request
+pub const FREE_PIXMAP_REQUEST: u8 = 54;
 /// Destroys a pixmap.
 ///
 /// Deletes the association between the pixmap ID and the pixmap. The pixmap
@@ -13969,8 +13971,6 @@ pub struct FreePixmapRequest {
     pub pixmap: Pixmap,
 }
 impl FreePixmapRequest {
-    /// Opcode for the FreePixmap request
-    pub const fn opcode() -> u8 { 54 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -13980,7 +13980,7 @@ impl FreePixmapRequest {
         let length_so_far = 0;
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            FREE_PIXMAP_REQUEST,
             0,
             0,
             0,
@@ -15099,6 +15099,8 @@ impl CreateGCAux {
     }
 }
 
+/// Opcode for the CreateGC request
+pub const CREATE_GC_REQUEST: u8 = 55;
 /// Creates a graphics context.
 ///
 /// Creates a graphics context. The graphics context can be used with any drawable
@@ -15129,8 +15131,6 @@ pub struct CreateGCRequest<'input> {
     pub value_list: &'input CreateGCAux,
 }
 impl<'input> CreateGCRequest<'input> {
-    /// Opcode for the CreateGC request
-    pub const fn opcode() -> u8 { 55 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15143,7 +15143,7 @@ impl<'input> CreateGCRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CREATE_GC_REQUEST,
             0,
             0,
             0,
@@ -15511,6 +15511,8 @@ impl ChangeGCAux {
     }
 }
 
+/// Opcode for the ChangeGC request
+pub const CHANGE_GC_REQUEST: u8 = 56;
 /// change graphics context components.
 ///
 /// Changes the components specified by `value_mask` for the specified graphics context.
@@ -15562,8 +15564,6 @@ pub struct ChangeGCRequest<'input> {
     pub value_list: &'input ChangeGCAux,
 }
 impl<'input> ChangeGCRequest<'input> {
-    /// Opcode for the ChangeGC request
-    pub const fn opcode() -> u8 { 56 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15575,7 +15575,7 @@ impl<'input> ChangeGCRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_GC_REQUEST,
             0,
             0,
             0,
@@ -15657,6 +15657,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CopyGC request
+pub const COPY_GC_REQUEST: u8 = 57;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CopyGCRequest {
     pub src_gc: Gcontext,
@@ -15664,8 +15666,6 @@ pub struct CopyGCRequest {
     pub value_mask: u32,
 }
 impl CopyGCRequest {
-    /// Opcode for the CopyGC request
-    pub const fn opcode() -> u8 { 57 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15677,7 +15677,7 @@ impl CopyGCRequest {
         let dst_gc_bytes = self.dst_gc.serialize();
         let value_mask_bytes = self.value_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            COPY_GC_REQUEST,
             0,
             0,
             0,
@@ -15717,6 +15717,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SetDashes request
+pub const SET_DASHES_REQUEST: u8 = 58;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetDashesRequest<'input> {
     pub gc: Gcontext,
@@ -15724,8 +15726,6 @@ pub struct SetDashesRequest<'input> {
     pub dashes: &'input [u8],
 }
 impl<'input> SetDashesRequest<'input> {
-    /// Opcode for the SetDashes request
-    pub const fn opcode() -> u8 { 58 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15738,7 +15738,7 @@ impl<'input> SetDashesRequest<'input> {
         let dashes_len = u16::try_from(self.dashes.len()).expect("`dashes` has too many elements");
         let dashes_len_bytes = dashes_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_DASHES_REQUEST,
             0,
             0,
             0,
@@ -15843,6 +15843,8 @@ impl TryFrom<u32> for ClipOrdering {
     }
 }
 
+/// Opcode for the SetClipRectangles request
+pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetClipRectanglesRequest<'input> {
     pub ordering: ClipOrdering,
@@ -15852,8 +15854,6 @@ pub struct SetClipRectanglesRequest<'input> {
     pub rectangles: &'input [Rectangle],
 }
 impl<'input> SetClipRectanglesRequest<'input> {
-    /// Opcode for the SetClipRectangles request
-    pub const fn opcode() -> u8 { 59 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15866,7 +15866,7 @@ impl<'input> SetClipRectanglesRequest<'input> {
         let clip_x_origin_bytes = self.clip_x_origin.serialize();
         let clip_y_origin_bytes = self.clip_y_origin.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_CLIP_RECTANGLES_REQUEST,
             ordering_bytes[0],
             0,
             0,
@@ -15906,6 +15906,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreeGC request
+pub const FREE_GC_REQUEST: u8 = 60;
 /// Destroys a graphics context.
 ///
 /// Destroys the specified `gc` and all associated storage.
@@ -15922,8 +15924,6 @@ pub struct FreeGCRequest {
     pub gc: Gcontext,
 }
 impl FreeGCRequest {
-    /// Opcode for the FreeGC request
-    pub const fn opcode() -> u8 { 60 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15933,7 +15933,7 @@ impl FreeGCRequest {
         let length_so_far = 0;
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            FREE_GC_REQUEST,
             0,
             0,
             0,
@@ -15972,6 +15972,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ClearArea request
+pub const CLEAR_AREA_REQUEST: u8 = 61;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClearAreaRequest {
     pub exposures: bool,
@@ -15982,8 +15984,6 @@ pub struct ClearAreaRequest {
     pub height: u16,
 }
 impl ClearAreaRequest {
-    /// Opcode for the ClearArea request
-    pub const fn opcode() -> u8 { 61 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -15998,7 +15998,7 @@ impl ClearAreaRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CLEAR_AREA_REQUEST,
             exposures_bytes[0],
             0,
             0,
@@ -16039,6 +16039,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CopyArea request
+pub const COPY_AREA_REQUEST: u8 = 62;
 /// copy areas.
 ///
 /// Copies the specified rectangle from `src_drawable` to `dst_drawable`.
@@ -16073,8 +16075,6 @@ pub struct CopyAreaRequest {
     pub height: u16,
 }
 impl CopyAreaRequest {
-    /// Opcode for the CopyArea request
-    pub const fn opcode() -> u8 { 62 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16092,7 +16092,7 @@ impl CopyAreaRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            COPY_AREA_REQUEST,
             0,
             0,
             0,
@@ -16169,6 +16169,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CopyPlane request
+pub const COPY_PLANE_REQUEST: u8 = 63;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CopyPlaneRequest {
     pub src_drawable: Drawable,
@@ -16183,8 +16185,6 @@ pub struct CopyPlaneRequest {
     pub bit_plane: u32,
 }
 impl CopyPlaneRequest {
-    /// Opcode for the CopyPlane request
-    pub const fn opcode() -> u8 { 63 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16203,7 +16203,7 @@ impl CopyPlaneRequest {
         let height_bytes = self.height.serialize();
         let bit_plane_bytes = self.bit_plane.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            COPY_PLANE_REQUEST,
             0,
             0,
             0,
@@ -16338,6 +16338,8 @@ impl TryFrom<u32> for CoordMode {
     }
 }
 
+/// Opcode for the PolyPoint request
+pub const POLY_POINT_REQUEST: u8 = 64;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolyPointRequest<'input> {
     pub coordinate_mode: CoordMode,
@@ -16346,8 +16348,6 @@ pub struct PolyPointRequest<'input> {
     pub points: &'input [Point],
 }
 impl<'input> PolyPointRequest<'input> {
-    /// Opcode for the PolyPoint request
-    pub const fn opcode() -> u8 { 64 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16359,7 +16359,7 @@ impl<'input> PolyPointRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_POINT_REQUEST,
             coordinate_mode_bytes[0],
             0,
             0,
@@ -16398,6 +16398,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PolyLine request
+pub const POLY_LINE_REQUEST: u8 = 65;
 /// draw lines.
 ///
 /// Draws `points_len`-1 lines between each pair of points (point[i], point[i+1])
@@ -16445,8 +16447,6 @@ pub struct PolyLineRequest<'input> {
     pub points: &'input [Point],
 }
 impl<'input> PolyLineRequest<'input> {
-    /// Opcode for the PolyLine request
-    pub const fn opcode() -> u8 { 65 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16458,7 +16458,7 @@ impl<'input> PolyLineRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_LINE_REQUEST,
             coordinate_mode_bytes[0],
             0,
             0,
@@ -16586,6 +16586,8 @@ impl Serialize for Segment {
     }
 }
 
+/// Opcode for the PolySegment request
+pub const POLY_SEGMENT_REQUEST: u8 = 66;
 /// draw lines.
 ///
 /// Draws multiple, unconnected lines. For each segment, a line is drawn between
@@ -16619,8 +16621,6 @@ pub struct PolySegmentRequest<'input> {
     pub segments: &'input [Segment],
 }
 impl<'input> PolySegmentRequest<'input> {
-    /// Opcode for the PolySegment request
-    pub const fn opcode() -> u8 { 66 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16631,7 +16631,7 @@ impl<'input> PolySegmentRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_SEGMENT_REQUEST,
             0,
             0,
             0,
@@ -16695,6 +16695,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PolyRectangle request
+pub const POLY_RECTANGLE_REQUEST: u8 = 67;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolyRectangleRequest<'input> {
     pub drawable: Drawable,
@@ -16702,8 +16704,6 @@ pub struct PolyRectangleRequest<'input> {
     pub rectangles: &'input [Rectangle],
 }
 impl<'input> PolyRectangleRequest<'input> {
-    /// Opcode for the PolyRectangle request
-    pub const fn opcode() -> u8 { 67 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16714,7 +16714,7 @@ impl<'input> PolyRectangleRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_RECTANGLE_REQUEST,
             0,
             0,
             0,
@@ -16752,6 +16752,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PolyArc request
+pub const POLY_ARC_REQUEST: u8 = 68;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolyArcRequest<'input> {
     pub drawable: Drawable,
@@ -16759,8 +16761,6 @@ pub struct PolyArcRequest<'input> {
     pub arcs: &'input [Arc],
 }
 impl<'input> PolyArcRequest<'input> {
-    /// Opcode for the PolyArc request
-    pub const fn opcode() -> u8 { 68 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16771,7 +16771,7 @@ impl<'input> PolyArcRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_ARC_REQUEST,
             0,
             0,
             0,
@@ -16874,6 +16874,8 @@ impl TryFrom<u32> for PolyShape {
     }
 }
 
+/// Opcode for the FillPoly request
+pub const FILL_POLY_REQUEST: u8 = 69;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FillPolyRequest<'input> {
     pub drawable: Drawable,
@@ -16883,8 +16885,6 @@ pub struct FillPolyRequest<'input> {
     pub points: &'input [Point],
 }
 impl<'input> FillPolyRequest<'input> {
-    /// Opcode for the FillPoly request
-    pub const fn opcode() -> u8 { 69 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16897,7 +16897,7 @@ impl<'input> FillPolyRequest<'input> {
         let shape_bytes = u8::from(self.shape).serialize();
         let coordinate_mode_bytes = u8::from(self.coordinate_mode).serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            FILL_POLY_REQUEST,
             0,
             0,
             0,
@@ -16941,6 +16941,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PolyFillRectangle request
+pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 /// Fills rectangles.
 ///
 /// Fills the specified rectangle(s) in the order listed in the array. For any
@@ -16973,8 +16975,6 @@ pub struct PolyFillRectangleRequest<'input> {
     pub rectangles: &'input [Rectangle],
 }
 impl<'input> PolyFillRectangleRequest<'input> {
-    /// Opcode for the PolyFillRectangle request
-    pub const fn opcode() -> u8 { 70 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -16985,7 +16985,7 @@ impl<'input> PolyFillRectangleRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_FILL_RECTANGLE_REQUEST,
             0,
             0,
             0,
@@ -17048,6 +17048,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PolyFillArc request
+pub const POLY_FILL_ARC_REQUEST: u8 = 71;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolyFillArcRequest<'input> {
     pub drawable: Drawable,
@@ -17055,8 +17057,6 @@ pub struct PolyFillArcRequest<'input> {
     pub arcs: &'input [Arc],
 }
 impl<'input> PolyFillArcRequest<'input> {
-    /// Opcode for the PolyFillArc request
-    pub const fn opcode() -> u8 { 71 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17067,7 +17067,7 @@ impl<'input> PolyFillArcRequest<'input> {
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_FILL_ARC_REQUEST,
             0,
             0,
             0,
@@ -17170,6 +17170,8 @@ impl TryFrom<u32> for ImageFormat {
     }
 }
 
+/// Opcode for the PutImage request
+pub const PUT_IMAGE_REQUEST: u8 = 72;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PutImageRequest<'input> {
     pub format: ImageFormat,
@@ -17184,8 +17186,6 @@ pub struct PutImageRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> PutImageRequest<'input> {
-    /// Opcode for the PutImage request
-    pub const fn opcode() -> u8 { 72 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17203,7 +17203,7 @@ impl<'input> PutImageRequest<'input> {
         let left_pad_bytes = self.left_pad.serialize();
         let depth_bytes = self.depth.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            PUT_IMAGE_REQUEST,
             format_bytes[0],
             0,
             0,
@@ -17259,6 +17259,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetImage request
+pub const GET_IMAGE_REQUEST: u8 = 73;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetImageRequest {
     pub format: ImageFormat,
@@ -17270,8 +17272,6 @@ pub struct GetImageRequest {
     pub plane_mask: u32,
 }
 impl GetImageRequest {
-    /// Opcode for the GetImage request
-    pub const fn opcode() -> u8 { 73 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17287,7 +17287,7 @@ impl GetImageRequest {
         let height_bytes = self.height.serialize();
         let plane_mask_bytes = self.plane_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_IMAGE_REQUEST,
             format_bytes[0],
             0,
             0,
@@ -17378,6 +17378,8 @@ impl GetImageReply {
     }
 }
 
+/// Opcode for the PolyText8 request
+pub const POLY_TEXT8_REQUEST: u8 = 74;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolyText8Request<'input> {
     pub drawable: Drawable,
@@ -17387,8 +17389,6 @@ pub struct PolyText8Request<'input> {
     pub items: &'input [u8],
 }
 impl<'input> PolyText8Request<'input> {
-    /// Opcode for the PolyText8 request
-    pub const fn opcode() -> u8 { 74 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17401,7 +17401,7 @@ impl<'input> PolyText8Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_TEXT8_REQUEST,
             0,
             0,
             0,
@@ -17444,6 +17444,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PolyText16 request
+pub const POLY_TEXT16_REQUEST: u8 = 75;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolyText16Request<'input> {
     pub drawable: Drawable,
@@ -17453,8 +17455,6 @@ pub struct PolyText16Request<'input> {
     pub items: &'input [u8],
 }
 impl<'input> PolyText16Request<'input> {
-    /// Opcode for the PolyText16 request
-    pub const fn opcode() -> u8 { 75 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17467,7 +17467,7 @@ impl<'input> PolyText16Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            POLY_TEXT16_REQUEST,
             0,
             0,
             0,
@@ -17510,6 +17510,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ImageText8 request
+pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 /// Draws text.
 ///
 /// Fills the destination rectangle with the background pixel from `gc`, then
@@ -17553,8 +17555,6 @@ pub struct ImageText8Request<'input> {
     pub string: &'input [u8],
 }
 impl<'input> ImageText8Request<'input> {
-    /// Opcode for the ImageText8 request
-    pub const fn opcode() -> u8 { 76 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17569,7 +17569,7 @@ impl<'input> ImageText8Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            IMAGE_TEXT8_REQUEST,
             string_len_bytes[0],
             0,
             0,
@@ -17646,6 +17646,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ImageText16 request
+pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 /// Draws text.
 ///
 /// Fills the destination rectangle with the background pixel from `gc`, then
@@ -17690,8 +17692,6 @@ pub struct ImageText16Request<'input> {
     pub string: &'input [Char2b],
 }
 impl<'input> ImageText16Request<'input> {
-    /// Opcode for the ImageText16 request
-    pub const fn opcode() -> u8 { 77 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17706,7 +17706,7 @@ impl<'input> ImageText16Request<'input> {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            IMAGE_TEXT16_REQUEST,
             string_len_bytes[0],
             0,
             0,
@@ -17855,6 +17855,8 @@ impl TryFrom<u32> for ColormapAlloc {
     }
 }
 
+/// Opcode for the CreateColormap request
+pub const CREATE_COLORMAP_REQUEST: u8 = 78;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateColormapRequest {
     pub alloc: ColormapAlloc,
@@ -17863,8 +17865,6 @@ pub struct CreateColormapRequest {
     pub visual: Visualid,
 }
 impl CreateColormapRequest {
-    /// Opcode for the CreateColormap request
-    pub const fn opcode() -> u8 { 78 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17877,7 +17877,7 @@ impl CreateColormapRequest {
         let window_bytes = self.window.serialize();
         let visual_bytes = self.visual.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CREATE_COLORMAP_REQUEST,
             alloc_bytes[0],
             0,
             0,
@@ -17916,13 +17916,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreeColormap request
+pub const FREE_COLORMAP_REQUEST: u8 = 79;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FreeColormapRequest {
     pub cmap: Colormap,
 }
 impl FreeColormapRequest {
-    /// Opcode for the FreeColormap request
-    pub const fn opcode() -> u8 { 79 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17932,7 +17932,7 @@ impl FreeColormapRequest {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            FREE_COLORMAP_REQUEST,
             0,
             0,
             0,
@@ -17960,14 +17960,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CopyColormapAndFree request
+pub const COPY_COLORMAP_AND_FREE_REQUEST: u8 = 80;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CopyColormapAndFreeRequest {
     pub mid: Colormap,
     pub src_cmap: Colormap,
 }
 impl CopyColormapAndFreeRequest {
-    /// Opcode for the CopyColormapAndFree request
-    pub const fn opcode() -> u8 { 80 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -17978,7 +17978,7 @@ impl CopyColormapAndFreeRequest {
         let mid_bytes = self.mid.serialize();
         let src_cmap_bytes = self.src_cmap.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            COPY_COLORMAP_AND_FREE_REQUEST,
             0,
             0,
             0,
@@ -18011,13 +18011,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the InstallColormap request
+pub const INSTALL_COLORMAP_REQUEST: u8 = 81;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InstallColormapRequest {
     pub cmap: Colormap,
 }
 impl InstallColormapRequest {
-    /// Opcode for the InstallColormap request
-    pub const fn opcode() -> u8 { 81 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18027,7 +18027,7 @@ impl InstallColormapRequest {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            INSTALL_COLORMAP_REQUEST,
             0,
             0,
             0,
@@ -18055,13 +18055,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the UninstallColormap request
+pub const UNINSTALL_COLORMAP_REQUEST: u8 = 82;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UninstallColormapRequest {
     pub cmap: Colormap,
 }
 impl UninstallColormapRequest {
-    /// Opcode for the UninstallColormap request
-    pub const fn opcode() -> u8 { 82 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18071,7 +18071,7 @@ impl UninstallColormapRequest {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            UNINSTALL_COLORMAP_REQUEST,
             0,
             0,
             0,
@@ -18099,13 +18099,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ListInstalledColormaps request
+pub const LIST_INSTALLED_COLORMAPS_REQUEST: u8 = 83;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListInstalledColormapsRequest {
     pub window: Window,
 }
 impl ListInstalledColormapsRequest {
-    /// Opcode for the ListInstalledColormaps request
-    pub const fn opcode() -> u8 { 83 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18115,7 +18115,7 @@ impl ListInstalledColormapsRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            LIST_INSTALLED_COLORMAPS_REQUEST,
             0,
             0,
             0,
@@ -18185,6 +18185,8 @@ impl ListInstalledColormapsReply {
     }
 }
 
+/// Opcode for the AllocColor request
+pub const ALLOC_COLOR_REQUEST: u8 = 84;
 /// Allocate a color.
 ///
 /// Allocates a read-only colormap entry corresponding to the closest RGB value
@@ -18211,8 +18213,6 @@ pub struct AllocColorRequest {
     pub blue: u16,
 }
 impl AllocColorRequest {
-    /// Opcode for the AllocColor request
-    pub const fn opcode() -> u8 { 84 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18225,7 +18225,7 @@ impl AllocColorRequest {
         let green_bytes = self.green.serialize();
         let blue_bytes = self.blue.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            ALLOC_COLOR_REQUEST,
             0,
             0,
             0,
@@ -18314,14 +18314,14 @@ impl TryFrom<&[u8]> for AllocColorReply {
     }
 }
 
+/// Opcode for the AllocNamedColor request
+pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AllocNamedColorRequest<'input> {
     pub cmap: Colormap,
     pub name: &'input [u8],
 }
 impl<'input> AllocNamedColorRequest<'input> {
-    /// Opcode for the AllocNamedColor request
-    pub const fn opcode() -> u8 { 85 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18333,7 +18333,7 @@ impl<'input> AllocNamedColorRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            ALLOC_NAMED_COLOR_REQUEST,
             0,
             0,
             0,
@@ -18406,6 +18406,8 @@ impl TryFrom<&[u8]> for AllocNamedColorReply {
     }
 }
 
+/// Opcode for the AllocColorCells request
+pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllocColorCellsRequest {
     pub contiguous: bool,
@@ -18414,8 +18416,6 @@ pub struct AllocColorCellsRequest {
     pub planes: u16,
 }
 impl AllocColorCellsRequest {
-    /// Opcode for the AllocColorCells request
-    pub const fn opcode() -> u8 { 86 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18428,7 +18428,7 @@ impl AllocColorCellsRequest {
         let colors_bytes = self.colors.serialize();
         let planes_bytes = self.planes.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            ALLOC_COLOR_CELLS_REQUEST,
             contiguous_bytes[0],
             0,
             0,
@@ -18521,6 +18521,8 @@ impl AllocColorCellsReply {
     }
 }
 
+/// Opcode for the AllocColorPlanes request
+pub const ALLOC_COLOR_PLANES_REQUEST: u8 = 87;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllocColorPlanesRequest {
     pub contiguous: bool,
@@ -18531,8 +18533,6 @@ pub struct AllocColorPlanesRequest {
     pub blues: u16,
 }
 impl AllocColorPlanesRequest {
-    /// Opcode for the AllocColorPlanes request
-    pub const fn opcode() -> u8 { 87 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18547,7 +18547,7 @@ impl AllocColorPlanesRequest {
         let greens_bytes = self.greens.serialize();
         let blues_bytes = self.blues.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            ALLOC_COLOR_PLANES_REQUEST,
             contiguous_bytes[0],
             0,
             0,
@@ -18637,6 +18637,8 @@ impl AllocColorPlanesReply {
     }
 }
 
+/// Opcode for the FreeColors request
+pub const FREE_COLORS_REQUEST: u8 = 88;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FreeColorsRequest<'input> {
     pub cmap: Colormap,
@@ -18644,8 +18646,6 @@ pub struct FreeColorsRequest<'input> {
     pub pixels: &'input [u32],
 }
 impl<'input> FreeColorsRequest<'input> {
-    /// Opcode for the FreeColors request
-    pub const fn opcode() -> u8 { 88 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18656,7 +18656,7 @@ impl<'input> FreeColorsRequest<'input> {
         let cmap_bytes = self.cmap.serialize();
         let plane_mask_bytes = self.plane_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            FREE_COLORS_REQUEST,
             0,
             0,
             0,
@@ -18820,14 +18820,14 @@ impl Serialize for Coloritem {
     }
 }
 
+/// Opcode for the StoreColors request
+pub const STORE_COLORS_REQUEST: u8 = 89;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoreColorsRequest<'input> {
     pub cmap: Colormap,
     pub items: &'input [Coloritem],
 }
 impl<'input> StoreColorsRequest<'input> {
-    /// Opcode for the StoreColors request
-    pub const fn opcode() -> u8 { 89 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18837,7 +18837,7 @@ impl<'input> StoreColorsRequest<'input> {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            STORE_COLORS_REQUEST,
             0,
             0,
             0,
@@ -18870,6 +18870,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the StoreNamedColor request
+pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoreNamedColorRequest<'input> {
     pub flags: u8,
@@ -18878,8 +18880,6 @@ pub struct StoreNamedColorRequest<'input> {
     pub name: &'input [u8],
 }
 impl<'input> StoreNamedColorRequest<'input> {
-    /// Opcode for the StoreNamedColor request
-    pub const fn opcode() -> u8 { 90 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -18893,7 +18893,7 @@ impl<'input> StoreNamedColorRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            STORE_NAMED_COLOR_REQUEST,
             flags_bytes[0],
             0,
             0,
@@ -18985,14 +18985,14 @@ impl Serialize for Rgb {
     }
 }
 
+/// Opcode for the QueryColors request
+pub const QUERY_COLORS_REQUEST: u8 = 91;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryColorsRequest<'input> {
     pub cmap: Colormap,
     pub pixels: &'input [u32],
 }
 impl<'input> QueryColorsRequest<'input> {
-    /// Opcode for the QueryColors request
-    pub const fn opcode() -> u8 { 91 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19002,7 +19002,7 @@ impl<'input> QueryColorsRequest<'input> {
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_COLORS_REQUEST,
             0,
             0,
             0,
@@ -19077,14 +19077,14 @@ impl QueryColorsReply {
     }
 }
 
+/// Opcode for the LookupColor request
+pub const LOOKUP_COLOR_REQUEST: u8 = 92;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LookupColorRequest<'input> {
     pub cmap: Colormap,
     pub name: &'input [u8],
 }
 impl<'input> LookupColorRequest<'input> {
-    /// Opcode for the LookupColor request
-    pub const fn opcode() -> u8 { 92 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19096,7 +19096,7 @@ impl<'input> LookupColorRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            LOOKUP_COLOR_REQUEST,
             0,
             0,
             0,
@@ -19226,6 +19226,8 @@ impl TryFrom<u32> for PixmapEnum {
     }
 }
 
+/// Opcode for the CreateCursor request
+pub const CREATE_CURSOR_REQUEST: u8 = 93;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateCursorRequest {
     pub cid: Cursor,
@@ -19241,8 +19243,6 @@ pub struct CreateCursorRequest {
     pub y: u16,
 }
 impl CreateCursorRequest {
-    /// Opcode for the CreateCursor request
-    pub const fn opcode() -> u8 { 93 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19262,7 +19262,7 @@ impl CreateCursorRequest {
         let x_bytes = self.x.serialize();
         let y_bytes = self.y.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CREATE_CURSOR_REQUEST,
             0,
             0,
             0,
@@ -19385,6 +19385,8 @@ impl TryFrom<u32> for FontEnum {
     }
 }
 
+/// Opcode for the CreateGlyphCursor request
+pub const CREATE_GLYPH_CURSOR_REQUEST: u8 = 94;
 /// create cursor.
 ///
 /// Creates a cursor from a font glyph. X provides a set of standard cursor shapes
@@ -19433,8 +19435,6 @@ pub struct CreateGlyphCursorRequest {
     pub back_blue: u16,
 }
 impl CreateGlyphCursorRequest {
-    /// Opcode for the CreateGlyphCursor request
-    pub const fn opcode() -> u8 { 94 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19454,7 +19454,7 @@ impl CreateGlyphCursorRequest {
         let back_green_bytes = self.back_green.serialize();
         let back_blue_bytes = self.back_blue.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CREATE_GLYPH_CURSOR_REQUEST,
             0,
             0,
             0,
@@ -19551,6 +19551,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the FreeCursor request
+pub const FREE_CURSOR_REQUEST: u8 = 95;
 /// Deletes a cursor.
 ///
 /// Deletes the association between the cursor resource ID and the specified
@@ -19568,8 +19570,6 @@ pub struct FreeCursorRequest {
     pub cursor: Cursor,
 }
 impl FreeCursorRequest {
-    /// Opcode for the FreeCursor request
-    pub const fn opcode() -> u8 { 95 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19579,7 +19579,7 @@ impl FreeCursorRequest {
         let length_so_far = 0;
         let cursor_bytes = self.cursor.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            FREE_CURSOR_REQUEST,
             0,
             0,
             0,
@@ -19619,6 +19619,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the RecolorCursor request
+pub const RECOLOR_CURSOR_REQUEST: u8 = 96;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RecolorCursorRequest {
     pub cursor: Cursor,
@@ -19630,8 +19632,6 @@ pub struct RecolorCursorRequest {
     pub back_blue: u16,
 }
 impl RecolorCursorRequest {
-    /// Opcode for the RecolorCursor request
-    pub const fn opcode() -> u8 { 96 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19647,7 +19647,7 @@ impl RecolorCursorRequest {
         let back_green_bytes = self.back_green.serialize();
         let back_blue_bytes = self.back_blue.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            RECOLOR_CURSOR_REQUEST,
             0,
             0,
             0,
@@ -19758,6 +19758,8 @@ impl TryFrom<u32> for QueryShapeOf {
     }
 }
 
+/// Opcode for the QueryBestSize request
+pub const QUERY_BEST_SIZE_REQUEST: u8 = 97;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryBestSizeRequest {
     pub class: QueryShapeOf,
@@ -19766,8 +19768,6 @@ pub struct QueryBestSizeRequest {
     pub height: u16,
 }
 impl QueryBestSizeRequest {
-    /// Opcode for the QueryBestSize request
-    pub const fn opcode() -> u8 { 97 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19780,7 +19780,7 @@ impl QueryBestSizeRequest {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_BEST_SIZE_REQUEST,
             class_bytes[0],
             0,
             0,
@@ -19842,6 +19842,8 @@ impl TryFrom<&[u8]> for QueryBestSizeReply {
     }
 }
 
+/// Opcode for the QueryExtension request
+pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 /// check if extension is present.
 ///
 /// Determines if the specified extension is present on this X11 server.
@@ -19869,8 +19871,6 @@ pub struct QueryExtensionRequest<'input> {
     pub name: &'input [u8],
 }
 impl<'input> QueryExtensionRequest<'input> {
-    /// Opcode for the QueryExtension request
-    pub const fn opcode() -> u8 { 98 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19881,7 +19881,7 @@ impl<'input> QueryExtensionRequest<'input> {
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            QUERY_EXTENSION_REQUEST,
             0,
             0,
             0,
@@ -19971,11 +19971,11 @@ impl TryFrom<&[u8]> for QueryExtensionReply {
     }
 }
 
+/// Opcode for the ListExtensions request
+pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListExtensionsRequest;
 impl ListExtensionsRequest {
-    /// Opcode for the ListExtensions request
-    pub const fn opcode() -> u8 { 99 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -19984,7 +19984,7 @@ impl ListExtensionsRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            LIST_EXTENSIONS_REQUEST,
             0,
             0,
             0,
@@ -20047,6 +20047,8 @@ impl ListExtensionsReply {
     }
 }
 
+/// Opcode for the ChangeKeyboardMapping request
+pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeKeyboardMappingRequest<'input> {
     pub keycode_count: u8,
@@ -20055,8 +20057,6 @@ pub struct ChangeKeyboardMappingRequest<'input> {
     pub keysyms: &'input [Keysym],
 }
 impl<'input> ChangeKeyboardMappingRequest<'input> {
-    /// Opcode for the ChangeKeyboardMapping request
-    pub const fn opcode() -> u8 { 100 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20068,7 +20068,7 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
         let first_keycode_bytes = self.first_keycode.serialize();
         let keysyms_per_keycode_bytes = self.keysyms_per_keycode.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_KEYBOARD_MAPPING_REQUEST,
             keycode_count_bytes[0],
             0,
             0,
@@ -20104,14 +20104,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetKeyboardMapping request
+pub const GET_KEYBOARD_MAPPING_REQUEST: u8 = 101;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetKeyboardMappingRequest {
     pub first_keycode: Keycode,
     pub count: u8,
 }
 impl GetKeyboardMappingRequest {
-    /// Opcode for the GetKeyboardMapping request
-    pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20122,7 +20122,7 @@ impl GetKeyboardMappingRequest {
         let first_keycode_bytes = self.first_keycode.serialize();
         let count_bytes = self.count.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            GET_KEYBOARD_MAPPING_REQUEST,
             0,
             0,
             0,
@@ -20531,13 +20531,13 @@ impl ChangeKeyboardControlAux {
     }
 }
 
+/// Opcode for the ChangeKeyboardControl request
+pub const CHANGE_KEYBOARD_CONTROL_REQUEST: u8 = 102;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeKeyboardControlRequest<'input> {
     pub value_list: &'input ChangeKeyboardControlAux,
 }
 impl<'input> ChangeKeyboardControlRequest<'input> {
-    /// Opcode for the ChangeKeyboardControl request
-    pub const fn opcode() -> u8 { 102 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20548,7 +20548,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_KEYBOARD_CONTROL_REQUEST,
             0,
             0,
             0,
@@ -20580,11 +20580,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetKeyboardControl request
+pub const GET_KEYBOARD_CONTROL_REQUEST: u8 = 103;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetKeyboardControlRequest;
 impl GetKeyboardControlRequest {
-    /// Opcode for the GetKeyboardControl request
-    pub const fn opcode() -> u8 { 103 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20593,7 +20593,7 @@ impl GetKeyboardControlRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GET_KEYBOARD_CONTROL_REQUEST,
             0,
             0,
             0,
@@ -20654,13 +20654,13 @@ impl TryFrom<&[u8]> for GetKeyboardControlReply {
     }
 }
 
+/// Opcode for the Bell request
+pub const BELL_REQUEST: u8 = 104;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BellRequest {
     pub percent: i8,
 }
 impl BellRequest {
-    /// Opcode for the Bell request
-    pub const fn opcode() -> u8 { 104 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20670,7 +20670,7 @@ impl BellRequest {
         let length_so_far = 0;
         let percent_bytes = self.percent.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            BELL_REQUEST,
             percent_bytes[0],
             0,
             0,
@@ -20694,6 +20694,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ChangePointerControl request
+pub const CHANGE_POINTER_CONTROL_REQUEST: u8 = 105;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangePointerControlRequest {
     pub acceleration_numerator: i16,
@@ -20703,8 +20705,6 @@ pub struct ChangePointerControlRequest {
     pub do_threshold: bool,
 }
 impl ChangePointerControlRequest {
-    /// Opcode for the ChangePointerControl request
-    pub const fn opcode() -> u8 { 105 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20718,7 +20718,7 @@ impl ChangePointerControlRequest {
         let do_acceleration_bytes = self.do_acceleration.serialize();
         let do_threshold_bytes = self.do_threshold.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_POINTER_CONTROL_REQUEST,
             0,
             0,
             0,
@@ -20754,11 +20754,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetPointerControl request
+pub const GET_POINTER_CONTROL_REQUEST: u8 = 106;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPointerControlRequest;
 impl GetPointerControlRequest {
-    /// Opcode for the GetPointerControl request
-    pub const fn opcode() -> u8 { 106 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20767,7 +20767,7 @@ impl GetPointerControlRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GET_POINTER_CONTROL_REQUEST,
             0,
             0,
             0,
@@ -20949,6 +20949,8 @@ impl TryFrom<u32> for Exposures {
     }
 }
 
+/// Opcode for the SetScreenSaver request
+pub const SET_SCREEN_SAVER_REQUEST: u8 = 107;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetScreenSaverRequest {
     pub timeout: i16,
@@ -20957,8 +20959,6 @@ pub struct SetScreenSaverRequest {
     pub allow_exposures: Exposures,
 }
 impl SetScreenSaverRequest {
-    /// Opcode for the SetScreenSaver request
-    pub const fn opcode() -> u8 { 107 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -20971,7 +20971,7 @@ impl SetScreenSaverRequest {
         let prefer_blanking_bytes = u8::from(self.prefer_blanking).serialize();
         let allow_exposures_bytes = u8::from(self.allow_exposures).serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_SCREEN_SAVER_REQUEST,
             0,
             0,
             0,
@@ -21006,11 +21006,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetScreenSaver request
+pub const GET_SCREEN_SAVER_REQUEST: u8 = 108;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetScreenSaverRequest;
 impl GetScreenSaverRequest {
-    /// Opcode for the GetScreenSaver request
-    pub const fn opcode() -> u8 { 108 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21019,7 +21019,7 @@ impl GetScreenSaverRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GET_SCREEN_SAVER_REQUEST,
             0,
             0,
             0,
@@ -21216,6 +21216,8 @@ impl TryFrom<u32> for Family {
     }
 }
 
+/// Opcode for the ChangeHosts request
+pub const CHANGE_HOSTS_REQUEST: u8 = 109;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeHostsRequest<'input> {
     pub mode: HostMode,
@@ -21223,8 +21225,6 @@ pub struct ChangeHostsRequest<'input> {
     pub address: &'input [u8],
 }
 impl<'input> ChangeHostsRequest<'input> {
-    /// Opcode for the ChangeHosts request
-    pub const fn opcode() -> u8 { 109 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21237,7 +21237,7 @@ impl<'input> ChangeHostsRequest<'input> {
         let address_len = u16::try_from(self.address.len()).expect("`address` has too many elements");
         let address_len_bytes = address_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            CHANGE_HOSTS_REQUEST,
             mode_bytes[0],
             0,
             0,
@@ -21331,11 +21331,11 @@ impl Host {
     }
 }
 
+/// Opcode for the ListHosts request
+pub const LIST_HOSTS_REQUEST: u8 = 110;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListHostsRequest;
 impl ListHostsRequest {
-    /// Opcode for the ListHosts request
-    pub const fn opcode() -> u8 { 110 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21344,7 +21344,7 @@ impl ListHostsRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            LIST_HOSTS_REQUEST,
             0,
             0,
             0,
@@ -21480,13 +21480,13 @@ impl TryFrom<u32> for AccessControl {
     }
 }
 
+/// Opcode for the SetAccessControl request
+pub const SET_ACCESS_CONTROL_REQUEST: u8 = 111;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetAccessControlRequest {
     pub mode: AccessControl,
 }
 impl SetAccessControlRequest {
-    /// Opcode for the SetAccessControl request
-    pub const fn opcode() -> u8 { 111 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21496,7 +21496,7 @@ impl SetAccessControlRequest {
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_ACCESS_CONTROL_REQUEST,
             mode_bytes[0],
             0,
             0,
@@ -21585,13 +21585,13 @@ impl TryFrom<u32> for CloseDown {
     }
 }
 
+/// Opcode for the SetCloseDownMode request
+pub const SET_CLOSE_DOWN_MODE_REQUEST: u8 = 112;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetCloseDownModeRequest {
     pub mode: CloseDown,
 }
 impl SetCloseDownModeRequest {
-    /// Opcode for the SetCloseDownMode request
-    pub const fn opcode() -> u8 { 112 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21601,7 +21601,7 @@ impl SetCloseDownModeRequest {
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_CLOSE_DOWN_MODE_REQUEST,
             mode_bytes[0],
             0,
             0,
@@ -21684,6 +21684,8 @@ impl TryFrom<u32> for Kill {
     }
 }
 
+/// Opcode for the KillClient request
+pub const KILL_CLIENT_REQUEST: u8 = 113;
 /// kills a client.
 ///
 /// Forces a close down of the client that created the specified `resource`.
@@ -21708,8 +21710,6 @@ pub struct KillClientRequest {
     pub resource: u32,
 }
 impl KillClientRequest {
-    /// Opcode for the KillClient request
-    pub const fn opcode() -> u8 { 113 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21719,7 +21719,7 @@ impl KillClientRequest {
         let length_so_far = 0;
         let resource_bytes = self.resource.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            KILL_CLIENT_REQUEST,
             0,
             0,
             0,
@@ -21768,6 +21768,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the RotateProperties request
+pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RotatePropertiesRequest<'input> {
     pub window: Window,
@@ -21775,8 +21777,6 @@ pub struct RotatePropertiesRequest<'input> {
     pub atoms: &'input [Atom],
 }
 impl<'input> RotatePropertiesRequest<'input> {
-    /// Opcode for the RotateProperties request
-    pub const fn opcode() -> u8 { 114 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21789,7 +21789,7 @@ impl<'input> RotatePropertiesRequest<'input> {
         let atoms_len_bytes = atoms_len.serialize();
         let delta_bytes = self.delta.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            ROTATE_PROPERTIES_REQUEST,
             0,
             0,
             0,
@@ -21897,13 +21897,13 @@ impl TryFrom<u32> for ScreenSaver {
     }
 }
 
+/// Opcode for the ForceScreenSaver request
+pub const FORCE_SCREEN_SAVER_REQUEST: u8 = 115;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ForceScreenSaverRequest {
     pub mode: ScreenSaver,
 }
 impl ForceScreenSaverRequest {
-    /// Opcode for the ForceScreenSaver request
-    pub const fn opcode() -> u8 { 115 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -21913,7 +21913,7 @@ impl ForceScreenSaverRequest {
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            FORCE_SCREEN_SAVER_REQUEST,
             mode_bytes[0],
             0,
             0,
@@ -22002,13 +22002,13 @@ impl TryFrom<u32> for MappingStatus {
     }
 }
 
+/// Opcode for the SetPointerMapping request
+pub const SET_POINTER_MAPPING_REQUEST: u8 = 116;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetPointerMappingRequest<'input> {
     pub map: &'input [u8],
 }
 impl<'input> SetPointerMappingRequest<'input> {
-    /// Opcode for the SetPointerMapping request
-    pub const fn opcode() -> u8 { 116 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -22019,7 +22019,7 @@ impl<'input> SetPointerMappingRequest<'input> {
         let map_len = u8::try_from(self.map.len()).expect("`map` has too many elements");
         let map_len_bytes = map_len.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_POINTER_MAPPING_REQUEST,
             map_len_bytes[0],
             0,
             0,
@@ -22071,11 +22071,11 @@ impl TryFrom<&[u8]> for SetPointerMappingReply {
     }
 }
 
+/// Opcode for the GetPointerMapping request
+pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPointerMappingRequest;
 impl GetPointerMappingRequest {
-    /// Opcode for the GetPointerMapping request
-    pub const fn opcode() -> u8 { 117 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -22084,7 +22084,7 @@ impl GetPointerMappingRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GET_POINTER_MAPPING_REQUEST,
             0,
             0,
             0,
@@ -22228,13 +22228,13 @@ impl TryFrom<u32> for MapIndex {
     }
 }
 
+/// Opcode for the SetModifierMapping request
+pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetModifierMappingRequest<'input> {
     pub keycodes: &'input [Keycode],
 }
 impl<'input> SetModifierMappingRequest<'input> {
-    /// Opcode for the SetModifierMapping request
-    pub const fn opcode() -> u8 { 118 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -22246,7 +22246,7 @@ impl<'input> SetModifierMappingRequest<'input> {
         let keycodes_per_modifier = u8::try_from(self.keycodes.len() / 8).expect("`keycodes` has too many elements");
         let keycodes_per_modifier_bytes = keycodes_per_modifier.serialize();
         let mut request0 = vec![
-            Self::opcode(),
+            SET_MODIFIER_MAPPING_REQUEST,
             keycodes_per_modifier_bytes[0],
             0,
             0,
@@ -22298,11 +22298,11 @@ impl TryFrom<&[u8]> for SetModifierMappingReply {
     }
 }
 
+/// Opcode for the GetModifierMapping request
+pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetModifierMappingRequest;
 impl GetModifierMappingRequest {
-    /// Opcode for the GetModifierMapping request
-    pub const fn opcode() -> u8 { 119 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -22311,7 +22311,7 @@ impl GetModifierMappingRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            GET_MODIFIER_MAPPING_REQUEST,
             0,
             0,
             0,
@@ -22376,11 +22376,11 @@ impl GetModifierMappingReply {
     }
 }
 
+/// Opcode for the NoOperation request
+pub const NO_OPERATION_REQUEST: u8 = 127;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoOperationRequest;
 impl NoOperationRequest {
-    /// Opcode for the NoOperation request
-    pub const fn opcode() -> u8 { 127 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -22389,7 +22389,7 @@ impl NoOperationRequest {
         let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
-            Self::opcode(),
+            NO_OPERATION_REQUEST,
             0,
             0,
             0,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -6030,11 +6030,11 @@ impl<'input> CreateWindowRequest<'input> {
     /// Opcode for the CreateWindow request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let depth_bytes = self.depth.serialize();
         let wid_bytes = self.wid.serialize();
@@ -6406,11 +6406,11 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
     /// Opcode for the ChangeWindowAttributes request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
@@ -6559,11 +6559,11 @@ impl GetWindowAttributesRequest {
     /// Opcode for the GetWindowAttributes request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -6711,11 +6711,11 @@ impl DestroyWindowRequest {
     /// Opcode for the DestroyWindow request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -6777,11 +6777,11 @@ impl DestroySubwindowsRequest {
     /// Opcode for the DestroySubwindows request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -6914,11 +6914,11 @@ impl ChangeSaveSetRequest {
     /// Opcode for the ChangeSaveSet request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let window_bytes = self.window.serialize();
@@ -7017,11 +7017,11 @@ impl ReparentWindowRequest {
     /// Opcode for the ReparentWindow request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let parent_bytes = self.parent.serialize();
@@ -7142,11 +7142,11 @@ impl MapWindowRequest {
     /// Opcode for the MapWindow request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -7221,11 +7221,11 @@ impl MapSubwindowsRequest {
     /// Opcode for the MapSubwindows request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -7286,11 +7286,11 @@ impl UnmapWindowRequest {
     /// Opcode for the UnmapWindow request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -7351,11 +7351,11 @@ impl UnmapSubwindowsRequest {
     /// Opcode for the UnmapSubwindows request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -7707,11 +7707,11 @@ impl<'input> ConfigureWindowRequest<'input> {
     /// Opcode for the ConfigureWindow request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let value_mask = u16::try_from(self.value_list.switch_expr()).unwrap();
@@ -7900,11 +7900,11 @@ impl CirculateWindowRequest {
     /// Opcode for the CirculateWindow request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let direction_bytes = u8::from(self.direction).serialize();
         let window_bytes = self.window.serialize();
@@ -7999,11 +7999,11 @@ impl GetGeometryRequest {
     /// Opcode for the GetGeometry request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
@@ -8166,11 +8166,11 @@ impl QueryTreeRequest {
     /// Opcode for the QueryTree request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -8344,11 +8344,11 @@ impl<'input> InternAtomRequest<'input> {
     /// Opcode for the InternAtom request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let only_if_exists_bytes = self.only_if_exists.serialize();
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
@@ -8464,11 +8464,11 @@ impl GetAtomNameRequest {
     /// Opcode for the GetAtomName request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let atom_bytes = self.atom.serialize();
         let mut request0 = vec![
@@ -8682,11 +8682,11 @@ impl<'input> ChangePropertyRequest<'input> {
     /// Opcode for the ChangeProperty request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let window_bytes = self.window.serialize();
@@ -8813,11 +8813,11 @@ impl DeletePropertyRequest {
     /// Opcode for the DeleteProperty request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let property_bytes = self.property.serialize();
@@ -8995,11 +8995,11 @@ impl GetPropertyRequest {
     /// Opcode for the GetProperty request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let delete_bytes = self.delete.serialize();
         let window_bytes = self.window.serialize();
@@ -9344,11 +9344,11 @@ impl ListPropertiesRequest {
     /// Opcode for the ListProperties request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -9461,11 +9461,11 @@ impl SetSelectionOwnerRequest {
     /// Opcode for the SetSelectionOwner request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let owner_bytes = self.owner.serialize();
         let selection_bytes = self.selection.serialize();
@@ -9567,11 +9567,11 @@ impl GetSelectionOwnerRequest {
     /// Opcode for the GetSelectionOwner request
     pub const fn opcode() -> u8 { 23 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let selection_bytes = self.selection.serialize();
         let mut request0 = vec![
@@ -9660,11 +9660,11 @@ impl ConvertSelectionRequest {
     /// Opcode for the ConvertSelection request
     pub const fn opcode() -> u8 { 24 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let requestor_bytes = self.requestor.serialize();
         let selection_bytes = self.selection.serialize();
@@ -9878,11 +9878,11 @@ impl<'input> SendEventRequest<'input> {
     /// Opcode for the SendEvent request
     pub const fn opcode() -> u8 { 25 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let propagate_bytes = self.propagate.serialize();
         let destination_bytes = self.destination.serialize();
@@ -10296,11 +10296,11 @@ impl GrabPointerRequest {
     /// Opcode for the GrabPointer request
     pub const fn opcode() -> u8 { 26 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let owner_events_bytes = self.owner_events.serialize();
         let grab_window_bytes = self.grab_window.serialize();
@@ -10497,11 +10497,11 @@ impl UngrabPointerRequest {
     /// Opcode for the UngrabPointer request
     pub const fn opcode() -> u8 { 27 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
@@ -10723,11 +10723,11 @@ impl GrabButtonRequest {
     /// Opcode for the GrabButton request
     pub const fn opcode() -> u8 { 28 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let owner_events_bytes = self.owner_events.serialize();
         let grab_window_bytes = self.grab_window.serialize();
@@ -10876,11 +10876,11 @@ impl UngrabButtonRequest {
     /// Opcode for the UngrabButton request
     pub const fn opcode() -> u8 { 29 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let button_bytes = u8::from(self.button).serialize();
         let grab_window_bytes = self.grab_window.serialize();
@@ -10932,11 +10932,11 @@ impl ChangeActivePointerGrabRequest {
     /// Opcode for the ChangeActivePointerGrab request
     pub const fn opcode() -> u8 { 30 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cursor_bytes = self.cursor.serialize();
         let time_bytes = self.time.serialize();
@@ -11060,11 +11060,11 @@ impl GrabKeyboardRequest {
     /// Opcode for the GrabKeyboard request
     pub const fn opcode() -> u8 { 31 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let owner_events_bytes = self.owner_events.serialize();
         let grab_window_bytes = self.grab_window.serialize();
@@ -11209,11 +11209,11 @@ impl UngrabKeyboardRequest {
     /// Opcode for the UngrabKeyboard request
     pub const fn opcode() -> u8 { 32 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
@@ -11379,11 +11379,11 @@ impl GrabKeyRequest {
     /// Opcode for the GrabKey request
     pub const fn opcode() -> u8 { 33 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let owner_events_bytes = self.owner_events.serialize();
         let grab_window_bytes = self.grab_window.serialize();
@@ -11532,11 +11532,11 @@ impl UngrabKeyRequest {
     /// Opcode for the UngrabKey request
     pub const fn opcode() -> u8 { 34 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let key_bytes = self.key.serialize();
         let grab_window_bytes = self.grab_window.serialize();
@@ -11771,11 +11771,11 @@ impl AllowEventsRequest {
     /// Opcode for the AllowEvents request
     pub const fn opcode() -> u8 { 35 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let time_bytes = self.time.serialize();
@@ -11835,11 +11835,11 @@ impl GrabServerRequest {
     /// Opcode for the GrabServer request
     pub const fn opcode() -> u8 { 36 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -11870,11 +11870,11 @@ impl UngrabServerRequest {
     /// Opcode for the UngrabServer request
     pub const fn opcode() -> u8 { 37 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -11920,11 +11920,11 @@ impl QueryPointerRequest {
     /// Opcode for the QueryPointer request
     pub const fn opcode() -> u8 { 38 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -12083,11 +12083,11 @@ impl GetMotionEventsRequest {
     /// Opcode for the GetMotionEvents request
     pub const fn opcode() -> u8 { 39 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let start_bytes = self.start.serialize();
@@ -12188,11 +12188,11 @@ impl TranslateCoordinatesRequest {
     /// Opcode for the TranslateCoordinates request
     pub const fn opcode() -> u8 { 40 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let src_window_bytes = self.src_window.serialize();
         let dst_window_bytes = self.dst_window.serialize();
@@ -12315,11 +12315,11 @@ impl WarpPointerRequest {
     /// Opcode for the WarpPointer request
     pub const fn opcode() -> u8 { 41 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let src_window_bytes = self.src_window.serialize();
         let dst_window_bytes = self.dst_window.serialize();
@@ -12539,11 +12539,11 @@ impl SetInputFocusRequest {
     /// Opcode for the SetInputFocus request
     pub const fn opcode() -> u8 { 42 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let revert_to_bytes = u8::from(self.revert_to).serialize();
         let focus_bytes = self.focus.serialize();
@@ -12628,11 +12628,11 @@ impl GetInputFocusRequest {
     /// Opcode for the GetInputFocus request
     pub const fn opcode() -> u8 { 43 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -12690,11 +12690,11 @@ impl QueryKeymapRequest {
     /// Opcode for the QueryKeymap request
     pub const fn opcode() -> u8 { 44 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -12774,11 +12774,11 @@ impl<'input> OpenFontRequest<'input> {
     /// Opcode for the OpenFont request
     pub const fn opcode() -> u8 { 45 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let fid_bytes = self.fid.serialize();
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
@@ -12848,11 +12848,11 @@ impl CloseFontRequest {
     /// Opcode for the CloseFont request
     pub const fn opcode() -> u8 { 46 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
@@ -13073,11 +13073,11 @@ impl QueryFontRequest {
     /// Opcode for the QueryFont request
     pub const fn opcode() -> u8 { 47 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
@@ -13253,11 +13253,11 @@ impl<'input> QueryTextExtentsRequest<'input> {
     /// Opcode for the QueryTextExtents request
     pub const fn opcode() -> u8 { 48 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let string_len = u32::try_from(self.string.len()).unwrap();
         let length_so_far = 0;
         let odd_length = (string_len & 1u32) != 0;
@@ -13440,11 +13440,11 @@ impl<'input> ListFontsRequest<'input> {
     /// Opcode for the ListFonts request
     pub const fn opcode() -> u8 { 49 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let max_names_bytes = self.max_names.serialize();
         let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
@@ -13562,11 +13562,11 @@ impl<'input> ListFontsWithInfoRequest<'input> {
     /// Opcode for the ListFontsWithInfo request
     pub const fn opcode() -> u8 { 50 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let max_names_bytes = self.max_names.serialize();
         let pattern_len = u16::try_from(self.pattern.len()).expect("`pattern` has too many elements");
@@ -13725,11 +13725,11 @@ impl<'input> SetFontPathRequest<'input> {
     /// Opcode for the SetFontPath request
     pub const fn opcode() -> u8 { 51 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let font_qty = u16::try_from(self.font.len()).expect("`font` has too many elements");
         let font_qty_bytes = font_qty.serialize();
@@ -13772,11 +13772,11 @@ impl GetFontPathRequest {
     /// Opcode for the GetFontPath request
     pub const fn opcode() -> u8 { 52 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -13878,11 +13878,11 @@ impl CreatePixmapRequest {
     /// Opcode for the CreatePixmap request
     pub const fn opcode() -> u8 { 53 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let depth_bytes = self.depth.serialize();
         let pid_bytes = self.pid.serialize();
@@ -13973,11 +13973,11 @@ impl FreePixmapRequest {
     /// Opcode for the FreePixmap request
     pub const fn opcode() -> u8 { 54 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let pixmap_bytes = self.pixmap.serialize();
         let mut request0 = vec![
@@ -15133,11 +15133,11 @@ impl<'input> CreateGCRequest<'input> {
     /// Opcode for the CreateGC request
     pub const fn opcode() -> u8 { 55 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cid_bytes = self.cid.serialize();
         let drawable_bytes = self.drawable.serialize();
@@ -15566,11 +15566,11 @@ impl<'input> ChangeGCRequest<'input> {
     /// Opcode for the ChangeGC request
     pub const fn opcode() -> u8 { 56 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let gc_bytes = self.gc.serialize();
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
@@ -15668,11 +15668,11 @@ impl CopyGCRequest {
     /// Opcode for the CopyGC request
     pub const fn opcode() -> u8 { 57 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let src_gc_bytes = self.src_gc.serialize();
         let dst_gc_bytes = self.dst_gc.serialize();
@@ -15728,11 +15728,11 @@ impl<'input> SetDashesRequest<'input> {
     /// Opcode for the SetDashes request
     pub const fn opcode() -> u8 { 58 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let gc_bytes = self.gc.serialize();
         let dash_offset_bytes = self.dash_offset.serialize();
@@ -15856,11 +15856,11 @@ impl<'input> SetClipRectanglesRequest<'input> {
     /// Opcode for the SetClipRectangles request
     pub const fn opcode() -> u8 { 59 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let ordering_bytes = u8::from(self.ordering).serialize();
         let gc_bytes = self.gc.serialize();
@@ -15926,11 +15926,11 @@ impl FreeGCRequest {
     /// Opcode for the FreeGC request
     pub const fn opcode() -> u8 { 60 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let gc_bytes = self.gc.serialize();
         let mut request0 = vec![
@@ -15986,11 +15986,11 @@ impl ClearAreaRequest {
     /// Opcode for the ClearArea request
     pub const fn opcode() -> u8 { 61 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let exposures_bytes = self.exposures.serialize();
         let window_bytes = self.window.serialize();
@@ -16077,11 +16077,11 @@ impl CopyAreaRequest {
     /// Opcode for the CopyArea request
     pub const fn opcode() -> u8 { 62 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let src_drawable_bytes = self.src_drawable.serialize();
         let dst_drawable_bytes = self.dst_drawable.serialize();
@@ -16187,11 +16187,11 @@ impl CopyPlaneRequest {
     /// Opcode for the CopyPlane request
     pub const fn opcode() -> u8 { 63 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let src_drawable_bytes = self.src_drawable.serialize();
         let dst_drawable_bytes = self.dst_drawable.serialize();
@@ -16350,11 +16350,11 @@ impl<'input> PolyPointRequest<'input> {
     /// Opcode for the PolyPoint request
     pub const fn opcode() -> u8 { 64 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let coordinate_mode_bytes = u8::from(self.coordinate_mode).serialize();
         let drawable_bytes = self.drawable.serialize();
@@ -16449,11 +16449,11 @@ impl<'input> PolyLineRequest<'input> {
     /// Opcode for the PolyLine request
     pub const fn opcode() -> u8 { 65 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let coordinate_mode_bytes = u8::from(self.coordinate_mode).serialize();
         let drawable_bytes = self.drawable.serialize();
@@ -16623,11 +16623,11 @@ impl<'input> PolySegmentRequest<'input> {
     /// Opcode for the PolySegment request
     pub const fn opcode() -> u8 { 66 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -16706,11 +16706,11 @@ impl<'input> PolyRectangleRequest<'input> {
     /// Opcode for the PolyRectangle request
     pub const fn opcode() -> u8 { 67 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -16763,11 +16763,11 @@ impl<'input> PolyArcRequest<'input> {
     /// Opcode for the PolyArc request
     pub const fn opcode() -> u8 { 68 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -16887,11 +16887,11 @@ impl<'input> FillPolyRequest<'input> {
     /// Opcode for the FillPoly request
     pub const fn opcode() -> u8 { 69 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -16977,11 +16977,11 @@ impl<'input> PolyFillRectangleRequest<'input> {
     /// Opcode for the PolyFillRectangle request
     pub const fn opcode() -> u8 { 70 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -17059,11 +17059,11 @@ impl<'input> PolyFillArcRequest<'input> {
     /// Opcode for the PolyFillArc request
     pub const fn opcode() -> u8 { 71 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -17188,11 +17188,11 @@ impl<'input> PutImageRequest<'input> {
     /// Opcode for the PutImage request
     pub const fn opcode() -> u8 { 72 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let format_bytes = u8::from(self.format).serialize();
         let drawable_bytes = self.drawable.serialize();
@@ -17274,11 +17274,11 @@ impl GetImageRequest {
     /// Opcode for the GetImage request
     pub const fn opcode() -> u8 { 73 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let format_bytes = u8::from(self.format).serialize();
         let drawable_bytes = self.drawable.serialize();
@@ -17391,11 +17391,11 @@ impl<'input> PolyText8Request<'input> {
     /// Opcode for the PolyText8 request
     pub const fn opcode() -> u8 { 74 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -17457,11 +17457,11 @@ impl<'input> PolyText16Request<'input> {
     /// Opcode for the PolyText16 request
     pub const fn opcode() -> u8 { 75 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
         let gc_bytes = self.gc.serialize();
@@ -17557,11 +17557,11 @@ impl<'input> ImageText8Request<'input> {
     /// Opcode for the ImageText8 request
     pub const fn opcode() -> u8 { 76 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let string_len = u8::try_from(self.string.len()).expect("`string` has too many elements");
         let string_len_bytes = string_len.serialize();
@@ -17694,11 +17694,11 @@ impl<'input> ImageText16Request<'input> {
     /// Opcode for the ImageText16 request
     pub const fn opcode() -> u8 { 77 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let string_len = u8::try_from(self.string.len()).expect("`string` has too many elements");
         let string_len_bytes = string_len.serialize();
@@ -17867,11 +17867,11 @@ impl CreateColormapRequest {
     /// Opcode for the CreateColormap request
     pub const fn opcode() -> u8 { 78 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let alloc_bytes = u8::from(self.alloc).serialize();
         let mid_bytes = self.mid.serialize();
@@ -17925,11 +17925,11 @@ impl FreeColormapRequest {
     /// Opcode for the FreeColormap request
     pub const fn opcode() -> u8 { 79 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
@@ -17970,11 +17970,11 @@ impl CopyColormapAndFreeRequest {
     /// Opcode for the CopyColormapAndFree request
     pub const fn opcode() -> u8 { 80 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mid_bytes = self.mid.serialize();
         let src_cmap_bytes = self.src_cmap.serialize();
@@ -18020,11 +18020,11 @@ impl InstallColormapRequest {
     /// Opcode for the InstallColormap request
     pub const fn opcode() -> u8 { 81 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
@@ -18064,11 +18064,11 @@ impl UninstallColormapRequest {
     /// Opcode for the UninstallColormap request
     pub const fn opcode() -> u8 { 82 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
@@ -18108,11 +18108,11 @@ impl ListInstalledColormapsRequest {
     /// Opcode for the ListInstalledColormaps request
     pub const fn opcode() -> u8 { 83 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
@@ -18215,11 +18215,11 @@ impl AllocColorRequest {
     /// Opcode for the AllocColor request
     pub const fn opcode() -> u8 { 84 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let red_bytes = self.red.serialize();
@@ -18324,11 +18324,11 @@ impl<'input> AllocNamedColorRequest<'input> {
     /// Opcode for the AllocNamedColor request
     pub const fn opcode() -> u8 { 85 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
@@ -18418,11 +18418,11 @@ impl AllocColorCellsRequest {
     /// Opcode for the AllocColorCells request
     pub const fn opcode() -> u8 { 86 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let contiguous_bytes = self.contiguous.serialize();
         let cmap_bytes = self.cmap.serialize();
@@ -18535,11 +18535,11 @@ impl AllocColorPlanesRequest {
     /// Opcode for the AllocColorPlanes request
     pub const fn opcode() -> u8 { 87 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let contiguous_bytes = self.contiguous.serialize();
         let cmap_bytes = self.cmap.serialize();
@@ -18648,11 +18648,11 @@ impl<'input> FreeColorsRequest<'input> {
     /// Opcode for the FreeColors request
     pub const fn opcode() -> u8 { 88 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let plane_mask_bytes = self.plane_mask.serialize();
@@ -18830,11 +18830,11 @@ impl<'input> StoreColorsRequest<'input> {
     /// Opcode for the StoreColors request
     pub const fn opcode() -> u8 { 89 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
@@ -18882,11 +18882,11 @@ impl<'input> StoreNamedColorRequest<'input> {
     /// Opcode for the StoreNamedColor request
     pub const fn opcode() -> u8 { 90 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let flags_bytes = self.flags.serialize();
         let cmap_bytes = self.cmap.serialize();
@@ -18995,11 +18995,11 @@ impl<'input> QueryColorsRequest<'input> {
     /// Opcode for the QueryColors request
     pub const fn opcode() -> u8 { 91 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let mut request0 = vec![
@@ -19087,11 +19087,11 @@ impl<'input> LookupColorRequest<'input> {
     /// Opcode for the LookupColor request
     pub const fn opcode() -> u8 { 92 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cmap_bytes = self.cmap.serialize();
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
@@ -19245,11 +19245,11 @@ impl CreateCursorRequest {
     /// Opcode for the CreateCursor request
     pub const fn opcode() -> u8 { 93 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cid_bytes = self.cid.serialize();
         let source_bytes = self.source.serialize();
@@ -19437,11 +19437,11 @@ impl CreateGlyphCursorRequest {
     /// Opcode for the CreateGlyphCursor request
     pub const fn opcode() -> u8 { 94 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cid_bytes = self.cid.serialize();
         let source_font_bytes = self.source_font.serialize();
@@ -19572,11 +19572,11 @@ impl FreeCursorRequest {
     /// Opcode for the FreeCursor request
     pub const fn opcode() -> u8 { 95 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cursor_bytes = self.cursor.serialize();
         let mut request0 = vec![
@@ -19634,11 +19634,11 @@ impl RecolorCursorRequest {
     /// Opcode for the RecolorCursor request
     pub const fn opcode() -> u8 { 96 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let cursor_bytes = self.cursor.serialize();
         let fore_red_bytes = self.fore_red.serialize();
@@ -19770,11 +19770,11 @@ impl QueryBestSizeRequest {
     /// Opcode for the QueryBestSize request
     pub const fn opcode() -> u8 { 97 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let class_bytes = u8::from(self.class).serialize();
         let drawable_bytes = self.drawable.serialize();
@@ -19873,11 +19873,11 @@ impl<'input> QueryExtensionRequest<'input> {
     /// Opcode for the QueryExtension request
     pub const fn opcode() -> u8 { 98 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
         let name_len_bytes = name_len.serialize();
@@ -19978,11 +19978,11 @@ impl ListExtensionsRequest {
     /// Opcode for the ListExtensions request
     pub const fn opcode() -> u8 { 99 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -20059,11 +20059,11 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
     /// Opcode for the ChangeKeyboardMapping request
     pub const fn opcode() -> u8 { 100 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let keycode_count_bytes = self.keycode_count.serialize();
         let first_keycode_bytes = self.first_keycode.serialize();
@@ -20114,11 +20114,11 @@ impl GetKeyboardMappingRequest {
     /// Opcode for the GetKeyboardMapping request
     pub const fn opcode() -> u8 { 101 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let first_keycode_bytes = self.first_keycode.serialize();
         let count_bytes = self.count.serialize();
@@ -20540,11 +20540,11 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
     /// Opcode for the ChangeKeyboardControl request
     pub const fn opcode() -> u8 { 102 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let value_mask = u32::try_from(self.value_list.switch_expr()).unwrap();
         let value_mask_bytes = value_mask.serialize();
@@ -20587,11 +20587,11 @@ impl GetKeyboardControlRequest {
     /// Opcode for the GetKeyboardControl request
     pub const fn opcode() -> u8 { 103 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -20663,11 +20663,11 @@ impl BellRequest {
     /// Opcode for the Bell request
     pub const fn opcode() -> u8 { 104 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let percent_bytes = self.percent.serialize();
         let mut request0 = vec![
@@ -20707,11 +20707,11 @@ impl ChangePointerControlRequest {
     /// Opcode for the ChangePointerControl request
     pub const fn opcode() -> u8 { 105 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let acceleration_numerator_bytes = self.acceleration_numerator.serialize();
         let acceleration_denominator_bytes = self.acceleration_denominator.serialize();
@@ -20761,11 +20761,11 @@ impl GetPointerControlRequest {
     /// Opcode for the GetPointerControl request
     pub const fn opcode() -> u8 { 106 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -20961,11 +20961,11 @@ impl SetScreenSaverRequest {
     /// Opcode for the SetScreenSaver request
     pub const fn opcode() -> u8 { 107 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let timeout_bytes = self.timeout.serialize();
         let interval_bytes = self.interval.serialize();
@@ -21013,11 +21013,11 @@ impl GetScreenSaverRequest {
     /// Opcode for the GetScreenSaver request
     pub const fn opcode() -> u8 { 108 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -21227,11 +21227,11 @@ impl<'input> ChangeHostsRequest<'input> {
     /// Opcode for the ChangeHosts request
     pub const fn opcode() -> u8 { 109 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let family_bytes = u8::from(self.family).serialize();
@@ -21338,11 +21338,11 @@ impl ListHostsRequest {
     /// Opcode for the ListHosts request
     pub const fn opcode() -> u8 { 110 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -21489,11 +21489,11 @@ impl SetAccessControlRequest {
     /// Opcode for the SetAccessControl request
     pub const fn opcode() -> u8 { 111 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
@@ -21594,11 +21594,11 @@ impl SetCloseDownModeRequest {
     /// Opcode for the SetCloseDownMode request
     pub const fn opcode() -> u8 { 112 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
@@ -21712,11 +21712,11 @@ impl KillClientRequest {
     /// Opcode for the KillClient request
     pub const fn opcode() -> u8 { 113 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let resource_bytes = self.resource.serialize();
         let mut request0 = vec![
@@ -21779,11 +21779,11 @@ impl<'input> RotatePropertiesRequest<'input> {
     /// Opcode for the RotateProperties request
     pub const fn opcode() -> u8 { 114 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let atoms_len = u16::try_from(self.atoms.len()).expect("`atoms` has too many elements");
@@ -21906,11 +21906,11 @@ impl ForceScreenSaverRequest {
     /// Opcode for the ForceScreenSaver request
     pub const fn opcode() -> u8 { 115 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mode_bytes = u8::from(self.mode).serialize();
         let mut request0 = vec![
@@ -22011,11 +22011,11 @@ impl<'input> SetPointerMappingRequest<'input> {
     /// Opcode for the SetPointerMapping request
     pub const fn opcode() -> u8 { 116 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let map_len = u8::try_from(self.map.len()).expect("`map` has too many elements");
         let map_len_bytes = map_len.serialize();
@@ -22078,11 +22078,11 @@ impl GetPointerMappingRequest {
     /// Opcode for the GetPointerMapping request
     pub const fn opcode() -> u8 { 117 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -22237,11 +22237,11 @@ impl<'input> SetModifierMappingRequest<'input> {
     /// Opcode for the SetModifierMapping request
     pub const fn opcode() -> u8 { 118 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         assert_eq!(self.keycodes.len() % 8, 0, "`keycodes` has an incorrect length, must be a multiple of 8");
         let keycodes_per_modifier = u8::try_from(self.keycodes.len() / 8).expect("`keycodes` has too many elements");
@@ -22305,11 +22305,11 @@ impl GetModifierMappingRequest {
     /// Opcode for the GetModifierMapping request
     pub const fn opcode() -> u8 { 119 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),
@@ -22383,11 +22383,11 @@ impl NoOperationRequest {
     /// Opcode for the NoOperation request
     pub const fn opcode() -> u8 { 127 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
+        let _ = conn;
         let length_so_far = 0;
         let mut request0 = vec![
             Self::opcode(),

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -43,7 +42,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -117,7 +116,7 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
     /// Opcode for the SetDeviceCreateContext request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -143,7 +142,7 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -164,7 +163,7 @@ impl GetDeviceCreateContextRequest {
     /// Opcode for the GetDeviceCreateContext request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -246,7 +245,7 @@ impl<'input> SetDeviceContextRequest<'input> {
     /// Opcode for the SetDeviceContext request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -277,7 +276,7 @@ impl<'input> SetDeviceContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_context<'c, 'input, Conn>(conn: &'c Conn, device: u32, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -301,7 +300,7 @@ impl GetDeviceContextRequest {
     /// Opcode for the GetDeviceContext request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -389,7 +388,7 @@ impl<'input> SetWindowCreateContextRequest<'input> {
     /// Opcode for the SetWindowCreateContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -415,7 +414,7 @@ impl<'input> SetWindowCreateContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_window_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -436,7 +435,7 @@ impl GetWindowCreateContextRequest {
     /// Opcode for the GetWindowCreateContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -517,7 +516,7 @@ impl GetWindowContextRequest {
     /// Opcode for the GetWindowContext request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -688,7 +687,7 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
     /// Opcode for the SetPropertyCreateContext request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -714,7 +713,7 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_property_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -735,7 +734,7 @@ impl GetPropertyCreateContextRequest {
     /// Opcode for the GetPropertyCreateContext request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -816,7 +815,7 @@ impl<'input> SetPropertyUseContextRequest<'input> {
     /// Opcode for the SetPropertyUseContext request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -842,7 +841,7 @@ impl<'input> SetPropertyUseContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_property_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -863,7 +862,7 @@ impl GetPropertyUseContextRequest {
     /// Opcode for the GetPropertyUseContext request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -945,7 +944,7 @@ impl GetPropertyContextRequest {
     /// Opcode for the GetPropertyContext request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1040,7 +1039,7 @@ impl GetPropertyDataContextRequest {
     /// Opcode for the GetPropertyDataContext request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1134,7 +1133,7 @@ impl ListPropertiesRequest {
     /// Opcode for the ListProperties request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1221,7 +1220,7 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
     /// Opcode for the SetSelectionCreateContext request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1247,7 +1246,7 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_selection_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1268,7 +1267,7 @@ impl GetSelectionCreateContextRequest {
     /// Opcode for the GetSelectionCreateContext request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1349,7 +1348,7 @@ impl<'input> SetSelectionUseContextRequest<'input> {
     /// Opcode for the SetSelectionUseContext request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1375,7 +1374,7 @@ impl<'input> SetSelectionUseContextRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn set_selection_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1396,7 +1395,7 @@ impl GetSelectionUseContextRequest {
     /// Opcode for the GetSelectionUseContext request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1477,7 +1476,7 @@ impl GetSelectionContextRequest {
     /// Opcode for the GetSelectionContext request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1565,7 +1564,7 @@ impl GetSelectionDataContextRequest {
     /// Opcode for the GetSelectionDataContext request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1651,7 +1650,7 @@ impl ListSelectionsRequest {
     /// Opcode for the ListSelections request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1731,7 +1730,7 @@ impl GetClientContextRequest {
     /// Opcode for the GetClientContext request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -43,7 +43,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -118,7 +117,6 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
     /// Opcode for the SetDeviceCreateContext request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -166,7 +164,6 @@ impl GetDeviceCreateContextRequest {
     /// Opcode for the GetDeviceCreateContext request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -249,7 +246,6 @@ impl<'input> SetDeviceContextRequest<'input> {
     /// Opcode for the SetDeviceContext request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -305,7 +301,6 @@ impl GetDeviceContextRequest {
     /// Opcode for the GetDeviceContext request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -394,7 +389,6 @@ impl<'input> SetWindowCreateContextRequest<'input> {
     /// Opcode for the SetWindowCreateContext request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -442,7 +436,6 @@ impl GetWindowCreateContextRequest {
     /// Opcode for the GetWindowCreateContext request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -524,7 +517,6 @@ impl GetWindowContextRequest {
     /// Opcode for the GetWindowContext request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -696,7 +688,6 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
     /// Opcode for the SetPropertyCreateContext request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -744,7 +735,6 @@ impl GetPropertyCreateContextRequest {
     /// Opcode for the GetPropertyCreateContext request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -826,7 +816,6 @@ impl<'input> SetPropertyUseContextRequest<'input> {
     /// Opcode for the SetPropertyUseContext request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -874,7 +863,6 @@ impl GetPropertyUseContextRequest {
     /// Opcode for the GetPropertyUseContext request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -957,7 +945,6 @@ impl GetPropertyContextRequest {
     /// Opcode for the GetPropertyContext request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1053,7 +1040,6 @@ impl GetPropertyDataContextRequest {
     /// Opcode for the GetPropertyDataContext request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1148,7 +1134,6 @@ impl ListPropertiesRequest {
     /// Opcode for the ListProperties request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1236,7 +1221,6 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
     /// Opcode for the SetSelectionCreateContext request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1284,7 +1268,6 @@ impl GetSelectionCreateContextRequest {
     /// Opcode for the GetSelectionCreateContext request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1366,7 +1349,6 @@ impl<'input> SetSelectionUseContextRequest<'input> {
     /// Opcode for the SetSelectionUseContext request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1414,7 +1396,6 @@ impl GetSelectionUseContextRequest {
     /// Opcode for the GetSelectionUseContext request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1496,7 +1477,6 @@ impl GetSelectionContextRequest {
     /// Opcode for the GetSelectionContext request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1585,7 +1565,6 @@ impl GetSelectionDataContextRequest {
     /// Opcode for the GetSelectionDataContext request
     pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1672,7 +1651,6 @@ impl ListSelectionsRequest {
     /// Opcode for the ListSelections request
     pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1753,7 +1731,6 @@ impl GetClientContextRequest {
     /// Opcode for the GetClientContext request
     pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -75,8 +75,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryVersionRequest {
-        client_major: client_major,
-        client_minor: client_minor,
+        client_major,
+        client_minor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -153,7 +153,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDeviceCreateContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -289,8 +289,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetDeviceContextRequest {
-        device: device,
-        context: context,
+        device,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -336,7 +336,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetDeviceContextRequest {
-        device: device,
+        device,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -429,7 +429,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetWindowCreateContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -555,7 +555,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetWindowContextRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -731,7 +731,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPropertyCreateContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -861,7 +861,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPropertyUseContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -993,8 +993,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPropertyContextRequest {
-        window: window,
-        property: property,
+        window,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1089,8 +1089,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPropertyDataContextRequest {
-        window: window,
-        property: property,
+        window,
+        property,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1179,7 +1179,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListPropertiesRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1271,7 +1271,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetSelectionCreateContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1401,7 +1401,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetSelectionUseContextRequest {
-        context: context,
+        context,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1527,7 +1527,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetSelectionContextRequest {
-        selection: selection,
+        selection,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1616,7 +1616,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetSelectionDataContextRequest {
-        selection: selection,
+        selection,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1784,7 +1784,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetClientContextRequest {
-        resource: resource,
+        resource,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -90,7 +90,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 /// Opcode for the SetDeviceCreateContext request
 pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
-pub fn set_device_create_context<'c, Conn>(conn: &'c Conn, context: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_device_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -186,7 +186,7 @@ impl GetDeviceCreateContextReply {
 
 /// Opcode for the SetDeviceContext request
 pub const SET_DEVICE_CONTEXT_REQUEST: u8 = 3;
-pub fn set_device_context<'c, Conn>(conn: &'c Conn, device: u32, context: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_device_context<'c, 'input, Conn>(conn: &'c Conn, device: u32, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -292,7 +292,7 @@ impl GetDeviceContextReply {
 
 /// Opcode for the SetWindowCreateContext request
 pub const SET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 5;
-pub fn set_window_create_context<'c, Conn>(conn: &'c Conn, context: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_window_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -541,7 +541,7 @@ impl ListItem {
 
 /// Opcode for the SetPropertyCreateContext request
 pub const SET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 8;
-pub fn set_property_create_context<'c, Conn>(conn: &'c Conn, context: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_property_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -637,7 +637,7 @@ impl GetPropertyCreateContextReply {
 
 /// Opcode for the SetPropertyUseContext request
 pub const SET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 10;
-pub fn set_property_use_context<'c, Conn>(conn: &'c Conn, context: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_property_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -952,7 +952,7 @@ impl ListPropertiesReply {
 
 /// Opcode for the SetSelectionCreateContext request
 pub const SET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 15;
-pub fn set_selection_create_context<'c, Conn>(conn: &'c Conn, context: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_selection_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1048,7 +1048,7 @@ impl GetSelectionCreateContextReply {
 
 /// Opcode for the SetSelectionUseContext request
 pub const SET_SELECTION_USE_CONTEXT_REQUEST: u8 = 17;
-pub fn set_selection_use_context<'c, Conn>(conn: &'c Conn, context: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_selection_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -1422,7 +1422,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_version(self, client_major, client_minor)
     }
-    fn xselinux_set_device_create_context<'c>(&'c self, context: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xselinux_set_device_create_context<'c, 'input>(&'c self, context: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_device_create_context(self, context)
     }
@@ -1430,7 +1430,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_device_create_context(self)
     }
-    fn xselinux_set_device_context<'c>(&'c self, device: u32, context: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xselinux_set_device_context<'c, 'input>(&'c self, device: u32, context: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_device_context(self, device, context)
     }
@@ -1438,7 +1438,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_device_context(self, device)
     }
-    fn xselinux_set_window_create_context<'c>(&'c self, context: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xselinux_set_window_create_context<'c, 'input>(&'c self, context: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_window_create_context(self, context)
     }
@@ -1450,7 +1450,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_window_context(self, window)
     }
-    fn xselinux_set_property_create_context<'c>(&'c self, context: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xselinux_set_property_create_context<'c, 'input>(&'c self, context: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_property_create_context(self, context)
     }
@@ -1458,7 +1458,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_property_create_context(self)
     }
-    fn xselinux_set_property_use_context<'c>(&'c self, context: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xselinux_set_property_use_context<'c, 'input>(&'c self, context: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_property_use_context(self, context)
     }
@@ -1478,7 +1478,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         list_properties(self, window)
     }
-    fn xselinux_set_selection_create_context<'c>(&'c self, context: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xselinux_set_selection_create_context<'c, 'input>(&'c self, context: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_selection_create_context(self, context)
     }
@@ -1486,7 +1486,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_selection_create_context(self)
     }
-    fn xselinux_set_selection_use_context<'c>(&'c self, context: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xselinux_set_selection_use_context<'c, 'input>(&'c self, context: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_selection_use_context(self, context)
     }

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -33,14 +33,14 @@ pub const X11_EXTENSION_NAME: &str = "SELinux";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
 }
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -53,7 +53,7 @@ impl QueryVersionRequest {
         let client_minor_bytes = self.client_minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
             client_major_bytes[0],
@@ -108,13 +108,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the SetDeviceCreateContext request
+pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetDeviceCreateContextRequest<'input> {
     pub context: &'input [u8],
 }
 impl<'input> SetDeviceCreateContextRequest<'input> {
-    /// Opcode for the SetDeviceCreateContext request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -127,7 +127,7 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_len_bytes[0],
@@ -157,11 +157,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDeviceCreateContext request
+pub const GET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceCreateContextRequest;
 impl GetDeviceCreateContextRequest {
-    /// Opcode for the GetDeviceCreateContext request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -172,7 +172,7 @@ impl GetDeviceCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_CREATE_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -236,14 +236,14 @@ impl GetDeviceCreateContextReply {
     }
 }
 
+/// Opcode for the SetDeviceContext request
+pub const SET_DEVICE_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetDeviceContextRequest<'input> {
     pub device: u32,
     pub context: &'input [u8],
 }
 impl<'input> SetDeviceContextRequest<'input> {
-    /// Opcode for the SetDeviceContext request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -257,7 +257,7 @@ impl<'input> SetDeviceContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_DEVICE_CONTEXT_REQUEST,
             0,
             0,
             device_bytes[0],
@@ -292,13 +292,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetDeviceContext request
+pub const GET_DEVICE_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetDeviceContextRequest {
     pub device: u32,
 }
 impl GetDeviceContextRequest {
-    /// Opcode for the GetDeviceContext request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -310,7 +310,7 @@ impl GetDeviceContextRequest {
         let device_bytes = self.device.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_DEVICE_CONTEXT_REQUEST,
             0,
             0,
             device_bytes[0],
@@ -380,13 +380,13 @@ impl GetDeviceContextReply {
     }
 }
 
+/// Opcode for the SetWindowCreateContext request
+pub const SET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetWindowCreateContextRequest<'input> {
     pub context: &'input [u8],
 }
 impl<'input> SetWindowCreateContextRequest<'input> {
-    /// Opcode for the SetWindowCreateContext request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -399,7 +399,7 @@ impl<'input> SetWindowCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_WINDOW_CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_len_bytes[0],
@@ -429,11 +429,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetWindowCreateContext request
+pub const GET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetWindowCreateContextRequest;
 impl GetWindowCreateContextRequest {
-    /// Opcode for the GetWindowCreateContext request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -444,7 +444,7 @@ impl GetWindowCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_WINDOW_CREATE_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -508,13 +508,13 @@ impl GetWindowCreateContextReply {
     }
 }
 
+/// Opcode for the GetWindowContext request
+pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetWindowContextRequest {
     pub window: xproto::Window,
 }
 impl GetWindowContextRequest {
-    /// Opcode for the GetWindowContext request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -526,7 +526,7 @@ impl GetWindowContextRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_WINDOW_CONTEXT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -679,13 +679,13 @@ impl ListItem {
     }
 }
 
+/// Opcode for the SetPropertyCreateContext request
+pub const SET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 8;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetPropertyCreateContextRequest<'input> {
     pub context: &'input [u8],
 }
 impl<'input> SetPropertyCreateContextRequest<'input> {
-    /// Opcode for the SetPropertyCreateContext request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -698,7 +698,7 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PROPERTY_CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_len_bytes[0],
@@ -728,11 +728,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetPropertyCreateContext request
+pub const GET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPropertyCreateContextRequest;
 impl GetPropertyCreateContextRequest {
-    /// Opcode for the GetPropertyCreateContext request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -743,7 +743,7 @@ impl GetPropertyCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PROPERTY_CREATE_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -807,13 +807,13 @@ impl GetPropertyCreateContextReply {
     }
 }
 
+/// Opcode for the SetPropertyUseContext request
+pub const SET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 10;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetPropertyUseContextRequest<'input> {
     pub context: &'input [u8],
 }
 impl<'input> SetPropertyUseContextRequest<'input> {
-    /// Opcode for the SetPropertyUseContext request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -826,7 +826,7 @@ impl<'input> SetPropertyUseContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PROPERTY_USE_CONTEXT_REQUEST,
             0,
             0,
             context_len_bytes[0],
@@ -856,11 +856,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetPropertyUseContext request
+pub const GET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPropertyUseContextRequest;
 impl GetPropertyUseContextRequest {
-    /// Opcode for the GetPropertyUseContext request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -871,7 +871,7 @@ impl GetPropertyUseContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PROPERTY_USE_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -935,14 +935,14 @@ impl GetPropertyUseContextReply {
     }
 }
 
+/// Opcode for the GetPropertyContext request
+pub const GET_PROPERTY_CONTEXT_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPropertyContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
 }
 impl GetPropertyContextRequest {
-    /// Opcode for the GetPropertyContext request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -955,7 +955,7 @@ impl GetPropertyContextRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PROPERTY_CONTEXT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1030,14 +1030,14 @@ impl GetPropertyContextReply {
     }
 }
 
+/// Opcode for the GetPropertyDataContext request
+pub const GET_PROPERTY_DATA_CONTEXT_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPropertyDataContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
 }
 impl GetPropertyDataContextRequest {
-    /// Opcode for the GetPropertyDataContext request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1050,7 +1050,7 @@ impl GetPropertyDataContextRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PROPERTY_DATA_CONTEXT_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1125,13 +1125,13 @@ impl GetPropertyDataContextReply {
     }
 }
 
+/// Opcode for the ListProperties request
+pub const LIST_PROPERTIES_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListPropertiesRequest {
     pub window: xproto::Window,
 }
 impl ListPropertiesRequest {
-    /// Opcode for the ListProperties request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1143,7 +1143,7 @@ impl ListPropertiesRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_PROPERTIES_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1212,13 +1212,13 @@ impl ListPropertiesReply {
     }
 }
 
+/// Opcode for the SetSelectionCreateContext request
+pub const SET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 15;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetSelectionCreateContextRequest<'input> {
     pub context: &'input [u8],
 }
 impl<'input> SetSelectionCreateContextRequest<'input> {
-    /// Opcode for the SetSelectionCreateContext request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1231,7 +1231,7 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_SELECTION_CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_len_bytes[0],
@@ -1261,11 +1261,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetSelectionCreateContext request
+pub const GET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetSelectionCreateContextRequest;
 impl GetSelectionCreateContextRequest {
-    /// Opcode for the GetSelectionCreateContext request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1276,7 +1276,7 @@ impl GetSelectionCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SELECTION_CREATE_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -1340,13 +1340,13 @@ impl GetSelectionCreateContextReply {
     }
 }
 
+/// Opcode for the SetSelectionUseContext request
+pub const SET_SELECTION_USE_CONTEXT_REQUEST: u8 = 17;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetSelectionUseContextRequest<'input> {
     pub context: &'input [u8],
 }
 impl<'input> SetSelectionUseContextRequest<'input> {
-    /// Opcode for the SetSelectionUseContext request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1359,7 +1359,7 @@ impl<'input> SetSelectionUseContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_SELECTION_USE_CONTEXT_REQUEST,
             0,
             0,
             context_len_bytes[0],
@@ -1389,11 +1389,11 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetSelectionUseContext request
+pub const GET_SELECTION_USE_CONTEXT_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetSelectionUseContextRequest;
 impl GetSelectionUseContextRequest {
-    /// Opcode for the GetSelectionUseContext request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1404,7 +1404,7 @@ impl GetSelectionUseContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SELECTION_USE_CONTEXT_REQUEST,
             0,
             0,
         ];
@@ -1468,13 +1468,13 @@ impl GetSelectionUseContextReply {
     }
 }
 
+/// Opcode for the GetSelectionContext request
+pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetSelectionContextRequest {
     pub selection: xproto::Atom,
 }
 impl GetSelectionContextRequest {
-    /// Opcode for the GetSelectionContext request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1486,7 +1486,7 @@ impl GetSelectionContextRequest {
         let selection_bytes = self.selection.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SELECTION_CONTEXT_REQUEST,
             0,
             0,
             selection_bytes[0],
@@ -1556,13 +1556,13 @@ impl GetSelectionContextReply {
     }
 }
 
+/// Opcode for the GetSelectionDataContext request
+pub const GET_SELECTION_DATA_CONTEXT_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetSelectionDataContextRequest {
     pub selection: xproto::Atom,
 }
 impl GetSelectionDataContextRequest {
-    /// Opcode for the GetSelectionDataContext request
-    pub const fn opcode() -> u8 { 20 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1574,7 +1574,7 @@ impl GetSelectionDataContextRequest {
         let selection_bytes = self.selection.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_SELECTION_DATA_CONTEXT_REQUEST,
             0,
             0,
             selection_bytes[0],
@@ -1644,11 +1644,11 @@ impl GetSelectionDataContextReply {
     }
 }
 
+/// Opcode for the ListSelections request
+pub const LIST_SELECTIONS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListSelectionsRequest;
 impl ListSelectionsRequest {
-    /// Opcode for the ListSelections request
-    pub const fn opcode() -> u8 { 21 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1659,7 +1659,7 @@ impl ListSelectionsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_SELECTIONS_REQUEST,
             0,
             0,
         ];
@@ -1722,13 +1722,13 @@ impl ListSelectionsReply {
     }
 }
 
+/// Opcode for the GetClientContext request
+pub const GET_CLIENT_CONTEXT_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetClientContextRequest {
     pub resource: u32,
 }
 impl GetClientContextRequest {
-    /// Opcode for the GetClientContext request
-    pub const fn opcode() -> u8 { 22 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1740,7 +1740,7 @@ impl GetClientContextRequest {
         let resource_bytes = self.resource.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_CLIENT_CONTEXT_REQUEST,
             0,
             0,
             resource_bytes[0],

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -55,7 +55,7 @@ impl QueryVersionRequest {
         let client_minor_bytes = self.client_minor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             client_major_bytes[0],
@@ -130,7 +130,7 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_len_bytes[0],
@@ -176,7 +176,7 @@ impl GetDeviceCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -262,7 +262,7 @@ impl<'input> SetDeviceContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetDeviceContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_bytes[0],
@@ -316,7 +316,7 @@ impl GetDeviceContextRequest {
         let device_bytes = self.device.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetDeviceContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             device_bytes[0],
@@ -406,7 +406,7 @@ impl<'input> SetWindowCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetWindowCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_len_bytes[0],
@@ -452,7 +452,7 @@ impl GetWindowCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetWindowCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -535,7 +535,7 @@ impl GetWindowContextRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetWindowContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -708,7 +708,7 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPropertyCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_len_bytes[0],
@@ -754,7 +754,7 @@ impl GetPropertyCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPropertyCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -838,7 +838,7 @@ impl<'input> SetPropertyUseContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPropertyUseContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_len_bytes[0],
@@ -884,7 +884,7 @@ impl GetPropertyUseContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPropertyUseContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -969,7 +969,7 @@ impl GetPropertyContextRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPropertyContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1065,7 +1065,7 @@ impl GetPropertyDataContextRequest {
         let property_bytes = self.property.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPropertyDataContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1159,7 +1159,7 @@ impl ListPropertiesRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListPropertiesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1248,7 +1248,7 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetSelectionCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_len_bytes[0],
@@ -1294,7 +1294,7 @@ impl GetSelectionCreateContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetSelectionCreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1378,7 +1378,7 @@ impl<'input> SetSelectionUseContextRequest<'input> {
         let context_len_bytes = context_len.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetSelectionUseContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_len_bytes[0],
@@ -1424,7 +1424,7 @@ impl GetSelectionUseContextRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetSelectionUseContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1507,7 +1507,7 @@ impl GetSelectionContextRequest {
         let selection_bytes = self.selection.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetSelectionContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             selection_bytes[0],
@@ -1596,7 +1596,7 @@ impl GetSelectionDataContextRequest {
         let selection_bytes = self.selection.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetSelectionDataContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             selection_bytes[0],
@@ -1682,7 +1682,7 @@ impl ListSelectionsRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListSelectionsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1764,7 +1764,7 @@ impl GetClientContextRequest {
         let resource_bytes = self.resource.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetClientContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             resource_bytes[0],

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -33,14 +33,14 @@ pub const X11_EXTENSION_NAME: &str = "XTEST";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (2, 2);
 
+/// Opcode for the GetVersion request
+pub const GET_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetVersionRequest {
     pub major_version: u8,
     pub minor_version: u16,
 }
 impl GetVersionRequest {
-    /// Opcode for the GetVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -53,7 +53,7 @@ impl GetVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_VERSION_REQUEST,
             0,
             0,
             major_version_bytes[0],
@@ -177,14 +177,14 @@ impl TryFrom<u32> for Cursor {
     }
 }
 
+/// Opcode for the CompareCursor request
+pub const COMPARE_CURSOR_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompareCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
 }
 impl CompareCursorRequest {
-    /// Opcode for the CompareCursor request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -197,7 +197,7 @@ impl CompareCursorRequest {
         let cursor_bytes = self.cursor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            COMPARE_CURSOR_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -253,6 +253,8 @@ impl TryFrom<&[u8]> for CompareCursorReply {
     }
 }
 
+/// Opcode for the FakeInput request
+pub const FAKE_INPUT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FakeInputRequest {
     pub type_: u8,
@@ -264,8 +266,6 @@ pub struct FakeInputRequest {
     pub deviceid: u8,
 }
 impl FakeInputRequest {
-    /// Opcode for the FakeInput request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -283,7 +283,7 @@ impl FakeInputRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            FAKE_INPUT_REQUEST,
             0,
             0,
             type_bytes[0],
@@ -344,13 +344,13 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GrabControl request
+pub const GRAB_CONTROL_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrabControlRequest {
     pub impervious: bool,
 }
 impl GrabControlRequest {
-    /// Opcode for the GrabControl request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -362,7 +362,7 @@ impl GrabControlRequest {
         let impervious_bytes = self.impervious.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GRAB_CONTROL_REQUEST,
             0,
             0,
             impervious_bytes[0],

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -75,8 +75,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetVersionRequest {
-        major_version: major_version,
-        minor_version: minor_version,
+        major_version,
+        minor_version,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -224,8 +224,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CompareCursorRequest {
-        window: window,
-        cursor: cursor,
+        window,
+        cursor,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -335,13 +335,13 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = FakeInputRequest {
-        type_: type_,
-        detail: detail,
-        time: time,
-        root: root,
-        root_x: root_x,
-        root_y: root_y,
-        deviceid: deviceid,
+        type_,
+        detail,
+        time,
+        root,
+        root_x,
+        root_y,
+        deviceid,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -387,7 +387,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GrabControlRequest {
-        impervious: impervious,
+        impervious,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -55,7 +55,7 @@ impl GetVersionRequest {
         let minor_version_bytes = self.minor_version.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             major_version_bytes[0],
@@ -200,7 +200,7 @@ impl CompareCursorRequest {
         let cursor_bytes = self.cursor.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CompareCursorRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -287,7 +287,7 @@ impl FakeInputRequest {
         let deviceid_bytes = self.deviceid.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            FakeInputRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             type_bytes[0],
@@ -367,7 +367,7 @@ impl GrabControlRequest {
         let impervious_bytes = self.impervious.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GrabControlRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             impervious_bytes[0],

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -43,7 +43,6 @@ impl GetVersionRequest {
     /// Opcode for the GetVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -188,7 +187,6 @@ impl CompareCursorRequest {
     /// Opcode for the CompareCursor request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -270,7 +268,6 @@ impl FakeInputRequest {
     /// Opcode for the FakeInput request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -356,7 +353,6 @@ impl GrabControlRequest {
     /// Opcode for the GrabControl request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -33,32 +34,53 @@ pub const X11_EXTENSION_NAME: &str = "XTEST";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (2, 2);
 
-/// Opcode for the GetVersion request
-pub const GET_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetVersionRequest {
+    pub major_version: u8,
+    pub minor_version: u16,
+}
+impl GetVersionRequest {
+    /// Opcode for the GetVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GetVersionRequest::opcode(),
+            0,
+            0,
+            major_version_bytes[0],
+            0,
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn get_version<Conn>(conn: &Conn, major_version: u8, minor_version: u16) -> Result<Cookie<'_, Conn, GetVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let major_version_bytes = major_version.serialize();
-    let minor_version_bytes = minor_version.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GET_VERSION_REQUEST,
-        0,
-        0,
-        major_version_bytes[0],
-        0,
-        minor_version_bytes[0],
-        minor_version_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GetVersionRequest {
+        major_version: major_version,
+        minor_version: minor_version,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -157,36 +179,57 @@ impl TryFrom<u32> for Cursor {
     }
 }
 
-/// Opcode for the CompareCursor request
-pub const COMPARE_CURSOR_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompareCursorRequest {
+    pub window: xproto::Window,
+    pub cursor: xproto::Cursor,
+}
+impl CompareCursorRequest {
+    /// Opcode for the CompareCursor request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let window_bytes = self.window.serialize();
+        let cursor_bytes = self.cursor.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CompareCursorRequest::opcode(),
+            0,
+            0,
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            cursor_bytes[0],
+            cursor_bytes[1],
+            cursor_bytes[2],
+            cursor_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn compare_cursor<Conn>(conn: &Conn, window: xproto::Window, cursor: xproto::Cursor) -> Result<Cookie<'_, Conn, CompareCursorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let window_bytes = window.serialize();
-    let cursor_bytes = cursor.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        COMPARE_CURSOR_REQUEST,
-        0,
-        0,
-        window_bytes[0],
-        window_bytes[1],
-        window_bytes[2],
-        window_bytes[3],
-        cursor_bytes[0],
-        cursor_bytes[1],
-        cursor_bytes[2],
-        cursor_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CompareCursorRequest {
+        window: window,
+        cursor: cursor,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -213,92 +256,142 @@ impl TryFrom<&[u8]> for CompareCursorReply {
     }
 }
 
-/// Opcode for the FakeInput request
-pub const FAKE_INPUT_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FakeInputRequest {
+    pub type_: u8,
+    pub detail: u8,
+    pub time: u32,
+    pub root: xproto::Window,
+    pub root_x: i16,
+    pub root_y: i16,
+    pub deviceid: u8,
+}
+impl FakeInputRequest {
+    /// Opcode for the FakeInput request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let type_bytes = self.type_.serialize();
+        let detail_bytes = self.detail.serialize();
+        let time_bytes = self.time.serialize();
+        let root_bytes = self.root.serialize();
+        let root_x_bytes = self.root_x.serialize();
+        let root_y_bytes = self.root_y.serialize();
+        let deviceid_bytes = self.deviceid.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            FakeInputRequest::opcode(),
+            0,
+            0,
+            type_bytes[0],
+            detail_bytes[0],
+            0,
+            0,
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            root_x_bytes[0],
+            root_x_bytes[1],
+            root_y_bytes[0],
+            root_y_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            deviceid_bytes[0],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn fake_input<Conn>(conn: &Conn, type_: u8, detail: u8, time: u32, root: xproto::Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let type_bytes = type_.serialize();
-    let detail_bytes = detail.serialize();
-    let time_bytes = time.serialize();
-    let root_bytes = root.serialize();
-    let root_x_bytes = root_x.serialize();
-    let root_y_bytes = root_y.serialize();
-    let deviceid_bytes = deviceid.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        FAKE_INPUT_REQUEST,
-        0,
-        0,
-        type_bytes[0],
-        detail_bytes[0],
-        0,
-        0,
-        time_bytes[0],
-        time_bytes[1],
-        time_bytes[2],
-        time_bytes[3],
-        root_bytes[0],
-        root_bytes[1],
-        root_bytes[2],
-        root_bytes[3],
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        root_x_bytes[0],
-        root_x_bytes[1],
-        root_y_bytes[0],
-        root_y_bytes[1],
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        deviceid_bytes[0],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = FakeInputRequest {
+        type_: type_,
+        detail: detail,
+        time: time,
+        root: root,
+        root_x: root_x,
+        root_y: root_y,
+        deviceid: deviceid,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the GrabControl request
-pub const GRAB_CONTROL_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GrabControlRequest {
+    pub impervious: bool,
+}
+impl GrabControlRequest {
+    /// Opcode for the GrabControl request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let impervious_bytes = self.impervious.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            GrabControlRequest::opcode(),
+            0,
+            0,
+            impervious_bytes[0],
+            0,
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn grab_control<Conn>(conn: &Conn, impervious: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let impervious_bytes = impervious.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        GRAB_CONTROL_REQUEST,
-        0,
-        0,
-        impervious_bytes[0],
-        0,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = GrabControlRequest {
+        impervious: impervious,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
 /// Extension trait defining the requests of this extension.

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -43,7 +42,7 @@ impl GetVersionRequest {
     /// Opcode for the GetVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -187,7 +186,7 @@ impl CompareCursorRequest {
     /// Opcode for the CompareCursor request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -268,7 +267,7 @@ impl FakeInputRequest {
     /// Opcode for the FakeInput request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -353,7 +352,7 @@ impl GrabControlRequest {
     /// Opcode for the GrabControl request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -1552,7 +1551,7 @@ impl QueryExtensionRequest {
     /// Opcode for the QueryExtension request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1617,7 +1616,7 @@ impl QueryAdaptorsRequest {
     /// Opcode for the QueryAdaptors request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1704,7 +1703,7 @@ impl QueryEncodingsRequest {
     /// Opcode for the QueryEncodings request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1792,7 +1791,7 @@ impl GrabPortRequest {
     /// Opcode for the GrabPort request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1871,7 +1870,7 @@ impl UngrabPortRequest {
     /// Opcode for the UngrabPort request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -1934,7 +1933,7 @@ impl PutVideoRequest {
     /// Opcode for the PutVideo request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2033,7 +2032,7 @@ impl PutStillRequest {
     /// Opcode for the PutStill request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2132,7 +2131,7 @@ impl GetVideoRequest {
     /// Opcode for the GetVideo request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2231,7 +2230,7 @@ impl GetStillRequest {
     /// Opcode for the GetStill request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2321,7 +2320,7 @@ impl StopVideoRequest {
     /// Opcode for the StopVideo request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2373,7 +2372,7 @@ impl SelectVideoNotifyRequest {
     /// Opcode for the SelectVideoNotify request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2425,7 +2424,7 @@ impl SelectPortNotifyRequest {
     /// Opcode for the SelectPortNotify request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2481,7 +2480,7 @@ impl QueryBestSizeRequest {
     /// Opcode for the QueryBestSize request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2577,7 +2576,7 @@ impl SetPortAttributeRequest {
     /// Opcode for the SetPortAttribute request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2635,7 +2634,7 @@ impl GetPortAttributeRequest {
     /// Opcode for the GetPortAttribute request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2711,7 +2710,7 @@ impl QueryPortAttributesRequest {
     /// Opcode for the QueryPortAttributes request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2800,7 +2799,7 @@ impl ListImageFormatsRequest {
     /// Opcode for the ListImageFormats request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -2890,7 +2889,7 @@ impl QueryImageAttributesRequest {
     /// Opcode for the QueryImageAttributes request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3013,7 +3012,7 @@ impl<'input> PutImageRequest<'input> {
     /// Opcode for the PutImage request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -3083,7 +3082,7 @@ impl<'input> PutImageRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), Cow::Borrowed(&padding0)], vec![]))
+        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
     }
 }
 pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3136,7 +3135,7 @@ impl ShmPutImageRequest {
     /// Opcode for the ShmPutImage request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -1562,7 +1562,7 @@ impl QueryExtensionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryExtensionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -1629,7 +1629,7 @@ impl QueryAdaptorsRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryAdaptorsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             window_bytes[0],
@@ -1717,7 +1717,7 @@ impl QueryEncodingsRequest {
         let port_bytes = self.port.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryEncodingsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -1807,7 +1807,7 @@ impl GrabPortRequest {
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GrabPortRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -1887,7 +1887,7 @@ impl UngrabPortRequest {
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            UngrabPortRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -1960,7 +1960,7 @@ impl PutVideoRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PutVideoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2060,7 +2060,7 @@ impl PutStillRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PutStillRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2160,7 +2160,7 @@ impl GetVideoRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetVideoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2260,7 +2260,7 @@ impl GetStillRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetStillRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2342,7 +2342,7 @@ impl StopVideoRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            StopVideoRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2395,7 +2395,7 @@ impl SelectVideoNotifyRequest {
         let onoff_bytes = self.onoff.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectVideoNotifyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             drawable_bytes[0],
@@ -2448,7 +2448,7 @@ impl SelectPortNotifyRequest {
         let onoff_bytes = self.onoff.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SelectPortNotifyRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2509,7 +2509,7 @@ impl QueryBestSizeRequest {
         let motion_bytes = self.motion.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryBestSizeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2603,7 +2603,7 @@ impl SetPortAttributeRequest {
         let value_bytes = self.value.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            SetPortAttributeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2661,7 +2661,7 @@ impl GetPortAttributeRequest {
         let attribute_bytes = self.attribute.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            GetPortAttributeRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2737,7 +2737,7 @@ impl QueryPortAttributesRequest {
         let port_bytes = self.port.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryPortAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2827,7 +2827,7 @@ impl ListImageFormatsRequest {
         let port_bytes = self.port.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListImageFormatsRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -2921,7 +2921,7 @@ impl QueryImageAttributesRequest {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryImageAttributesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -3055,7 +3055,7 @@ impl<'input> PutImageRequest<'input> {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            PutImageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],
@@ -3182,7 +3182,7 @@ impl ShmPutImageRequest {
         let send_event_bytes = self.send_event.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ShmPutImageRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_bytes[0],

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -1552,7 +1552,6 @@ impl QueryExtensionRequest {
     /// Opcode for the QueryExtension request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1618,7 +1617,6 @@ impl QueryAdaptorsRequest {
     /// Opcode for the QueryAdaptors request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1706,7 +1704,6 @@ impl QueryEncodingsRequest {
     /// Opcode for the QueryEncodings request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1795,7 +1792,6 @@ impl GrabPortRequest {
     /// Opcode for the GrabPort request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1875,7 +1871,6 @@ impl UngrabPortRequest {
     /// Opcode for the UngrabPort request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -1939,7 +1934,6 @@ impl PutVideoRequest {
     /// Opcode for the PutVideo request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2039,7 +2033,6 @@ impl PutStillRequest {
     /// Opcode for the PutStill request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2139,7 +2132,6 @@ impl GetVideoRequest {
     /// Opcode for the GetVideo request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2239,7 +2231,6 @@ impl GetStillRequest {
     /// Opcode for the GetStill request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2330,7 +2321,6 @@ impl StopVideoRequest {
     /// Opcode for the StopVideo request
     pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2383,7 +2373,6 @@ impl SelectVideoNotifyRequest {
     /// Opcode for the SelectVideoNotify request
     pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2436,7 +2425,6 @@ impl SelectPortNotifyRequest {
     /// Opcode for the SelectPortNotify request
     pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2493,7 +2481,6 @@ impl QueryBestSizeRequest {
     /// Opcode for the QueryBestSize request
     pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2590,7 +2577,6 @@ impl SetPortAttributeRequest {
     /// Opcode for the SetPortAttribute request
     pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2649,7 +2635,6 @@ impl GetPortAttributeRequest {
     /// Opcode for the GetPortAttribute request
     pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2726,7 +2711,6 @@ impl QueryPortAttributesRequest {
     /// Opcode for the QueryPortAttributes request
     pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2816,7 +2800,6 @@ impl ListImageFormatsRequest {
     /// Opcode for the ListImageFormats request
     pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -2907,7 +2890,6 @@ impl QueryImageAttributesRequest {
     /// Opcode for the QueryImageAttributes request
     pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3031,7 +3013,6 @@ impl<'input> PutImageRequest<'input> {
     /// Opcode for the PutImage request
     pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -3155,7 +3136,6 @@ impl ShmPutImageRequest {
     /// Opcode for the ShmPutImage request
     pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -1545,11 +1545,11 @@ impl From<PortNotifyEvent> for [u8; 32] {
     }
 }
 
+/// Opcode for the QueryExtension request
+pub const QUERY_EXTENSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryExtensionRequest;
 impl QueryExtensionRequest {
-    /// Opcode for the QueryExtension request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1560,7 +1560,7 @@ impl QueryExtensionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_EXTENSION_REQUEST,
             0,
             0,
         ];
@@ -1608,13 +1608,13 @@ impl TryFrom<&[u8]> for QueryExtensionReply {
     }
 }
 
+/// Opcode for the QueryAdaptors request
+pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryAdaptorsRequest {
     pub window: xproto::Window,
 }
 impl QueryAdaptorsRequest {
-    /// Opcode for the QueryAdaptors request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1626,7 +1626,7 @@ impl QueryAdaptorsRequest {
         let window_bytes = self.window.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_ADAPTORS_REQUEST,
             0,
             0,
             window_bytes[0],
@@ -1695,13 +1695,13 @@ impl QueryAdaptorsReply {
     }
 }
 
+/// Opcode for the QueryEncodings request
+pub const QUERY_ENCODINGS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryEncodingsRequest {
     pub port: Port,
 }
 impl QueryEncodingsRequest {
-    /// Opcode for the QueryEncodings request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1713,7 +1713,7 @@ impl QueryEncodingsRequest {
         let port_bytes = self.port.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_ENCODINGS_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -1782,14 +1782,14 @@ impl QueryEncodingsReply {
     }
 }
 
+/// Opcode for the GrabPort request
+pub const GRAB_PORT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
 }
 impl GrabPortRequest {
-    /// Opcode for the GrabPort request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1802,7 +1802,7 @@ impl GrabPortRequest {
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GRAB_PORT_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -1861,14 +1861,14 @@ impl TryFrom<&[u8]> for GrabPortReply {
     }
 }
 
+/// Opcode for the UngrabPort request
+pub const UNGRAB_PORT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UngrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
 }
 impl UngrabPortRequest {
-    /// Opcode for the UngrabPort request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1881,7 +1881,7 @@ impl UngrabPortRequest {
         let time_bytes = self.time.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            UNGRAB_PORT_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -1915,6 +1915,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PutVideo request
+pub const PUT_VIDEO_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PutVideoRequest {
     pub port: Port,
@@ -1930,8 +1932,6 @@ pub struct PutVideoRequest {
     pub drw_h: u16,
 }
 impl PutVideoRequest {
-    /// Opcode for the PutVideo request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -1953,7 +1953,7 @@ impl PutVideoRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PUT_VIDEO_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2014,6 +2014,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the PutStill request
+pub const PUT_STILL_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PutStillRequest {
     pub port: Port,
@@ -2029,8 +2031,6 @@ pub struct PutStillRequest {
     pub drw_h: u16,
 }
 impl PutStillRequest {
-    /// Opcode for the PutStill request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2052,7 +2052,7 @@ impl PutStillRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PUT_STILL_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2113,6 +2113,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetVideo request
+pub const GET_VIDEO_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetVideoRequest {
     pub port: Port,
@@ -2128,8 +2130,6 @@ pub struct GetVideoRequest {
     pub drw_h: u16,
 }
 impl GetVideoRequest {
-    /// Opcode for the GetVideo request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2151,7 +2151,7 @@ impl GetVideoRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_VIDEO_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2212,6 +2212,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetStill request
+pub const GET_STILL_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetStillRequest {
     pub port: Port,
@@ -2227,8 +2229,6 @@ pub struct GetStillRequest {
     pub drw_h: u16,
 }
 impl GetStillRequest {
-    /// Opcode for the GetStill request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2250,7 +2250,7 @@ impl GetStillRequest {
         let drw_h_bytes = self.drw_h.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_STILL_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2311,14 +2311,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the StopVideo request
+pub const STOP_VIDEO_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StopVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
 }
 impl StopVideoRequest {
-    /// Opcode for the StopVideo request
-    pub const fn opcode() -> u8 { 9 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2331,7 +2331,7 @@ impl StopVideoRequest {
         let drawable_bytes = self.drawable.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            STOP_VIDEO_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2363,14 +2363,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SelectVideoNotify request
+pub const SELECT_VIDEO_NOTIFY_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectVideoNotifyRequest {
     pub drawable: xproto::Drawable,
     pub onoff: bool,
 }
 impl SelectVideoNotifyRequest {
-    /// Opcode for the SelectVideoNotify request
-    pub const fn opcode() -> u8 { 10 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2383,7 +2383,7 @@ impl SelectVideoNotifyRequest {
         let onoff_bytes = self.onoff.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_VIDEO_NOTIFY_REQUEST,
             0,
             0,
             drawable_bytes[0],
@@ -2415,14 +2415,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the SelectPortNotify request
+pub const SELECT_PORT_NOTIFY_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectPortNotifyRequest {
     pub port: Port,
     pub onoff: bool,
 }
 impl SelectPortNotifyRequest {
-    /// Opcode for the SelectPortNotify request
-    pub const fn opcode() -> u8 { 11 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2435,7 +2435,7 @@ impl SelectPortNotifyRequest {
         let onoff_bytes = self.onoff.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SELECT_PORT_NOTIFY_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2467,6 +2467,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the QueryBestSize request
+pub const QUERY_BEST_SIZE_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryBestSizeRequest {
     pub port: Port,
@@ -2477,8 +2479,6 @@ pub struct QueryBestSizeRequest {
     pub motion: bool,
 }
 impl QueryBestSizeRequest {
-    /// Opcode for the QueryBestSize request
-    pub const fn opcode() -> u8 { 12 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2495,7 +2495,7 @@ impl QueryBestSizeRequest {
         let motion_bytes = self.motion.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_BEST_SIZE_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2566,6 +2566,8 @@ impl TryFrom<&[u8]> for QueryBestSizeReply {
     }
 }
 
+/// Opcode for the SetPortAttribute request
+pub const SET_PORT_ATTRIBUTE_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetPortAttributeRequest {
     pub port: Port,
@@ -2573,8 +2575,6 @@ pub struct SetPortAttributeRequest {
     pub value: i32,
 }
 impl SetPortAttributeRequest {
-    /// Opcode for the SetPortAttribute request
-    pub const fn opcode() -> u8 { 13 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2588,7 +2588,7 @@ impl SetPortAttributeRequest {
         let value_bytes = self.value.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SET_PORT_ATTRIBUTE_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2625,14 +2625,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the GetPortAttribute request
+pub const GET_PORT_ATTRIBUTE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
 }
 impl GetPortAttributeRequest {
-    /// Opcode for the GetPortAttribute request
-    pub const fn opcode() -> u8 { 14 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2645,7 +2645,7 @@ impl GetPortAttributeRequest {
         let attribute_bytes = self.attribute.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            GET_PORT_ATTRIBUTE_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2702,13 +2702,13 @@ impl TryFrom<&[u8]> for GetPortAttributeReply {
     }
 }
 
+/// Opcode for the QueryPortAttributes request
+pub const QUERY_PORT_ATTRIBUTES_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryPortAttributesRequest {
     pub port: Port,
 }
 impl QueryPortAttributesRequest {
-    /// Opcode for the QueryPortAttributes request
-    pub const fn opcode() -> u8 { 15 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2720,7 +2720,7 @@ impl QueryPortAttributesRequest {
         let port_bytes = self.port.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_PORT_ATTRIBUTES_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2791,13 +2791,13 @@ impl QueryPortAttributesReply {
     }
 }
 
+/// Opcode for the ListImageFormats request
+pub const LIST_IMAGE_FORMATS_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListImageFormatsRequest {
     pub port: Port,
 }
 impl ListImageFormatsRequest {
-    /// Opcode for the ListImageFormats request
-    pub const fn opcode() -> u8 { 16 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2809,7 +2809,7 @@ impl ListImageFormatsRequest {
         let port_bytes = self.port.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_IMAGE_FORMATS_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2878,6 +2878,8 @@ impl ListImageFormatsReply {
     }
 }
 
+/// Opcode for the QueryImageAttributes request
+pub const QUERY_IMAGE_ATTRIBUTES_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryImageAttributesRequest {
     pub port: Port,
@@ -2886,8 +2888,6 @@ pub struct QueryImageAttributesRequest {
     pub height: u16,
 }
 impl QueryImageAttributesRequest {
-    /// Opcode for the QueryImageAttributes request
-    pub const fn opcode() -> u8 { 17 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -2902,7 +2902,7 @@ impl QueryImageAttributesRequest {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_IMAGE_ATTRIBUTES_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -2990,6 +2990,8 @@ impl QueryImageAttributesReply {
     }
 }
 
+/// Opcode for the PutImage request
+pub const PUT_IMAGE_REQUEST: u8 = 18;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PutImageRequest<'input> {
     pub port: Port,
@@ -3009,8 +3011,6 @@ pub struct PutImageRequest<'input> {
     pub data: &'input [u8],
 }
 impl<'input> PutImageRequest<'input> {
-    /// Opcode for the PutImage request
-    pub const fn opcode() -> u8 { 18 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3035,7 +3035,7 @@ impl<'input> PutImageRequest<'input> {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            PUT_IMAGE_REQUEST,
             0,
             0,
             port_bytes[0],
@@ -3111,6 +3111,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ShmPutImage request
+pub const SHM_PUT_IMAGE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ShmPutImageRequest {
     pub port: Port,
@@ -3132,8 +3134,6 @@ pub struct ShmPutImageRequest {
     pub send_event: u8,
 }
 impl ShmPutImageRequest {
-    /// Opcode for the ShmPutImage request
-    pub const fn opcode() -> u8 { 19 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -3161,7 +3161,7 @@ impl ShmPutImageRequest {
         let send_event_bytes = self.send_event.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            SHM_PUT_IMAGE_REQUEST,
             0,
             0,
             port_bytes[0],

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -1649,7 +1649,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryAdaptorsRequest {
-        window: window,
+        window,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1737,7 +1737,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryEncodingsRequest {
-        port: port,
+        port,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1833,8 +1833,8 @@ where
 {
     let time: xproto::Timestamp = time.into();
     let request0 = GrabPortRequest {
-        port: port,
-        time: time,
+        port,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1913,8 +1913,8 @@ where
 {
     let time: xproto::Timestamp = time.into();
     let request0 = UngrabPortRequest {
-        port: port,
-        time: time,
+        port,
+        time,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2004,17 +2004,17 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PutVideoRequest {
-        port: port,
-        drawable: drawable,
-        gc: gc,
-        vid_x: vid_x,
-        vid_y: vid_y,
-        vid_w: vid_w,
-        vid_h: vid_h,
-        drw_x: drw_x,
-        drw_y: drw_y,
-        drw_w: drw_w,
-        drw_h: drw_h,
+        port,
+        drawable,
+        gc,
+        vid_x,
+        vid_y,
+        vid_w,
+        vid_h,
+        drw_x,
+        drw_y,
+        drw_w,
+        drw_h,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2104,17 +2104,17 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PutStillRequest {
-        port: port,
-        drawable: drawable,
-        gc: gc,
-        vid_x: vid_x,
-        vid_y: vid_y,
-        vid_w: vid_w,
-        vid_h: vid_h,
-        drw_x: drw_x,
-        drw_y: drw_y,
-        drw_w: drw_w,
-        drw_h: drw_h,
+        port,
+        drawable,
+        gc,
+        vid_x,
+        vid_y,
+        vid_w,
+        vid_h,
+        drw_x,
+        drw_y,
+        drw_w,
+        drw_h,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2204,17 +2204,17 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetVideoRequest {
-        port: port,
-        drawable: drawable,
-        gc: gc,
-        vid_x: vid_x,
-        vid_y: vid_y,
-        vid_w: vid_w,
-        vid_h: vid_h,
-        drw_x: drw_x,
-        drw_y: drw_y,
-        drw_w: drw_w,
-        drw_h: drw_h,
+        port,
+        drawable,
+        gc,
+        vid_x,
+        vid_y,
+        vid_w,
+        vid_h,
+        drw_x,
+        drw_y,
+        drw_w,
+        drw_h,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2304,17 +2304,17 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetStillRequest {
-        port: port,
-        drawable: drawable,
-        gc: gc,
-        vid_x: vid_x,
-        vid_y: vid_y,
-        vid_w: vid_w,
-        vid_h: vid_h,
-        drw_x: drw_x,
-        drw_y: drw_y,
-        drw_w: drw_w,
-        drw_h: drw_h,
+        port,
+        drawable,
+        gc,
+        vid_x,
+        vid_y,
+        vid_w,
+        vid_h,
+        drw_x,
+        drw_y,
+        drw_w,
+        drw_h,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2366,8 +2366,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = StopVideoRequest {
-        port: port,
-        drawable: drawable,
+        port,
+        drawable,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2419,8 +2419,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SelectVideoNotifyRequest {
-        drawable: drawable,
-        onoff: onoff,
+        drawable,
+        onoff,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2472,8 +2472,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SelectPortNotifyRequest {
-        port: port,
-        onoff: onoff,
+        port,
+        onoff,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2541,12 +2541,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryBestSizeRequest {
-        port: port,
-        vid_w: vid_w,
-        vid_h: vid_h,
-        drw_w: drw_w,
-        drw_h: drw_h,
-        motion: motion,
+        port,
+        vid_w,
+        vid_h,
+        drw_w,
+        drw_h,
+        motion,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2631,9 +2631,9 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetPortAttributeRequest {
-        port: port,
-        attribute: attribute,
-        value: value,
+        port,
+        attribute,
+        value,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2685,8 +2685,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = GetPortAttributeRequest {
-        port: port,
-        attribute: attribute,
+        port,
+        attribute,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2757,7 +2757,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryPortAttributesRequest {
-        port: port,
+        port,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2847,7 +2847,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListImageFormatsRequest {
-        port: port,
+        port,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2949,10 +2949,10 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryImageAttributesRequest {
-        port: port,
-        id: id,
-        width: width,
-        height: height,
+        port,
+        id,
+        width,
+        height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3110,21 +3110,21 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = PutImageRequest {
-        port: port,
-        drawable: drawable,
-        gc: gc,
-        id: id,
-        src_x: src_x,
-        src_y: src_y,
-        src_w: src_w,
-        src_h: src_h,
-        drw_x: drw_x,
-        drw_y: drw_y,
-        drw_w: drw_w,
-        drw_h: drw_h,
-        width: width,
-        height: height,
-        data: data,
+        port,
+        drawable,
+        gc,
+        id,
+        src_x,
+        src_y,
+        src_w,
+        src_h,
+        drw_x,
+        drw_y,
+        drw_w,
+        drw_h,
+        width,
+        height,
+        data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3246,23 +3246,23 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ShmPutImageRequest {
-        port: port,
-        drawable: drawable,
-        gc: gc,
-        shmseg: shmseg,
-        id: id,
-        offset: offset,
-        src_x: src_x,
-        src_y: src_y,
-        src_w: src_w,
-        src_h: src_h,
-        drw_x: drw_x,
-        drw_y: drw_y,
-        drw_w: drw_w,
-        drw_h: drw_h,
-        width: width,
-        height: height,
-        send_event: send_event,
+        port,
+        drawable,
+        gc,
+        shmseg,
+        id,
+        offset,
+        src_x,
+        src_y,
+        src_w,
+        src_h,
+        drw_x,
+        drw_y,
+        drw_w,
+        drw_h,
+        width,
+        height,
+        send_event,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -2560,7 +2560,7 @@ impl QueryImageAttributesReply {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 18;
-pub fn put_image<'c, Conn>(conn: &'c Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
@@ -2798,7 +2798,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_image_attributes(self, port, id, width, height)
     }
-    fn xv_put_image<'c>(&'c self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &[u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xv_put_image<'c, 'input>(&'c self, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         put_image(self, port, drawable, gc, id, src_x, src_y, src_w, src_h, drw_x, drw_y, drw_w, drw_h, width, height, data)
     }

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -142,7 +142,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            QueryVersionRequest::opcode(),
+            Self::opcode(),
             0,
             0,
         ];
@@ -209,7 +209,7 @@ impl ListSurfaceTypesRequest {
         let port_id_bytes = self.port_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListSurfaceTypesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_id_bytes[0],
@@ -307,7 +307,7 @@ impl CreateContextRequest {
         let flags_bytes = self.flags.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_id_bytes[0],
@@ -420,7 +420,7 @@ impl DestroyContextRequest {
         let context_id_bytes = self.context_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroyContextRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             context_id_bytes[0],
@@ -468,7 +468,7 @@ impl CreateSurfaceRequest {
         let context_id_bytes = self.context_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateSurfaceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             surface_id_bytes[0],
@@ -559,7 +559,7 @@ impl DestroySurfaceRequest {
         let surface_id_bytes = self.surface_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroySurfaceRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             surface_id_bytes[0],
@@ -613,7 +613,7 @@ impl CreateSubpictureRequest {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            CreateSubpictureRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             subpicture_id_bytes[0],
@@ -726,7 +726,7 @@ impl DestroySubpictureRequest {
         let subpicture_id_bytes = self.subpicture_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            DestroySubpictureRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             subpicture_id_bytes[0],
@@ -774,7 +774,7 @@ impl ListSubpictureTypesRequest {
         let surface_id_bytes = self.surface_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            ListSubpictureTypesRequest::opcode(),
+            Self::opcode(),
             0,
             0,
             port_id_bytes[0],

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -8,7 +8,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ use std::io::IoSlice;
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
 use crate::x11_utils::{Serialize, TryParse};
-use crate::connection::RequestConnection;
+use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 use crate::errors::{ConnectionError, ParseError};
@@ -132,7 +131,7 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -197,7 +196,7 @@ impl ListSurfaceTypesRequest {
     /// Opcode for the ListSurfaceTypes request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -289,7 +288,7 @@ impl CreateContextRequest {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -406,7 +405,7 @@ impl DestroyContextRequest {
     /// Opcode for the DestroyContext request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -452,7 +451,7 @@ impl CreateSurfaceRequest {
     /// Opcode for the CreateSurface request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -543,7 +542,7 @@ impl DestroySurfaceRequest {
     /// Opcode for the DestroySurface request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -592,7 +591,7 @@ impl CreateSubpictureRequest {
     /// Opcode for the CreateSubpicture request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -708,7 +707,7 @@ impl DestroySubpictureRequest {
     /// Opcode for the DestroySubpicture request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {
@@ -754,7 +753,7 @@ impl ListSubpictureTypesRequest {
     /// Opcode for the ListSubpictureTypes request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
     {

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -132,7 +132,6 @@ impl QueryVersionRequest {
     /// Opcode for the QueryVersion request
     pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -198,7 +197,6 @@ impl ListSurfaceTypesRequest {
     /// Opcode for the ListSurfaceTypes request
     pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -291,7 +289,6 @@ impl CreateContextRequest {
     /// Opcode for the CreateContext request
     pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -409,7 +406,6 @@ impl DestroyContextRequest {
     /// Opcode for the DestroyContext request
     pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -456,7 +452,6 @@ impl CreateSurfaceRequest {
     /// Opcode for the CreateSurface request
     pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -548,7 +543,6 @@ impl DestroySurfaceRequest {
     /// Opcode for the DestroySurface request
     pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -598,7 +592,6 @@ impl CreateSubpictureRequest {
     /// Opcode for the CreateSubpicture request
     pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -715,7 +708,6 @@ impl DestroySubpictureRequest {
     /// Opcode for the DestroySubpicture request
     pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,
@@ -762,7 +754,6 @@ impl ListSubpictureTypesRequest {
     /// Opcode for the ListSubpictureTypes request
     pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
-    #[allow(unused)]
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
     where
         Conn: RequestConnection + ?Sized,

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -229,7 +229,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListSurfaceTypesRequest {
-        port_id: port_id,
+        port_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -343,12 +343,12 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateContextRequest {
-        context_id: context_id,
-        port_id: port_id,
-        surface_id: surface_id,
-        width: width,
-        height: height,
-        flags: flags,
+        context_id,
+        port_id,
+        surface_id,
+        width,
+        height,
+        flags,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -440,7 +440,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroyContextRequest {
-        context_id: context_id,
+        context_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -492,8 +492,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateSurfaceRequest {
-        surface_id: surface_id,
-        context_id: context_id,
+        surface_id,
+        context_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -579,7 +579,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroySurfaceRequest {
-        surface_id: surface_id,
+        surface_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -645,11 +645,11 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = CreateSubpictureRequest {
-        subpicture_id: subpicture_id,
-        context: context,
-        xvimage_id: xvimage_id,
-        width: width,
-        height: height,
+        subpicture_id,
+        context,
+        xvimage_id,
+        width,
+        height,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -746,7 +746,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = DestroySubpictureRequest {
-        subpicture_id: subpicture_id,
+        subpicture_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -798,8 +798,8 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ListSubpictureTypesRequest {
-        port_id: port_id,
-        surface_id: surface_id,
+        port_id,
+        surface_id,
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -125,26 +126,41 @@ impl Serialize for SurfaceInfo {
     }
 }
 
-/// Opcode for the QueryVersion request
-pub const QUERY_VERSION_REQUEST: u8 = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryVersionRequest;
+impl QueryVersionRequest {
+    /// Opcode for the QueryVersion request
+    pub const fn opcode() -> u8 { 0 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            QueryVersionRequest::opcode(),
+            0,
+            0,
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let mut request0 = [
-        extension_information.major_opcode,
-        QUERY_VERSION_REQUEST,
-        0,
-        0,
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = QueryVersionRequest;
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -174,31 +190,50 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
-/// Opcode for the ListSurfaceTypes request
-pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListSurfaceTypesRequest {
+    pub port_id: xv::Port,
+}
+impl ListSurfaceTypesRequest {
+    /// Opcode for the ListSurfaceTypes request
+    pub const fn opcode() -> u8 { 1 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let port_id_bytes = self.port_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListSurfaceTypesRequest::opcode(),
+            0,
+            0,
+            port_id_bytes[0],
+            port_id_bytes[1],
+            port_id_bytes[2],
+            port_id_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_surface_types<Conn>(conn: &Conn, port_id: xv::Port) -> Result<Cookie<'_, Conn, ListSurfaceTypesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let port_id_bytes = port_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_SURFACE_TYPES_REQUEST,
-        0,
-        0,
-        port_id_bytes[0],
-        port_id_bytes[1],
-        port_id_bytes[2],
-        port_id_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListSurfaceTypesRequest {
+        port_id: port_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -243,52 +278,81 @@ impl ListSurfaceTypesReply {
     }
 }
 
-/// Opcode for the CreateContext request
-pub const CREATE_CONTEXT_REQUEST: u8 = 2;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateContextRequest {
+    pub context_id: Context,
+    pub port_id: xv::Port,
+    pub surface_id: Surface,
+    pub width: u16,
+    pub height: u16,
+    pub flags: u32,
+}
+impl CreateContextRequest {
+    /// Opcode for the CreateContext request
+    pub const fn opcode() -> u8 { 2 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let context_id_bytes = self.context_id.serialize();
+        let port_id_bytes = self.port_id.serialize();
+        let surface_id_bytes = self.surface_id.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let flags_bytes = self.flags.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateContextRequest::opcode(),
+            0,
+            0,
+            context_id_bytes[0],
+            context_id_bytes[1],
+            context_id_bytes[2],
+            context_id_bytes[3],
+            port_id_bytes[0],
+            port_id_bytes[1],
+            port_id_bytes[2],
+            port_id_bytes[3],
+            surface_id_bytes[0],
+            surface_id_bytes[1],
+            surface_id_bytes[2],
+            surface_id_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            flags_bytes[0],
+            flags_bytes[1],
+            flags_bytes[2],
+            flags_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_context<Conn>(conn: &Conn, context_id: Context, port_id: xv::Port, surface_id: Surface, width: u16, height: u16, flags: u32) -> Result<Cookie<'_, Conn, CreateContextReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let context_id_bytes = context_id.serialize();
-    let port_id_bytes = port_id.serialize();
-    let surface_id_bytes = surface_id.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let flags_bytes = flags.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_CONTEXT_REQUEST,
-        0,
-        0,
-        context_id_bytes[0],
-        context_id_bytes[1],
-        context_id_bytes[2],
-        context_id_bytes[3],
-        port_id_bytes[0],
-        port_id_bytes[1],
-        port_id_bytes[2],
-        port_id_bytes[3],
-        surface_id_bytes[0],
-        surface_id_bytes[1],
-        surface_id_bytes[2],
-        surface_id_bytes[3],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-        flags_bytes[0],
-        flags_bytes[1],
-        flags_bytes[2],
-        flags_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateContextRequest {
+        context_id: context_id,
+        port_id: port_id,
+        surface_id: surface_id,
+        width: width,
+        height: height,
+        flags: flags,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -337,63 +401,103 @@ impl CreateContextReply {
     }
 }
 
-/// Opcode for the DestroyContext request
-pub const DESTROY_CONTEXT_REQUEST: u8 = 3;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroyContextRequest {
+    pub context_id: Context,
+}
+impl DestroyContextRequest {
+    /// Opcode for the DestroyContext request
+    pub const fn opcode() -> u8 { 3 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let context_id_bytes = self.context_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroyContextRequest::opcode(),
+            0,
+            0,
+            context_id_bytes[0],
+            context_id_bytes[1],
+            context_id_bytes[2],
+            context_id_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_context<Conn>(conn: &Conn, context_id: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let context_id_bytes = context_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_CONTEXT_REQUEST,
-        0,
-        0,
-        context_id_bytes[0],
-        context_id_bytes[1],
-        context_id_bytes[2],
-        context_id_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroyContextRequest {
+        context_id: context_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateSurface request
-pub const CREATE_SURFACE_REQUEST: u8 = 4;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateSurfaceRequest {
+    pub surface_id: Surface,
+    pub context_id: Context,
+}
+impl CreateSurfaceRequest {
+    /// Opcode for the CreateSurface request
+    pub const fn opcode() -> u8 { 4 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let surface_id_bytes = self.surface_id.serialize();
+        let context_id_bytes = self.context_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateSurfaceRequest::opcode(),
+            0,
+            0,
+            surface_id_bytes[0],
+            surface_id_bytes[1],
+            surface_id_bytes[2],
+            surface_id_bytes[3],
+            context_id_bytes[0],
+            context_id_bytes[1],
+            context_id_bytes[2],
+            context_id_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_surface<Conn>(conn: &Conn, surface_id: Surface, context_id: Context) -> Result<Cookie<'_, Conn, CreateSurfaceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let surface_id_bytes = surface_id.serialize();
-    let context_id_bytes = context_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_SURFACE_REQUEST,
-        0,
-        0,
-        surface_id_bytes[0],
-        surface_id_bytes[1],
-        surface_id_bytes[2],
-        surface_id_bytes[3],
-        context_id_bytes[0],
-        context_id_bytes[1],
-        context_id_bytes[2],
-        context_id_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateSurfaceRequest {
+        surface_id: surface_id,
+        context_id: context_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -436,74 +540,120 @@ impl CreateSurfaceReply {
     }
 }
 
-/// Opcode for the DestroySurface request
-pub const DESTROY_SURFACE_REQUEST: u8 = 5;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroySurfaceRequest {
+    pub surface_id: Surface,
+}
+impl DestroySurfaceRequest {
+    /// Opcode for the DestroySurface request
+    pub const fn opcode() -> u8 { 5 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let surface_id_bytes = self.surface_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroySurfaceRequest::opcode(),
+            0,
+            0,
+            surface_id_bytes[0],
+            surface_id_bytes[1],
+            surface_id_bytes[2],
+            surface_id_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_surface<Conn>(conn: &Conn, surface_id: Surface) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let surface_id_bytes = surface_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_SURFACE_REQUEST,
-        0,
-        0,
-        surface_id_bytes[0],
-        surface_id_bytes[1],
-        surface_id_bytes[2],
-        surface_id_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroySurfaceRequest {
+        surface_id: surface_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the CreateSubpicture request
-pub const CREATE_SUBPICTURE_REQUEST: u8 = 6;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateSubpictureRequest {
+    pub subpicture_id: Subpicture,
+    pub context: Context,
+    pub xvimage_id: u32,
+    pub width: u16,
+    pub height: u16,
+}
+impl CreateSubpictureRequest {
+    /// Opcode for the CreateSubpicture request
+    pub const fn opcode() -> u8 { 6 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let subpicture_id_bytes = self.subpicture_id.serialize();
+        let context_bytes = self.context.serialize();
+        let xvimage_id_bytes = self.xvimage_id.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            CreateSubpictureRequest::opcode(),
+            0,
+            0,
+            subpicture_id_bytes[0],
+            subpicture_id_bytes[1],
+            subpicture_id_bytes[2],
+            subpicture_id_bytes[3],
+            context_bytes[0],
+            context_bytes[1],
+            context_bytes[2],
+            context_bytes[3],
+            xvimage_id_bytes[0],
+            xvimage_id_bytes[1],
+            xvimage_id_bytes[2],
+            xvimage_id_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn create_subpicture<Conn>(conn: &Conn, subpicture_id: Subpicture, context: Context, xvimage_id: u32, width: u16, height: u16) -> Result<Cookie<'_, Conn, CreateSubpictureReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let subpicture_id_bytes = subpicture_id.serialize();
-    let context_bytes = context.serialize();
-    let xvimage_id_bytes = xvimage_id.serialize();
-    let width_bytes = width.serialize();
-    let height_bytes = height.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        CREATE_SUBPICTURE_REQUEST,
-        0,
-        0,
-        subpicture_id_bytes[0],
-        subpicture_id_bytes[1],
-        subpicture_id_bytes[2],
-        subpicture_id_bytes[3],
-        context_bytes[0],
-        context_bytes[1],
-        context_bytes[2],
-        context_bytes[3],
-        xvimage_id_bytes[0],
-        xvimage_id_bytes[1],
-        xvimage_id_bytes[2],
-        xvimage_id_bytes[3],
-        width_bytes[0],
-        width_bytes[1],
-        height_bytes[0],
-        height_bytes[1],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = CreateSubpictureRequest {
+        subpicture_id: subpicture_id,
+        context: context,
+        xvimage_id: xvimage_id,
+        width: width,
+        height: height,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -557,63 +707,103 @@ impl CreateSubpictureReply {
     }
 }
 
-/// Opcode for the DestroySubpicture request
-pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestroySubpictureRequest {
+    pub subpicture_id: Subpicture,
+}
+impl DestroySubpictureRequest {
+    /// Opcode for the DestroySubpicture request
+    pub const fn opcode() -> u8 { 7 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let subpicture_id_bytes = self.subpicture_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            DestroySubpictureRequest::opcode(),
+            0,
+            0,
+            subpicture_id_bytes[0],
+            subpicture_id_bytes[1],
+            subpicture_id_bytes[2],
+            subpicture_id_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn destroy_subpicture<Conn>(conn: &Conn, subpicture_id: Subpicture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let subpicture_id_bytes = subpicture_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        DESTROY_SUBPICTURE_REQUEST,
-        0,
-        0,
-        subpicture_id_bytes[0],
-        subpicture_id_bytes[1],
-        subpicture_id_bytes[2],
-        subpicture_id_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_without_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = DestroySubpictureRequest {
+        subpicture_id: subpicture_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
-/// Opcode for the ListSubpictureTypes request
-pub const LIST_SUBPICTURE_TYPES_REQUEST: u8 = 8;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListSubpictureTypesRequest {
+    pub port_id: xv::Port,
+    pub surface_id: Surface,
+}
+impl ListSubpictureTypesRequest {
+    /// Opcode for the ListSubpictureTypes request
+    pub const fn opcode() -> u8 { 8 }
+    /// Serialize this request into bytes for the provided connection
+    #[allow(unused)]
+    fn serialize<'input, Conn>(self, conn: &Conn) -> Result<(Vec<Cow<'input, [u8]>>, Vec<RawFdContainer>), ConnectionError>
+    where
+        Conn: RequestConnection + ?Sized,
+    {
+        let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
+            .ok_or(ConnectionError::UnsupportedExtension)?;
+        let length_so_far = 0;
+        let port_id_bytes = self.port_id.serialize();
+        let surface_id_bytes = self.surface_id.serialize();
+        let mut request0 = vec![
+            extension_information.major_opcode,
+            ListSubpictureTypesRequest::opcode(),
+            0,
+            0,
+            port_id_bytes[0],
+            port_id_bytes[1],
+            port_id_bytes[2],
+            port_id_bytes[3],
+            surface_id_bytes[0],
+            surface_id_bytes[1],
+            surface_id_bytes[2],
+            surface_id_bytes[3],
+        ];
+        let length_so_far = length_so_far + request0.len();
+        assert_eq!(length_so_far % 4, 0);
+        let length = u16::try_from(length_so_far / 4).unwrap_or(0);
+        request0[2..4].copy_from_slice(&length.to_ne_bytes());
+        Ok((vec![request0.into()], vec![]))
+    }
+}
 pub fn list_subpicture_types<Conn>(conn: &Conn, port_id: xv::Port, surface_id: Surface) -> Result<Cookie<'_, Conn, ListSubpictureTypesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
 {
-    let extension_information = conn.extension_information(X11_EXTENSION_NAME)?
-        .ok_or(ConnectionError::UnsupportedExtension)?;
-    let length_so_far = 0;
-    let port_id_bytes = port_id.serialize();
-    let surface_id_bytes = surface_id.serialize();
-    let mut request0 = [
-        extension_information.major_opcode,
-        LIST_SUBPICTURE_TYPES_REQUEST,
-        0,
-        0,
-        port_id_bytes[0],
-        port_id_bytes[1],
-        port_id_bytes[2],
-        port_id_bytes[3],
-        surface_id_bytes[0],
-        surface_id_bytes[1],
-        surface_id_bytes[2],
-        surface_id_bytes[3],
-    ];
-    let length_so_far = length_so_far + request0.len();
-    assert_eq!(length_so_far % 4, 0);
-    let length = u16::try_from(length_so_far / 4).unwrap_or(0);
-    request0[2..4].copy_from_slice(&length.to_ne_bytes());
-    Ok(conn.send_request_with_reply(&[IoSlice::new(&request0)], vec![])?)
+    let request0 = ListSubpictureTypesRequest {
+        port_id: port_id,
+        surface_id: surface_id,
+    };
+    let (bytes, fds) = request0.serialize(conn)?;
+    let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
+    Ok(conn.send_request_with_reply(&slices, fds)?)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -125,11 +125,11 @@ impl Serialize for SurfaceInfo {
     }
 }
 
+/// Opcode for the QueryVersion request
+pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
-    /// Opcode for the QueryVersion request
-    pub const fn opcode() -> u8 { 0 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -140,7 +140,7 @@ impl QueryVersionRequest {
         let length_so_far = 0;
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            QUERY_VERSION_REQUEST,
             0,
             0,
         ];
@@ -188,13 +188,13 @@ impl TryFrom<&[u8]> for QueryVersionReply {
     }
 }
 
+/// Opcode for the ListSurfaceTypes request
+pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListSurfaceTypesRequest {
     pub port_id: xv::Port,
 }
 impl ListSurfaceTypesRequest {
-    /// Opcode for the ListSurfaceTypes request
-    pub const fn opcode() -> u8 { 1 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -206,7 +206,7 @@ impl ListSurfaceTypesRequest {
         let port_id_bytes = self.port_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_SURFACE_TYPES_REQUEST,
             0,
             0,
             port_id_bytes[0],
@@ -275,6 +275,8 @@ impl ListSurfaceTypesReply {
     }
 }
 
+/// Opcode for the CreateContext request
+pub const CREATE_CONTEXT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateContextRequest {
     pub context_id: Context,
@@ -285,8 +287,6 @@ pub struct CreateContextRequest {
     pub flags: u32,
 }
 impl CreateContextRequest {
-    /// Opcode for the CreateContext request
-    pub const fn opcode() -> u8 { 2 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -303,7 +303,7 @@ impl CreateContextRequest {
         let flags_bytes = self.flags.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_CONTEXT_REQUEST,
             0,
             0,
             context_id_bytes[0],
@@ -397,13 +397,13 @@ impl CreateContextReply {
     }
 }
 
+/// Opcode for the DestroyContext request
+pub const DESTROY_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroyContextRequest {
     pub context_id: Context,
 }
 impl DestroyContextRequest {
-    /// Opcode for the DestroyContext request
-    pub const fn opcode() -> u8 { 3 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -415,7 +415,7 @@ impl DestroyContextRequest {
         let context_id_bytes = self.context_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_CONTEXT_REQUEST,
             0,
             0,
             context_id_bytes[0],
@@ -442,14 +442,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateSurface request
+pub const CREATE_SURFACE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateSurfaceRequest {
     pub surface_id: Surface,
     pub context_id: Context,
 }
 impl CreateSurfaceRequest {
-    /// Opcode for the CreateSurface request
-    pub const fn opcode() -> u8 { 4 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -462,7 +462,7 @@ impl CreateSurfaceRequest {
         let context_id_bytes = self.context_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_SURFACE_REQUEST,
             0,
             0,
             surface_id_bytes[0],
@@ -534,13 +534,13 @@ impl CreateSurfaceReply {
     }
 }
 
+/// Opcode for the DestroySurface request
+pub const DESTROY_SURFACE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroySurfaceRequest {
     pub surface_id: Surface,
 }
 impl DestroySurfaceRequest {
-    /// Opcode for the DestroySurface request
-    pub const fn opcode() -> u8 { 5 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -552,7 +552,7 @@ impl DestroySurfaceRequest {
         let surface_id_bytes = self.surface_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_SURFACE_REQUEST,
             0,
             0,
             surface_id_bytes[0],
@@ -579,6 +579,8 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the CreateSubpicture request
+pub const CREATE_SUBPICTURE_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CreateSubpictureRequest {
     pub subpicture_id: Subpicture,
@@ -588,8 +590,6 @@ pub struct CreateSubpictureRequest {
     pub height: u16,
 }
 impl CreateSubpictureRequest {
-    /// Opcode for the CreateSubpicture request
-    pub const fn opcode() -> u8 { 6 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -605,7 +605,7 @@ impl CreateSubpictureRequest {
         let height_bytes = self.height.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            CREATE_SUBPICTURE_REQUEST,
             0,
             0,
             subpicture_id_bytes[0],
@@ -699,13 +699,13 @@ impl CreateSubpictureReply {
     }
 }
 
+/// Opcode for the DestroySubpicture request
+pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DestroySubpictureRequest {
     pub subpicture_id: Subpicture,
 }
 impl DestroySubpictureRequest {
-    /// Opcode for the DestroySubpicture request
-    pub const fn opcode() -> u8 { 7 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -717,7 +717,7 @@ impl DestroySubpictureRequest {
         let subpicture_id_bytes = self.subpicture_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            DESTROY_SUBPICTURE_REQUEST,
             0,
             0,
             subpicture_id_bytes[0],
@@ -744,14 +744,14 @@ where
     Ok(conn.send_request_without_reply(&slices, fds)?)
 }
 
+/// Opcode for the ListSubpictureTypes request
+pub const LIST_SUBPICTURE_TYPES_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ListSubpictureTypesRequest {
     pub port_id: xv::Port,
     pub surface_id: Surface,
 }
 impl ListSubpictureTypesRequest {
-    /// Opcode for the ListSubpictureTypes request
-    pub const fn opcode() -> u8 { 8 }
     /// Serialize this request into bytes for the provided connection
     fn serialize<'input, Conn>(self, conn: &Conn) -> Result<BufWithFds<PiecewiseBuf<'input>>, ConnectionError>
     where
@@ -764,7 +764,7 @@ impl ListSubpictureTypesRequest {
         let surface_id_bytes = self.surface_id.serialize();
         let mut request0 = vec![
             extension_information.major_opcode,
-            Self::opcode(),
+            LIST_SUBPICTURE_TYPES_REQUEST,
             0,
             0,
             port_id_bytes[0],

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -12,7 +12,7 @@ use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 pub use crate::errors::{ConnectError, ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::extension_manager::ExtensionManager;
 use crate::protocol::bigreq::{ConnectionExt as _, EnableReply};
-use crate::protocol::xproto::{GetInputFocusRequest, Setup, SetupRequest};
+use crate::protocol::xproto::{Setup, SetupRequest, GET_INPUT_FOCUS_REQUEST};
 use crate::utils::RawFdContainer;
 use crate::x11_utils::{ExtensionInformation, Serialize};
 
@@ -245,7 +245,7 @@ impl<R: ReadFD + Poll, W: WriteFD + Poll> RustConnection<R, W> {
     ) -> Result<MutexGuardInner<'a>, std::io::Error> {
         let length = 1u16.to_ne_bytes();
         let request = [
-            GetInputFocusRequest::opcode(),
+            GET_INPUT_FOCUS_REQUEST,
             0, /* pad */
             length[0],
             length[1],

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -12,7 +12,7 @@ use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
 pub use crate::errors::{ConnectError, ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::extension_manager::ExtensionManager;
 use crate::protocol::bigreq::{ConnectionExt as _, EnableReply};
-use crate::protocol::xproto::{Setup, SetupRequest, GET_INPUT_FOCUS_REQUEST};
+use crate::protocol::xproto::{GetInputFocusRequest, Setup, SetupRequest};
 use crate::utils::RawFdContainer;
 use crate::x11_utils::{ExtensionInformation, Serialize};
 
@@ -245,7 +245,7 @@ impl<R: ReadFD + Poll, W: WriteFD + Poll> RustConnection<R, W> {
     ) -> Result<MutexGuardInner<'a>, std::io::Error> {
         let length = 1u16.to_ne_bytes();
         let request = [
-            GET_INPUT_FOCUS_REQUEST,
+            GetInputFocusRequest::opcode(),
             0, /* pad */
             length[0],
             length[1],

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -62,7 +62,7 @@ mod fake_stream {
     use x11rb::connection::SequenceNumber;
     use x11rb::errors::ConnectError;
     use x11rb::protocol::xproto::{
-        ImageOrder, Setup, CLIENT_MESSAGE_EVENT, GET_INPUT_FOCUS_REQUEST, SEND_EVENT_REQUEST,
+        GetInputFocusRequest, ImageOrder, SendEventRequest, Setup, CLIENT_MESSAGE_EVENT,
     };
     use x11rb::rust_connection::{Poll, ReadFD, RustConnection, WriteFD};
     use x11rb::utils::RawFdContainer;
@@ -194,13 +194,15 @@ mod fake_stream {
             }
 
             self.seqno += 1;
-            match buf[0] {
-                GET_INPUT_FOCUS_REQUEST => self
-                    .send
+            // Can't use match here until https://github.com/rust-lang/rust/issues/57240 is fixed.
+            if buf[0] == GetInputFocusRequest::opcode() {
+                self.send
                     .send(Packet::GetInputFocusReply(self.seqno))
-                    .unwrap(),
-                SEND_EVENT_REQUEST => self.send.send(Packet::Event).unwrap(),
-                _ => unimplemented!(),
+                    .unwrap()
+            } else if buf[0] == SendEventRequest::opcode() {
+                self.send.send(Packet::Event).unwrap()
+            } else {
+                unimplemented!()
             }
             // Compute how much of the package was not yet received
             self.skip = usize::from(u16::from_ne_bytes([buf[2], buf[3]])) * 4 - buf.len();

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -183,7 +183,7 @@ fn test_poly_segment() -> Result<(), ReplyError> {
     conn.poly_segment(drawable, gc, &segments)?;
 
     let mut expected = Vec::new();
-    expected.push(x11rb::protocol::xproto::POLY_SEGMENT_REQUEST);
+    expected.push(x11rb::protocol::xproto::PolySegmentRequest::opcode());
     expected.push(0); // padding
     expected.extend(&length.to_ne_bytes()); // length, not in the xml
     expected.extend(&drawable.to_ne_bytes());
@@ -209,7 +209,7 @@ fn test_big_requests() -> Result<(), ConnectionError> {
     conn.poly_text16(drawable, gc, x, y, &big_buffer)?;
 
     let mut expected = Vec::new();
-    expected.push(x11rb::protocol::xproto::POLY_TEXT16_REQUEST);
+    expected.push(x11rb::protocol::xproto::PolyText16Request::opcode());
     // padding
     expected.push(0);
     // Length of zero: we use big requests
@@ -262,7 +262,7 @@ fn test_send_event() -> Result<(), ConnectionError> {
     conn.send_event(propagate, destination, event_mask, event)?;
 
     let mut expected = Vec::new();
-    expected.push(x11rb::protocol::xproto::SEND_EVENT_REQUEST);
+    expected.push(x11rb::protocol::xproto::SendEventRequest::opcode());
     expected.push(propagate as _);
     expected.extend(&((12u16 + 32u16) / 4).to_ne_bytes());
     expected.extend(&destination.to_ne_bytes());

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -183,7 +183,7 @@ fn test_poly_segment() -> Result<(), ReplyError> {
     conn.poly_segment(drawable, gc, &segments)?;
 
     let mut expected = Vec::new();
-    expected.push(x11rb::protocol::xproto::PolySegmentRequest::opcode());
+    expected.push(x11rb::protocol::xproto::POLY_SEGMENT_REQUEST);
     expected.push(0); // padding
     expected.extend(&length.to_ne_bytes()); // length, not in the xml
     expected.extend(&drawable.to_ne_bytes());
@@ -209,7 +209,7 @@ fn test_big_requests() -> Result<(), ConnectionError> {
     conn.poly_text16(drawable, gc, x, y, &big_buffer)?;
 
     let mut expected = Vec::new();
-    expected.push(x11rb::protocol::xproto::PolyText16Request::opcode());
+    expected.push(x11rb::protocol::xproto::POLY_TEXT16_REQUEST);
     // padding
     expected.push(0);
     // Length of zero: we use big requests
@@ -262,7 +262,7 @@ fn test_send_event() -> Result<(), ConnectionError> {
     conn.send_event(propagate, destination, event_mask, event)?;
 
     let mut expected = Vec::new();
-    expected.push(x11rb::protocol::xproto::SendEventRequest::opcode());
+    expected.push(x11rb::protocol::xproto::SEND_EVENT_REQUEST);
     expected.push(propagate as _);
     expected.extend(&((12u16 + 32u16) / 4).to_ne_bytes());
     expected.extend(&destination.to_ne_bytes());


### PR DESCRIPTION
This PR creates a `FooRequest` struct for every X11 request `Foo` with the appropriate parameters, and then moves the existing serialization logic out of the generated helper functions and into a method that consumes the request struct. My motivation for this is that I want to use these structs to *parse* X11 requests to decode protocol traffic, but the parsing code is not included in this PR. It would be straightforward to build on this to complete #212 as well (by breaking the serialize method off into its own trait and adding `send_request_struct_...` methods on `Connection`).

This is largely boilerplate. It passes all the automated tests and I've done some visual inspection of bits of the generated code as well, though obviously there's too much to go through everything line by line.

Things that I think are worth paying attention to in a review:

1. I got rid of the `FOO_REQUEST` constants and replaced them with a `FooRequest::opcode()`. I think this is cleaner but it a) does break compatibility to some extent and b) despite being a const fn `opcode()` cannot be used in a match arm until rust-lang/rust#57240 is fixed, so you may want that added back.
2. The request byte buffer can no longer live on the stack (since the function that generates it returns before we call into the connection sending machinery). It ends up getting packaged into a Vec (i.e. heap allocated) but I don't think that should be a big concern.
3. Given the above, I wanted to preserve the existing `IoSlice` behavior, but `IoSlice` cannot own buffers, so the serialization method on the struct now returns a `Vec<Cow<'input, [u8]>>` which are `Cow::Owned`s for the byte buffers generated in serialization and `Cow::Borrowed` for external buffers that are embedded in the struct or static data like padding.
4. `SendEventRequest` is a bit tricky. I've chosen for now to make its event just be an `&'input [u8; 32]`. I think a `Cow` would be better in some ways but fixed length arrays do not implement ToOwned so they don't play well with `Cow`, and erasing the length didn't feel right.