### PR TITLE
xcbgen & generator: Remove fxhash and use Rust's default hash function

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -7,6 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fxhash = "0.2.1"
 roxmltree = "0.11.0"
 xcbgen = { path = "../xcbgen-rs" }

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::PathBuf;
-
-use fxhash::FxHashMap;
 
 #[macro_use]
 mod output;
@@ -11,8 +10,8 @@ mod special_cases;
 
 use output::Output;
 
-pub(crate) fn generate(module: &xcbgen::defs::Module) -> FxHashMap<PathBuf, String> {
-    let mut out_map = FxHashMap::default();
+pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String> {
+    let mut out_map = HashMap::new();
 
     let mut main_out = Output::new();
     write_code_header(&mut main_out);
@@ -38,7 +37,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> FxHashMap<PathBuf, Stri
     outln!(main_out, "");
 
     let caches = RefCell::new(namespace::Caches::default());
-    let mut enum_cases = FxHashMap::default();
+    let mut enum_cases = HashMap::new();
     for ns in module.sorted_namespaces() {
         let mut ns_out = Output::new();
         namespace::generate(&ns, &caches, &mut ns_out, &mut enum_cases);

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -3,15 +3,15 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::hash_map::Entry as HashMapEntry;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-use fxhash::{FxHashMap, FxHashSet};
 use xcbgen::defs as xcbdefs;
 
 use super::output::Output;
 use super::{get_ns_name_prefix, special_cases};
 
-type EnumCases = FxHashMap<String, (Vec<String>, Vec<String>)>;
+type EnumCases = HashMap<String, (Vec<String>, Vec<String>)>;
 
 /// Generate a Rust module for namespace `ns`.
 pub(super) fn generate(
@@ -128,9 +128,9 @@ pub(super) fn generate_request_enum(
 /// Caches to avoid repeating some operations.
 #[derive(Default)]
 pub(super) struct Caches {
-    derives: FxHashMap<usize, Derives>,
-    enum_has_repeated_values: FxHashMap<usize, bool>,
-    rust_type_names: FxHashMap<usize, String>,
+    derives: HashMap<usize, Derives>,
+    enum_has_repeated_values: HashMap<usize, bool>,
+    rust_type_names: HashMap<usize, String>,
 }
 
 struct NamespaceGenerator<'ns, 'c> {
@@ -444,7 +444,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn generate_aux(
         &self,
         request_def: &xcbdefs::RequestDef,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         switch_field: &xcbdefs::SwitchField,
         function_name: &str,
         out: &mut Output,
@@ -527,7 +527,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         request_def: &xcbdefs::RequestDef,
         name: &str,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         gathered: &GatheredRequestFields,
         out: &mut Output,
     ) {
@@ -1506,7 +1506,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         name: &str,
         fields: &[xcbdefs::FieldDef],
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         out: &mut Output,
     ) {
         outln!(out, "impl From<&{}> for [u8; 32] {{", name);
@@ -1666,7 +1666,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         });
         outln!(out, "}}");
 
-        let mut seen_field_types = FxHashSet::default();
+        let mut seen_field_types = HashSet::new();
 
         for field in fields.iter() {
             // Get the original type (without type aliases)
@@ -1724,7 +1724,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 out.indented(|out| {
                     let bytes_name = self.emit_field_serialize(
                         field,
-                        &FxHashMap::default(),
+                        &HashMap::new(),
                         |field| to_rust_variable_name(field),
                         &mut result_bytes,
                         out,
@@ -1830,7 +1830,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         });
         outln!(out, "}}");
 
-        let mut events_with_from = FxHashSet::default();
+        let mut events_with_from = HashSet::new();
 
         for allowed in event_struct_def.alloweds.iter() {
             for event in allowed.resolved.borrow().iter() {
@@ -2161,7 +2161,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         name_prefix: &str,
         fields: &[xcbdefs::FieldDef],
-        parent_deducible_fields: &FxHashMap<String, DeducibleField>,
+        parent_deducible_fields: &HashMap<String, DeducibleField>,
         generate_try_parse: bool,
         generate_serialize: bool,
         out: &mut Output,
@@ -2184,7 +2184,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         name_prefix: &str,
         switch: &xcbdefs::SwitchField,
-        parent_deducible_fields: &FxHashMap<String, DeducibleField>,
+        parent_deducible_fields: &HashMap<String, DeducibleField>,
         generate_try_parse: bool,
         generate_serialize: bool,
         out: &mut Output,
@@ -2486,7 +2486,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         name: &str,
         fields: &[xcbdefs::FieldDef],
         external_params: &[xcbdefs::ExternalParam],
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         skip_length_field: bool,
         size: u32,
         out: &mut Output,
@@ -2577,7 +2577,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         name: &str,
         fields: &[xcbdefs::FieldDef],
         external_params: &[xcbdefs::ExternalParam],
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         skip_length_field: bool,
         out: &mut Output,
     ) {
@@ -2666,7 +2666,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         switch: &xcbdefs::SwitchField,
         name: &str,
-        parent_deducible_fields: &FxHashMap<String, DeducibleField>,
+        parent_deducible_fields: &HashMap<String, DeducibleField>,
         generate_try_parse: bool,
         generate_serialize: bool,
         doc: Option<&str>,
@@ -3216,7 +3216,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         switch: &xcbdefs::SwitchField,
         name: &str,
-        parent_deducible_fields: &FxHashMap<String, DeducibleField>,
+        parent_deducible_fields: &HashMap<String, DeducibleField>,
         case_infos: &[CaseInfo],
         size: u32,
         out: &mut Output,
@@ -3362,7 +3362,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         switch: &xcbdefs::SwitchField,
         name: &str,
-        parent_deducible_fields: &FxHashMap<String, DeducibleField>,
+        parent_deducible_fields: &HashMap<String, DeducibleField>,
         case_infos: &[CaseInfo],
         out: &mut Output,
     ) {
@@ -3904,7 +3904,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn emit_field_serialize(
         &self,
         field: &xcbdefs::FieldDef,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         mut wrap_field_ref: impl FnMut(&str) -> String,
         result_bytes: &mut Vec<String>,
         out: &mut Output,
@@ -4011,7 +4011,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn emit_field_serialize_into(
         &self,
         field: &xcbdefs::FieldDef,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         mut wrap_field_ref: impl FnMut(&str) -> String,
         bytes_name: &str,
         out: &mut Output,
@@ -4118,7 +4118,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn emit_assert_for_field_serialize(
         &self,
         field: &xcbdefs::FieldDef,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
         mut wrap_field_ref: impl FnMut(&str) -> String,
         out: &mut Output,
     ) {
@@ -4199,7 +4199,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn emit_assert_for_switch_serialize(
         &self,
         switch: &xcbdefs::SwitchField,
-        parent_deducible_fields: &FxHashMap<String, DeducibleField>,
+        parent_deducible_fields: &HashMap<String, DeducibleField>,
         out: &mut Output,
     ) {
         let needs_expr_assert =
@@ -4869,7 +4869,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         match self.caches.borrow_mut().enum_has_repeated_values.entry(id) {
             HashMapEntry::Occupied(entry) => *entry.get(),
             HashMapEntry::Vacant(entry) => {
-                let mut value_set = FxHashSet::default();
+                let mut value_set = HashSet::new();
                 let mut has_repeated = false;
                 for enum_item in enum_def.items.iter() {
                     let value = match enum_item.value {
@@ -4893,7 +4893,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn gather_request_fields(
         &self,
         request_def: &xcbdefs::RequestDef,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
     ) -> GatheredRequestFields {
         let mut letter_iter = b'A'..=b'Z';
 
@@ -5353,7 +5353,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn field_is_visible(
         &self,
         field: &xcbdefs::FieldDef,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
     ) -> bool {
         match field {
             xcbdefs::FieldDef::Pad(_) => false,
@@ -5373,7 +5373,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn case_has_single_visible_field(
         &self,
         case: &xcbdefs::SwitchCase,
-        deducible_fields: &FxHashMap<String, DeducibleField>,
+        deducible_fields: &HashMap<String, DeducibleField>,
     ) -> bool {
         let num_visible_fields = case
             .fields
@@ -5488,7 +5488,7 @@ enum DeducibleFieldOp {
 
 /// Gathers deducible fields (fields whose value can be calculated
 /// from other fields) from a list of fields.
-fn gather_deducible_fields(fields: &[xcbdefs::FieldDef]) -> FxHashMap<String, DeducibleField> {
+fn gather_deducible_fields(fields: &[xcbdefs::FieldDef]) -> HashMap<String, DeducibleField> {
     fn extract_length(expr: &xcbdefs::Expression) -> Option<(String, DeducibleLengthFieldOp)> {
         match expr {
             xcbdefs::Expression::FieldRef(field_ref_expr) => Some((
@@ -5533,7 +5533,7 @@ fn gather_deducible_fields(fields: &[xcbdefs::FieldDef]) -> FxHashMap<String, De
         }
     }
 
-    let mut deducible_fields = FxHashMap::default();
+    let mut deducible_fields = HashMap::new();
     for field in fields.iter() {
         let deducible_field = match field {
             xcbdefs::FieldDef::List(list_field) => list_field

--- a/xcbgen-rs/Cargo.toml
+++ b/xcbgen-rs/Cargo.toml
@@ -7,6 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fxhash = "0.2.1"
 once_cell = "1.4.0"
 roxmltree = "0.11.0"

--- a/xcbgen-rs/src/defs/mod.rs
+++ b/xcbgen-rs/src/defs/mod.rs
@@ -6,9 +6,9 @@
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry as HashMapEntry;
+use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
-use fxhash::FxHashMap;
 use once_cell::unsync::OnceCell;
 
 mod alignment;
@@ -27,14 +27,14 @@ pub use top_level::*;
 #[derive(Debug)]
 pub struct Module {
     /// All namespaces in this module
-    pub namespaces: RefCell<FxHashMap<String, Rc<Namespace>>>,
+    pub namespaces: RefCell<HashMap<String, Rc<Namespace>>>,
 }
 
 impl Module {
     /// Create a new, empty module
     pub fn new() -> Rc<Self> {
         Rc::new(Module {
-            namespaces: RefCell::new(FxHashMap::default()),
+            namespaces: RefCell::new(HashMap::new()),
         })
     }
 
@@ -127,19 +127,19 @@ pub struct Namespace {
     pub ext_info: Option<ExtInfo>,
 
     /// Other namespaces that are imported into this namespace.
-    pub imports: RefCell<FxHashMap<String, Import>>,
+    pub imports: RefCell<HashMap<String, Import>>,
 
     /// The requests that are defined in this module.
-    pub request_defs: RefCell<FxHashMap<String, Rc<RequestDef>>>,
+    pub request_defs: RefCell<HashMap<String, Rc<RequestDef>>>,
 
     /// The events that are defined in this module.
-    pub event_defs: RefCell<FxHashMap<String, EventDef>>,
+    pub event_defs: RefCell<HashMap<String, EventDef>>,
 
     /// The errors that are defined in this module.
-    pub error_defs: RefCell<FxHashMap<String, ErrorDef>>,
+    pub error_defs: RefCell<HashMap<String, ErrorDef>>,
 
     /// The types that are defined in this module.
-    pub type_defs: RefCell<FxHashMap<String, TypeDef>>,
+    pub type_defs: RefCell<HashMap<String, TypeDef>>,
 
     /// All definitions in this module in the order they appear in the XML description.
     pub src_order_defs: RefCell<Vec<Def>>,
@@ -156,11 +156,11 @@ impl Namespace {
             module: Rc::downgrade(module),
             header,
             ext_info,
-            imports: RefCell::new(FxHashMap::default()),
-            request_defs: RefCell::new(FxHashMap::default()),
-            event_defs: RefCell::new(FxHashMap::default()),
-            error_defs: RefCell::new(FxHashMap::default()),
-            type_defs: RefCell::new(FxHashMap::default()),
+            imports: RefCell::new(HashMap::new()),
+            request_defs: RefCell::new(HashMap::new()),
+            event_defs: RefCell::new(HashMap::new()),
+            error_defs: RefCell::new(HashMap::new()),
+            type_defs: RefCell::new(HashMap::new()),
             src_order_defs: RefCell::new(Vec::new()),
         })
     }

--- a/xcbgen-rs/src/resolver/nesting_checker.rs
+++ b/xcbgen-rs/src/resolver/nesting_checker.rs
@@ -1,6 +1,5 @@
+use std::collections::HashSet;
 use std::rc::Rc;
-
-use fxhash::FxHashSet;
 
 use crate::{defs, ResolveError};
 
@@ -14,14 +13,14 @@ pub(super) fn check(module: &defs::Module) -> Result<(), ResolveError> {
 struct NestingChecker {
     stack: Vec<NestingStackItem>,
     /// Pointers converted to `usize`.
-    checked: FxHashSet<usize>,
+    checked: HashSet<usize>,
 }
 
 impl NestingChecker {
     fn new() -> Self {
         Self {
             stack: Vec::new(),
-            checked: FxHashSet::default(),
+            checked: HashSet::default(),
         }
     }
 


### PR DESCRIPTION
It is supposed to be slower, but doing some improper benchmarking the difference is negligible for this case.