### PR TITLE
Move read buffering into `PacketReader`

### DIFF
--- a/examples/xclock_utc.rs
+++ b/examples/xclock_utc.rs
@@ -170,7 +170,7 @@ fn redraw(
 fn do_poll(conn: &RustConnection) -> nix::Result<()> {
     use std::os::unix::io::AsRawFd;
 
-    let fd = conn.with_read(|r| r.get_ref().as_raw_fd());
+    let fd = conn.with_read(|r| r.as_raw_fd());
 
     // We do not really care about the result of poll. Either there was a timeout, in which case we
     // try to handle events (there are none) and then redraw. Or there was an event, in which case

--- a/src/rust_connection/fd_read_write.rs
+++ b/src/rust_connection/fd_read_write.rs
@@ -4,7 +4,7 @@
 //! file descriptors.
 
 use std::collections::VecDeque;
-use std::io::{Error, ErrorKind, IoSlice, Read, Result};
+use std::io::{Error, ErrorKind, IoSlice, Result};
 
 use crate::utils::RawFdContainer;
 
@@ -300,79 +300,6 @@ pub trait ReadFD: Poll {
             }
         }
         Ok(())
-    }
-}
-
-/// A version of [`std::io::BufReader`] that supports receiving file descriptors.
-#[derive(Debug)]
-pub struct BufReadFD<R: ReadFD> {
-    inner: R,
-    buf: Box<[u8]>,
-    // The following two variables describe the range of available data in `buf`
-    start: usize,
-    end: usize,
-}
-
-impl<R: ReadFD> BufReadFD<R> {
-    /// Creates a new `BufReadFD` with a default buffer capacity.
-    pub fn new(inner: R) -> Self {
-        // Chosen by checking what libxcb does
-        let default = 4096;
-        Self::with_capacity(default, inner)
-    }
-
-    /// Creates a new `BufReadFD` with the specified buffer capacity.
-    pub fn with_capacity(capacity: usize, inner: R) -> Self {
-        Self {
-            inner,
-            buf: vec![0; capacity].into_boxed_slice(),
-            start: 0,
-            end: 0,
-        }
-    }
-
-    /// Gets a mutable reference to the underlying FD reader.
-    ///
-    /// It is inadvisable to directly read from the underlying reader.
-    pub fn get_mut(&mut self) -> &mut R {
-        &mut self.inner
-    }
-
-    /// Gets a reference to the underlying FD reader.
-    ///
-    /// It is inadvisable to directly read from the underlying reader.
-    pub fn get_ref(&self) -> &R {
-        &self.inner
-    }
-}
-
-impl<R: ReadFD> ReadFD for BufReadFD<R> {
-    fn read(&mut self, buf: &mut [u8], fd_storage: &mut Vec<RawFdContainer>) -> Result<usize> {
-        if self.start >= self.end {
-            // We have no data buffered
-            if buf.len() >= self.buf.len() {
-                // This is a large read, bypass our buffer
-                return self.inner.read(buf, fd_storage);
-            }
-            // Read something new from the inner reader
-            self.end = self.inner.read(&mut self.buf, fd_storage)?;
-            self.start = 0;
-        }
-        // Read data from our buffer
-        let nread = (&self.buf[self.start..self.end]).read(buf)?;
-        self.start += nread;
-        Ok(nread)
-    }
-}
-
-impl<T: ReadFD> Poll for BufReadFD<T> {
-    fn poll(&mut self, read: bool, write: bool) -> Result<(bool, bool)> {
-        if read && self.start < self.end {
-            // Avoid blocking poll if read buffer is not empty.
-            Ok((true, false))
-        } else {
-            self.inner.poll(read, write)
-        }
     }
 }
 


### PR DESCRIPTION
Read buffer has been moved into `PacketReader`.

Additionally, buffering is now "stateless" (there aren't start/end cursors). Instead, `PacketReader` will read from `inner` to fill the buffer and then will extract full/partial packets until the buffer is empty. So, `try_read_packets` always enters and leaves with the buffer empty.