### PR TITLE
Use Cows for (most) members with lifetimes.

### DIFF
--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -735,7 +737,7 @@ pub const GET_BUFFERS_REQUEST: u8 = 5;
 pub struct GetBuffersRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
-    pub attachments: &'input [u32],
+    pub attachments: Cow<'input, [u32]>,
 }
 impl<'input> GetBuffersRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -780,7 +782,7 @@ where
     let request0 = GetBuffersRequest {
         drawable,
         count,
-        attachments,
+        attachments: Cow::Borrowed(attachments),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -928,7 +930,7 @@ pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
 pub struct GetBuffersWithFormatRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
-    pub attachments: &'input [AttachFormat],
+    pub attachments: Cow<'input, [AttachFormat]>,
 }
 impl<'input> GetBuffersWithFormatRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -973,7 +975,7 @@ where
     let request0 = GetBuffersWithFormatRequest {
         drawable,
         count,
-        attachments,
+        attachments: Cow::Borrowed(attachments),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -496,13 +498,13 @@ impl<'input> RenderRequest<'input> {
             context_tag_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn render<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -560,13 +562,13 @@ impl<'input> RenderLargeRequest<'input> {
             data_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn render_large<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, request_num: u16, request_total: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1541,13 +1543,13 @@ impl<'input> VendorPrivateRequest<'input> {
             context_tag_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn vendor_private<'c, 'input, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1598,13 +1600,13 @@ impl<'input> VendorPrivateWithReplyRequest<'input> {
             context_tag_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn vendor_private_with_reply<'c, 'input, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<Cookie<'c, Conn, VendorPrivateWithReplyReply>, ConnectionError>
@@ -1875,13 +1877,13 @@ impl<'input> ClientInfoRequest<'input> {
             str_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.string[..]).len();
+        let length_so_far = length_so_far + self.string.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.string[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.string.into(), padding0.into()], vec![]))
     }
 }
 pub fn client_info<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1995,7 +1997,7 @@ pub struct CreatePixmapRequest<'input> {
     pub fbconfig: Fbconfig,
     pub pixmap: xproto::Pixmap,
     pub glx_pixmap: Pixmap,
-    pub attribs: &'input [u32],
+    pub attribs: Cow<'input, [u32]>,
 }
 impl<'input> CreatePixmapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2059,7 +2061,7 @@ where
         fbconfig,
         pixmap,
         glx_pixmap,
-        attribs,
+        attribs: Cow::Borrowed(attribs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2378,7 +2380,7 @@ pub struct CreatePbufferRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
     pub pbuffer: Pbuffer,
-    pub attribs: &'input [u32],
+    pub attribs: Cow<'input, [u32]>,
 }
 impl<'input> CreatePbufferRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2436,7 +2438,7 @@ where
         screen,
         fbconfig,
         pbuffer,
-        attribs,
+        attribs: Cow::Borrowed(attribs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2581,7 +2583,7 @@ pub const CHANGE_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 30;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeDrawableAttributesRequest<'input> {
     pub drawable: Drawable,
-    pub attribs: &'input [u32],
+    pub attribs: Cow<'input, [u32]>,
 }
 impl<'input> ChangeDrawableAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2627,7 +2629,7 @@ where
 {
     let request0 = ChangeDrawableAttributesRequest {
         drawable,
-        attribs,
+        attribs: Cow::Borrowed(attribs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2642,7 +2644,7 @@ pub struct CreateWindowRequest<'input> {
     pub fbconfig: Fbconfig,
     pub window: xproto::Window,
     pub glx_window: Window,
-    pub attribs: &'input [u32],
+    pub attribs: Cow<'input, [u32]>,
 }
 impl<'input> CreateWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2706,7 +2708,7 @@ where
         fbconfig,
         window,
         glx_window,
-        attribs,
+        attribs: Cow::Borrowed(attribs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2764,7 +2766,7 @@ pub const SET_CLIENT_INFO_ARB_REQUEST: u8 = 33;
 pub struct SetClientInfoARBRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
-    pub gl_versions: &'input [u32],
+    pub gl_versions: Cow<'input, [u32]>,
     pub gl_extension_string: &'input [u8],
     pub glx_extension_string: &'input [u8],
 }
@@ -2815,14 +2817,14 @@ impl<'input> SetClientInfoARBRequest<'input> {
         let length_so_far = length_so_far + request0.len();
         let gl_versions_bytes = self.gl_versions.serialize();
         let length_so_far = length_so_far + gl_versions_bytes.len();
-        let length_so_far = length_so_far + (&self.gl_extension_string[..]).len();
-        let length_so_far = length_so_far + (&self.glx_extension_string[..]).len();
+        let length_so_far = length_so_far + self.gl_extension_string.len();
+        let length_so_far = length_so_far + self.glx_extension_string.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), gl_versions_bytes.into(), (&self.gl_extension_string[..]).into(), (&self.glx_extension_string[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), gl_versions_bytes.into(), self.gl_extension_string.into(), self.glx_extension_string.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_client_info_arb<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2832,7 +2834,7 @@ where
     let request0 = SetClientInfoARBRequest {
         major_version,
         minor_version,
-        gl_versions,
+        gl_versions: Cow::Borrowed(gl_versions),
         gl_extension_string,
         glx_extension_string,
     };
@@ -2850,7 +2852,7 @@ pub struct CreateContextAttribsARBRequest<'input> {
     pub screen: u32,
     pub share_list: Context,
     pub is_direct: bool,
-    pub attribs: &'input [u32],
+    pub attribs: Cow<'input, [u32]>,
 }
 impl<'input> CreateContextAttribsARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2920,7 +2922,7 @@ where
         screen,
         share_list,
         is_direct,
-        attribs,
+        attribs: Cow::Borrowed(attribs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2933,7 +2935,7 @@ pub const SET_CLIENT_INFO2_ARB_REQUEST: u8 = 35;
 pub struct SetClientInfo2ARBRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
-    pub gl_versions: &'input [u32],
+    pub gl_versions: Cow<'input, [u32]>,
     pub gl_extension_string: &'input [u8],
     pub glx_extension_string: &'input [u8],
 }
@@ -2984,14 +2986,14 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
         let length_so_far = length_so_far + request0.len();
         let gl_versions_bytes = self.gl_versions.serialize();
         let length_so_far = length_so_far + gl_versions_bytes.len();
-        let length_so_far = length_so_far + (&self.gl_extension_string[..]).len();
-        let length_so_far = length_so_far + (&self.glx_extension_string[..]).len();
+        let length_so_far = length_so_far + self.gl_extension_string.len();
+        let length_so_far = length_so_far + self.glx_extension_string.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), gl_versions_bytes.into(), (&self.gl_extension_string[..]).into(), (&self.glx_extension_string[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), gl_versions_bytes.into(), self.gl_extension_string.into(), self.glx_extension_string.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_client_info2_arb<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3001,7 +3003,7 @@ where
     let request0 = SetClientInfo2ARBRequest {
         major_version,
         minor_version,
-        gl_versions,
+        gl_versions: Cow::Borrowed(gl_versions),
         gl_extension_string,
         glx_extension_string,
     };
@@ -6877,7 +6879,7 @@ pub const ARE_TEXTURES_RESIDENT_REQUEST: u8 = 143;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AreTexturesResidentRequest<'input> {
     pub context_tag: ContextTag,
-    pub textures: &'input [u32],
+    pub textures: Cow<'input, [u32]>,
 }
 impl<'input> AreTexturesResidentRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6922,7 +6924,7 @@ where
 {
     let request0 = AreTexturesResidentRequest {
         context_tag,
-        textures,
+        textures: Cow::Borrowed(textures),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6977,7 +6979,7 @@ pub const DELETE_TEXTURES_REQUEST: u8 = 144;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteTexturesRequest<'input> {
     pub context_tag: ContextTag,
-    pub textures: &'input [u32],
+    pub textures: Cow<'input, [u32]>,
 }
 impl<'input> DeleteTexturesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -7022,7 +7024,7 @@ where
 {
     let request0 = DeleteTexturesRequest {
         context_tag,
-        textures,
+        textures: Cow::Borrowed(textures),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8736,7 +8738,7 @@ pub const DELETE_QUERIES_ARB_REQUEST: u8 = 161;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteQueriesARBRequest<'input> {
     pub context_tag: ContextTag,
-    pub ids: &'input [u32],
+    pub ids: Cow<'input, [u32]>,
 }
 impl<'input> DeleteQueriesARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -8781,7 +8783,7 @@ where
 {
     let request0 = DeleteQueriesARBRequest {
         context_tag,
-        ids,
+        ids: Cow::Borrowed(ids),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -596,7 +598,7 @@ pub struct PixmapRequest<'input> {
     pub target_msc: u64,
     pub divisor: u64,
     pub remainder: u64,
-    pub notifies: &'input [Notify],
+    pub notifies: Cow<'input, [Notify]>,
 }
 impl<'input> PixmapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -725,7 +727,7 @@ where
         target_msc,
         divisor,
         remainder,
-        notifies,
+        notifies: Cow::Borrowed(notifies),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -1897,7 +1899,7 @@ pub struct ConfigureOutputPropertyRequest<'input> {
     pub property: xproto::Atom,
     pub pending: bool,
     pub range: bool,
-    pub values: &'input [i32],
+    pub values: Cow<'input, [i32]>,
 }
 impl<'input> ConfigureOutputPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1950,7 +1952,7 @@ where
         property,
         pending,
         range,
-        values,
+        values: Cow::Borrowed(values),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2012,13 +2014,13 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         ];
         let length_so_far = length_so_far + request0.len();
         assert_eq!(self.data.len(), usize::try_from(self.num_units.checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2272,13 +2274,13 @@ impl<'input> CreateModeRequest<'input> {
             mode_info_bytes[31],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_mode<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode_info: ModeInfo, name: &'input [u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
@@ -2608,7 +2610,7 @@ pub struct SetCrtcConfigRequest<'input> {
     pub y: i16,
     pub mode: Mode,
     pub rotation: u16,
-    pub outputs: &'input [Output],
+    pub outputs: Cow<'input, [Output]>,
 }
 impl<'input> SetCrtcConfigRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2681,7 +2683,7 @@ where
         y,
         mode,
         rotation,
-        outputs,
+        outputs: Cow::Borrowed(outputs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2883,9 +2885,9 @@ pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetCrtcGammaRequest<'input> {
     pub crtc: Crtc,
-    pub red: &'input [u16],
-    pub green: &'input [u16],
-    pub blue: &'input [u16],
+    pub red: Cow<'input, [u16]>,
+    pub green: Cow<'input, [u16]>,
+    pub blue: Cow<'input, [u16]>,
 }
 impl<'input> SetCrtcGammaRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2936,9 +2938,9 @@ where
 {
     let request0 = SetCrtcGammaRequest {
         crtc,
-        red,
-        green,
-        blue,
+        red: Cow::Borrowed(red),
+        green: Cow::Borrowed(green),
+        blue: Cow::Borrowed(blue),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3161,7 +3163,7 @@ pub struct SetCrtcTransformRequest<'input> {
     pub crtc: Crtc,
     pub transform: render::Transform,
     pub filter_name: &'input [u8],
-    pub filter_params: &'input [render::Fixed],
+    pub filter_params: Cow<'input, [render::Fixed]>,
 }
 impl<'input> SetCrtcTransformRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3227,7 +3229,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.filter_name[..]).len();
+        let length_so_far = length_so_far + self.filter_name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         let filter_params_bytes = self.filter_params.serialize();
@@ -3237,7 +3239,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.filter_name[..]).into(), padding0.into(), filter_params_bytes.into(), padding1.into()], vec![]))
+        Ok((vec![request0.into(), self.filter_name.into(), padding0.into(), filter_params_bytes.into(), padding1.into()], vec![]))
     }
 }
 pub fn set_crtc_transform<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, transform: render::Transform, filter_name: &'input [u8], filter_params: &'input [render::Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3248,7 +3250,7 @@ where
         crtc,
         transform,
         filter_name,
-        filter_params,
+        filter_params: Cow::Borrowed(filter_params),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4384,7 +4386,7 @@ pub struct ConfigureProviderPropertyRequest<'input> {
     pub property: xproto::Atom,
     pub pending: bool,
     pub range: bool,
-    pub values: &'input [i32],
+    pub values: Cow<'input, [i32]>,
 }
 impl<'input> ConfigureProviderPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4437,7 +4439,7 @@ where
         property,
         pending,
         range,
-        values,
+        values: Cow::Borrowed(values),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4499,13 +4501,13 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         ];
         let length_so_far = length_so_far + request0.len();
         assert_eq!(self.data.len(), usize::try_from(self.num_items.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -5624,8 +5626,8 @@ pub const CREATE_LEASE_REQUEST: u8 = 45;
 pub struct CreateLeaseRequest<'input> {
     pub window: xproto::Window,
     pub lid: Lease,
-    pub crtcs: &'input [Crtc],
-    pub outputs: &'input [Output],
+    pub crtcs: Cow<'input, [Crtc]>,
+    pub outputs: Cow<'input, [Output]>,
 }
 impl<'input> CreateLeaseRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -5680,8 +5682,8 @@ where
     let request0 = CreateLeaseRequest {
         window,
         lid,
-        crtcs,
-        outputs,
+        crtcs: Cow::Borrowed(crtcs),
+        outputs: Cow::Borrowed(outputs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -575,8 +577,8 @@ pub const CREATE_CONTEXT_REQUEST: u8 = 1;
 pub struct CreateContextRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
-    pub client_specs: &'input [ClientSpec],
-    pub ranges: &'input [Range],
+    pub client_specs: Cow<'input, [ClientSpec]>,
+    pub ranges: Cow<'input, [Range]>,
 }
 impl<'input> CreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -635,8 +637,8 @@ where
     let request0 = CreateContextRequest {
         context,
         element_header,
-        client_specs,
-        ranges,
+        client_specs: Cow::Borrowed(client_specs),
+        ranges: Cow::Borrowed(ranges),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -649,8 +651,8 @@ pub const REGISTER_CLIENTS_REQUEST: u8 = 2;
 pub struct RegisterClientsRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
-    pub client_specs: &'input [ClientSpec],
-    pub ranges: &'input [Range],
+    pub client_specs: Cow<'input, [ClientSpec]>,
+    pub ranges: Cow<'input, [Range]>,
 }
 impl<'input> RegisterClientsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -709,8 +711,8 @@ where
     let request0 = RegisterClientsRequest {
         context,
         element_header,
-        client_specs,
-        ranges,
+        client_specs: Cow::Borrowed(client_specs),
+        ranges: Cow::Borrowed(ranges),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -722,7 +724,7 @@ pub const UNREGISTER_CLIENTS_REQUEST: u8 = 3;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnregisterClientsRequest<'input> {
     pub context: Context,
-    pub client_specs: &'input [ClientSpec],
+    pub client_specs: Cow<'input, [ClientSpec]>,
 }
 impl<'input> UnregisterClientsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -767,7 +769,7 @@ where
 {
     let request0 = UnregisterClientsRequest {
         context,
-        client_specs,
+        client_specs: Cow::Borrowed(client_specs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -2283,12 +2285,12 @@ impl CreatePictureAux {
 
 /// Opcode for the CreatePicture request
 pub const CREATE_PICTURE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreatePictureRequest<'input> {
     pub pid: Picture,
     pub drawable: xproto::Drawable,
     pub format: Pictformat,
-    pub value_list: &'input CreatePictureAux,
+    pub value_list: Cow<'input, CreatePictureAux>,
 }
 impl<'input> CreatePictureRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2345,7 +2347,7 @@ where
         pid,
         drawable,
         format,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2537,10 +2539,10 @@ impl ChangePictureAux {
 
 /// Opcode for the ChangePicture request
 pub const CHANGE_PICTURE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangePictureRequest<'input> {
     pub picture: Picture,
-    pub value_list: &'input ChangePictureAux,
+    pub value_list: Cow<'input, ChangePictureAux>,
 }
 impl<'input> ChangePictureRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2585,7 +2587,7 @@ where
 {
     let request0 = ChangePictureRequest {
         picture,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2599,7 +2601,7 @@ pub struct SetPictureClipRectanglesRequest<'input> {
     pub picture: Picture,
     pub clip_x_origin: i16,
     pub clip_y_origin: i16,
-    pub rectangles: &'input [xproto::Rectangle],
+    pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
 impl<'input> SetPictureClipRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2646,7 +2648,7 @@ where
         picture,
         clip_x_origin,
         clip_y_origin,
-        rectangles,
+        rectangles: Cow::Borrowed(rectangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2816,7 +2818,7 @@ pub struct TrapezoidsRequest<'input> {
     pub mask_format: Pictformat,
     pub src_x: i16,
     pub src_y: i16,
-    pub traps: &'input [Trapezoid],
+    pub traps: Cow<'input, [Trapezoid]>,
 }
 impl<'input> TrapezoidsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2881,7 +2883,7 @@ where
         mask_format,
         src_x,
         src_y,
-        traps,
+        traps: Cow::Borrowed(traps),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2898,7 +2900,7 @@ pub struct TrianglesRequest<'input> {
     pub mask_format: Pictformat,
     pub src_x: i16,
     pub src_y: i16,
-    pub triangles: &'input [Triangle],
+    pub triangles: Cow<'input, [Triangle]>,
 }
 impl<'input> TrianglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2963,7 +2965,7 @@ where
         mask_format,
         src_x,
         src_y,
-        triangles,
+        triangles: Cow::Borrowed(triangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2980,7 +2982,7 @@ pub struct TriStripRequest<'input> {
     pub mask_format: Pictformat,
     pub src_x: i16,
     pub src_y: i16,
-    pub points: &'input [Pointfix],
+    pub points: Cow<'input, [Pointfix]>,
 }
 impl<'input> TriStripRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3045,7 +3047,7 @@ where
         mask_format,
         src_x,
         src_y,
-        points,
+        points: Cow::Borrowed(points),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3062,7 +3064,7 @@ pub struct TriFanRequest<'input> {
     pub mask_format: Pictformat,
     pub src_x: i16,
     pub src_y: i16,
-    pub points: &'input [Pointfix],
+    pub points: Cow<'input, [Pointfix]>,
 }
 impl<'input> TriFanRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3127,7 +3129,7 @@ where
         mask_format,
         src_x,
         src_y,
-        points,
+        points: Cow::Borrowed(points),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3288,8 +3290,8 @@ pub const ADD_GLYPHS_REQUEST: u8 = 20;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddGlyphsRequest<'input> {
     pub glyphset: Glyphset,
-    pub glyphids: &'input [u32],
-    pub glyphs: &'input [Glyphinfo],
+    pub glyphids: Cow<'input, [u32]>,
+    pub glyphs: Cow<'input, [Glyphinfo]>,
     pub data: &'input [u8],
 }
 impl<'input> AddGlyphsRequest<'input> {
@@ -3324,13 +3326,13 @@ impl<'input> AddGlyphsRequest<'input> {
         assert_eq!(self.glyphs.len(), usize::try_from(glyphs_len).unwrap(), "`glyphs` has an incorrect length");
         let glyphs_bytes = self.glyphs.serialize();
         let length_so_far = length_so_far + glyphs_bytes.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), glyphids_bytes.into(), glyphs_bytes.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), glyphids_bytes.into(), glyphs_bytes.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn add_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphids: &'input [u32], glyphs: &'input [Glyphinfo], data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3339,8 +3341,8 @@ where
 {
     let request0 = AddGlyphsRequest {
         glyphset,
-        glyphids,
-        glyphs,
+        glyphids: Cow::Borrowed(glyphids),
+        glyphs: Cow::Borrowed(glyphs),
         data,
     };
     let (bytes, fds) = request0.serialize(conn)?;
@@ -3353,7 +3355,7 @@ pub const FREE_GLYPHS_REQUEST: u8 = 22;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FreeGlyphsRequest<'input> {
     pub glyphset: Glyphset,
-    pub glyphs: &'input [Glyph],
+    pub glyphs: Cow<'input, [Glyph]>,
 }
 impl<'input> FreeGlyphsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3392,7 +3394,7 @@ where
 {
     let request0 = FreeGlyphsRequest {
         glyphset,
-        glyphs,
+        glyphs: Cow::Borrowed(glyphs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -3459,13 +3461,13 @@ impl<'input> CompositeGlyphs8Request<'input> {
             src_y_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.glyphcmds[..]).len();
+        let length_so_far = length_so_far + self.glyphcmds.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.glyphcmds.into(), padding0.into()], vec![]))
     }
 }
 pub fn composite_glyphs8<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3547,13 +3549,13 @@ impl<'input> CompositeGlyphs16Request<'input> {
             src_y_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.glyphcmds[..]).len();
+        let length_so_far = length_so_far + self.glyphcmds.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.glyphcmds.into(), padding0.into()], vec![]))
     }
 }
 pub fn composite_glyphs16<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3635,13 +3637,13 @@ impl<'input> CompositeGlyphs32Request<'input> {
             src_y_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.glyphcmds[..]).len();
+        let length_so_far = length_so_far + self.glyphcmds.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.glyphcmds[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.glyphcmds.into(), padding0.into()], vec![]))
     }
 }
 pub fn composite_glyphs32<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -3670,7 +3672,7 @@ pub struct FillRectanglesRequest<'input> {
     pub op: PictOp,
     pub dst: Picture,
     pub color: Color,
-    pub rects: &'input [xproto::Rectangle],
+    pub rects: Cow<'input, [xproto::Rectangle]>,
 }
 impl<'input> FillRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3725,7 +3727,7 @@ where
         op,
         dst,
         color,
-        rects,
+        rects: Cow::Borrowed(rects),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4085,7 +4087,7 @@ pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
 pub struct SetPictureFilterRequest<'input> {
     pub picture: Picture,
     pub filter: &'input [u8],
-    pub values: &'input [Fixed],
+    pub values: Cow<'input, [Fixed]>,
 }
 impl<'input> SetPictureFilterRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4114,7 +4116,7 @@ impl<'input> SetPictureFilterRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.filter[..]).len();
+        let length_so_far = length_so_far + self.filter.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         let values_bytes = self.values.serialize();
@@ -4124,7 +4126,7 @@ impl<'input> SetPictureFilterRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.filter[..]).into(), padding0.into(), values_bytes.into(), padding1.into()], vec![]))
+        Ok((vec![request0.into(), self.filter.into(), padding0.into(), values_bytes.into(), padding1.into()], vec![]))
     }
 }
 pub fn set_picture_filter<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, filter: &'input [u8], values: &'input [Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -4134,7 +4136,7 @@ where
     let request0 = SetPictureFilterRequest {
         picture,
         filter,
-        values,
+        values: Cow::Borrowed(values),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4188,7 +4190,7 @@ pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateAnimCursorRequest<'input> {
     pub cid: xproto::Cursor,
-    pub cursors: &'input [Animcursorelt],
+    pub cursors: Cow<'input, [Animcursorelt]>,
 }
 impl<'input> CreateAnimCursorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4227,7 +4229,7 @@ where
 {
     let request0 = CreateAnimCursorRequest {
         cid,
-        cursors,
+        cursors: Cow::Borrowed(cursors),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4349,7 +4351,7 @@ pub struct AddTrapsRequest<'input> {
     pub picture: Picture,
     pub x_off: i16,
     pub y_off: i16,
-    pub traps: &'input [Trap],
+    pub traps: Cow<'input, [Trap]>,
 }
 impl<'input> AddTrapsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4396,7 +4398,7 @@ where
         picture,
         x_off,
         y_off,
-        traps,
+        traps: Cow::Borrowed(traps),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4466,8 +4468,8 @@ pub struct CreateLinearGradientRequest<'input> {
     pub picture: Picture,
     pub p1: Pointfix,
     pub p2: Pointfix,
-    pub stops: &'input [Fixed],
-    pub colors: &'input [Color],
+    pub stops: Cow<'input, [Fixed]>,
+    pub colors: Cow<'input, [Color]>,
 }
 impl<'input> CreateLinearGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4535,8 +4537,8 @@ where
         picture,
         p1,
         p2,
-        stops,
-        colors,
+        stops: Cow::Borrowed(stops),
+        colors: Cow::Borrowed(colors),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4552,8 +4554,8 @@ pub struct CreateRadialGradientRequest<'input> {
     pub outer: Pointfix,
     pub inner_radius: Fixed,
     pub outer_radius: Fixed,
-    pub stops: &'input [Fixed],
-    pub colors: &'input [Color],
+    pub stops: Cow<'input, [Fixed]>,
+    pub colors: Cow<'input, [Color]>,
 }
 impl<'input> CreateRadialGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4633,8 +4635,8 @@ where
         outer,
         inner_radius,
         outer_radius,
-        stops,
-        colors,
+        stops: Cow::Borrowed(stops),
+        colors: Cow::Borrowed(colors),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4648,8 +4650,8 @@ pub struct CreateConicalGradientRequest<'input> {
     pub picture: Picture,
     pub center: Pointfix,
     pub angle: Fixed,
-    pub stops: &'input [Fixed],
-    pub colors: &'input [Color],
+    pub stops: Cow<'input, [Fixed]>,
+    pub colors: Cow<'input, [Color]>,
 }
 impl<'input> CreateConicalGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4713,8 +4715,8 @@ where
         picture,
         center,
         angle,
-        stops,
-        colors,
+        stops: Cow::Borrowed(stops),
+        colors: Cow::Borrowed(colors),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -745,7 +747,7 @@ impl TryFrom<&[u8]> for QueryClientPixmapBytesReply {
 pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryClientIdsRequest<'input> {
-    pub specs: &'input [ClientIdSpec],
+    pub specs: Cow<'input, [ClientIdSpec]>,
 }
 impl<'input> QueryClientIdsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -784,7 +786,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = QueryClientIdsRequest {
-        specs,
+        specs: Cow::Borrowed(specs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -838,7 +840,7 @@ pub const QUERY_RESOURCE_BYTES_REQUEST: u8 = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryResourceBytesRequest<'input> {
     pub client: u32,
-    pub specs: &'input [ResourceIdSpec],
+    pub specs: Cow<'input, [ResourceIdSpec]>,
 }
 impl<'input> QueryResourceBytesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -883,7 +885,7 @@ where
 {
     let request0 = QueryResourceBytesRequest {
         client,
-        specs,
+        specs: Cow::Borrowed(specs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -649,7 +651,7 @@ impl SetAttributesAux {
 
 /// Opcode for the SetAttributes request
 pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetAttributesRequest<'input> {
     pub drawable: xproto::Drawable,
     pub x: i16,
@@ -660,7 +662,7 @@ pub struct SetAttributesRequest<'input> {
     pub class: xproto::WindowClass,
     pub depth: u8,
     pub visual: xproto::Visualid,
-    pub value_list: &'input SetAttributesAux,
+    pub value_list: Cow<'input, SetAttributesAux>,
 }
 impl<'input> SetAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -737,7 +739,7 @@ where
         class,
         depth,
         visual,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -339,7 +341,7 @@ pub struct RectanglesRequest<'input> {
     pub destination_window: xproto::Window,
     pub x_offset: i16,
     pub y_offset: i16,
-    pub rectangles: &'input [xproto::Rectangle],
+    pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
 impl<'input> RectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -396,7 +398,7 @@ where
         destination_window,
         x_offset,
         y_offset,
-        rectangles,
+        rectangles: Cow::Borrowed(rectangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -1035,7 +1037,7 @@ impl TryFrom<&[u8]> for QueryCounterReply {
 pub const AWAIT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AwaitRequest<'input> {
-    pub wait_list: &'input [Waitcondition],
+    pub wait_list: Cow<'input, [Waitcondition]>,
 }
 impl<'input> AwaitRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1068,7 +1070,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AwaitRequest {
-        wait_list,
+        wait_list: Cow::Borrowed(wait_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1288,10 +1290,10 @@ impl CreateAlarmAux {
 
 /// Opcode for the CreateAlarm request
 pub const CREATE_ALARM_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateAlarmRequest<'input> {
     pub id: Alarm,
-    pub value_list: &'input CreateAlarmAux,
+    pub value_list: Cow<'input, CreateAlarmAux>,
 }
 impl<'input> CreateAlarmRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1336,7 +1338,7 @@ where
 {
     let request0 = CreateAlarmRequest {
         id,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1444,10 +1446,10 @@ impl ChangeAlarmAux {
 
 /// Opcode for the ChangeAlarm request
 pub const CHANGE_ALARM_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeAlarmRequest<'input> {
     pub id: Alarm,
-    pub value_list: &'input ChangeAlarmAux,
+    pub value_list: Cow<'input, ChangeAlarmAux>,
 }
 impl<'input> ChangeAlarmRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1492,7 +1494,7 @@ where
 {
     let request0 = ChangeAlarmRequest {
         id,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2013,7 +2015,7 @@ impl TryFrom<&[u8]> for QueryFenceReply {
 pub const AWAIT_FENCE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AwaitFenceRequest<'input> {
-    pub fence_list: &'input [Fence],
+    pub fence_list: Cow<'input, [Fence]>,
 }
 impl<'input> AwaitFenceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2046,7 +2048,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = AwaitFenceRequest {
-        fence_list,
+        fence_list: Cow::Borrowed(fence_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -629,13 +631,13 @@ impl<'input> ModModeLineRequest<'input> {
             privsize_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.private[..]).len();
+        let length_so_far = length_so_far + self.private.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.private[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.private.into(), padding0.into()], vec![]))
     }
 }
 pub fn mod_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1144,13 +1146,13 @@ impl<'input> AddModeLineRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.private[..]).len();
+        let length_so_far = length_so_far + self.private.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.private[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.private.into(), padding0.into()], vec![]))
     }
 }
 pub fn add_mode_line<'c, 'input, Conn, A, B>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1288,13 +1290,13 @@ impl<'input> DeleteModeLineRequest<'input> {
             privsize_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.private[..]).len();
+        let length_so_far = length_so_far + self.private.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.private[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.private.into(), padding0.into()], vec![]))
     }
 }
 pub fn delete_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1419,13 +1421,13 @@ impl<'input> ValidateModeLineRequest<'input> {
             privsize_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.private[..]).len();
+        let length_so_far = length_so_far + self.private.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.private[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.private.into(), padding0.into()], vec![]))
     }
 }
 pub fn validate_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
@@ -1576,13 +1578,13 @@ impl<'input> SwitchToModeRequest<'input> {
             privsize_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.private[..]).len();
+        let length_so_far = length_so_far + self.private.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.private[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.private.into(), padding0.into()], vec![]))
     }
 }
 pub fn switch_to_mode<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2131,9 +2133,9 @@ pub const SET_GAMMA_RAMP_REQUEST: u8 = 18;
 pub struct SetGammaRampRequest<'input> {
     pub screen: u16,
     pub size: u16,
-    pub red: &'input [u16],
-    pub green: &'input [u16],
-    pub blue: &'input [u16],
+    pub red: Cow<'input, [u16]>,
+    pub green: Cow<'input, [u16]>,
+    pub blue: Cow<'input, [u16]>,
 }
 impl<'input> SetGammaRampRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2181,9 +2183,9 @@ where
     let request0 = SetGammaRampRequest {
         screen,
         size,
-        red,
-        green,
-        blue,
+        red: Cow::Borrowed(red),
+        green: Cow::Borrowed(green),
+        blue: Cow::Borrowed(blue),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -1132,7 +1134,7 @@ pub const CREATE_REGION_REQUEST: u8 = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateRegionRequest<'input> {
     pub region: Region,
-    pub rectangles: &'input [xproto::Rectangle],
+    pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
 impl<'input> CreateRegionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1171,7 +1173,7 @@ where
 {
     let request0 = CreateRegionRequest {
         region,
-        rectangles,
+        rectangles: Cow::Borrowed(rectangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1443,7 +1445,7 @@ pub const SET_REGION_REQUEST: u8 = 11;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetRegionRequest<'input> {
     pub region: Region,
-    pub rectangles: &'input [xproto::Rectangle],
+    pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
 impl<'input> SetRegionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1482,7 +1484,7 @@ where
 {
     let request0 = SetRegionRequest {
         region,
-        rectangles,
+        rectangles: Cow::Borrowed(rectangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2209,13 +2211,13 @@ impl<'input> SetCursorNameRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_cursor_name<'c, 'input, Conn>(conn: &'c Conn, cursor: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2504,13 +2506,13 @@ impl<'input> ChangeCursorByNameRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_cursor_by_name<'c, 'input, Conn>(conn: &'c Conn, src: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -2770,7 +2772,7 @@ pub struct CreatePointerBarrierRequest<'input> {
     pub x2: u16,
     pub y2: u16,
     pub directions: u32,
-    pub devices: &'input [u16],
+    pub devices: Cow<'input, [u16]>,
 }
 impl<'input> CreatePointerBarrierRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2845,7 +2847,7 @@ where
         x2,
         y2,
         directions,
-        devices,
+        devices: Cow::Borrowed(devices),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -112,13 +114,13 @@ impl<'input> GetExtensionVersionRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn get_extension_version<'c, 'input, Conn>(conn: &'c Conn, name: &'input [u8]) -> Result<Cookie<'c, Conn, GetExtensionVersionReply>, ConnectionError>
@@ -1288,7 +1290,7 @@ pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectExtensionEventRequest<'input> {
     pub window: xproto::Window,
-    pub classes: &'input [EventClass],
+    pub classes: Cow<'input, [EventClass]>,
 }
 impl<'input> SelectExtensionEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1333,7 +1335,7 @@ where
 {
     let request0 = SelectExtensionEventRequest {
         window,
-        classes,
+        classes: Cow::Borrowed(classes),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1520,7 +1522,7 @@ pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
 pub struct ChangeDeviceDontPropagateListRequest<'input> {
     pub window: xproto::Window,
     pub mode: PropagateMode,
-    pub classes: &'input [EventClass],
+    pub classes: Cow<'input, [EventClass]>,
 }
 impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1567,7 +1569,7 @@ where
     let request0 = ChangeDeviceDontPropagateListRequest {
         window,
         mode,
-        classes,
+        classes: Cow::Borrowed(classes),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -1968,7 +1970,7 @@ pub struct GrabDeviceRequest<'input> {
     pub other_device_mode: xproto::GrabMode,
     pub owner_events: bool,
     pub device_id: u8,
-    pub classes: &'input [EventClass],
+    pub classes: Cow<'input, [EventClass]>,
 }
 impl<'input> GrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2033,7 +2035,7 @@ where
         other_device_mode,
         owner_events,
         device_id,
-        classes,
+        classes: Cow::Borrowed(classes),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2193,7 +2195,7 @@ pub struct GrabDeviceKeyRequest<'input> {
     pub this_device_mode: xproto::GrabMode,
     pub other_device_mode: xproto::GrabMode,
     pub owner_events: bool,
-    pub classes: &'input [EventClass],
+    pub classes: Cow<'input, [EventClass]>,
 }
 impl<'input> GrabDeviceKeyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2266,7 +2268,7 @@ where
         this_device_mode,
         other_device_mode,
         owner_events,
-        classes,
+        classes: Cow::Borrowed(classes),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -2356,7 +2358,7 @@ pub struct GrabDeviceButtonRequest<'input> {
     pub other_device_mode: xproto::GrabMode,
     pub button: u8,
     pub owner_events: bool,
-    pub classes: &'input [EventClass],
+    pub classes: Cow<'input, [EventClass]>,
 }
 impl<'input> GrabDeviceButtonRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2429,7 +2431,7 @@ where
         other_device_mode,
         button,
         owner_events,
-        classes,
+        classes: Cow::Borrowed(classes),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -4962,7 +4964,7 @@ pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub first_keycode: KeyCode,
     pub keysyms_per_keycode: u8,
     pub keycode_count: u8,
-    pub keysyms: &'input [xproto::Keysym],
+    pub keysyms: Cow<'input, [xproto::Keysym]>,
 }
 impl<'input> ChangeDeviceKeyMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -5008,7 +5010,7 @@ where
         first_keycode,
         keysyms_per_keycode,
         keycode_count,
-        keysyms,
+        keysyms: Cow::Borrowed(keysyms),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -5136,13 +5138,13 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.keymaps[..]).len();
+        let length_so_far = length_so_far + self.keymaps.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.keymaps[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.keymaps.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, keymaps: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceModifierMappingReply>, ConnectionError>
@@ -5310,13 +5312,13 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.map[..]).len();
+        let length_so_far = length_so_far + self.map.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.map[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.map.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_button_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceButtonMappingReply>, ConnectionError>
@@ -6095,7 +6097,7 @@ pub const SET_DEVICE_VALUATORS_REQUEST: u8 = 33;
 pub struct SetDeviceValuatorsRequest<'input> {
     pub device_id: u8,
     pub first_valuator: u8,
-    pub valuators: &'input [i32],
+    pub valuators: Cow<'input, [i32]>,
 }
 impl<'input> SetDeviceValuatorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6138,7 +6140,7 @@ where
     let request0 = SetDeviceValuatorsRequest {
         device_id,
         first_valuator,
-        valuators,
+        valuators: Cow::Borrowed(valuators),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8137,7 +8139,7 @@ pub struct ChangeDevicePropertyRequest<'input> {
     pub device_id: u8,
     pub mode: xproto::PropMode,
     pub num_items: u32,
-    pub items: &'input ChangeDevicePropertyAux,
+    pub items: Cow<'input, ChangeDevicePropertyAux>,
 }
 impl<'input> ChangeDevicePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -8198,7 +8200,7 @@ where
         device_id,
         mode,
         num_items,
-        items,
+        items: Cow::Borrowed(items),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9570,7 +9572,7 @@ impl Serialize for HierarchyChange {
 pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIChangeHierarchyRequest<'input> {
-    pub changes: &'input [HierarchyChange],
+    pub changes: Cow<'input, [HierarchyChange]>,
 }
 impl<'input> XIChangeHierarchyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9609,7 +9611,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XIChangeHierarchyRequest {
-        changes,
+        changes: Cow::Borrowed(changes),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9903,7 +9905,7 @@ pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XISelectEventsRequest<'input> {
     pub window: xproto::Window,
-    pub masks: &'input [EventMask],
+    pub masks: Cow<'input, [EventMask]>,
 }
 impl<'input> XISelectEventsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9948,7 +9950,7 @@ where
 {
     let request0 = XISelectEventsRequest {
         window,
-        masks,
+        masks: Cow::Borrowed(masks),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -11564,7 +11566,7 @@ pub struct XIGrabDeviceRequest<'input> {
     pub mode: xproto::GrabMode,
     pub paired_device_mode: xproto::GrabMode,
     pub owner_events: GrabOwner,
-    pub mask: &'input [u32],
+    pub mask: Cow<'input, [u32]>,
 }
 impl<'input> XIGrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -11637,7 +11639,7 @@ where
         mode,
         paired_device_mode,
         owner_events,
-        mask,
+        mask: Cow::Borrowed(mask),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12102,8 +12104,8 @@ pub struct XIPassiveGrabDeviceRequest<'input> {
     pub grab_mode: GrabMode22,
     pub paired_device_mode: xproto::GrabMode,
     pub owner_events: GrabOwner,
-    pub mask: &'input [u32],
-    pub modifiers: &'input [u32],
+    pub mask: Cow<'input, [u32]>,
+    pub modifiers: Cow<'input, [u32]>,
 }
 impl<'input> XIPassiveGrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -12192,8 +12194,8 @@ where
         grab_mode,
         paired_device_mode,
         owner_events,
-        mask,
-        modifiers,
+        mask: Cow::Borrowed(mask),
+        modifiers: Cow::Borrowed(modifiers),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12250,7 +12252,7 @@ pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub detail: u32,
     pub deviceid: DeviceId,
     pub grab_type: GrabType,
-    pub modifiers: &'input [u32],
+    pub modifiers: Cow<'input, [u32]>,
 }
 impl<'input> XIPassiveUngrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -12311,7 +12313,7 @@ where
         detail,
         deviceid,
         grab_type,
-        modifiers,
+        modifiers: Cow::Borrowed(modifiers),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12478,7 +12480,7 @@ pub struct XIChangePropertyRequest<'input> {
     pub property: xproto::Atom,
     pub type_: xproto::Atom,
     pub num_items: u32,
-    pub items: &'input XIChangePropertyAux,
+    pub items: Cow<'input, XIChangePropertyAux>,
 }
 impl<'input> XIChangePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -12541,7 +12543,7 @@ where
         property,
         type_,
         num_items,
-        items,
+        items: Cow::Borrowed(items),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -12926,7 +12928,7 @@ impl Serialize for BarrierReleasePointerInfo {
 pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XIBarrierReleasePointerRequest<'input> {
-    pub barriers: &'input [BarrierReleasePointerInfo],
+    pub barriers: Cow<'input, [BarrierReleasePointerInfo]>,
 }
 impl<'input> XIBarrierReleasePointerRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -12965,7 +12967,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = XIBarrierReleasePointerRequest {
-        barriers,
+        barriers: Cow::Borrowed(barriers),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15834,8 +15836,8 @@ pub struct SendExtensionEventRequest<'input> {
     pub destination: xproto::Window,
     pub device_id: u8,
     pub propagate: bool,
-    pub events: &'input [EventForSend],
-    pub classes: &'input [EventClass],
+    pub events: Cow<'input, [EventForSend]>,
+    pub classes: Cow<'input, [EventClass]>,
 }
 impl<'input> SendExtensionEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -15892,8 +15894,8 @@ where
         destination,
         device_id,
         propagate,
-        events,
-        classes,
+        events: Cow::Borrowed(events),
+        classes: Cow::Borrowed(classes),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -6805,7 +6807,7 @@ impl SelectEventsAux {
 
 /// Opcode for the SelectEvents request
 pub const SELECT_EVENTS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectEventsRequest<'input> {
     pub device_spec: DeviceSpec,
     pub affect_which: u16,
@@ -6813,7 +6815,7 @@ pub struct SelectEventsRequest<'input> {
     pub select_all: u16,
     pub affect_map: u16,
     pub map: u16,
-    pub details: &'input SelectEventsAux,
+    pub details: Cow<'input, SelectEventsAux>,
 }
 impl<'input> SelectEventsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6880,7 +6882,7 @@ where
         select_all,
         affect_map,
         map,
-        details,
+        details: Cow::Borrowed(details),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7286,7 +7288,7 @@ impl TryFrom<&[u8]> for GetControlsReply {
 
 /// Opcode for the SetControls request
 pub const SET_CONTROLS_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetControlsRequest<'input> {
     pub device_spec: DeviceSpec,
     pub affect_internal_real_mods: u8,
@@ -8006,7 +8008,7 @@ pub struct SetMapRequest<'input> {
     pub n_v_mod_map_keys: u8,
     pub total_v_mod_map_keys: u8,
     pub virtual_mods: u16,
-    pub values: &'input SetMapAux,
+    pub values: Cow<'input, SetMapAux>,
 }
 impl<'input> SetMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -8127,7 +8129,7 @@ where
         n_v_mod_map_keys,
         total_v_mod_map_keys,
         virtual_mods,
-        values,
+        values: Cow::Borrowed(values),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8258,8 +8260,8 @@ pub struct SetCompatMapRequest<'input> {
     pub truncate_si: bool,
     pub groups: u8,
     pub first_si: u16,
-    pub si: &'input [SymInterpret],
-    pub group_maps: &'input [ModDef],
+    pub si: Cow<'input, [SymInterpret]>,
+    pub group_maps: Cow<'input, [ModDef]>,
 }
 impl<'input> SetCompatMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -8321,8 +8323,8 @@ where
         truncate_si,
         groups,
         first_si,
-        si,
-        group_maps,
+        si: Cow::Borrowed(si),
+        group_maps: Cow::Borrowed(group_maps),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8492,7 +8494,7 @@ pub const SET_INDICATOR_MAP_REQUEST: u8 = 14;
 pub struct SetIndicatorMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub which: u32,
-    pub maps: &'input [IndicatorMap],
+    pub maps: Cow<'input, [IndicatorMap]>,
 }
 impl<'input> SetIndicatorMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -8538,7 +8540,7 @@ where
     let request0 = SetIndicatorMapRequest {
         device_spec,
         which,
-        maps,
+        maps: Cow::Borrowed(maps),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -9289,7 +9291,7 @@ pub struct SetNamesRequest<'input> {
     pub n_keys: u8,
     pub n_key_aliases: u8,
     pub total_kt_level_names: u16,
-    pub values: &'input SetNamesAux,
+    pub values: Cow<'input, SetNamesAux>,
 }
 impl<'input> SetNamesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9378,7 +9380,7 @@ where
         n_keys,
         n_key_aliases,
         total_kt_level_names,
-        values,
+        values: Cow::Borrowed(values),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10567,8 +10569,8 @@ pub struct SetDeviceInfoRequest<'input> {
     pub device_spec: DeviceSpec,
     pub first_btn: u8,
     pub change: u16,
-    pub btn_actions: &'input [Action],
-    pub leds: &'input [DeviceLedInfo],
+    pub btn_actions: Cow<'input, [Action]>,
+    pub leds: Cow<'input, [DeviceLedInfo]>,
 }
 impl<'input> SetDeviceInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -10623,8 +10625,8 @@ where
         device_spec,
         first_btn,
         change,
-        btn_actions,
-        leds,
+        btn_actions: Cow::Borrowed(btn_actions),
+        leds: Cow::Borrowed(leds),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -10683,13 +10685,13 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
             ctrls_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.message[..]).len();
+        let length_so_far = length_so_far + self.message.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.message[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.message.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_debugging_flags<'c, 'input, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &'input [String8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -501,14 +503,14 @@ impl<'input> PrintGetPrinterListRequest<'input> {
             locale_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.printer_name[..]).len();
-        let length_so_far = length_so_far + (&self.locale[..]).len();
+        let length_so_far = length_so_far + self.printer_name.len();
+        let length_so_far = length_so_far + self.locale.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.printer_name[..]).into(), (&self.locale[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.printer_name.into(), self.locale.into(), padding0.into()], vec![]))
     }
 }
 pub fn print_get_printer_list<'c, 'input, Conn>(conn: &'c Conn, printer_name: &'input [String8], locale: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetPrinterListReply>, ConnectionError>
@@ -643,14 +645,14 @@ impl<'input> CreateContextRequest<'input> {
             locale_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.printer_name[..]).len();
-        let length_so_far = length_so_far + (&self.locale[..]).len();
+        let length_so_far = length_so_far + self.printer_name.len();
+        let length_so_far = length_so_far + self.locale.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.printer_name[..]).into(), (&self.locale[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.printer_name.into(), self.locale.into(), padding0.into()], vec![]))
     }
 }
 pub fn create_context<'c, 'input, Conn>(conn: &'c Conn, context_id: u32, printer_name: &'input [String8], locale: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1103,15 +1105,15 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
             len_options_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
-        let length_so_far = length_so_far + (&self.doc_format[..]).len();
-        let length_so_far = length_so_far + (&self.options[..]).len();
+        let length_so_far = length_so_far + self.data.len();
+        let length_so_far = length_so_far + self.doc_format.len();
+        let length_so_far = length_so_far + self.options.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), (&self.doc_format[..]).into(), (&self.options[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), self.doc_format.into(), self.options.into(), padding0.into()], vec![]))
     }
 }
 pub fn print_put_document_data<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, data: &'input [u8], doc_format: &'input [String8], options: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1577,13 +1579,13 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn print_get_one_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, pool: u8, name: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetOneAttributesReply>, ConnectionError>
@@ -1685,13 +1687,13 @@ impl<'input> PrintSetAttributesRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.attributes[..]).len();
+        let length_so_far = length_so_far + self.attributes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.attributes[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.attributes.into(), padding0.into()], vec![]))
     }
 }
 pub fn print_set_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -13,6 +13,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -6013,7 +6015,7 @@ pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// * `xcb_generate_id`: function
 /// * `MapWindow`: request
 /// * `CreateNotify`: event
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateWindowRequest<'input> {
     pub depth: u8,
     pub wid: Window,
@@ -6025,7 +6027,7 @@ pub struct CreateWindowRequest<'input> {
     pub border_width: u16,
     pub class: WindowClass,
     pub visual: Visualid,
-    pub value_list: &'input CreateWindowAux,
+    pub value_list: Cow<'input, CreateWindowAux>,
 }
 impl<'input> CreateWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6161,7 +6163,7 @@ where
         border_width,
         class,
         visual,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -6398,10 +6400,10 @@ pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// * `Pixmap` - TODO: reasons?
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeWindowAttributesRequest<'input> {
     pub window: Window,
-    pub value_list: &'input ChangeWindowAttributesAux,
+    pub value_list: Cow<'input, ChangeWindowAttributesAux>,
 }
 impl<'input> ChangeWindowAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6466,7 +6468,7 @@ where
 {
     let request0 = ChangeWindowAttributesRequest {
         window,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -7699,10 +7701,10 @@ pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 ///     xcb_flush(c);
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConfigureWindowRequest<'input> {
     pub window: Window,
-    pub value_list: &'input ConfigureWindowAux,
+    pub value_list: Cow<'input, ConfigureWindowAux>,
 }
 impl<'input> ConfigureWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -7796,7 +7798,7 @@ where
 {
     let request0 = ConfigureWindowRequest {
         window,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -8363,13 +8365,13 @@ impl<'input> InternAtomRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 /// Get atom identifier by name.
@@ -8721,13 +8723,13 @@ impl<'input> ChangePropertyRequest<'input> {
         ];
         let length_so_far = length_so_far + request0.len();
         assert_eq!(self.data.len(), usize::try_from(self.data_len.checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 /// Changes a window property.
@@ -9868,7 +9870,7 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 ///     free(event);
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendEventRequest<'input> {
     pub propagate: bool,
     pub destination: Window,
@@ -12797,13 +12799,13 @@ impl<'input> OpenFontRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 /// opens a font.
@@ -13248,7 +13250,7 @@ pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryTextExtentsRequest<'input> {
     pub font: Fontable,
-    pub string: &'input [Char2b],
+    pub string: Cow<'input, [Char2b]>,
 }
 impl<'input> QueryTextExtentsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -13323,7 +13325,7 @@ where
 {
     let request0 = QueryTextExtentsRequest {
         font,
-        string,
+        string: Cow::Borrowed(string),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -13459,13 +13461,13 @@ impl<'input> ListFontsRequest<'input> {
             pattern_len_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.pattern[..]).len();
+        let length_so_far = length_so_far + self.pattern.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.pattern[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.pattern.into(), padding0.into()], vec![]))
     }
 }
 /// get matching font names.
@@ -13581,13 +13583,13 @@ impl<'input> ListFontsWithInfoRequest<'input> {
             pattern_len_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.pattern[..]).len();
+        let length_so_far = length_so_far + self.pattern.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.pattern[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.pattern.into(), padding0.into()], vec![]))
     }
 }
 /// get matching font names and information.
@@ -13720,7 +13722,7 @@ impl ListFontsWithInfoReply {
 pub const SET_FONT_PATH_REQUEST: u8 = 51;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetFontPathRequest<'input> {
-    pub font: &'input [Str],
+    pub font: Cow<'input, [Str]>,
 }
 impl<'input> SetFontPathRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -13758,7 +13760,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = SetFontPathRequest {
-        font,
+        font: Cow::Borrowed(font),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15124,11 +15126,11 @@ pub const CREATE_GC_REQUEST: u8 = 55;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateGCRequest<'input> {
     pub cid: Gcontext,
     pub drawable: Drawable,
-    pub value_list: &'input CreateGCAux,
+    pub value_list: Cow<'input, CreateGCAux>,
 }
 impl<'input> CreateGCRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -15201,7 +15203,7 @@ where
     let request0 = CreateGCRequest {
         cid,
         drawable,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15558,10 +15560,10 @@ pub const CHANGE_GC_REQUEST: u8 = 56;
 ///     xcb_flush(conn);
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeGCRequest<'input> {
     pub gc: Gcontext,
-    pub value_list: &'input ChangeGCAux,
+    pub value_list: Cow<'input, ChangeGCAux>,
 }
 impl<'input> ChangeGCRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -15650,7 +15652,7 @@ where
 {
     let request0 = ChangeGCRequest {
         gc,
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -15752,13 +15754,13 @@ impl<'input> SetDashesRequest<'input> {
             dashes_len_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.dashes[..]).len();
+        let length_so_far = length_so_far + self.dashes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.dashes[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.dashes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_dashes<'c, 'input, Conn>(conn: &'c Conn, gc: Gcontext, dash_offset: u16, dashes: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -15851,7 +15853,7 @@ pub struct SetClipRectanglesRequest<'input> {
     pub gc: Gcontext,
     pub clip_x_origin: i16,
     pub clip_y_origin: i16,
-    pub rectangles: &'input [Rectangle],
+    pub rectangles: Cow<'input, [Rectangle]>,
 }
 impl<'input> SetClipRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -15899,7 +15901,7 @@ where
         gc,
         clip_x_origin,
         clip_y_origin,
-        rectangles,
+        rectangles: Cow::Borrowed(rectangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16345,7 +16347,7 @@ pub struct PolyPointRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
     pub gc: Gcontext,
-    pub points: &'input [Point],
+    pub points: Cow<'input, [Point]>,
 }
 impl<'input> PolyPointRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -16391,7 +16393,7 @@ where
         coordinate_mode,
         drawable,
         gc,
-        points,
+        points: Cow::Borrowed(points),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16444,7 +16446,7 @@ pub struct PolyLineRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
     pub gc: Gcontext,
-    pub points: &'input [Point],
+    pub points: Cow<'input, [Point]>,
 }
 impl<'input> PolyLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -16529,7 +16531,7 @@ where
         coordinate_mode,
         drawable,
         gc,
-        points,
+        points: Cow::Borrowed(points),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16618,7 +16620,7 @@ pub const POLY_SEGMENT_REQUEST: u8 = 66;
 pub struct PolySegmentRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
-    pub segments: &'input [Segment],
+    pub segments: Cow<'input, [Segment]>,
 }
 impl<'input> PolySegmentRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -16688,7 +16690,7 @@ where
     let request0 = PolySegmentRequest {
         drawable,
         gc,
-        segments,
+        segments: Cow::Borrowed(segments),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16701,7 +16703,7 @@ pub const POLY_RECTANGLE_REQUEST: u8 = 67;
 pub struct PolyRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
-    pub rectangles: &'input [Rectangle],
+    pub rectangles: Cow<'input, [Rectangle]>,
 }
 impl<'input> PolyRectangleRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -16745,7 +16747,7 @@ where
     let request0 = PolyRectangleRequest {
         drawable,
         gc,
-        rectangles,
+        rectangles: Cow::Borrowed(rectangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16758,7 +16760,7 @@ pub const POLY_ARC_REQUEST: u8 = 68;
 pub struct PolyArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
-    pub arcs: &'input [Arc],
+    pub arcs: Cow<'input, [Arc]>,
 }
 impl<'input> PolyArcRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -16802,7 +16804,7 @@ where
     let request0 = PolyArcRequest {
         drawable,
         gc,
-        arcs,
+        arcs: Cow::Borrowed(arcs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16882,7 +16884,7 @@ pub struct FillPolyRequest<'input> {
     pub gc: Gcontext,
     pub shape: PolyShape,
     pub coordinate_mode: CoordMode,
-    pub points: &'input [Point],
+    pub points: Cow<'input, [Point]>,
 }
 impl<'input> FillPolyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -16934,7 +16936,7 @@ where
         gc,
         shape,
         coordinate_mode,
-        points,
+        points: Cow::Borrowed(points),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -16972,7 +16974,7 @@ pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 pub struct PolyFillRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
-    pub rectangles: &'input [Rectangle],
+    pub rectangles: Cow<'input, [Rectangle]>,
 }
 impl<'input> PolyFillRectangleRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -17041,7 +17043,7 @@ where
     let request0 = PolyFillRectangleRequest {
         drawable,
         gc,
-        rectangles,
+        rectangles: Cow::Borrowed(rectangles),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17054,7 +17056,7 @@ pub const POLY_FILL_ARC_REQUEST: u8 = 71;
 pub struct PolyFillArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
-    pub arcs: &'input [Arc],
+    pub arcs: Cow<'input, [Arc]>,
 }
 impl<'input> PolyFillArcRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -17098,7 +17100,7 @@ where
     let request0 = PolyFillArcRequest {
         drawable,
         gc,
-        arcs,
+        arcs: Cow::Borrowed(arcs),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -17229,13 +17231,13 @@ impl<'input> PutImageRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -17419,13 +17421,13 @@ impl<'input> PolyText8Request<'input> {
             y_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.items[..]).len();
+        let length_so_far = length_so_far + self.items.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.items[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.items.into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_text8<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -17485,13 +17487,13 @@ impl<'input> PolyText16Request<'input> {
             y_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.items[..]).len();
+        let length_so_far = length_so_far + self.items.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.items[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.items.into(), padding0.into()], vec![]))
     }
 }
 pub fn poly_text16<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -17587,13 +17589,13 @@ impl<'input> ImageText8Request<'input> {
             y_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.string[..]).len();
+        let length_so_far = length_so_far + self.string.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.string[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.string.into(), padding0.into()], vec![]))
     }
 }
 /// Draws text.
@@ -17689,7 +17691,7 @@ pub struct ImageText16Request<'input> {
     pub gc: Gcontext,
     pub x: i16,
     pub y: i16,
-    pub string: &'input [Char2b],
+    pub string: Cow<'input, [Char2b]>,
 }
 impl<'input> ImageText16Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -17778,7 +17780,7 @@ where
         gc,
         x,
         y,
-        string,
+        string: Cow::Borrowed(string),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18347,13 +18349,13 @@ impl<'input> AllocNamedColorRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn alloc_named_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
@@ -18643,7 +18645,7 @@ pub const FREE_COLORS_REQUEST: u8 = 88;
 pub struct FreeColorsRequest<'input> {
     pub cmap: Colormap,
     pub plane_mask: u32,
-    pub pixels: &'input [u32],
+    pub pixels: Cow<'input, [u32]>,
 }
 impl<'input> FreeColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -18687,7 +18689,7 @@ where
     let request0 = FreeColorsRequest {
         cmap,
         plane_mask,
-        pixels,
+        pixels: Cow::Borrowed(pixels),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18825,7 +18827,7 @@ pub const STORE_COLORS_REQUEST: u8 = 89;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoreColorsRequest<'input> {
     pub cmap: Colormap,
-    pub items: &'input [Coloritem],
+    pub items: Cow<'input, [Coloritem]>,
 }
 impl<'input> StoreColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -18863,7 +18865,7 @@ where
 {
     let request0 = StoreColorsRequest {
         cmap,
-        items,
+        items: Cow::Borrowed(items),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -18911,13 +18913,13 @@ impl<'input> StoreNamedColorRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn store_named_color<'c, 'input, Conn, A>(conn: &'c Conn, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -18990,7 +18992,7 @@ pub const QUERY_COLORS_REQUEST: u8 = 91;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryColorsRequest<'input> {
     pub cmap: Colormap,
-    pub pixels: &'input [u32],
+    pub pixels: Cow<'input, [u32]>,
 }
 impl<'input> QueryColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19028,7 +19030,7 @@ where
 {
     let request0 = QueryColorsRequest {
         cmap,
-        pixels,
+        pixels: Cow::Borrowed(pixels),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -19110,13 +19112,13 @@ impl<'input> LookupColorRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 pub fn lookup_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
@@ -19891,13 +19893,13 @@ impl<'input> QueryExtensionRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.name[..]).len();
+        let length_so_far = length_so_far + self.name.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.name[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.name.into(), padding0.into()], vec![]))
     }
 }
 /// check if extension is present.
@@ -20054,7 +20056,7 @@ pub struct ChangeKeyboardMappingRequest<'input> {
     pub keycode_count: u8,
     pub first_keycode: Keycode,
     pub keysyms_per_keycode: u8,
-    pub keysyms: &'input [Keysym],
+    pub keysyms: Cow<'input, [Keysym]>,
 }
 impl<'input> ChangeKeyboardMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -20097,7 +20099,7 @@ where
         keycode_count,
         first_keycode,
         keysyms_per_keycode,
-        keysyms,
+        keysyms: Cow::Borrowed(keysyms),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -20533,9 +20535,9 @@ impl ChangeKeyboardControlAux {
 
 /// Opcode for the ChangeKeyboardControl request
 pub const CHANGE_KEYBOARD_CONTROL_REQUEST: u8 = 102;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangeKeyboardControlRequest<'input> {
-    pub value_list: &'input ChangeKeyboardControlAux,
+    pub value_list: Cow<'input, ChangeKeyboardControlAux>,
 }
 impl<'input> ChangeKeyboardControlRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -20573,7 +20575,7 @@ where
     Conn: RequestConnection + ?Sized,
 {
     let request0 = ChangeKeyboardControlRequest {
-        value_list,
+        value_list: Cow::Borrowed(value_list),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -21247,13 +21249,13 @@ impl<'input> ChangeHostsRequest<'input> {
             address_len_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.address[..]).len();
+        let length_so_far = length_so_far + self.address.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.address[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.address.into(), padding0.into()], vec![]))
     }
 }
 pub fn change_hosts<'c, 'input, Conn>(conn: &'c Conn, mode: HostMode, family: Family, address: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -21774,7 +21776,7 @@ pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
 pub struct RotatePropertiesRequest<'input> {
     pub window: Window,
     pub delta: i16,
-    pub atoms: &'input [Atom],
+    pub atoms: Cow<'input, [Atom]>,
 }
 impl<'input> RotatePropertiesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -21820,7 +21822,7 @@ where
     let request0 = RotatePropertiesRequest {
         window,
         delta,
-        atoms,
+        atoms: Cow::Borrowed(atoms),
     };
     let (bytes, fds) = request0.serialize(conn)?;
     let slices = bytes.iter().map(|b| IoSlice::new(&*b)).collect::<Vec<_>>();
@@ -22025,13 +22027,13 @@ impl<'input> SetPointerMappingRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.map[..]).len();
+        let length_so_far = length_so_far + self.map.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.map[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.map.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_pointer_mapping<'c, 'input, Conn>(conn: &'c Conn, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetPointerMappingReply>, ConnectionError>
@@ -22252,13 +22254,13 @@ impl<'input> SetModifierMappingRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.keycodes[..]).len();
+        let length_so_far = length_so_far + self.keycodes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.keycodes[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.keycodes.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, keycodes: &'input [Keycode]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -136,13 +138,13 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
             context_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.context[..]).len();
+        let length_so_far = length_so_far + self.context.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.context.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -270,13 +272,13 @@ impl<'input> SetDeviceContextRequest<'input> {
             context_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.context[..]).len();
+        let length_so_far = length_so_far + self.context.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.context.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_device_context<'c, 'input, Conn>(conn: &'c Conn, device: u32, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -408,13 +410,13 @@ impl<'input> SetWindowCreateContextRequest<'input> {
             context_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.context[..]).len();
+        let length_so_far = length_so_far + self.context.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.context.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_window_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -707,13 +709,13 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
             context_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.context[..]).len();
+        let length_so_far = length_so_far + self.context.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.context.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_property_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -835,13 +837,13 @@ impl<'input> SetPropertyUseContextRequest<'input> {
             context_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.context[..]).len();
+        let length_so_far = length_so_far + self.context.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.context.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_property_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1240,13 +1242,13 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
             context_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.context[..]).len();
+        let length_so_far = length_so_far + self.context.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.context.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_selection_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
@@ -1368,13 +1370,13 @@ impl<'input> SetSelectionUseContextRequest<'input> {
             context_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.context[..]).len();
+        let length_so_far = length_so_far + self.context.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.context[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.context.into(), padding0.into()], vec![]))
     }
 }
 pub fn set_selection_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;
@@ -3076,13 +3078,13 @@ impl<'input> PutImageRequest<'input> {
             height_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let length_so_far = length_so_far + (&self.data[..]).len();
+        let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), (&self.data[..]).into(), padding0.into()], vec![]))
+        Ok((vec![request0.into(), self.data.into(), padding0.into()], vec![]))
     }
 }
 pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -8,6 +8,8 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::eq_op)]
 
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use std::convert::TryFrom;
 #[allow(unused_imports)]
 use std::convert::TryInto;


### PR DESCRIPTION
When serializing requests, whether or not our data has a lifetime is not that important, because we can just return a Cow from the struct's serialize function. This is the corresponding change for parsing requests. When parsing, values that are generated during parsing must be owned and not borrowed. The only exception to this is raw byte buffers which can remain untouched.

While we're here, remove unnecessary length erasures (i.e. &foo[..]) on &'input [T]s. This is only needed for fixed-length arrays.