### PR TITLE
Make it easier to parse replies without program state

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String
     }
     outln!(main_out, "");
 
-    namespace::generate_request_enum(&mut main_out, module, enum_cases);
+    namespace::generate_request_reply_enum(&mut main_out, module, enum_cases);
     error_events::generate(&mut main_out, module);
 
     out_map.insert(PathBuf::from("mod.rs"), main_out.into_data());

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -179,6 +179,13 @@ pub(super) fn generate_request_reply_enum(
         }
     });
     outln!(out, "}}");
+    outln!(out, "impl From<()> for Reply {{");
+    out.indented(|out| {
+        outln!(out, "fn from(_: ()) -> Reply {{");
+        outln!(out.indent(), "Reply::Void");
+        outln!(out, "}}");
+    });
+    outln!(out, "}}");
     for ns in namespaces.iter() {
         let has_feature = super::ext_has_feature(&ns.header);
 
@@ -266,7 +273,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "#[allow(unused_imports)]");
         outln!(
             out,
-            "use crate::x11_utils::{{RequestHeader, Serialize, TryParse}};"
+            "use crate::x11_utils::{{Request, RequestHeader, Serialize, TryParse}};"
         );
         outln!(
             out,
@@ -1230,6 +1237,18 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             });
             outln!(out, "}}");
         });
+        outln!(out, "}}");
+        outln!(
+            out,
+            "impl{lifetime} Request for {name}Request{lifetime} {{",
+            lifetime = struct_lifetime_block,
+            name = name
+        );
+        if request_def.reply.is_some() {
+            outln!(out.indent(), "type Reply = {}Reply;", name);
+        } else {
+            outln!(out.indent(), "type Reply = ();");
+        }
         outln!(out, "}}");
     }
 

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -68,6 +68,9 @@ impl EnableRequest {
         Ok(EnableRequest
         )
     }
+}
+impl Request for EnableRequest {
+    type Reply = EnableReply;
 }
 pub fn enable<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, EnableReply>, ConnectionError>
 where

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -158,6 +158,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u32, client_minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -253,6 +256,9 @@ impl RedirectWindowRequest {
         })
     }
 }
+impl Request for RedirectWindowRequest {
+    type Reply = ();
+}
 pub fn redirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -319,6 +325,9 @@ impl RedirectSubwindowsRequest {
             update,
         })
     }
+}
+impl Request for RedirectSubwindowsRequest {
+    type Reply = ();
 }
 pub fn redirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -387,6 +396,9 @@ impl UnredirectWindowRequest {
         })
     }
 }
+impl Request for UnredirectWindowRequest {
+    type Reply = ();
+}
 pub fn unredirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -454,6 +466,9 @@ impl UnredirectSubwindowsRequest {
         })
     }
 }
+impl Request for UnredirectSubwindowsRequest {
+    type Reply = ();
+}
 pub fn unredirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -518,6 +533,9 @@ impl CreateRegionFromBorderClipRequest {
             window,
         })
     }
+}
+impl Request for CreateRegionFromBorderClipRequest {
+    type Reply = ();
 }
 pub fn create_region_from_border_clip<Conn>(conn: &Conn, region: xfixes::Region, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -584,6 +602,9 @@ impl NameWindowPixmapRequest {
         })
     }
 }
+impl Request for NameWindowPixmapRequest {
+    type Reply = ();
+}
 pub fn name_window_pixmap<Conn>(conn: &Conn, window: xproto::Window, pixmap: xproto::Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -640,6 +661,9 @@ impl GetOverlayWindowRequest {
             window,
         })
     }
+}
+impl Request for GetOverlayWindowRequest {
+    type Reply = GetOverlayWindowReply;
 }
 pub fn get_overlay_window<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetOverlayWindowReply>, ConnectionError>
 where
@@ -722,6 +746,9 @@ impl ReleaseOverlayWindowRequest {
             window,
         })
     }
+}
+impl Request for ReleaseOverlayWindowRequest {
+    type Reply = ();
 }
 pub fn release_overlay_window<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -229,6 +229,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u32, client_minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -332,6 +335,9 @@ impl CreateRequest {
         })
     }
 }
+impl Request for CreateRequest {
+    type Reply = ();
+}
 pub fn create<Conn>(conn: &Conn, damage: Damage, drawable: xproto::Drawable, level: ReportLevel) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -389,6 +395,9 @@ impl DestroyRequest {
             damage,
         })
     }
+}
+impl Request for DestroyRequest {
+    type Reply = ();
 }
 pub fn destroy<Conn>(conn: &Conn, damage: Damage) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -462,6 +471,9 @@ impl SubtractRequest {
         })
     }
 }
+impl Request for SubtractRequest {
+    type Reply = ();
+}
 pub fn subtract<Conn, A, B>(conn: &Conn, damage: Damage, repair: A, parts: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -531,6 +543,9 @@ impl AddRequest {
             region,
         })
     }
+}
+impl Request for AddRequest {
+    type Reply = ();
 }
 pub fn add<Conn>(conn: &Conn, drawable: xproto::Drawable, region: xfixes::Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -81,6 +81,9 @@ impl GetVersionRequest {
             client_minor_version,
         })
     }
+}
+impl Request for GetVersionRequest {
+    type Reply = GetVersionReply;
 }
 pub fn get_version<Conn>(conn: &Conn, client_major_version: u16, client_minor_version: u16) -> Result<Cookie<'_, Conn, GetVersionReply>, ConnectionError>
 where
@@ -157,6 +160,9 @@ impl CapableRequest {
         )
     }
 }
+impl Request for CapableRequest {
+    type Reply = CapableReply;
+}
 pub fn capable<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, CapableReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -227,6 +233,9 @@ impl GetTimeoutsRequest {
         Ok(GetTimeoutsRequest
         )
     }
+}
+impl Request for GetTimeoutsRequest {
+    type Reply = GetTimeoutsReply;
 }
 pub fn get_timeouts<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetTimeoutsReply>, ConnectionError>
 where
@@ -324,6 +333,9 @@ impl SetTimeoutsRequest {
         })
     }
 }
+impl Request for SetTimeoutsRequest {
+    type Reply = ();
+}
 pub fn set_timeouts<Conn>(conn: &Conn, standby_timeout: u16, suspend_timeout: u16, off_timeout: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -373,6 +385,9 @@ impl EnableRequest {
         )
     }
 }
+impl Request for EnableRequest {
+    type Reply = ();
+}
 pub fn enable<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -417,6 +432,9 @@ impl DisableRequest {
         Ok(DisableRequest
         )
     }
+}
+impl Request for DisableRequest {
+    type Reply = ();
 }
 pub fn disable<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -541,6 +559,9 @@ impl ForceLevelRequest {
         })
     }
 }
+impl Request for ForceLevelRequest {
+    type Reply = ();
+}
 pub fn force_level<Conn>(conn: &Conn, power_level: DPMSMode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -587,6 +608,9 @@ impl InfoRequest {
         Ok(InfoRequest
         )
     }
+}
+impl Request for InfoRequest {
+    type Reply = InfoReply;
 }
 pub fn info<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, InfoReply>, ConnectionError>
 where

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -422,6 +422,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, major_version: u32, minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -514,6 +517,9 @@ impl ConnectRequest {
             driver_type,
         })
     }
+}
+impl Request for ConnectRequest {
+    type Reply = ConnectReply;
 }
 pub fn connect<Conn>(conn: &Conn, window: xproto::Window, driver_type: DriverType) -> Result<Cookie<'_, Conn, ConnectReply>, ConnectionError>
 where
@@ -643,6 +649,9 @@ impl AuthenticateRequest {
         })
     }
 }
+impl Request for AuthenticateRequest {
+    type Reply = AuthenticateReply;
+}
 pub fn authenticate<Conn>(conn: &Conn, window: xproto::Window, magic: u32) -> Result<Cookie<'_, Conn, AuthenticateReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -725,6 +734,9 @@ impl CreateDrawableRequest {
         })
     }
 }
+impl Request for CreateDrawableRequest {
+    type Reply = ();
+}
 pub fn create_drawable<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -780,6 +792,9 @@ impl DestroyDrawableRequest {
             drawable,
         })
     }
+}
+impl Request for DestroyDrawableRequest {
+    type Reply = ();
 }
 pub fn destroy_drawable<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -858,6 +873,9 @@ impl<'input> GetBuffersRequest<'input> {
             attachments: Cow::Owned(attachments),
         })
     }
+}
+impl<'input> Request for GetBuffersRequest<'input> {
+    type Reply = GetBuffersReply;
 }
 pub fn get_buffers<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &'input [u32]) -> Result<Cookie<'c, Conn, GetBuffersReply>, ConnectionError>
 where
@@ -987,6 +1005,9 @@ impl CopyRegionRequest {
         })
     }
 }
+impl Request for CopyRegionRequest {
+    type Reply = CopyRegionReply;
+}
 pub fn copy_region<Conn>(conn: &Conn, drawable: xproto::Drawable, region: u32, dest: u32, src: u32) -> Result<Cookie<'_, Conn, CopyRegionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1090,6 +1111,9 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
             attachments: Cow::Owned(attachments),
         })
     }
+}
+impl<'input> Request for GetBuffersWithFormatRequest<'input> {
+    type Reply = GetBuffersWithFormatReply;
 }
 pub fn get_buffers_with_format<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, count: u32, attachments: &'input [AttachFormat]) -> Result<Cookie<'c, Conn, GetBuffersWithFormatReply>, ConnectionError>
 where
@@ -1243,6 +1267,9 @@ impl SwapBuffersRequest {
         })
     }
 }
+impl Request for SwapBuffersRequest {
+    type Reply = SwapBuffersReply;
+}
 pub fn swap_buffers<Conn>(conn: &Conn, drawable: xproto::Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, SwapBuffersReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1331,6 +1358,9 @@ impl GetMSCRequest {
             drawable,
         })
     }
+}
+impl Request for GetMSCRequest {
+    type Reply = GetMSCReply;
 }
 pub fn get_msc<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, GetMSCReply>, ConnectionError>
 where
@@ -1471,6 +1501,9 @@ impl WaitMSCRequest {
         })
     }
 }
+impl Request for WaitMSCRequest {
+    type Reply = WaitMSCReply;
+}
 pub fn wait_msc<Conn>(conn: &Conn, drawable: xproto::Drawable, target_msc_hi: u32, target_msc_lo: u32, divisor_hi: u32, divisor_lo: u32, remainder_hi: u32, remainder_lo: u32) -> Result<Cookie<'_, Conn, WaitMSCReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1584,6 +1617,9 @@ impl WaitSBCRequest {
         })
     }
 }
+impl Request for WaitSBCRequest {
+    type Reply = WaitSBCReply;
+}
 pub fn wait_sbc<Conn>(conn: &Conn, drawable: xproto::Drawable, target_sbc_hi: u32, target_sbc_lo: u32) -> Result<Cookie<'_, Conn, WaitSBCReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1685,6 +1721,9 @@ impl SwapIntervalRequest {
         })
     }
 }
+impl Request for SwapIntervalRequest {
+    type Reply = ();
+}
 pub fn swap_interval<Conn>(conn: &Conn, drawable: xproto::Drawable, interval: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1749,6 +1788,9 @@ impl GetParamRequest {
             param,
         })
     }
+}
+impl Request for GetParamRequest {
+    type Reply = GetParamReply;
 }
 pub fn get_param<Conn>(conn: &Conn, drawable: xproto::Drawable, param: u32) -> Result<Cookie<'_, Conn, GetParamReply>, ConnectionError>
 where

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -86,6 +86,9 @@ impl QueryVersionRequest {
             minor_version,
         })
     }
+}
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
 }
 pub fn query_version<Conn>(conn: &Conn, major_version: u32, minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
@@ -178,6 +181,9 @@ impl OpenRequest {
             provider,
         })
     }
+}
+impl Request for OpenRequest {
+    type Reply = OpenReply;
 }
 pub fn open<Conn>(conn: &Conn, drawable: xproto::Drawable, provider: u32) -> Result<CookieWithFds<'_, Conn, OpenReply>, ConnectionError>
 where
@@ -313,6 +319,9 @@ impl PixmapFromBufferRequest {
         })
     }
 }
+impl Request for PixmapFromBufferRequest {
+    type Reply = ();
+}
 pub fn pixmap_from_buffer<Conn, A>(conn: &Conn, pixmap: xproto::Pixmap, drawable: xproto::Drawable, size: u32, width: u16, height: u16, stride: u16, depth: u8, bpp: u8, pixmap_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -378,6 +387,9 @@ impl BufferFromPixmapRequest {
             pixmap,
         })
     }
+}
+impl Request for BufferFromPixmapRequest {
+    type Reply = BufferFromPixmapReply;
 }
 pub fn buffer_from_pixmap<Conn>(conn: &Conn, pixmap: xproto::Pixmap) -> Result<CookieWithFds<'_, Conn, BufferFromPixmapReply>, ConnectionError>
 where
@@ -497,6 +509,9 @@ impl FenceFromFDRequest {
         })
     }
 }
+impl Request for FenceFromFDRequest {
+    type Reply = ();
+}
 pub fn fence_from_fd<Conn, A>(conn: &Conn, drawable: xproto::Drawable, fence: u32, initially_triggered: bool, fence_fd: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -565,6 +580,9 @@ impl FDFromFenceRequest {
             fence,
         })
     }
+}
+impl Request for FDFromFenceRequest {
+    type Reply = FDFromFenceReply;
 }
 pub fn fd_from_fence<Conn>(conn: &Conn, drawable: xproto::Drawable, fence: u32) -> Result<CookieWithFds<'_, Conn, FDFromFenceReply>, ConnectionError>
 where
@@ -664,6 +682,9 @@ impl GetSupportedModifiersRequest {
             bpp,
         })
     }
+}
+impl Request for GetSupportedModifiersRequest {
+    type Reply = GetSupportedModifiersReply;
 }
 pub fn get_supported_modifiers<Conn>(conn: &Conn, window: u32, depth: u8, bpp: u8) -> Result<Cookie<'_, Conn, GetSupportedModifiersReply>, ConnectionError>
 where
@@ -904,6 +925,9 @@ impl PixmapFromBuffersRequest {
         })
     }
 }
+impl Request for PixmapFromBuffersRequest {
+    type Reply = ();
+}
 pub fn pixmap_from_buffers<Conn>(conn: &Conn, pixmap: xproto::Pixmap, window: xproto::Window, width: u16, height: u16, stride0: u32, offset0: u32, stride1: u32, offset1: u32, stride2: u32, offset2: u32, stride3: u32, offset3: u32, depth: u8, bpp: u8, modifier: u64, buffers: Vec<RawFdContainer>) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -974,6 +998,9 @@ impl BuffersFromPixmapRequest {
             pixmap,
         })
     }
+}
+impl Request for BuffersFromPixmapRequest {
+    type Reply = BuffersFromPixmapReply;
 }
 pub fn buffers_from_pixmap<Conn>(conn: &Conn, pixmap: xproto::Pixmap) -> Result<CookieWithFds<'_, Conn, BuffersFromPixmapReply>, ConnectionError>
 where

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -81,6 +81,9 @@ impl QueryVersionRequest {
             client_minor_version,
         })
     }
+}
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
 }
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u16, client_minor_version: u16) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -520,6 +520,9 @@ impl<'input> RenderRequest<'input> {
         })
     }
 }
+impl<'input> Request for RenderRequest<'input> {
+    type Reply = ();
+}
 pub fn render<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -601,6 +604,9 @@ impl<'input> RenderLargeRequest<'input> {
             data,
         })
     }
+}
+impl<'input> Request for RenderLargeRequest<'input> {
+    type Reply = ();
 }
 pub fn render_large<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, request_num: u16, request_total: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -694,6 +700,9 @@ impl CreateContextRequest {
         })
     }
 }
+impl Request for CreateContextRequest {
+    type Reply = ();
+}
 pub fn create_context<Conn>(conn: &Conn, context: Context, visual: xproto::Visualid, screen: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -753,6 +762,9 @@ impl DestroyContextRequest {
             context,
         })
     }
+}
+impl Request for DestroyContextRequest {
+    type Reply = ();
 }
 pub fn destroy_context<Conn>(conn: &Conn, context: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -825,6 +837,9 @@ impl MakeCurrentRequest {
             old_context_tag,
         })
     }
+}
+impl Request for MakeCurrentRequest {
+    type Reply = MakeCurrentReply;
 }
 pub fn make_current<Conn>(conn: &Conn, drawable: Drawable, context: Context, old_context_tag: ContextTag) -> Result<Cookie<'_, Conn, MakeCurrentReply>, ConnectionError>
 where
@@ -909,6 +924,9 @@ impl IsDirectRequest {
             context,
         })
     }
+}
+impl Request for IsDirectRequest {
+    type Reply = IsDirectReply;
 }
 pub fn is_direct<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, IsDirectReply>, ConnectionError>
 where
@@ -1000,6 +1018,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, major_version: u32, minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1085,6 +1106,9 @@ impl WaitGLRequest {
         })
     }
 }
+impl Request for WaitGLRequest {
+    type Reply = ();
+}
 pub fn wait_gl<Conn>(conn: &Conn, context_tag: ContextTag) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1140,6 +1164,9 @@ impl WaitXRequest {
             context_tag,
         })
     }
+}
+impl Request for WaitXRequest {
+    type Reply = ();
 }
 pub fn wait_x<Conn>(conn: &Conn, context_tag: ContextTag) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1220,6 +1247,9 @@ impl CopyContextRequest {
             src_context_tag,
         })
     }
+}
+impl Request for CopyContextRequest {
+    type Reply = ();
 }
 pub fn copy_context<Conn>(conn: &Conn, src: Context, dest: Context, mask: u32, src_context_tag: ContextTag) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1376,6 +1406,9 @@ impl SwapBuffersRequest {
         })
     }
 }
+impl Request for SwapBuffersRequest {
+    type Reply = ();
+}
 pub fn swap_buffers<Conn>(conn: &Conn, context_tag: ContextTag, drawable: Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1465,6 +1498,9 @@ impl UseXFontRequest {
         })
     }
 }
+impl Request for UseXFontRequest {
+    type Reply = ();
+}
 pub fn use_x_font<Conn>(conn: &Conn, context_tag: ContextTag, font: xproto::Font, first: u32, count: u32, list_base: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1549,6 +1585,9 @@ impl CreateGLXPixmapRequest {
         })
     }
 }
+impl Request for CreateGLXPixmapRequest {
+    type Reply = ();
+}
 pub fn create_glx_pixmap<Conn>(conn: &Conn, screen: u32, visual: xproto::Visualid, pixmap: xproto::Pixmap, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1607,6 +1646,9 @@ impl GetVisualConfigsRequest {
             screen,
         })
     }
+}
+impl Request for GetVisualConfigsRequest {
+    type Reply = GetVisualConfigsReply;
 }
 pub fn get_visual_configs<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, GetVisualConfigsReply>, ConnectionError>
 where
@@ -1708,6 +1750,9 @@ impl DestroyGLXPixmapRequest {
         })
     }
 }
+impl Request for DestroyGLXPixmapRequest {
+    type Reply = ();
+}
 pub fn destroy_glx_pixmap<Conn>(conn: &Conn, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1777,6 +1822,9 @@ impl<'input> VendorPrivateRequest<'input> {
             data,
         })
     }
+}
+impl<'input> Request for VendorPrivateRequest<'input> {
+    type Reply = ();
 }
 pub fn vendor_private<'c, 'input, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -1849,6 +1897,9 @@ impl<'input> VendorPrivateWithReplyRequest<'input> {
             data,
         })
     }
+}
+impl<'input> Request for VendorPrivateWithReplyRequest<'input> {
+    type Reply = VendorPrivateWithReplyReply;
 }
 pub fn vendor_private_with_reply<'c, 'input, Conn>(conn: &'c Conn, vendor_code: u32, context_tag: ContextTag, data: &'input [u8]) -> Result<Cookie<'c, Conn, VendorPrivateWithReplyReply>, ConnectionError>
 where
@@ -1954,6 +2005,9 @@ impl QueryExtensionsStringRequest {
         })
     }
 }
+impl Request for QueryExtensionsStringRequest {
+    type Reply = QueryExtensionsStringReply;
+}
 pub fn query_extensions_string<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, QueryExtensionsStringReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2044,6 +2098,9 @@ impl QueryServerStringRequest {
             name,
         })
     }
+}
+impl Request for QueryServerStringRequest {
+    type Reply = QueryServerStringReply;
 }
 pub fn query_server_string<Conn>(conn: &Conn, screen: u32, name: u32) -> Result<Cookie<'_, Conn, QueryServerStringReply>, ConnectionError>
 where
@@ -2167,6 +2224,9 @@ impl<'input> ClientInfoRequest<'input> {
         })
     }
 }
+impl<'input> Request for ClientInfoRequest<'input> {
+    type Reply = ();
+}
 pub fn client_info<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2224,6 +2284,9 @@ impl GetFBConfigsRequest {
             screen,
         })
     }
+}
+impl Request for GetFBConfigsRequest {
+    type Reply = GetFBConfigsReply;
 }
 pub fn get_fb_configs<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, GetFBConfigsReply>, ConnectionError>
 where
@@ -2364,6 +2427,9 @@ impl<'input> CreatePixmapRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreatePixmapRequest<'input> {
+    type Reply = ();
+}
 pub fn create_pixmap<'c, 'input, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pixmap: xproto::Pixmap, glx_pixmap: Pixmap, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2423,6 +2489,9 @@ impl DestroyPixmapRequest {
             glx_pixmap,
         })
     }
+}
+impl Request for DestroyPixmapRequest {
+    type Reply = ();
 }
 pub fn destroy_pixmap<Conn>(conn: &Conn, glx_pixmap: Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2521,6 +2590,9 @@ impl CreateNewContextRequest {
         })
     }
 }
+impl Request for CreateNewContextRequest {
+    type Reply = ();
+}
 pub fn create_new_context<Conn>(conn: &Conn, context: Context, fbconfig: Fbconfig, screen: u32, render_type: u32, share_list: Context, is_direct: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2581,6 +2653,9 @@ impl QueryContextRequest {
             context,
         })
     }
+}
+impl Request for QueryContextRequest {
+    type Reply = QueryContextReply;
 }
 pub fn query_context<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, QueryContextReply>, ConnectionError>
 where
@@ -2705,6 +2780,9 @@ impl MakeContextCurrentRequest {
         })
     }
 }
+impl Request for MakeContextCurrentRequest {
+    type Reply = MakeContextCurrentReply;
+}
 pub fn make_context_current<Conn>(conn: &Conn, old_context_tag: ContextTag, drawable: Drawable, read_drawable: Drawable, context: Context) -> Result<Cookie<'_, Conn, MakeContextCurrentReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2821,6 +2899,9 @@ impl<'input> CreatePbufferRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreatePbufferRequest<'input> {
+    type Reply = ();
+}
 pub fn create_pbuffer<'c, 'input, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, pbuffer: Pbuffer, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2880,6 +2961,9 @@ impl DestroyPbufferRequest {
         })
     }
 }
+impl Request for DestroyPbufferRequest {
+    type Reply = ();
+}
 pub fn destroy_pbuffer<Conn>(conn: &Conn, pbuffer: Pbuffer) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2935,6 +3019,9 @@ impl GetDrawableAttributesRequest {
             drawable,
         })
     }
+}
+impl Request for GetDrawableAttributesRequest {
+    type Reply = GetDrawableAttributesReply;
 }
 pub fn get_drawable_attributes<Conn>(conn: &Conn, drawable: Drawable) -> Result<Cookie<'_, Conn, GetDrawableAttributesReply>, ConnectionError>
 where
@@ -3050,6 +3137,9 @@ impl<'input> ChangeDrawableAttributesRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeDrawableAttributesRequest<'input> {
+    type Reply = ();
+}
 pub fn change_drawable_attributes<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3146,6 +3236,9 @@ impl<'input> CreateWindowRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateWindowRequest<'input> {
+    type Reply = ();
+}
 pub fn create_window<'c, 'input, Conn>(conn: &'c Conn, screen: u32, fbconfig: Fbconfig, window: xproto::Window, glx_window: Window, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3205,6 +3298,9 @@ impl DeleteWindowRequest {
             glxwindow,
         })
     }
+}
+impl Request for DeleteWindowRequest {
+    type Reply = ();
 }
 pub fn delete_window<Conn>(conn: &Conn, glxwindow: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -3306,6 +3402,9 @@ impl<'input> SetClientInfoARBRequest<'input> {
             glx_extension_string,
         })
     }
+}
+impl<'input> Request for SetClientInfoARBRequest<'input> {
+    type Reply = ();
 }
 pub fn set_client_info_arb<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -3415,6 +3514,9 @@ impl<'input> CreateContextAttribsARBRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateContextAttribsARBRequest<'input> {
+    type Reply = ();
+}
 pub fn create_context_attribs_arb<'c, 'input, Conn>(conn: &'c Conn, context: Context, fbconfig: Fbconfig, screen: u32, share_list: Context, is_direct: bool, attribs: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3521,6 +3623,9 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetClientInfo2ARBRequest<'input> {
+    type Reply = ();
+}
 pub fn set_client_info2_arb<'c, 'input, Conn>(conn: &'c Conn, major_version: u32, minor_version: u32, gl_versions: &'input [u32], gl_extension_string: &'input [u8], glx_extension_string: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3597,6 +3702,9 @@ impl NewListRequest {
         })
     }
 }
+impl Request for NewListRequest {
+    type Reply = ();
+}
 pub fn new_list<Conn>(conn: &Conn, context_tag: ContextTag, list: u32, mode: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3654,6 +3762,9 @@ impl EndListRequest {
             context_tag,
         })
     }
+}
+impl Request for EndListRequest {
+    type Reply = ();
 }
 pub fn end_list<Conn>(conn: &Conn, context_tag: ContextTag) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -3727,6 +3838,9 @@ impl DeleteListsRequest {
         })
     }
 }
+impl Request for DeleteListsRequest {
+    type Reply = ();
+}
 pub fn delete_lists<Conn>(conn: &Conn, context_tag: ContextTag, list: u32, range: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3792,6 +3906,9 @@ impl GenListsRequest {
             range,
         })
     }
+}
+impl Request for GenListsRequest {
+    type Reply = GenListsReply;
 }
 pub fn gen_lists<Conn>(conn: &Conn, context_tag: ContextTag, range: i32) -> Result<Cookie<'_, Conn, GenListsReply>, ConnectionError>
 where
@@ -3891,6 +4008,9 @@ impl FeedbackBufferRequest {
         })
     }
 }
+impl Request for FeedbackBufferRequest {
+    type Reply = ();
+}
 pub fn feedback_buffer<Conn>(conn: &Conn, context_tag: ContextTag, size: i32, type_: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3957,6 +4077,9 @@ impl SelectBufferRequest {
         })
     }
 }
+impl Request for SelectBufferRequest {
+    type Reply = ();
+}
 pub fn select_buffer<Conn>(conn: &Conn, context_tag: ContextTag, size: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4021,6 +4144,9 @@ impl RenderModeRequest {
             mode,
         })
     }
+}
+impl Request for RenderModeRequest {
+    type Reply = RenderModeReply;
 }
 pub fn render_mode<Conn>(conn: &Conn, context_tag: ContextTag, mode: u32) -> Result<Cookie<'_, Conn, RenderModeReply>, ConnectionError>
 where
@@ -4175,6 +4301,9 @@ impl FinishRequest {
         })
     }
 }
+impl Request for FinishRequest {
+    type Reply = FinishReply;
+}
 pub fn finish<Conn>(conn: &Conn, context_tag: ContextTag) -> Result<Cookie<'_, Conn, FinishReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4270,6 +4399,9 @@ impl PixelStorefRequest {
         })
     }
 }
+impl Request for PixelStorefRequest {
+    type Reply = ();
+}
 pub fn pixel_storef<Conn>(conn: &Conn, context_tag: ContextTag, pname: u32, datum: Float32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4343,6 +4475,9 @@ impl PixelStoreiRequest {
             datum,
         })
     }
+}
+impl Request for PixelStoreiRequest {
+    type Reply = ();
 }
 pub fn pixel_storei<Conn>(conn: &Conn, context_tag: ContextTag, pname: u32, datum: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -4462,6 +4597,9 @@ impl ReadPixelsRequest {
         })
     }
 }
+impl Request for ReadPixelsRequest {
+    type Reply = ReadPixelsReply;
+}
 pub fn read_pixels<Conn>(conn: &Conn, context_tag: ContextTag, x: i32, y: i32, width: i32, height: i32, format: u32, type_: u32, swap_bytes: bool, lsb_first: bool) -> Result<Cookie<'_, Conn, ReadPixelsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4576,6 +4714,9 @@ impl GetBooleanvRequest {
         })
     }
 }
+impl Request for GetBooleanvRequest {
+    type Reply = GetBooleanvReply;
+}
 pub fn get_booleanv<Conn>(conn: &Conn, context_tag: ContextTag, pname: i32) -> Result<Cookie<'_, Conn, GetBooleanvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4686,6 +4827,9 @@ impl GetClipPlaneRequest {
         })
     }
 }
+impl Request for GetClipPlaneRequest {
+    type Reply = GetClipPlaneReply;
+}
 pub fn get_clip_plane<Conn>(conn: &Conn, context_tag: ContextTag, plane: i32) -> Result<Cookie<'_, Conn, GetClipPlaneReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4792,6 +4936,9 @@ impl GetDoublevRequest {
         })
     }
 }
+impl Request for GetDoublevRequest {
+    type Reply = GetDoublevReply;
+}
 pub fn get_doublev<Conn>(conn: &Conn, context_tag: ContextTag, pname: u32) -> Result<Cookie<'_, Conn, GetDoublevReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4894,6 +5041,9 @@ impl GetErrorRequest {
         })
     }
 }
+impl Request for GetErrorRequest {
+    type Reply = GetErrorReply;
+}
 pub fn get_error<Conn>(conn: &Conn, context_tag: ContextTag) -> Result<Cookie<'_, Conn, GetErrorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4982,6 +5132,9 @@ impl GetFloatvRequest {
             pname,
         })
     }
+}
+impl Request for GetFloatvRequest {
+    type Reply = GetFloatvReply;
 }
 pub fn get_floatv<Conn>(conn: &Conn, context_tag: ContextTag, pname: u32) -> Result<Cookie<'_, Conn, GetFloatvReply>, ConnectionError>
 where
@@ -5092,6 +5245,9 @@ impl GetIntegervRequest {
             pname,
         })
     }
+}
+impl Request for GetIntegervRequest {
+    type Reply = GetIntegervReply;
 }
 pub fn get_integerv<Conn>(conn: &Conn, context_tag: ContextTag, pname: u32) -> Result<Cookie<'_, Conn, GetIntegervReply>, ConnectionError>
 where
@@ -5210,6 +5366,9 @@ impl GetLightfvRequest {
             pname,
         })
     }
+}
+impl Request for GetLightfvRequest {
+    type Reply = GetLightfvReply;
 }
 pub fn get_lightfv<Conn>(conn: &Conn, context_tag: ContextTag, light: u32, pname: u32) -> Result<Cookie<'_, Conn, GetLightfvReply>, ConnectionError>
 where
@@ -5330,6 +5489,9 @@ impl GetLightivRequest {
         })
     }
 }
+impl Request for GetLightivRequest {
+    type Reply = GetLightivReply;
+}
 pub fn get_lightiv<Conn>(conn: &Conn, context_tag: ContextTag, light: u32, pname: u32) -> Result<Cookie<'_, Conn, GetLightivReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5448,6 +5610,9 @@ impl GetMapdvRequest {
             query,
         })
     }
+}
+impl Request for GetMapdvRequest {
+    type Reply = GetMapdvReply;
 }
 pub fn get_mapdv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, query: u32) -> Result<Cookie<'_, Conn, GetMapdvReply>, ConnectionError>
 where
@@ -5568,6 +5733,9 @@ impl GetMapfvRequest {
         })
     }
 }
+impl Request for GetMapfvRequest {
+    type Reply = GetMapfvReply;
+}
 pub fn get_mapfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, query: u32) -> Result<Cookie<'_, Conn, GetMapfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5686,6 +5854,9 @@ impl GetMapivRequest {
             query,
         })
     }
+}
+impl Request for GetMapivRequest {
+    type Reply = GetMapivReply;
 }
 pub fn get_mapiv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, query: u32) -> Result<Cookie<'_, Conn, GetMapivReply>, ConnectionError>
 where
@@ -5806,6 +5977,9 @@ impl GetMaterialfvRequest {
         })
     }
 }
+impl Request for GetMaterialfvRequest {
+    type Reply = GetMaterialfvReply;
+}
 pub fn get_materialfv<Conn>(conn: &Conn, context_tag: ContextTag, face: u32, pname: u32) -> Result<Cookie<'_, Conn, GetMaterialfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5925,6 +6099,9 @@ impl GetMaterialivRequest {
         })
     }
 }
+impl Request for GetMaterialivRequest {
+    type Reply = GetMaterialivReply;
+}
 pub fn get_materialiv<Conn>(conn: &Conn, context_tag: ContextTag, face: u32, pname: u32) -> Result<Cookie<'_, Conn, GetMaterialivReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6036,6 +6213,9 @@ impl GetPixelMapfvRequest {
         })
     }
 }
+impl Request for GetPixelMapfvRequest {
+    type Reply = GetPixelMapfvReply;
+}
 pub fn get_pixel_mapfv<Conn>(conn: &Conn, context_tag: ContextTag, map: u32) -> Result<Cookie<'_, Conn, GetPixelMapfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6145,6 +6325,9 @@ impl GetPixelMapuivRequest {
             map,
         })
     }
+}
+impl Request for GetPixelMapuivRequest {
+    type Reply = GetPixelMapuivReply;
 }
 pub fn get_pixel_mapuiv<Conn>(conn: &Conn, context_tag: ContextTag, map: u32) -> Result<Cookie<'_, Conn, GetPixelMapuivReply>, ConnectionError>
 where
@@ -6256,6 +6439,9 @@ impl GetPixelMapusvRequest {
         })
     }
 }
+impl Request for GetPixelMapusvRequest {
+    type Reply = GetPixelMapusvReply;
+}
 pub fn get_pixel_mapusv<Conn>(conn: &Conn, context_tag: ContextTag, map: u32) -> Result<Cookie<'_, Conn, GetPixelMapusvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6366,6 +6552,9 @@ impl GetPolygonStippleRequest {
         })
     }
 }
+impl Request for GetPolygonStippleRequest {
+    type Reply = GetPolygonStippleReply;
+}
 pub fn get_polygon_stipple<Conn>(conn: &Conn, context_tag: ContextTag, lsb_first: bool) -> Result<Cookie<'_, Conn, GetPolygonStippleReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6472,6 +6661,9 @@ impl GetStringRequest {
             name,
         })
     }
+}
+impl Request for GetStringRequest {
+    type Reply = GetStringReply;
 }
 pub fn get_string<Conn>(conn: &Conn, context_tag: ContextTag, name: u32) -> Result<Cookie<'_, Conn, GetStringReply>, ConnectionError>
 where
@@ -6589,6 +6781,9 @@ impl GetTexEnvfvRequest {
             pname,
         })
     }
+}
+impl Request for GetTexEnvfvRequest {
+    type Reply = GetTexEnvfvReply;
 }
 pub fn get_tex_envfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetTexEnvfvReply>, ConnectionError>
 where
@@ -6709,6 +6904,9 @@ impl GetTexEnvivRequest {
         })
     }
 }
+impl Request for GetTexEnvivRequest {
+    type Reply = GetTexEnvivReply;
+}
 pub fn get_tex_enviv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetTexEnvivReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6827,6 +7025,9 @@ impl GetTexGendvRequest {
             pname,
         })
     }
+}
+impl Request for GetTexGendvRequest {
+    type Reply = GetTexGendvReply;
 }
 pub fn get_tex_gendv<Conn>(conn: &Conn, context_tag: ContextTag, coord: u32, pname: u32) -> Result<Cookie<'_, Conn, GetTexGendvReply>, ConnectionError>
 where
@@ -6947,6 +7148,9 @@ impl GetTexGenfvRequest {
         })
     }
 }
+impl Request for GetTexGenfvRequest {
+    type Reply = GetTexGenfvReply;
+}
 pub fn get_tex_genfv<Conn>(conn: &Conn, context_tag: ContextTag, coord: u32, pname: u32) -> Result<Cookie<'_, Conn, GetTexGenfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7065,6 +7269,9 @@ impl GetTexGenivRequest {
             pname,
         })
     }
+}
+impl Request for GetTexGenivRequest {
+    type Reply = GetTexGenivReply;
 }
 pub fn get_tex_geniv<Conn>(conn: &Conn, context_tag: ContextTag, coord: u32, pname: u32) -> Result<Cookie<'_, Conn, GetTexGenivReply>, ConnectionError>
 where
@@ -7209,6 +7416,9 @@ impl GetTexImageRequest {
         })
     }
 }
+impl Request for GetTexImageRequest {
+    type Reply = GetTexImageReply;
+}
 pub fn get_tex_image<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, level: i32, format: u32, type_: u32, swap_bytes: bool) -> Result<Cookie<'_, Conn, GetTexImageReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7335,6 +7545,9 @@ impl GetTexParameterfvRequest {
         })
     }
 }
+impl Request for GetTexParameterfvRequest {
+    type Reply = GetTexParameterfvReply;
+}
 pub fn get_tex_parameterfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetTexParameterfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7453,6 +7666,9 @@ impl GetTexParameterivRequest {
             pname,
         })
     }
+}
+impl Request for GetTexParameterivRequest {
+    type Reply = GetTexParameterivReply;
 }
 pub fn get_tex_parameteriv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetTexParameterivReply>, ConnectionError>
 where
@@ -7580,6 +7796,9 @@ impl GetTexLevelParameterfvRequest {
             pname,
         })
     }
+}
+impl Request for GetTexLevelParameterfvRequest {
+    type Reply = GetTexLevelParameterfvReply;
 }
 pub fn get_tex_level_parameterfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, level: i32, pname: u32) -> Result<Cookie<'_, Conn, GetTexLevelParameterfvReply>, ConnectionError>
 where
@@ -7709,6 +7928,9 @@ impl GetTexLevelParameterivRequest {
         })
     }
 }
+impl Request for GetTexLevelParameterivRequest {
+    type Reply = GetTexLevelParameterivReply;
+}
 pub fn get_tex_level_parameteriv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, level: i32, pname: u32) -> Result<Cookie<'_, Conn, GetTexLevelParameterivReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7821,6 +8043,9 @@ impl IsEnabledRequest {
         })
     }
 }
+impl Request for IsEnabledRequest {
+    type Reply = IsEnabledReply;
+}
 pub fn is_enabled<Conn>(conn: &Conn, context_tag: ContextTag, capability: u32) -> Result<Cookie<'_, Conn, IsEnabledReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7911,6 +8136,9 @@ impl IsListRequest {
         })
     }
 }
+impl Request for IsListRequest {
+    type Reply = IsListReply;
+}
 pub fn is_list<Conn>(conn: &Conn, context_tag: ContextTag, list: u32) -> Result<Cookie<'_, Conn, IsListReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7993,6 +8221,9 @@ impl FlushRequest {
         })
     }
 }
+impl Request for FlushRequest {
+    type Reply = ();
+}
 pub fn flush<Conn>(conn: &Conn, context_tag: ContextTag) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8062,6 +8293,9 @@ impl<'input> AreTexturesResidentRequest<'input> {
             textures: Cow::Owned(textures),
         })
     }
+}
+impl<'input> Request for AreTexturesResidentRequest<'input> {
+    type Reply = AreTexturesResidentReply;
 }
 pub fn are_textures_resident<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, textures: &'input [u32]) -> Result<Cookie<'c, Conn, AreTexturesResidentReply>, ConnectionError>
 where
@@ -8177,6 +8411,9 @@ impl<'input> DeleteTexturesRequest<'input> {
         })
     }
 }
+impl<'input> Request for DeleteTexturesRequest<'input> {
+    type Reply = ();
+}
 pub fn delete_textures<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, textures: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8241,6 +8478,9 @@ impl GenTexturesRequest {
             n,
         })
     }
+}
+impl Request for GenTexturesRequest {
+    type Reply = GenTexturesReply;
 }
 pub fn gen_textures<Conn>(conn: &Conn, context_tag: ContextTag, n: i32) -> Result<Cookie<'_, Conn, GenTexturesReply>, ConnectionError>
 where
@@ -8346,6 +8586,9 @@ impl IsTextureRequest {
             texture,
         })
     }
+}
+impl Request for IsTextureRequest {
+    type Reply = IsTextureReply;
 }
 pub fn is_texture<Conn>(conn: &Conn, context_tag: ContextTag, texture: u32) -> Result<Cookie<'_, Conn, IsTextureReply>, ConnectionError>
 where
@@ -8460,6 +8703,9 @@ impl GetColorTableRequest {
             swap_bytes,
         })
     }
+}
+impl Request for GetColorTableRequest {
+    type Reply = GetColorTableReply;
 }
 pub fn get_color_table<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, format: u32, type_: u32, swap_bytes: bool) -> Result<Cookie<'_, Conn, GetColorTableReply>, ConnectionError>
 where
@@ -8582,6 +8828,9 @@ impl GetColorTableParameterfvRequest {
         })
     }
 }
+impl Request for GetColorTableParameterfvRequest {
+    type Reply = GetColorTableParameterfvReply;
+}
 pub fn get_color_table_parameterfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetColorTableParameterfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8700,6 +8949,9 @@ impl GetColorTableParameterivRequest {
             pname,
         })
     }
+}
+impl Request for GetColorTableParameterivRequest {
+    type Reply = GetColorTableParameterivReply;
 }
 pub fn get_color_table_parameteriv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetColorTableParameterivReply>, ConnectionError>
 where
@@ -8836,6 +9088,9 @@ impl GetConvolutionFilterRequest {
         })
     }
 }
+impl Request for GetConvolutionFilterRequest {
+    type Reply = GetConvolutionFilterReply;
+}
 pub fn get_convolution_filter<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, format: u32, type_: u32, swap_bytes: bool) -> Result<Cookie<'_, Conn, GetConvolutionFilterReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8959,6 +9214,9 @@ impl GetConvolutionParameterfvRequest {
         })
     }
 }
+impl Request for GetConvolutionParameterfvRequest {
+    type Reply = GetConvolutionParameterfvReply;
+}
 pub fn get_convolution_parameterfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetConvolutionParameterfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9077,6 +9335,9 @@ impl GetConvolutionParameterivRequest {
             pname,
         })
     }
+}
+impl Request for GetConvolutionParameterivRequest {
+    type Reply = GetConvolutionParameterivReply;
 }
 pub fn get_convolution_parameteriv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetConvolutionParameterivReply>, ConnectionError>
 where
@@ -9212,6 +9473,9 @@ impl GetSeparableFilterRequest {
             swap_bytes,
         })
     }
+}
+impl Request for GetSeparableFilterRequest {
+    type Reply = GetSeparableFilterReply;
 }
 pub fn get_separable_filter<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, format: u32, type_: u32, swap_bytes: bool) -> Result<Cookie<'_, Conn, GetSeparableFilterReply>, ConnectionError>
 where
@@ -9356,6 +9620,9 @@ impl GetHistogramRequest {
         })
     }
 }
+impl Request for GetHistogramRequest {
+    type Reply = GetHistogramReply;
+}
 pub fn get_histogram<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, format: u32, type_: u32, swap_bytes: bool, reset: bool) -> Result<Cookie<'_, Conn, GetHistogramReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9478,6 +9745,9 @@ impl GetHistogramParameterfvRequest {
         })
     }
 }
+impl Request for GetHistogramParameterfvRequest {
+    type Reply = GetHistogramParameterfvReply;
+}
 pub fn get_histogram_parameterfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetHistogramParameterfvReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9596,6 +9866,9 @@ impl GetHistogramParameterivRequest {
             pname,
         })
     }
+}
+impl Request for GetHistogramParameterivRequest {
+    type Reply = GetHistogramParameterivReply;
 }
 pub fn get_histogram_parameteriv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetHistogramParameterivReply>, ConnectionError>
 where
@@ -9736,6 +10009,9 @@ impl GetMinmaxRequest {
         })
     }
 }
+impl Request for GetMinmaxRequest {
+    type Reply = GetMinmaxReply;
+}
 pub fn get_minmax<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, format: u32, type_: u32, swap_bytes: bool, reset: bool) -> Result<Cookie<'_, Conn, GetMinmaxReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9854,6 +10130,9 @@ impl GetMinmaxParameterfvRequest {
             pname,
         })
     }
+}
+impl Request for GetMinmaxParameterfvRequest {
+    type Reply = GetMinmaxParameterfvReply;
 }
 pub fn get_minmax_parameterfv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetMinmaxParameterfvReply>, ConnectionError>
 where
@@ -9974,6 +10253,9 @@ impl GetMinmaxParameterivRequest {
         })
     }
 }
+impl Request for GetMinmaxParameterivRequest {
+    type Reply = GetMinmaxParameterivReply;
+}
 pub fn get_minmax_parameteriv<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetMinmaxParameterivReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10093,6 +10375,9 @@ impl GetCompressedTexImageARBRequest {
         })
     }
 }
+impl Request for GetCompressedTexImageARBRequest {
+    type Reply = GetCompressedTexImageARBReply;
+}
 pub fn get_compressed_tex_image_arb<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, level: i32) -> Result<Cookie<'_, Conn, GetCompressedTexImageARBReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10210,6 +10495,9 @@ impl<'input> DeleteQueriesARBRequest<'input> {
         })
     }
 }
+impl<'input> Request for DeleteQueriesARBRequest<'input> {
+    type Reply = ();
+}
 pub fn delete_queries_arb<'c, 'input, Conn>(conn: &'c Conn, context_tag: ContextTag, ids: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10274,6 +10562,9 @@ impl GenQueriesARBRequest {
             n,
         })
     }
+}
+impl Request for GenQueriesARBRequest {
+    type Reply = GenQueriesARBReply;
 }
 pub fn gen_queries_arb<Conn>(conn: &Conn, context_tag: ContextTag, n: i32) -> Result<Cookie<'_, Conn, GenQueriesARBReply>, ConnectionError>
 where
@@ -10380,6 +10671,9 @@ impl IsQueryARBRequest {
         })
     }
 }
+impl Request for IsQueryARBRequest {
+    type Reply = IsQueryARBReply;
+}
 pub fn is_query_arb<Conn>(conn: &Conn, context_tag: ContextTag, id: u32) -> Result<Cookie<'_, Conn, IsQueryARBReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10477,6 +10771,9 @@ impl GetQueryivARBRequest {
             pname,
         })
     }
+}
+impl Request for GetQueryivARBRequest {
+    type Reply = GetQueryivARBReply;
 }
 pub fn get_queryiv_arb<Conn>(conn: &Conn, context_tag: ContextTag, target: u32, pname: u32) -> Result<Cookie<'_, Conn, GetQueryivARBReply>, ConnectionError>
 where
@@ -10597,6 +10894,9 @@ impl GetQueryObjectivARBRequest {
         })
     }
 }
+impl Request for GetQueryObjectivARBRequest {
+    type Reply = GetQueryObjectivARBReply;
+}
 pub fn get_query_objectiv_arb<Conn>(conn: &Conn, context_tag: ContextTag, id: u32, pname: u32) -> Result<Cookie<'_, Conn, GetQueryObjectivARBReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10715,6 +11015,9 @@ impl GetQueryObjectuivARBRequest {
             pname,
         })
     }
+}
+impl Request for GetQueryObjectuivARBRequest {
+    type Reply = GetQueryObjectuivARBReply;
 }
 pub fn get_query_objectuiv_arb<Conn>(conn: &Conn, context_tag: ContextTag, id: u32, pname: u32) -> Result<Cookie<'_, Conn, GetQueryObjectuivARBReply>, ConnectionError>
 where

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2713,6 +2713,1881 @@ pub enum Reply {
     #[cfg(feature = "xvmc")]
     XvmcListSubpictureTypes(xvmc::ListSubpictureTypesReply),
 }
+impl From<xproto::GetWindowAttributesReply> for Reply {
+  fn from(reply: xproto::GetWindowAttributesReply) -> Reply {
+    Reply::GetWindowAttributes(reply)
+  }
+}
+impl From<xproto::GetGeometryReply> for Reply {
+  fn from(reply: xproto::GetGeometryReply) -> Reply {
+    Reply::GetGeometry(reply)
+  }
+}
+impl From<xproto::QueryTreeReply> for Reply {
+  fn from(reply: xproto::QueryTreeReply) -> Reply {
+    Reply::QueryTree(reply)
+  }
+}
+impl From<xproto::InternAtomReply> for Reply {
+  fn from(reply: xproto::InternAtomReply) -> Reply {
+    Reply::InternAtom(reply)
+  }
+}
+impl From<xproto::GetAtomNameReply> for Reply {
+  fn from(reply: xproto::GetAtomNameReply) -> Reply {
+    Reply::GetAtomName(reply)
+  }
+}
+impl From<xproto::GetPropertyReply> for Reply {
+  fn from(reply: xproto::GetPropertyReply) -> Reply {
+    Reply::GetProperty(reply)
+  }
+}
+impl From<xproto::ListPropertiesReply> for Reply {
+  fn from(reply: xproto::ListPropertiesReply) -> Reply {
+    Reply::ListProperties(reply)
+  }
+}
+impl From<xproto::GetSelectionOwnerReply> for Reply {
+  fn from(reply: xproto::GetSelectionOwnerReply) -> Reply {
+    Reply::GetSelectionOwner(reply)
+  }
+}
+impl From<xproto::GrabPointerReply> for Reply {
+  fn from(reply: xproto::GrabPointerReply) -> Reply {
+    Reply::GrabPointer(reply)
+  }
+}
+impl From<xproto::GrabKeyboardReply> for Reply {
+  fn from(reply: xproto::GrabKeyboardReply) -> Reply {
+    Reply::GrabKeyboard(reply)
+  }
+}
+impl From<xproto::QueryPointerReply> for Reply {
+  fn from(reply: xproto::QueryPointerReply) -> Reply {
+    Reply::QueryPointer(reply)
+  }
+}
+impl From<xproto::GetMotionEventsReply> for Reply {
+  fn from(reply: xproto::GetMotionEventsReply) -> Reply {
+    Reply::GetMotionEvents(reply)
+  }
+}
+impl From<xproto::TranslateCoordinatesReply> for Reply {
+  fn from(reply: xproto::TranslateCoordinatesReply) -> Reply {
+    Reply::TranslateCoordinates(reply)
+  }
+}
+impl From<xproto::GetInputFocusReply> for Reply {
+  fn from(reply: xproto::GetInputFocusReply) -> Reply {
+    Reply::GetInputFocus(reply)
+  }
+}
+impl From<xproto::QueryKeymapReply> for Reply {
+  fn from(reply: xproto::QueryKeymapReply) -> Reply {
+    Reply::QueryKeymap(reply)
+  }
+}
+impl From<xproto::QueryFontReply> for Reply {
+  fn from(reply: xproto::QueryFontReply) -> Reply {
+    Reply::QueryFont(reply)
+  }
+}
+impl From<xproto::QueryTextExtentsReply> for Reply {
+  fn from(reply: xproto::QueryTextExtentsReply) -> Reply {
+    Reply::QueryTextExtents(reply)
+  }
+}
+impl From<xproto::ListFontsReply> for Reply {
+  fn from(reply: xproto::ListFontsReply) -> Reply {
+    Reply::ListFonts(reply)
+  }
+}
+impl From<xproto::ListFontsWithInfoReply> for Reply {
+  fn from(reply: xproto::ListFontsWithInfoReply) -> Reply {
+    Reply::ListFontsWithInfo(reply)
+  }
+}
+impl From<xproto::GetFontPathReply> for Reply {
+  fn from(reply: xproto::GetFontPathReply) -> Reply {
+    Reply::GetFontPath(reply)
+  }
+}
+impl From<xproto::GetImageReply> for Reply {
+  fn from(reply: xproto::GetImageReply) -> Reply {
+    Reply::GetImage(reply)
+  }
+}
+impl From<xproto::ListInstalledColormapsReply> for Reply {
+  fn from(reply: xproto::ListInstalledColormapsReply) -> Reply {
+    Reply::ListInstalledColormaps(reply)
+  }
+}
+impl From<xproto::AllocColorReply> for Reply {
+  fn from(reply: xproto::AllocColorReply) -> Reply {
+    Reply::AllocColor(reply)
+  }
+}
+impl From<xproto::AllocNamedColorReply> for Reply {
+  fn from(reply: xproto::AllocNamedColorReply) -> Reply {
+    Reply::AllocNamedColor(reply)
+  }
+}
+impl From<xproto::AllocColorCellsReply> for Reply {
+  fn from(reply: xproto::AllocColorCellsReply) -> Reply {
+    Reply::AllocColorCells(reply)
+  }
+}
+impl From<xproto::AllocColorPlanesReply> for Reply {
+  fn from(reply: xproto::AllocColorPlanesReply) -> Reply {
+    Reply::AllocColorPlanes(reply)
+  }
+}
+impl From<xproto::QueryColorsReply> for Reply {
+  fn from(reply: xproto::QueryColorsReply) -> Reply {
+    Reply::QueryColors(reply)
+  }
+}
+impl From<xproto::LookupColorReply> for Reply {
+  fn from(reply: xproto::LookupColorReply) -> Reply {
+    Reply::LookupColor(reply)
+  }
+}
+impl From<xproto::QueryBestSizeReply> for Reply {
+  fn from(reply: xproto::QueryBestSizeReply) -> Reply {
+    Reply::QueryBestSize(reply)
+  }
+}
+impl From<xproto::QueryExtensionReply> for Reply {
+  fn from(reply: xproto::QueryExtensionReply) -> Reply {
+    Reply::QueryExtension(reply)
+  }
+}
+impl From<xproto::ListExtensionsReply> for Reply {
+  fn from(reply: xproto::ListExtensionsReply) -> Reply {
+    Reply::ListExtensions(reply)
+  }
+}
+impl From<xproto::GetKeyboardMappingReply> for Reply {
+  fn from(reply: xproto::GetKeyboardMappingReply) -> Reply {
+    Reply::GetKeyboardMapping(reply)
+  }
+}
+impl From<xproto::GetKeyboardControlReply> for Reply {
+  fn from(reply: xproto::GetKeyboardControlReply) -> Reply {
+    Reply::GetKeyboardControl(reply)
+  }
+}
+impl From<xproto::GetPointerControlReply> for Reply {
+  fn from(reply: xproto::GetPointerControlReply) -> Reply {
+    Reply::GetPointerControl(reply)
+  }
+}
+impl From<xproto::GetScreenSaverReply> for Reply {
+  fn from(reply: xproto::GetScreenSaverReply) -> Reply {
+    Reply::GetScreenSaver(reply)
+  }
+}
+impl From<xproto::ListHostsReply> for Reply {
+  fn from(reply: xproto::ListHostsReply) -> Reply {
+    Reply::ListHosts(reply)
+  }
+}
+impl From<xproto::SetPointerMappingReply> for Reply {
+  fn from(reply: xproto::SetPointerMappingReply) -> Reply {
+    Reply::SetPointerMapping(reply)
+  }
+}
+impl From<xproto::GetPointerMappingReply> for Reply {
+  fn from(reply: xproto::GetPointerMappingReply) -> Reply {
+    Reply::GetPointerMapping(reply)
+  }
+}
+impl From<xproto::SetModifierMappingReply> for Reply {
+  fn from(reply: xproto::SetModifierMappingReply) -> Reply {
+    Reply::SetModifierMapping(reply)
+  }
+}
+impl From<xproto::GetModifierMappingReply> for Reply {
+  fn from(reply: xproto::GetModifierMappingReply) -> Reply {
+    Reply::GetModifierMapping(reply)
+  }
+}
+impl From<bigreq::EnableReply> for Reply {
+  fn from(reply: bigreq::EnableReply) -> Reply {
+    Reply::BigreqEnable(reply)
+  }
+}
+#[cfg(feature = "composite")]
+impl From<composite::QueryVersionReply> for Reply {
+  fn from(reply: composite::QueryVersionReply) -> Reply {
+    Reply::CompositeQueryVersion(reply)
+  }
+}
+#[cfg(feature = "composite")]
+impl From<composite::GetOverlayWindowReply> for Reply {
+  fn from(reply: composite::GetOverlayWindowReply) -> Reply {
+    Reply::CompositeGetOverlayWindow(reply)
+  }
+}
+#[cfg(feature = "damage")]
+impl From<damage::QueryVersionReply> for Reply {
+  fn from(reply: damage::QueryVersionReply) -> Reply {
+    Reply::DamageQueryVersion(reply)
+  }
+}
+#[cfg(feature = "dpms")]
+impl From<dpms::GetVersionReply> for Reply {
+  fn from(reply: dpms::GetVersionReply) -> Reply {
+    Reply::DpmsGetVersion(reply)
+  }
+}
+#[cfg(feature = "dpms")]
+impl From<dpms::CapableReply> for Reply {
+  fn from(reply: dpms::CapableReply) -> Reply {
+    Reply::DpmsCapable(reply)
+  }
+}
+#[cfg(feature = "dpms")]
+impl From<dpms::GetTimeoutsReply> for Reply {
+  fn from(reply: dpms::GetTimeoutsReply) -> Reply {
+    Reply::DpmsGetTimeouts(reply)
+  }
+}
+#[cfg(feature = "dpms")]
+impl From<dpms::InfoReply> for Reply {
+  fn from(reply: dpms::InfoReply) -> Reply {
+    Reply::DpmsInfo(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::QueryVersionReply> for Reply {
+  fn from(reply: dri2::QueryVersionReply) -> Reply {
+    Reply::Dri2QueryVersion(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::ConnectReply> for Reply {
+  fn from(reply: dri2::ConnectReply) -> Reply {
+    Reply::Dri2Connect(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::AuthenticateReply> for Reply {
+  fn from(reply: dri2::AuthenticateReply) -> Reply {
+    Reply::Dri2Authenticate(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::GetBuffersReply> for Reply {
+  fn from(reply: dri2::GetBuffersReply) -> Reply {
+    Reply::Dri2GetBuffers(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::CopyRegionReply> for Reply {
+  fn from(reply: dri2::CopyRegionReply) -> Reply {
+    Reply::Dri2CopyRegion(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::GetBuffersWithFormatReply> for Reply {
+  fn from(reply: dri2::GetBuffersWithFormatReply) -> Reply {
+    Reply::Dri2GetBuffersWithFormat(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::SwapBuffersReply> for Reply {
+  fn from(reply: dri2::SwapBuffersReply) -> Reply {
+    Reply::Dri2SwapBuffers(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::GetMSCReply> for Reply {
+  fn from(reply: dri2::GetMSCReply) -> Reply {
+    Reply::Dri2GetMSC(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::WaitMSCReply> for Reply {
+  fn from(reply: dri2::WaitMSCReply) -> Reply {
+    Reply::Dri2WaitMSC(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::WaitSBCReply> for Reply {
+  fn from(reply: dri2::WaitSBCReply) -> Reply {
+    Reply::Dri2WaitSBC(reply)
+  }
+}
+#[cfg(feature = "dri2")]
+impl From<dri2::GetParamReply> for Reply {
+  fn from(reply: dri2::GetParamReply) -> Reply {
+    Reply::Dri2GetParam(reply)
+  }
+}
+#[cfg(feature = "dri3")]
+impl From<dri3::QueryVersionReply> for Reply {
+  fn from(reply: dri3::QueryVersionReply) -> Reply {
+    Reply::Dri3QueryVersion(reply)
+  }
+}
+#[cfg(feature = "dri3")]
+impl From<dri3::OpenReply> for Reply {
+  fn from(reply: dri3::OpenReply) -> Reply {
+    Reply::Dri3Open(reply)
+  }
+}
+#[cfg(feature = "dri3")]
+impl From<dri3::BufferFromPixmapReply> for Reply {
+  fn from(reply: dri3::BufferFromPixmapReply) -> Reply {
+    Reply::Dri3BufferFromPixmap(reply)
+  }
+}
+#[cfg(feature = "dri3")]
+impl From<dri3::FDFromFenceReply> for Reply {
+  fn from(reply: dri3::FDFromFenceReply) -> Reply {
+    Reply::Dri3FDFromFence(reply)
+  }
+}
+#[cfg(feature = "dri3")]
+impl From<dri3::GetSupportedModifiersReply> for Reply {
+  fn from(reply: dri3::GetSupportedModifiersReply) -> Reply {
+    Reply::Dri3GetSupportedModifiers(reply)
+  }
+}
+#[cfg(feature = "dri3")]
+impl From<dri3::BuffersFromPixmapReply> for Reply {
+  fn from(reply: dri3::BuffersFromPixmapReply) -> Reply {
+    Reply::Dri3BuffersFromPixmap(reply)
+  }
+}
+impl From<ge::QueryVersionReply> for Reply {
+  fn from(reply: ge::QueryVersionReply) -> Reply {
+    Reply::GeQueryVersion(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::MakeCurrentReply> for Reply {
+  fn from(reply: glx::MakeCurrentReply) -> Reply {
+    Reply::GlxMakeCurrent(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::IsDirectReply> for Reply {
+  fn from(reply: glx::IsDirectReply) -> Reply {
+    Reply::GlxIsDirect(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::QueryVersionReply> for Reply {
+  fn from(reply: glx::QueryVersionReply) -> Reply {
+    Reply::GlxQueryVersion(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetVisualConfigsReply> for Reply {
+  fn from(reply: glx::GetVisualConfigsReply) -> Reply {
+    Reply::GlxGetVisualConfigs(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::VendorPrivateWithReplyReply> for Reply {
+  fn from(reply: glx::VendorPrivateWithReplyReply) -> Reply {
+    Reply::GlxVendorPrivateWithReply(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::QueryExtensionsStringReply> for Reply {
+  fn from(reply: glx::QueryExtensionsStringReply) -> Reply {
+    Reply::GlxQueryExtensionsString(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::QueryServerStringReply> for Reply {
+  fn from(reply: glx::QueryServerStringReply) -> Reply {
+    Reply::GlxQueryServerString(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetFBConfigsReply> for Reply {
+  fn from(reply: glx::GetFBConfigsReply) -> Reply {
+    Reply::GlxGetFBConfigs(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::QueryContextReply> for Reply {
+  fn from(reply: glx::QueryContextReply) -> Reply {
+    Reply::GlxQueryContext(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::MakeContextCurrentReply> for Reply {
+  fn from(reply: glx::MakeContextCurrentReply) -> Reply {
+    Reply::GlxMakeContextCurrent(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetDrawableAttributesReply> for Reply {
+  fn from(reply: glx::GetDrawableAttributesReply) -> Reply {
+    Reply::GlxGetDrawableAttributes(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GenListsReply> for Reply {
+  fn from(reply: glx::GenListsReply) -> Reply {
+    Reply::GlxGenLists(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::RenderModeReply> for Reply {
+  fn from(reply: glx::RenderModeReply) -> Reply {
+    Reply::GlxRenderMode(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::FinishReply> for Reply {
+  fn from(reply: glx::FinishReply) -> Reply {
+    Reply::GlxFinish(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::ReadPixelsReply> for Reply {
+  fn from(reply: glx::ReadPixelsReply) -> Reply {
+    Reply::GlxReadPixels(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetBooleanvReply> for Reply {
+  fn from(reply: glx::GetBooleanvReply) -> Reply {
+    Reply::GlxGetBooleanv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetClipPlaneReply> for Reply {
+  fn from(reply: glx::GetClipPlaneReply) -> Reply {
+    Reply::GlxGetClipPlane(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetDoublevReply> for Reply {
+  fn from(reply: glx::GetDoublevReply) -> Reply {
+    Reply::GlxGetDoublev(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetErrorReply> for Reply {
+  fn from(reply: glx::GetErrorReply) -> Reply {
+    Reply::GlxGetError(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetFloatvReply> for Reply {
+  fn from(reply: glx::GetFloatvReply) -> Reply {
+    Reply::GlxGetFloatv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetIntegervReply> for Reply {
+  fn from(reply: glx::GetIntegervReply) -> Reply {
+    Reply::GlxGetIntegerv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetLightfvReply> for Reply {
+  fn from(reply: glx::GetLightfvReply) -> Reply {
+    Reply::GlxGetLightfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetLightivReply> for Reply {
+  fn from(reply: glx::GetLightivReply) -> Reply {
+    Reply::GlxGetLightiv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMapdvReply> for Reply {
+  fn from(reply: glx::GetMapdvReply) -> Reply {
+    Reply::GlxGetMapdv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMapfvReply> for Reply {
+  fn from(reply: glx::GetMapfvReply) -> Reply {
+    Reply::GlxGetMapfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMapivReply> for Reply {
+  fn from(reply: glx::GetMapivReply) -> Reply {
+    Reply::GlxGetMapiv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMaterialfvReply> for Reply {
+  fn from(reply: glx::GetMaterialfvReply) -> Reply {
+    Reply::GlxGetMaterialfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMaterialivReply> for Reply {
+  fn from(reply: glx::GetMaterialivReply) -> Reply {
+    Reply::GlxGetMaterialiv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetPixelMapfvReply> for Reply {
+  fn from(reply: glx::GetPixelMapfvReply) -> Reply {
+    Reply::GlxGetPixelMapfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetPixelMapuivReply> for Reply {
+  fn from(reply: glx::GetPixelMapuivReply) -> Reply {
+    Reply::GlxGetPixelMapuiv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetPixelMapusvReply> for Reply {
+  fn from(reply: glx::GetPixelMapusvReply) -> Reply {
+    Reply::GlxGetPixelMapusv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetPolygonStippleReply> for Reply {
+  fn from(reply: glx::GetPolygonStippleReply) -> Reply {
+    Reply::GlxGetPolygonStipple(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetStringReply> for Reply {
+  fn from(reply: glx::GetStringReply) -> Reply {
+    Reply::GlxGetString(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexEnvfvReply> for Reply {
+  fn from(reply: glx::GetTexEnvfvReply) -> Reply {
+    Reply::GlxGetTexEnvfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexEnvivReply> for Reply {
+  fn from(reply: glx::GetTexEnvivReply) -> Reply {
+    Reply::GlxGetTexEnviv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexGendvReply> for Reply {
+  fn from(reply: glx::GetTexGendvReply) -> Reply {
+    Reply::GlxGetTexGendv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexGenfvReply> for Reply {
+  fn from(reply: glx::GetTexGenfvReply) -> Reply {
+    Reply::GlxGetTexGenfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexGenivReply> for Reply {
+  fn from(reply: glx::GetTexGenivReply) -> Reply {
+    Reply::GlxGetTexGeniv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexImageReply> for Reply {
+  fn from(reply: glx::GetTexImageReply) -> Reply {
+    Reply::GlxGetTexImage(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexParameterfvReply> for Reply {
+  fn from(reply: glx::GetTexParameterfvReply) -> Reply {
+    Reply::GlxGetTexParameterfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexParameterivReply> for Reply {
+  fn from(reply: glx::GetTexParameterivReply) -> Reply {
+    Reply::GlxGetTexParameteriv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexLevelParameterfvReply> for Reply {
+  fn from(reply: glx::GetTexLevelParameterfvReply) -> Reply {
+    Reply::GlxGetTexLevelParameterfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetTexLevelParameterivReply> for Reply {
+  fn from(reply: glx::GetTexLevelParameterivReply) -> Reply {
+    Reply::GlxGetTexLevelParameteriv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::IsEnabledReply> for Reply {
+  fn from(reply: glx::IsEnabledReply) -> Reply {
+    Reply::GlxIsEnabled(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::IsListReply> for Reply {
+  fn from(reply: glx::IsListReply) -> Reply {
+    Reply::GlxIsList(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::AreTexturesResidentReply> for Reply {
+  fn from(reply: glx::AreTexturesResidentReply) -> Reply {
+    Reply::GlxAreTexturesResident(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GenTexturesReply> for Reply {
+  fn from(reply: glx::GenTexturesReply) -> Reply {
+    Reply::GlxGenTextures(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::IsTextureReply> for Reply {
+  fn from(reply: glx::IsTextureReply) -> Reply {
+    Reply::GlxIsTexture(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetColorTableReply> for Reply {
+  fn from(reply: glx::GetColorTableReply) -> Reply {
+    Reply::GlxGetColorTable(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetColorTableParameterfvReply> for Reply {
+  fn from(reply: glx::GetColorTableParameterfvReply) -> Reply {
+    Reply::GlxGetColorTableParameterfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetColorTableParameterivReply> for Reply {
+  fn from(reply: glx::GetColorTableParameterivReply) -> Reply {
+    Reply::GlxGetColorTableParameteriv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetConvolutionFilterReply> for Reply {
+  fn from(reply: glx::GetConvolutionFilterReply) -> Reply {
+    Reply::GlxGetConvolutionFilter(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetConvolutionParameterfvReply> for Reply {
+  fn from(reply: glx::GetConvolutionParameterfvReply) -> Reply {
+    Reply::GlxGetConvolutionParameterfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetConvolutionParameterivReply> for Reply {
+  fn from(reply: glx::GetConvolutionParameterivReply) -> Reply {
+    Reply::GlxGetConvolutionParameteriv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetSeparableFilterReply> for Reply {
+  fn from(reply: glx::GetSeparableFilterReply) -> Reply {
+    Reply::GlxGetSeparableFilter(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetHistogramReply> for Reply {
+  fn from(reply: glx::GetHistogramReply) -> Reply {
+    Reply::GlxGetHistogram(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetHistogramParameterfvReply> for Reply {
+  fn from(reply: glx::GetHistogramParameterfvReply) -> Reply {
+    Reply::GlxGetHistogramParameterfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetHistogramParameterivReply> for Reply {
+  fn from(reply: glx::GetHistogramParameterivReply) -> Reply {
+    Reply::GlxGetHistogramParameteriv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMinmaxReply> for Reply {
+  fn from(reply: glx::GetMinmaxReply) -> Reply {
+    Reply::GlxGetMinmax(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMinmaxParameterfvReply> for Reply {
+  fn from(reply: glx::GetMinmaxParameterfvReply) -> Reply {
+    Reply::GlxGetMinmaxParameterfv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetMinmaxParameterivReply> for Reply {
+  fn from(reply: glx::GetMinmaxParameterivReply) -> Reply {
+    Reply::GlxGetMinmaxParameteriv(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetCompressedTexImageARBReply> for Reply {
+  fn from(reply: glx::GetCompressedTexImageARBReply) -> Reply {
+    Reply::GlxGetCompressedTexImageARB(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GenQueriesARBReply> for Reply {
+  fn from(reply: glx::GenQueriesARBReply) -> Reply {
+    Reply::GlxGenQueriesARB(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::IsQueryARBReply> for Reply {
+  fn from(reply: glx::IsQueryARBReply) -> Reply {
+    Reply::GlxIsQueryARB(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetQueryivARBReply> for Reply {
+  fn from(reply: glx::GetQueryivARBReply) -> Reply {
+    Reply::GlxGetQueryivARB(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetQueryObjectivARBReply> for Reply {
+  fn from(reply: glx::GetQueryObjectivARBReply) -> Reply {
+    Reply::GlxGetQueryObjectivARB(reply)
+  }
+}
+#[cfg(feature = "glx")]
+impl From<glx::GetQueryObjectuivARBReply> for Reply {
+  fn from(reply: glx::GetQueryObjectuivARBReply) -> Reply {
+    Reply::GlxGetQueryObjectuivARB(reply)
+  }
+}
+#[cfg(feature = "present")]
+impl From<present::QueryVersionReply> for Reply {
+  fn from(reply: present::QueryVersionReply) -> Reply {
+    Reply::PresentQueryVersion(reply)
+  }
+}
+#[cfg(feature = "present")]
+impl From<present::QueryCapabilitiesReply> for Reply {
+  fn from(reply: present::QueryCapabilitiesReply) -> Reply {
+    Reply::PresentQueryCapabilities(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::QueryVersionReply> for Reply {
+  fn from(reply: randr::QueryVersionReply) -> Reply {
+    Reply::RandrQueryVersion(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::SetScreenConfigReply> for Reply {
+  fn from(reply: randr::SetScreenConfigReply) -> Reply {
+    Reply::RandrSetScreenConfig(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetScreenInfoReply> for Reply {
+  fn from(reply: randr::GetScreenInfoReply) -> Reply {
+    Reply::RandrGetScreenInfo(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetScreenSizeRangeReply> for Reply {
+  fn from(reply: randr::GetScreenSizeRangeReply) -> Reply {
+    Reply::RandrGetScreenSizeRange(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetScreenResourcesReply> for Reply {
+  fn from(reply: randr::GetScreenResourcesReply) -> Reply {
+    Reply::RandrGetScreenResources(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetOutputInfoReply> for Reply {
+  fn from(reply: randr::GetOutputInfoReply) -> Reply {
+    Reply::RandrGetOutputInfo(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::ListOutputPropertiesReply> for Reply {
+  fn from(reply: randr::ListOutputPropertiesReply) -> Reply {
+    Reply::RandrListOutputProperties(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::QueryOutputPropertyReply> for Reply {
+  fn from(reply: randr::QueryOutputPropertyReply) -> Reply {
+    Reply::RandrQueryOutputProperty(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetOutputPropertyReply> for Reply {
+  fn from(reply: randr::GetOutputPropertyReply) -> Reply {
+    Reply::RandrGetOutputProperty(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::CreateModeReply> for Reply {
+  fn from(reply: randr::CreateModeReply) -> Reply {
+    Reply::RandrCreateMode(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetCrtcInfoReply> for Reply {
+  fn from(reply: randr::GetCrtcInfoReply) -> Reply {
+    Reply::RandrGetCrtcInfo(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::SetCrtcConfigReply> for Reply {
+  fn from(reply: randr::SetCrtcConfigReply) -> Reply {
+    Reply::RandrSetCrtcConfig(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetCrtcGammaSizeReply> for Reply {
+  fn from(reply: randr::GetCrtcGammaSizeReply) -> Reply {
+    Reply::RandrGetCrtcGammaSize(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetCrtcGammaReply> for Reply {
+  fn from(reply: randr::GetCrtcGammaReply) -> Reply {
+    Reply::RandrGetCrtcGamma(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetScreenResourcesCurrentReply> for Reply {
+  fn from(reply: randr::GetScreenResourcesCurrentReply) -> Reply {
+    Reply::RandrGetScreenResourcesCurrent(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetCrtcTransformReply> for Reply {
+  fn from(reply: randr::GetCrtcTransformReply) -> Reply {
+    Reply::RandrGetCrtcTransform(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetPanningReply> for Reply {
+  fn from(reply: randr::GetPanningReply) -> Reply {
+    Reply::RandrGetPanning(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::SetPanningReply> for Reply {
+  fn from(reply: randr::SetPanningReply) -> Reply {
+    Reply::RandrSetPanning(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetOutputPrimaryReply> for Reply {
+  fn from(reply: randr::GetOutputPrimaryReply) -> Reply {
+    Reply::RandrGetOutputPrimary(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetProvidersReply> for Reply {
+  fn from(reply: randr::GetProvidersReply) -> Reply {
+    Reply::RandrGetProviders(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetProviderInfoReply> for Reply {
+  fn from(reply: randr::GetProviderInfoReply) -> Reply {
+    Reply::RandrGetProviderInfo(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::ListProviderPropertiesReply> for Reply {
+  fn from(reply: randr::ListProviderPropertiesReply) -> Reply {
+    Reply::RandrListProviderProperties(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::QueryProviderPropertyReply> for Reply {
+  fn from(reply: randr::QueryProviderPropertyReply) -> Reply {
+    Reply::RandrQueryProviderProperty(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetProviderPropertyReply> for Reply {
+  fn from(reply: randr::GetProviderPropertyReply) -> Reply {
+    Reply::RandrGetProviderProperty(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::GetMonitorsReply> for Reply {
+  fn from(reply: randr::GetMonitorsReply) -> Reply {
+    Reply::RandrGetMonitors(reply)
+  }
+}
+#[cfg(feature = "randr")]
+impl From<randr::CreateLeaseReply> for Reply {
+  fn from(reply: randr::CreateLeaseReply) -> Reply {
+    Reply::RandrCreateLease(reply)
+  }
+}
+#[cfg(feature = "record")]
+impl From<record::QueryVersionReply> for Reply {
+  fn from(reply: record::QueryVersionReply) -> Reply {
+    Reply::RecordQueryVersion(reply)
+  }
+}
+#[cfg(feature = "record")]
+impl From<record::GetContextReply> for Reply {
+  fn from(reply: record::GetContextReply) -> Reply {
+    Reply::RecordGetContext(reply)
+  }
+}
+#[cfg(feature = "record")]
+impl From<record::EnableContextReply> for Reply {
+  fn from(reply: record::EnableContextReply) -> Reply {
+    Reply::RecordEnableContext(reply)
+  }
+}
+#[cfg(feature = "render")]
+impl From<render::QueryVersionReply> for Reply {
+  fn from(reply: render::QueryVersionReply) -> Reply {
+    Reply::RenderQueryVersion(reply)
+  }
+}
+#[cfg(feature = "render")]
+impl From<render::QueryPictFormatsReply> for Reply {
+  fn from(reply: render::QueryPictFormatsReply) -> Reply {
+    Reply::RenderQueryPictFormats(reply)
+  }
+}
+#[cfg(feature = "render")]
+impl From<render::QueryPictIndexValuesReply> for Reply {
+  fn from(reply: render::QueryPictIndexValuesReply) -> Reply {
+    Reply::RenderQueryPictIndexValues(reply)
+  }
+}
+#[cfg(feature = "render")]
+impl From<render::QueryFiltersReply> for Reply {
+  fn from(reply: render::QueryFiltersReply) -> Reply {
+    Reply::RenderQueryFilters(reply)
+  }
+}
+#[cfg(feature = "res")]
+impl From<res::QueryVersionReply> for Reply {
+  fn from(reply: res::QueryVersionReply) -> Reply {
+    Reply::ResQueryVersion(reply)
+  }
+}
+#[cfg(feature = "res")]
+impl From<res::QueryClientsReply> for Reply {
+  fn from(reply: res::QueryClientsReply) -> Reply {
+    Reply::ResQueryClients(reply)
+  }
+}
+#[cfg(feature = "res")]
+impl From<res::QueryClientResourcesReply> for Reply {
+  fn from(reply: res::QueryClientResourcesReply) -> Reply {
+    Reply::ResQueryClientResources(reply)
+  }
+}
+#[cfg(feature = "res")]
+impl From<res::QueryClientPixmapBytesReply> for Reply {
+  fn from(reply: res::QueryClientPixmapBytesReply) -> Reply {
+    Reply::ResQueryClientPixmapBytes(reply)
+  }
+}
+#[cfg(feature = "res")]
+impl From<res::QueryClientIdsReply> for Reply {
+  fn from(reply: res::QueryClientIdsReply) -> Reply {
+    Reply::ResQueryClientIds(reply)
+  }
+}
+#[cfg(feature = "res")]
+impl From<res::QueryResourceBytesReply> for Reply {
+  fn from(reply: res::QueryResourceBytesReply) -> Reply {
+    Reply::ResQueryResourceBytes(reply)
+  }
+}
+#[cfg(feature = "screensaver")]
+impl From<screensaver::QueryVersionReply> for Reply {
+  fn from(reply: screensaver::QueryVersionReply) -> Reply {
+    Reply::ScreensaverQueryVersion(reply)
+  }
+}
+#[cfg(feature = "screensaver")]
+impl From<screensaver::QueryInfoReply> for Reply {
+  fn from(reply: screensaver::QueryInfoReply) -> Reply {
+    Reply::ScreensaverQueryInfo(reply)
+  }
+}
+#[cfg(feature = "shape")]
+impl From<shape::QueryVersionReply> for Reply {
+  fn from(reply: shape::QueryVersionReply) -> Reply {
+    Reply::ShapeQueryVersion(reply)
+  }
+}
+#[cfg(feature = "shape")]
+impl From<shape::QueryExtentsReply> for Reply {
+  fn from(reply: shape::QueryExtentsReply) -> Reply {
+    Reply::ShapeQueryExtents(reply)
+  }
+}
+#[cfg(feature = "shape")]
+impl From<shape::InputSelectedReply> for Reply {
+  fn from(reply: shape::InputSelectedReply) -> Reply {
+    Reply::ShapeInputSelected(reply)
+  }
+}
+#[cfg(feature = "shape")]
+impl From<shape::GetRectanglesReply> for Reply {
+  fn from(reply: shape::GetRectanglesReply) -> Reply {
+    Reply::ShapeGetRectangles(reply)
+  }
+}
+#[cfg(feature = "shm")]
+impl From<shm::QueryVersionReply> for Reply {
+  fn from(reply: shm::QueryVersionReply) -> Reply {
+    Reply::ShmQueryVersion(reply)
+  }
+}
+#[cfg(feature = "shm")]
+impl From<shm::GetImageReply> for Reply {
+  fn from(reply: shm::GetImageReply) -> Reply {
+    Reply::ShmGetImage(reply)
+  }
+}
+#[cfg(feature = "shm")]
+impl From<shm::CreateSegmentReply> for Reply {
+  fn from(reply: shm::CreateSegmentReply) -> Reply {
+    Reply::ShmCreateSegment(reply)
+  }
+}
+#[cfg(feature = "sync")]
+impl From<sync::InitializeReply> for Reply {
+  fn from(reply: sync::InitializeReply) -> Reply {
+    Reply::SyncInitialize(reply)
+  }
+}
+#[cfg(feature = "sync")]
+impl From<sync::ListSystemCountersReply> for Reply {
+  fn from(reply: sync::ListSystemCountersReply) -> Reply {
+    Reply::SyncListSystemCounters(reply)
+  }
+}
+#[cfg(feature = "sync")]
+impl From<sync::QueryCounterReply> for Reply {
+  fn from(reply: sync::QueryCounterReply) -> Reply {
+    Reply::SyncQueryCounter(reply)
+  }
+}
+#[cfg(feature = "sync")]
+impl From<sync::QueryAlarmReply> for Reply {
+  fn from(reply: sync::QueryAlarmReply) -> Reply {
+    Reply::SyncQueryAlarm(reply)
+  }
+}
+#[cfg(feature = "sync")]
+impl From<sync::GetPriorityReply> for Reply {
+  fn from(reply: sync::GetPriorityReply) -> Reply {
+    Reply::SyncGetPriority(reply)
+  }
+}
+#[cfg(feature = "sync")]
+impl From<sync::QueryFenceReply> for Reply {
+  fn from(reply: sync::QueryFenceReply) -> Reply {
+    Reply::SyncQueryFence(reply)
+  }
+}
+impl From<xc_misc::GetVersionReply> for Reply {
+  fn from(reply: xc_misc::GetVersionReply) -> Reply {
+    Reply::XcMiscGetVersion(reply)
+  }
+}
+impl From<xc_misc::GetXIDRangeReply> for Reply {
+  fn from(reply: xc_misc::GetXIDRangeReply) -> Reply {
+    Reply::XcMiscGetXIDRange(reply)
+  }
+}
+impl From<xc_misc::GetXIDListReply> for Reply {
+  fn from(reply: xc_misc::GetXIDListReply) -> Reply {
+    Reply::XcMiscGetXIDList(reply)
+  }
+}
+#[cfg(feature = "xevie")]
+impl From<xevie::QueryVersionReply> for Reply {
+  fn from(reply: xevie::QueryVersionReply) -> Reply {
+    Reply::XevieQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xevie")]
+impl From<xevie::StartReply> for Reply {
+  fn from(reply: xevie::StartReply) -> Reply {
+    Reply::XevieStart(reply)
+  }
+}
+#[cfg(feature = "xevie")]
+impl From<xevie::EndReply> for Reply {
+  fn from(reply: xevie::EndReply) -> Reply {
+    Reply::XevieEnd(reply)
+  }
+}
+#[cfg(feature = "xevie")]
+impl From<xevie::SendReply> for Reply {
+  fn from(reply: xevie::SendReply) -> Reply {
+    Reply::XevieSend(reply)
+  }
+}
+#[cfg(feature = "xevie")]
+impl From<xevie::SelectInputReply> for Reply {
+  fn from(reply: xevie::SelectInputReply) -> Reply {
+    Reply::XevieSelectInput(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::QueryVersionReply> for Reply {
+  fn from(reply: xf86dri::QueryVersionReply) -> Reply {
+    Reply::Xf86driQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::QueryDirectRenderingCapableReply> for Reply {
+  fn from(reply: xf86dri::QueryDirectRenderingCapableReply) -> Reply {
+    Reply::Xf86driQueryDirectRenderingCapable(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::OpenConnectionReply> for Reply {
+  fn from(reply: xf86dri::OpenConnectionReply) -> Reply {
+    Reply::Xf86driOpenConnection(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::GetClientDriverNameReply> for Reply {
+  fn from(reply: xf86dri::GetClientDriverNameReply) -> Reply {
+    Reply::Xf86driGetClientDriverName(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::CreateContextReply> for Reply {
+  fn from(reply: xf86dri::CreateContextReply) -> Reply {
+    Reply::Xf86driCreateContext(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::CreateDrawableReply> for Reply {
+  fn from(reply: xf86dri::CreateDrawableReply) -> Reply {
+    Reply::Xf86driCreateDrawable(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::GetDrawableInfoReply> for Reply {
+  fn from(reply: xf86dri::GetDrawableInfoReply) -> Reply {
+    Reply::Xf86driGetDrawableInfo(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::GetDeviceInfoReply> for Reply {
+  fn from(reply: xf86dri::GetDeviceInfoReply) -> Reply {
+    Reply::Xf86driGetDeviceInfo(reply)
+  }
+}
+#[cfg(feature = "xf86dri")]
+impl From<xf86dri::AuthConnectionReply> for Reply {
+  fn from(reply: xf86dri::AuthConnectionReply) -> Reply {
+    Reply::Xf86driAuthConnection(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::QueryVersionReply> for Reply {
+  fn from(reply: xf86vidmode::QueryVersionReply) -> Reply {
+    Reply::Xf86vidmodeQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetModeLineReply> for Reply {
+  fn from(reply: xf86vidmode::GetModeLineReply) -> Reply {
+    Reply::Xf86vidmodeGetModeLine(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetMonitorReply> for Reply {
+  fn from(reply: xf86vidmode::GetMonitorReply) -> Reply {
+    Reply::Xf86vidmodeGetMonitor(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetAllModeLinesReply> for Reply {
+  fn from(reply: xf86vidmode::GetAllModeLinesReply) -> Reply {
+    Reply::Xf86vidmodeGetAllModeLines(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::ValidateModeLineReply> for Reply {
+  fn from(reply: xf86vidmode::ValidateModeLineReply) -> Reply {
+    Reply::Xf86vidmodeValidateModeLine(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetViewPortReply> for Reply {
+  fn from(reply: xf86vidmode::GetViewPortReply) -> Reply {
+    Reply::Xf86vidmodeGetViewPort(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetDotClocksReply> for Reply {
+  fn from(reply: xf86vidmode::GetDotClocksReply) -> Reply {
+    Reply::Xf86vidmodeGetDotClocks(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetGammaReply> for Reply {
+  fn from(reply: xf86vidmode::GetGammaReply) -> Reply {
+    Reply::Xf86vidmodeGetGamma(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetGammaRampReply> for Reply {
+  fn from(reply: xf86vidmode::GetGammaRampReply) -> Reply {
+    Reply::Xf86vidmodeGetGammaRamp(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetGammaRampSizeReply> for Reply {
+  fn from(reply: xf86vidmode::GetGammaRampSizeReply) -> Reply {
+    Reply::Xf86vidmodeGetGammaRampSize(reply)
+  }
+}
+#[cfg(feature = "xf86vidmode")]
+impl From<xf86vidmode::GetPermissionsReply> for Reply {
+  fn from(reply: xf86vidmode::GetPermissionsReply) -> Reply {
+    Reply::Xf86vidmodeGetPermissions(reply)
+  }
+}
+#[cfg(feature = "xfixes")]
+impl From<xfixes::QueryVersionReply> for Reply {
+  fn from(reply: xfixes::QueryVersionReply) -> Reply {
+    Reply::XfixesQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xfixes")]
+impl From<xfixes::GetCursorImageReply> for Reply {
+  fn from(reply: xfixes::GetCursorImageReply) -> Reply {
+    Reply::XfixesGetCursorImage(reply)
+  }
+}
+#[cfg(feature = "xfixes")]
+impl From<xfixes::FetchRegionReply> for Reply {
+  fn from(reply: xfixes::FetchRegionReply) -> Reply {
+    Reply::XfixesFetchRegion(reply)
+  }
+}
+#[cfg(feature = "xfixes")]
+impl From<xfixes::GetCursorNameReply> for Reply {
+  fn from(reply: xfixes::GetCursorNameReply) -> Reply {
+    Reply::XfixesGetCursorName(reply)
+  }
+}
+#[cfg(feature = "xfixes")]
+impl From<xfixes::GetCursorImageAndNameReply> for Reply {
+  fn from(reply: xfixes::GetCursorImageAndNameReply) -> Reply {
+    Reply::XfixesGetCursorImageAndName(reply)
+  }
+}
+#[cfg(feature = "xinerama")]
+impl From<xinerama::QueryVersionReply> for Reply {
+  fn from(reply: xinerama::QueryVersionReply) -> Reply {
+    Reply::XineramaQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xinerama")]
+impl From<xinerama::GetStateReply> for Reply {
+  fn from(reply: xinerama::GetStateReply) -> Reply {
+    Reply::XineramaGetState(reply)
+  }
+}
+#[cfg(feature = "xinerama")]
+impl From<xinerama::GetScreenCountReply> for Reply {
+  fn from(reply: xinerama::GetScreenCountReply) -> Reply {
+    Reply::XineramaGetScreenCount(reply)
+  }
+}
+#[cfg(feature = "xinerama")]
+impl From<xinerama::GetScreenSizeReply> for Reply {
+  fn from(reply: xinerama::GetScreenSizeReply) -> Reply {
+    Reply::XineramaGetScreenSize(reply)
+  }
+}
+#[cfg(feature = "xinerama")]
+impl From<xinerama::IsActiveReply> for Reply {
+  fn from(reply: xinerama::IsActiveReply) -> Reply {
+    Reply::XineramaIsActive(reply)
+  }
+}
+#[cfg(feature = "xinerama")]
+impl From<xinerama::QueryScreensReply> for Reply {
+  fn from(reply: xinerama::QueryScreensReply) -> Reply {
+    Reply::XineramaQueryScreens(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetExtensionVersionReply> for Reply {
+  fn from(reply: xinput::GetExtensionVersionReply) -> Reply {
+    Reply::XinputGetExtensionVersion(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::ListInputDevicesReply> for Reply {
+  fn from(reply: xinput::ListInputDevicesReply) -> Reply {
+    Reply::XinputListInputDevices(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::OpenDeviceReply> for Reply {
+  fn from(reply: xinput::OpenDeviceReply) -> Reply {
+    Reply::XinputOpenDevice(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::SetDeviceModeReply> for Reply {
+  fn from(reply: xinput::SetDeviceModeReply) -> Reply {
+    Reply::XinputSetDeviceMode(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetSelectedExtensionEventsReply> for Reply {
+  fn from(reply: xinput::GetSelectedExtensionEventsReply) -> Reply {
+    Reply::XinputGetSelectedExtensionEvents(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDeviceDontPropagateListReply> for Reply {
+  fn from(reply: xinput::GetDeviceDontPropagateListReply) -> Reply {
+    Reply::XinputGetDeviceDontPropagateList(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDeviceMotionEventsReply> for Reply {
+  fn from(reply: xinput::GetDeviceMotionEventsReply) -> Reply {
+    Reply::XinputGetDeviceMotionEvents(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::ChangeKeyboardDeviceReply> for Reply {
+  fn from(reply: xinput::ChangeKeyboardDeviceReply) -> Reply {
+    Reply::XinputChangeKeyboardDevice(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::ChangePointerDeviceReply> for Reply {
+  fn from(reply: xinput::ChangePointerDeviceReply) -> Reply {
+    Reply::XinputChangePointerDevice(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GrabDeviceReply> for Reply {
+  fn from(reply: xinput::GrabDeviceReply) -> Reply {
+    Reply::XinputGrabDevice(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDeviceFocusReply> for Reply {
+  fn from(reply: xinput::GetDeviceFocusReply) -> Reply {
+    Reply::XinputGetDeviceFocus(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetFeedbackControlReply> for Reply {
+  fn from(reply: xinput::GetFeedbackControlReply) -> Reply {
+    Reply::XinputGetFeedbackControl(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDeviceKeyMappingReply> for Reply {
+  fn from(reply: xinput::GetDeviceKeyMappingReply) -> Reply {
+    Reply::XinputGetDeviceKeyMapping(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDeviceModifierMappingReply> for Reply {
+  fn from(reply: xinput::GetDeviceModifierMappingReply) -> Reply {
+    Reply::XinputGetDeviceModifierMapping(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::SetDeviceModifierMappingReply> for Reply {
+  fn from(reply: xinput::SetDeviceModifierMappingReply) -> Reply {
+    Reply::XinputSetDeviceModifierMapping(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDeviceButtonMappingReply> for Reply {
+  fn from(reply: xinput::GetDeviceButtonMappingReply) -> Reply {
+    Reply::XinputGetDeviceButtonMapping(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::SetDeviceButtonMappingReply> for Reply {
+  fn from(reply: xinput::SetDeviceButtonMappingReply) -> Reply {
+    Reply::XinputSetDeviceButtonMapping(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::QueryDeviceStateReply> for Reply {
+  fn from(reply: xinput::QueryDeviceStateReply) -> Reply {
+    Reply::XinputQueryDeviceState(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::SetDeviceValuatorsReply> for Reply {
+  fn from(reply: xinput::SetDeviceValuatorsReply) -> Reply {
+    Reply::XinputSetDeviceValuators(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDeviceControlReply> for Reply {
+  fn from(reply: xinput::GetDeviceControlReply) -> Reply {
+    Reply::XinputGetDeviceControl(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::ChangeDeviceControlReply> for Reply {
+  fn from(reply: xinput::ChangeDeviceControlReply) -> Reply {
+    Reply::XinputChangeDeviceControl(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::ListDevicePropertiesReply> for Reply {
+  fn from(reply: xinput::ListDevicePropertiesReply) -> Reply {
+    Reply::XinputListDeviceProperties(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::GetDevicePropertyReply> for Reply {
+  fn from(reply: xinput::GetDevicePropertyReply) -> Reply {
+    Reply::XinputGetDeviceProperty(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIQueryPointerReply> for Reply {
+  fn from(reply: xinput::XIQueryPointerReply) -> Reply {
+    Reply::XinputXIQueryPointer(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIGetClientPointerReply> for Reply {
+  fn from(reply: xinput::XIGetClientPointerReply) -> Reply {
+    Reply::XinputXIGetClientPointer(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIQueryVersionReply> for Reply {
+  fn from(reply: xinput::XIQueryVersionReply) -> Reply {
+    Reply::XinputXIQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIQueryDeviceReply> for Reply {
+  fn from(reply: xinput::XIQueryDeviceReply) -> Reply {
+    Reply::XinputXIQueryDevice(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIGetFocusReply> for Reply {
+  fn from(reply: xinput::XIGetFocusReply) -> Reply {
+    Reply::XinputXIGetFocus(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIGrabDeviceReply> for Reply {
+  fn from(reply: xinput::XIGrabDeviceReply) -> Reply {
+    Reply::XinputXIGrabDevice(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIPassiveGrabDeviceReply> for Reply {
+  fn from(reply: xinput::XIPassiveGrabDeviceReply) -> Reply {
+    Reply::XinputXIPassiveGrabDevice(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIListPropertiesReply> for Reply {
+  fn from(reply: xinput::XIListPropertiesReply) -> Reply {
+    Reply::XinputXIListProperties(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIGetPropertyReply> for Reply {
+  fn from(reply: xinput::XIGetPropertyReply) -> Reply {
+    Reply::XinputXIGetProperty(reply)
+  }
+}
+#[cfg(feature = "xinput")]
+impl From<xinput::XIGetSelectedEventsReply> for Reply {
+  fn from(reply: xinput::XIGetSelectedEventsReply) -> Reply {
+    Reply::XinputXIGetSelectedEvents(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::UseExtensionReply> for Reply {
+  fn from(reply: xkb::UseExtensionReply) -> Reply {
+    Reply::XkbUseExtension(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetStateReply> for Reply {
+  fn from(reply: xkb::GetStateReply) -> Reply {
+    Reply::XkbGetState(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetControlsReply> for Reply {
+  fn from(reply: xkb::GetControlsReply) -> Reply {
+    Reply::XkbGetControls(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetMapReply> for Reply {
+  fn from(reply: xkb::GetMapReply) -> Reply {
+    Reply::XkbGetMap(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetCompatMapReply> for Reply {
+  fn from(reply: xkb::GetCompatMapReply) -> Reply {
+    Reply::XkbGetCompatMap(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetIndicatorStateReply> for Reply {
+  fn from(reply: xkb::GetIndicatorStateReply) -> Reply {
+    Reply::XkbGetIndicatorState(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetIndicatorMapReply> for Reply {
+  fn from(reply: xkb::GetIndicatorMapReply) -> Reply {
+    Reply::XkbGetIndicatorMap(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetNamedIndicatorReply> for Reply {
+  fn from(reply: xkb::GetNamedIndicatorReply) -> Reply {
+    Reply::XkbGetNamedIndicator(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetNamesReply> for Reply {
+  fn from(reply: xkb::GetNamesReply) -> Reply {
+    Reply::XkbGetNames(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::PerClientFlagsReply> for Reply {
+  fn from(reply: xkb::PerClientFlagsReply) -> Reply {
+    Reply::XkbPerClientFlags(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::ListComponentsReply> for Reply {
+  fn from(reply: xkb::ListComponentsReply) -> Reply {
+    Reply::XkbListComponents(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetKbdByNameReply> for Reply {
+  fn from(reply: xkb::GetKbdByNameReply) -> Reply {
+    Reply::XkbGetKbdByName(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::GetDeviceInfoReply> for Reply {
+  fn from(reply: xkb::GetDeviceInfoReply) -> Reply {
+    Reply::XkbGetDeviceInfo(reply)
+  }
+}
+#[cfg(feature = "xkb")]
+impl From<xkb::SetDebuggingFlagsReply> for Reply {
+  fn from(reply: xkb::SetDebuggingFlagsReply) -> Reply {
+    Reply::XkbSetDebuggingFlags(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintQueryVersionReply> for Reply {
+  fn from(reply: xprint::PrintQueryVersionReply) -> Reply {
+    Reply::XprintPrintQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetPrinterListReply> for Reply {
+  fn from(reply: xprint::PrintGetPrinterListReply) -> Reply {
+    Reply::XprintPrintGetPrinterList(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetContextReply> for Reply {
+  fn from(reply: xprint::PrintGetContextReply) -> Reply {
+    Reply::XprintPrintGetContext(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetScreenOfContextReply> for Reply {
+  fn from(reply: xprint::PrintGetScreenOfContextReply) -> Reply {
+    Reply::XprintPrintGetScreenOfContext(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetDocumentDataReply> for Reply {
+  fn from(reply: xprint::PrintGetDocumentDataReply) -> Reply {
+    Reply::XprintPrintGetDocumentData(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintInputSelectedReply> for Reply {
+  fn from(reply: xprint::PrintInputSelectedReply) -> Reply {
+    Reply::XprintPrintInputSelected(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetAttributesReply> for Reply {
+  fn from(reply: xprint::PrintGetAttributesReply) -> Reply {
+    Reply::XprintPrintGetAttributes(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetOneAttributesReply> for Reply {
+  fn from(reply: xprint::PrintGetOneAttributesReply) -> Reply {
+    Reply::XprintPrintGetOneAttributes(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetPageDimensionsReply> for Reply {
+  fn from(reply: xprint::PrintGetPageDimensionsReply) -> Reply {
+    Reply::XprintPrintGetPageDimensions(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintQueryScreensReply> for Reply {
+  fn from(reply: xprint::PrintQueryScreensReply) -> Reply {
+    Reply::XprintPrintQueryScreens(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintSetImageResolutionReply> for Reply {
+  fn from(reply: xprint::PrintSetImageResolutionReply) -> Reply {
+    Reply::XprintPrintSetImageResolution(reply)
+  }
+}
+#[cfg(feature = "xprint")]
+impl From<xprint::PrintGetImageResolutionReply> for Reply {
+  fn from(reply: xprint::PrintGetImageResolutionReply) -> Reply {
+    Reply::XprintPrintGetImageResolution(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::QueryVersionReply> for Reply {
+  fn from(reply: xselinux::QueryVersionReply) -> Reply {
+    Reply::XselinuxQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetDeviceCreateContextReply> for Reply {
+  fn from(reply: xselinux::GetDeviceCreateContextReply) -> Reply {
+    Reply::XselinuxGetDeviceCreateContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetDeviceContextReply> for Reply {
+  fn from(reply: xselinux::GetDeviceContextReply) -> Reply {
+    Reply::XselinuxGetDeviceContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetWindowCreateContextReply> for Reply {
+  fn from(reply: xselinux::GetWindowCreateContextReply) -> Reply {
+    Reply::XselinuxGetWindowCreateContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetWindowContextReply> for Reply {
+  fn from(reply: xselinux::GetWindowContextReply) -> Reply {
+    Reply::XselinuxGetWindowContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetPropertyCreateContextReply> for Reply {
+  fn from(reply: xselinux::GetPropertyCreateContextReply) -> Reply {
+    Reply::XselinuxGetPropertyCreateContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetPropertyUseContextReply> for Reply {
+  fn from(reply: xselinux::GetPropertyUseContextReply) -> Reply {
+    Reply::XselinuxGetPropertyUseContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetPropertyContextReply> for Reply {
+  fn from(reply: xselinux::GetPropertyContextReply) -> Reply {
+    Reply::XselinuxGetPropertyContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetPropertyDataContextReply> for Reply {
+  fn from(reply: xselinux::GetPropertyDataContextReply) -> Reply {
+    Reply::XselinuxGetPropertyDataContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::ListPropertiesReply> for Reply {
+  fn from(reply: xselinux::ListPropertiesReply) -> Reply {
+    Reply::XselinuxListProperties(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetSelectionCreateContextReply> for Reply {
+  fn from(reply: xselinux::GetSelectionCreateContextReply) -> Reply {
+    Reply::XselinuxGetSelectionCreateContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetSelectionUseContextReply> for Reply {
+  fn from(reply: xselinux::GetSelectionUseContextReply) -> Reply {
+    Reply::XselinuxGetSelectionUseContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetSelectionContextReply> for Reply {
+  fn from(reply: xselinux::GetSelectionContextReply) -> Reply {
+    Reply::XselinuxGetSelectionContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetSelectionDataContextReply> for Reply {
+  fn from(reply: xselinux::GetSelectionDataContextReply) -> Reply {
+    Reply::XselinuxGetSelectionDataContext(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::ListSelectionsReply> for Reply {
+  fn from(reply: xselinux::ListSelectionsReply) -> Reply {
+    Reply::XselinuxListSelections(reply)
+  }
+}
+#[cfg(feature = "xselinux")]
+impl From<xselinux::GetClientContextReply> for Reply {
+  fn from(reply: xselinux::GetClientContextReply) -> Reply {
+    Reply::XselinuxGetClientContext(reply)
+  }
+}
+#[cfg(feature = "xtest")]
+impl From<xtest::GetVersionReply> for Reply {
+  fn from(reply: xtest::GetVersionReply) -> Reply {
+    Reply::XtestGetVersion(reply)
+  }
+}
+#[cfg(feature = "xtest")]
+impl From<xtest::CompareCursorReply> for Reply {
+  fn from(reply: xtest::CompareCursorReply) -> Reply {
+    Reply::XtestCompareCursor(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::QueryExtensionReply> for Reply {
+  fn from(reply: xv::QueryExtensionReply) -> Reply {
+    Reply::XvQueryExtension(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::QueryAdaptorsReply> for Reply {
+  fn from(reply: xv::QueryAdaptorsReply) -> Reply {
+    Reply::XvQueryAdaptors(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::QueryEncodingsReply> for Reply {
+  fn from(reply: xv::QueryEncodingsReply) -> Reply {
+    Reply::XvQueryEncodings(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::GrabPortReply> for Reply {
+  fn from(reply: xv::GrabPortReply) -> Reply {
+    Reply::XvGrabPort(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::QueryBestSizeReply> for Reply {
+  fn from(reply: xv::QueryBestSizeReply) -> Reply {
+    Reply::XvQueryBestSize(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::GetPortAttributeReply> for Reply {
+  fn from(reply: xv::GetPortAttributeReply) -> Reply {
+    Reply::XvGetPortAttribute(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::QueryPortAttributesReply> for Reply {
+  fn from(reply: xv::QueryPortAttributesReply) -> Reply {
+    Reply::XvQueryPortAttributes(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::ListImageFormatsReply> for Reply {
+  fn from(reply: xv::ListImageFormatsReply) -> Reply {
+    Reply::XvListImageFormats(reply)
+  }
+}
+#[cfg(feature = "xv")]
+impl From<xv::QueryImageAttributesReply> for Reply {
+  fn from(reply: xv::QueryImageAttributesReply) -> Reply {
+    Reply::XvQueryImageAttributes(reply)
+  }
+}
+#[cfg(feature = "xvmc")]
+impl From<xvmc::QueryVersionReply> for Reply {
+  fn from(reply: xvmc::QueryVersionReply) -> Reply {
+    Reply::XvmcQueryVersion(reply)
+  }
+}
+#[cfg(feature = "xvmc")]
+impl From<xvmc::ListSurfaceTypesReply> for Reply {
+  fn from(reply: xvmc::ListSurfaceTypesReply) -> Reply {
+    Reply::XvmcListSurfaceTypes(reply)
+  }
+}
+#[cfg(feature = "xvmc")]
+impl From<xvmc::CreateContextReply> for Reply {
+  fn from(reply: xvmc::CreateContextReply) -> Reply {
+    Reply::XvmcCreateContext(reply)
+  }
+}
+#[cfg(feature = "xvmc")]
+impl From<xvmc::CreateSurfaceReply> for Reply {
+  fn from(reply: xvmc::CreateSurfaceReply) -> Reply {
+    Reply::XvmcCreateSurface(reply)
+  }
+}
+#[cfg(feature = "xvmc")]
+impl From<xvmc::CreateSubpictureReply> for Reply {
+  fn from(reply: xvmc::CreateSubpictureReply) -> Reply {
+    Reply::XvmcCreateSubpicture(reply)
+  }
+}
+#[cfg(feature = "xvmc")]
+impl From<xvmc::ListSubpictureTypesReply> for Reply {
+  fn from(reply: xvmc::ListSubpictureTypesReply) -> Reply {
+    Reply::XvmcListSubpictureTypes(reply)
+  }
+}
 
 /// Enumeration of all possible X11 errors.
 #[derive(Debug, Clone)]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2713,6 +2713,11 @@ pub enum Reply {
     #[cfg(feature = "xvmc")]
     XvmcListSubpictureTypes(xvmc::ListSubpictureTypesReply),
 }
+impl From<()> for Reply {
+    fn from(_: ()) -> Reply {
+        Reply::Void
+    }
+}
 impl From<xproto::GetWindowAttributesReply> for Reply {
   fn from(reply: xproto::GetWindowAttributesReply) -> Reply {
     Reply::GetWindowAttributes(reply)

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2112,6 +2112,608 @@ impl<'input> Request<'input> {
     }
 }
 
+/// Enumeration of all possible X11 replies.
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum Reply {
+    Void,
+    GetWindowAttributes(xproto::GetWindowAttributesReply),
+    GetGeometry(xproto::GetGeometryReply),
+    QueryTree(xproto::QueryTreeReply),
+    InternAtom(xproto::InternAtomReply),
+    GetAtomName(xproto::GetAtomNameReply),
+    GetProperty(xproto::GetPropertyReply),
+    ListProperties(xproto::ListPropertiesReply),
+    GetSelectionOwner(xproto::GetSelectionOwnerReply),
+    GrabPointer(xproto::GrabPointerReply),
+    GrabKeyboard(xproto::GrabKeyboardReply),
+    QueryPointer(xproto::QueryPointerReply),
+    GetMotionEvents(xproto::GetMotionEventsReply),
+    TranslateCoordinates(xproto::TranslateCoordinatesReply),
+    GetInputFocus(xproto::GetInputFocusReply),
+    QueryKeymap(xproto::QueryKeymapReply),
+    QueryFont(xproto::QueryFontReply),
+    QueryTextExtents(xproto::QueryTextExtentsReply),
+    ListFonts(xproto::ListFontsReply),
+    ListFontsWithInfo(xproto::ListFontsWithInfoReply),
+    GetFontPath(xproto::GetFontPathReply),
+    GetImage(xproto::GetImageReply),
+    ListInstalledColormaps(xproto::ListInstalledColormapsReply),
+    AllocColor(xproto::AllocColorReply),
+    AllocNamedColor(xproto::AllocNamedColorReply),
+    AllocColorCells(xproto::AllocColorCellsReply),
+    AllocColorPlanes(xproto::AllocColorPlanesReply),
+    QueryColors(xproto::QueryColorsReply),
+    LookupColor(xproto::LookupColorReply),
+    QueryBestSize(xproto::QueryBestSizeReply),
+    QueryExtension(xproto::QueryExtensionReply),
+    ListExtensions(xproto::ListExtensionsReply),
+    GetKeyboardMapping(xproto::GetKeyboardMappingReply),
+    GetKeyboardControl(xproto::GetKeyboardControlReply),
+    GetPointerControl(xproto::GetPointerControlReply),
+    GetScreenSaver(xproto::GetScreenSaverReply),
+    ListHosts(xproto::ListHostsReply),
+    SetPointerMapping(xproto::SetPointerMappingReply),
+    GetPointerMapping(xproto::GetPointerMappingReply),
+    SetModifierMapping(xproto::SetModifierMappingReply),
+    GetModifierMapping(xproto::GetModifierMappingReply),
+    BigreqEnable(bigreq::EnableReply),
+    #[cfg(feature = "composite")]
+    CompositeQueryVersion(composite::QueryVersionReply),
+    #[cfg(feature = "composite")]
+    CompositeGetOverlayWindow(composite::GetOverlayWindowReply),
+    #[cfg(feature = "damage")]
+    DamageQueryVersion(damage::QueryVersionReply),
+    #[cfg(feature = "dpms")]
+    DpmsGetVersion(dpms::GetVersionReply),
+    #[cfg(feature = "dpms")]
+    DpmsCapable(dpms::CapableReply),
+    #[cfg(feature = "dpms")]
+    DpmsGetTimeouts(dpms::GetTimeoutsReply),
+    #[cfg(feature = "dpms")]
+    DpmsInfo(dpms::InfoReply),
+    #[cfg(feature = "dri2")]
+    Dri2QueryVersion(dri2::QueryVersionReply),
+    #[cfg(feature = "dri2")]
+    Dri2Connect(dri2::ConnectReply),
+    #[cfg(feature = "dri2")]
+    Dri2Authenticate(dri2::AuthenticateReply),
+    #[cfg(feature = "dri2")]
+    Dri2GetBuffers(dri2::GetBuffersReply),
+    #[cfg(feature = "dri2")]
+    Dri2CopyRegion(dri2::CopyRegionReply),
+    #[cfg(feature = "dri2")]
+    Dri2GetBuffersWithFormat(dri2::GetBuffersWithFormatReply),
+    #[cfg(feature = "dri2")]
+    Dri2SwapBuffers(dri2::SwapBuffersReply),
+    #[cfg(feature = "dri2")]
+    Dri2GetMSC(dri2::GetMSCReply),
+    #[cfg(feature = "dri2")]
+    Dri2WaitMSC(dri2::WaitMSCReply),
+    #[cfg(feature = "dri2")]
+    Dri2WaitSBC(dri2::WaitSBCReply),
+    #[cfg(feature = "dri2")]
+    Dri2GetParam(dri2::GetParamReply),
+    #[cfg(feature = "dri3")]
+    Dri3QueryVersion(dri3::QueryVersionReply),
+    #[cfg(feature = "dri3")]
+    Dri3Open(dri3::OpenReply),
+    #[cfg(feature = "dri3")]
+    Dri3BufferFromPixmap(dri3::BufferFromPixmapReply),
+    #[cfg(feature = "dri3")]
+    Dri3FDFromFence(dri3::FDFromFenceReply),
+    #[cfg(feature = "dri3")]
+    Dri3GetSupportedModifiers(dri3::GetSupportedModifiersReply),
+    #[cfg(feature = "dri3")]
+    Dri3BuffersFromPixmap(dri3::BuffersFromPixmapReply),
+    GeQueryVersion(ge::QueryVersionReply),
+    #[cfg(feature = "glx")]
+    GlxMakeCurrent(glx::MakeCurrentReply),
+    #[cfg(feature = "glx")]
+    GlxIsDirect(glx::IsDirectReply),
+    #[cfg(feature = "glx")]
+    GlxQueryVersion(glx::QueryVersionReply),
+    #[cfg(feature = "glx")]
+    GlxGetVisualConfigs(glx::GetVisualConfigsReply),
+    #[cfg(feature = "glx")]
+    GlxVendorPrivateWithReply(glx::VendorPrivateWithReplyReply),
+    #[cfg(feature = "glx")]
+    GlxQueryExtensionsString(glx::QueryExtensionsStringReply),
+    #[cfg(feature = "glx")]
+    GlxQueryServerString(glx::QueryServerStringReply),
+    #[cfg(feature = "glx")]
+    GlxGetFBConfigs(glx::GetFBConfigsReply),
+    #[cfg(feature = "glx")]
+    GlxQueryContext(glx::QueryContextReply),
+    #[cfg(feature = "glx")]
+    GlxMakeContextCurrent(glx::MakeContextCurrentReply),
+    #[cfg(feature = "glx")]
+    GlxGetDrawableAttributes(glx::GetDrawableAttributesReply),
+    #[cfg(feature = "glx")]
+    GlxGenLists(glx::GenListsReply),
+    #[cfg(feature = "glx")]
+    GlxRenderMode(glx::RenderModeReply),
+    #[cfg(feature = "glx")]
+    GlxFinish(glx::FinishReply),
+    #[cfg(feature = "glx")]
+    GlxReadPixels(glx::ReadPixelsReply),
+    #[cfg(feature = "glx")]
+    GlxGetBooleanv(glx::GetBooleanvReply),
+    #[cfg(feature = "glx")]
+    GlxGetClipPlane(glx::GetClipPlaneReply),
+    #[cfg(feature = "glx")]
+    GlxGetDoublev(glx::GetDoublevReply),
+    #[cfg(feature = "glx")]
+    GlxGetError(glx::GetErrorReply),
+    #[cfg(feature = "glx")]
+    GlxGetFloatv(glx::GetFloatvReply),
+    #[cfg(feature = "glx")]
+    GlxGetIntegerv(glx::GetIntegervReply),
+    #[cfg(feature = "glx")]
+    GlxGetLightfv(glx::GetLightfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetLightiv(glx::GetLightivReply),
+    #[cfg(feature = "glx")]
+    GlxGetMapdv(glx::GetMapdvReply),
+    #[cfg(feature = "glx")]
+    GlxGetMapfv(glx::GetMapfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetMapiv(glx::GetMapivReply),
+    #[cfg(feature = "glx")]
+    GlxGetMaterialfv(glx::GetMaterialfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetMaterialiv(glx::GetMaterialivReply),
+    #[cfg(feature = "glx")]
+    GlxGetPixelMapfv(glx::GetPixelMapfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetPixelMapuiv(glx::GetPixelMapuivReply),
+    #[cfg(feature = "glx")]
+    GlxGetPixelMapusv(glx::GetPixelMapusvReply),
+    #[cfg(feature = "glx")]
+    GlxGetPolygonStipple(glx::GetPolygonStippleReply),
+    #[cfg(feature = "glx")]
+    GlxGetString(glx::GetStringReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexEnvfv(glx::GetTexEnvfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexEnviv(glx::GetTexEnvivReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexGendv(glx::GetTexGendvReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexGenfv(glx::GetTexGenfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexGeniv(glx::GetTexGenivReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexImage(glx::GetTexImageReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexParameterfv(glx::GetTexParameterfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexParameteriv(glx::GetTexParameterivReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexLevelParameterfv(glx::GetTexLevelParameterfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetTexLevelParameteriv(glx::GetTexLevelParameterivReply),
+    #[cfg(feature = "glx")]
+    GlxIsEnabled(glx::IsEnabledReply),
+    #[cfg(feature = "glx")]
+    GlxIsList(glx::IsListReply),
+    #[cfg(feature = "glx")]
+    GlxAreTexturesResident(glx::AreTexturesResidentReply),
+    #[cfg(feature = "glx")]
+    GlxGenTextures(glx::GenTexturesReply),
+    #[cfg(feature = "glx")]
+    GlxIsTexture(glx::IsTextureReply),
+    #[cfg(feature = "glx")]
+    GlxGetColorTable(glx::GetColorTableReply),
+    #[cfg(feature = "glx")]
+    GlxGetColorTableParameterfv(glx::GetColorTableParameterfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetColorTableParameteriv(glx::GetColorTableParameterivReply),
+    #[cfg(feature = "glx")]
+    GlxGetConvolutionFilter(glx::GetConvolutionFilterReply),
+    #[cfg(feature = "glx")]
+    GlxGetConvolutionParameterfv(glx::GetConvolutionParameterfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetConvolutionParameteriv(glx::GetConvolutionParameterivReply),
+    #[cfg(feature = "glx")]
+    GlxGetSeparableFilter(glx::GetSeparableFilterReply),
+    #[cfg(feature = "glx")]
+    GlxGetHistogram(glx::GetHistogramReply),
+    #[cfg(feature = "glx")]
+    GlxGetHistogramParameterfv(glx::GetHistogramParameterfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetHistogramParameteriv(glx::GetHistogramParameterivReply),
+    #[cfg(feature = "glx")]
+    GlxGetMinmax(glx::GetMinmaxReply),
+    #[cfg(feature = "glx")]
+    GlxGetMinmaxParameterfv(glx::GetMinmaxParameterfvReply),
+    #[cfg(feature = "glx")]
+    GlxGetMinmaxParameteriv(glx::GetMinmaxParameterivReply),
+    #[cfg(feature = "glx")]
+    GlxGetCompressedTexImageARB(glx::GetCompressedTexImageARBReply),
+    #[cfg(feature = "glx")]
+    GlxGenQueriesARB(glx::GenQueriesARBReply),
+    #[cfg(feature = "glx")]
+    GlxIsQueryARB(glx::IsQueryARBReply),
+    #[cfg(feature = "glx")]
+    GlxGetQueryivARB(glx::GetQueryivARBReply),
+    #[cfg(feature = "glx")]
+    GlxGetQueryObjectivARB(glx::GetQueryObjectivARBReply),
+    #[cfg(feature = "glx")]
+    GlxGetQueryObjectuivARB(glx::GetQueryObjectuivARBReply),
+    #[cfg(feature = "present")]
+    PresentQueryVersion(present::QueryVersionReply),
+    #[cfg(feature = "present")]
+    PresentQueryCapabilities(present::QueryCapabilitiesReply),
+    #[cfg(feature = "randr")]
+    RandrQueryVersion(randr::QueryVersionReply),
+    #[cfg(feature = "randr")]
+    RandrSetScreenConfig(randr::SetScreenConfigReply),
+    #[cfg(feature = "randr")]
+    RandrGetScreenInfo(randr::GetScreenInfoReply),
+    #[cfg(feature = "randr")]
+    RandrGetScreenSizeRange(randr::GetScreenSizeRangeReply),
+    #[cfg(feature = "randr")]
+    RandrGetScreenResources(randr::GetScreenResourcesReply),
+    #[cfg(feature = "randr")]
+    RandrGetOutputInfo(randr::GetOutputInfoReply),
+    #[cfg(feature = "randr")]
+    RandrListOutputProperties(randr::ListOutputPropertiesReply),
+    #[cfg(feature = "randr")]
+    RandrQueryOutputProperty(randr::QueryOutputPropertyReply),
+    #[cfg(feature = "randr")]
+    RandrGetOutputProperty(randr::GetOutputPropertyReply),
+    #[cfg(feature = "randr")]
+    RandrCreateMode(randr::CreateModeReply),
+    #[cfg(feature = "randr")]
+    RandrGetCrtcInfo(randr::GetCrtcInfoReply),
+    #[cfg(feature = "randr")]
+    RandrSetCrtcConfig(randr::SetCrtcConfigReply),
+    #[cfg(feature = "randr")]
+    RandrGetCrtcGammaSize(randr::GetCrtcGammaSizeReply),
+    #[cfg(feature = "randr")]
+    RandrGetCrtcGamma(randr::GetCrtcGammaReply),
+    #[cfg(feature = "randr")]
+    RandrGetScreenResourcesCurrent(randr::GetScreenResourcesCurrentReply),
+    #[cfg(feature = "randr")]
+    RandrGetCrtcTransform(randr::GetCrtcTransformReply),
+    #[cfg(feature = "randr")]
+    RandrGetPanning(randr::GetPanningReply),
+    #[cfg(feature = "randr")]
+    RandrSetPanning(randr::SetPanningReply),
+    #[cfg(feature = "randr")]
+    RandrGetOutputPrimary(randr::GetOutputPrimaryReply),
+    #[cfg(feature = "randr")]
+    RandrGetProviders(randr::GetProvidersReply),
+    #[cfg(feature = "randr")]
+    RandrGetProviderInfo(randr::GetProviderInfoReply),
+    #[cfg(feature = "randr")]
+    RandrListProviderProperties(randr::ListProviderPropertiesReply),
+    #[cfg(feature = "randr")]
+    RandrQueryProviderProperty(randr::QueryProviderPropertyReply),
+    #[cfg(feature = "randr")]
+    RandrGetProviderProperty(randr::GetProviderPropertyReply),
+    #[cfg(feature = "randr")]
+    RandrGetMonitors(randr::GetMonitorsReply),
+    #[cfg(feature = "randr")]
+    RandrCreateLease(randr::CreateLeaseReply),
+    #[cfg(feature = "record")]
+    RecordQueryVersion(record::QueryVersionReply),
+    #[cfg(feature = "record")]
+    RecordGetContext(record::GetContextReply),
+    #[cfg(feature = "record")]
+    RecordEnableContext(record::EnableContextReply),
+    #[cfg(feature = "render")]
+    RenderQueryVersion(render::QueryVersionReply),
+    #[cfg(feature = "render")]
+    RenderQueryPictFormats(render::QueryPictFormatsReply),
+    #[cfg(feature = "render")]
+    RenderQueryPictIndexValues(render::QueryPictIndexValuesReply),
+    #[cfg(feature = "render")]
+    RenderQueryFilters(render::QueryFiltersReply),
+    #[cfg(feature = "res")]
+    ResQueryVersion(res::QueryVersionReply),
+    #[cfg(feature = "res")]
+    ResQueryClients(res::QueryClientsReply),
+    #[cfg(feature = "res")]
+    ResQueryClientResources(res::QueryClientResourcesReply),
+    #[cfg(feature = "res")]
+    ResQueryClientPixmapBytes(res::QueryClientPixmapBytesReply),
+    #[cfg(feature = "res")]
+    ResQueryClientIds(res::QueryClientIdsReply),
+    #[cfg(feature = "res")]
+    ResQueryResourceBytes(res::QueryResourceBytesReply),
+    #[cfg(feature = "screensaver")]
+    ScreensaverQueryVersion(screensaver::QueryVersionReply),
+    #[cfg(feature = "screensaver")]
+    ScreensaverQueryInfo(screensaver::QueryInfoReply),
+    #[cfg(feature = "shape")]
+    ShapeQueryVersion(shape::QueryVersionReply),
+    #[cfg(feature = "shape")]
+    ShapeQueryExtents(shape::QueryExtentsReply),
+    #[cfg(feature = "shape")]
+    ShapeInputSelected(shape::InputSelectedReply),
+    #[cfg(feature = "shape")]
+    ShapeGetRectangles(shape::GetRectanglesReply),
+    #[cfg(feature = "shm")]
+    ShmQueryVersion(shm::QueryVersionReply),
+    #[cfg(feature = "shm")]
+    ShmGetImage(shm::GetImageReply),
+    #[cfg(feature = "shm")]
+    ShmCreateSegment(shm::CreateSegmentReply),
+    #[cfg(feature = "sync")]
+    SyncInitialize(sync::InitializeReply),
+    #[cfg(feature = "sync")]
+    SyncListSystemCounters(sync::ListSystemCountersReply),
+    #[cfg(feature = "sync")]
+    SyncQueryCounter(sync::QueryCounterReply),
+    #[cfg(feature = "sync")]
+    SyncQueryAlarm(sync::QueryAlarmReply),
+    #[cfg(feature = "sync")]
+    SyncGetPriority(sync::GetPriorityReply),
+    #[cfg(feature = "sync")]
+    SyncQueryFence(sync::QueryFenceReply),
+    XcMiscGetVersion(xc_misc::GetVersionReply),
+    XcMiscGetXIDRange(xc_misc::GetXIDRangeReply),
+    XcMiscGetXIDList(xc_misc::GetXIDListReply),
+    #[cfg(feature = "xevie")]
+    XevieQueryVersion(xevie::QueryVersionReply),
+    #[cfg(feature = "xevie")]
+    XevieStart(xevie::StartReply),
+    #[cfg(feature = "xevie")]
+    XevieEnd(xevie::EndReply),
+    #[cfg(feature = "xevie")]
+    XevieSend(xevie::SendReply),
+    #[cfg(feature = "xevie")]
+    XevieSelectInput(xevie::SelectInputReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driQueryVersion(xf86dri::QueryVersionReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driQueryDirectRenderingCapable(xf86dri::QueryDirectRenderingCapableReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driOpenConnection(xf86dri::OpenConnectionReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driGetClientDriverName(xf86dri::GetClientDriverNameReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driCreateContext(xf86dri::CreateContextReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driCreateDrawable(xf86dri::CreateDrawableReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driGetDrawableInfo(xf86dri::GetDrawableInfoReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driGetDeviceInfo(xf86dri::GetDeviceInfoReply),
+    #[cfg(feature = "xf86dri")]
+    Xf86driAuthConnection(xf86dri::AuthConnectionReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeQueryVersion(xf86vidmode::QueryVersionReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetModeLine(xf86vidmode::GetModeLineReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetMonitor(xf86vidmode::GetMonitorReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetAllModeLines(xf86vidmode::GetAllModeLinesReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeValidateModeLine(xf86vidmode::ValidateModeLineReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetViewPort(xf86vidmode::GetViewPortReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetDotClocks(xf86vidmode::GetDotClocksReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetGamma(xf86vidmode::GetGammaReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetGammaRamp(xf86vidmode::GetGammaRampReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetGammaRampSize(xf86vidmode::GetGammaRampSizeReply),
+    #[cfg(feature = "xf86vidmode")]
+    Xf86vidmodeGetPermissions(xf86vidmode::GetPermissionsReply),
+    #[cfg(feature = "xfixes")]
+    XfixesQueryVersion(xfixes::QueryVersionReply),
+    #[cfg(feature = "xfixes")]
+    XfixesGetCursorImage(xfixes::GetCursorImageReply),
+    #[cfg(feature = "xfixes")]
+    XfixesFetchRegion(xfixes::FetchRegionReply),
+    #[cfg(feature = "xfixes")]
+    XfixesGetCursorName(xfixes::GetCursorNameReply),
+    #[cfg(feature = "xfixes")]
+    XfixesGetCursorImageAndName(xfixes::GetCursorImageAndNameReply),
+    #[cfg(feature = "xinerama")]
+    XineramaQueryVersion(xinerama::QueryVersionReply),
+    #[cfg(feature = "xinerama")]
+    XineramaGetState(xinerama::GetStateReply),
+    #[cfg(feature = "xinerama")]
+    XineramaGetScreenCount(xinerama::GetScreenCountReply),
+    #[cfg(feature = "xinerama")]
+    XineramaGetScreenSize(xinerama::GetScreenSizeReply),
+    #[cfg(feature = "xinerama")]
+    XineramaIsActive(xinerama::IsActiveReply),
+    #[cfg(feature = "xinerama")]
+    XineramaQueryScreens(xinerama::QueryScreensReply),
+    #[cfg(feature = "xinput")]
+    XinputGetExtensionVersion(xinput::GetExtensionVersionReply),
+    #[cfg(feature = "xinput")]
+    XinputListInputDevices(xinput::ListInputDevicesReply),
+    #[cfg(feature = "xinput")]
+    XinputOpenDevice(xinput::OpenDeviceReply),
+    #[cfg(feature = "xinput")]
+    XinputSetDeviceMode(xinput::SetDeviceModeReply),
+    #[cfg(feature = "xinput")]
+    XinputGetSelectedExtensionEvents(xinput::GetSelectedExtensionEventsReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceDontPropagateList(xinput::GetDeviceDontPropagateListReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceMotionEvents(xinput::GetDeviceMotionEventsReply),
+    #[cfg(feature = "xinput")]
+    XinputChangeKeyboardDevice(xinput::ChangeKeyboardDeviceReply),
+    #[cfg(feature = "xinput")]
+    XinputChangePointerDevice(xinput::ChangePointerDeviceReply),
+    #[cfg(feature = "xinput")]
+    XinputGrabDevice(xinput::GrabDeviceReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceFocus(xinput::GetDeviceFocusReply),
+    #[cfg(feature = "xinput")]
+    XinputGetFeedbackControl(xinput::GetFeedbackControlReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceKeyMapping(xinput::GetDeviceKeyMappingReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceModifierMapping(xinput::GetDeviceModifierMappingReply),
+    #[cfg(feature = "xinput")]
+    XinputSetDeviceModifierMapping(xinput::SetDeviceModifierMappingReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceButtonMapping(xinput::GetDeviceButtonMappingReply),
+    #[cfg(feature = "xinput")]
+    XinputSetDeviceButtonMapping(xinput::SetDeviceButtonMappingReply),
+    #[cfg(feature = "xinput")]
+    XinputQueryDeviceState(xinput::QueryDeviceStateReply),
+    #[cfg(feature = "xinput")]
+    XinputSetDeviceValuators(xinput::SetDeviceValuatorsReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceControl(xinput::GetDeviceControlReply),
+    #[cfg(feature = "xinput")]
+    XinputChangeDeviceControl(xinput::ChangeDeviceControlReply),
+    #[cfg(feature = "xinput")]
+    XinputListDeviceProperties(xinput::ListDevicePropertiesReply),
+    #[cfg(feature = "xinput")]
+    XinputGetDeviceProperty(xinput::GetDevicePropertyReply),
+    #[cfg(feature = "xinput")]
+    XinputXIQueryPointer(xinput::XIQueryPointerReply),
+    #[cfg(feature = "xinput")]
+    XinputXIGetClientPointer(xinput::XIGetClientPointerReply),
+    #[cfg(feature = "xinput")]
+    XinputXIQueryVersion(xinput::XIQueryVersionReply),
+    #[cfg(feature = "xinput")]
+    XinputXIQueryDevice(xinput::XIQueryDeviceReply),
+    #[cfg(feature = "xinput")]
+    XinputXIGetFocus(xinput::XIGetFocusReply),
+    #[cfg(feature = "xinput")]
+    XinputXIGrabDevice(xinput::XIGrabDeviceReply),
+    #[cfg(feature = "xinput")]
+    XinputXIPassiveGrabDevice(xinput::XIPassiveGrabDeviceReply),
+    #[cfg(feature = "xinput")]
+    XinputXIListProperties(xinput::XIListPropertiesReply),
+    #[cfg(feature = "xinput")]
+    XinputXIGetProperty(xinput::XIGetPropertyReply),
+    #[cfg(feature = "xinput")]
+    XinputXIGetSelectedEvents(xinput::XIGetSelectedEventsReply),
+    #[cfg(feature = "xkb")]
+    XkbUseExtension(xkb::UseExtensionReply),
+    #[cfg(feature = "xkb")]
+    XkbGetState(xkb::GetStateReply),
+    #[cfg(feature = "xkb")]
+    XkbGetControls(xkb::GetControlsReply),
+    #[cfg(feature = "xkb")]
+    XkbGetMap(xkb::GetMapReply),
+    #[cfg(feature = "xkb")]
+    XkbGetCompatMap(xkb::GetCompatMapReply),
+    #[cfg(feature = "xkb")]
+    XkbGetIndicatorState(xkb::GetIndicatorStateReply),
+    #[cfg(feature = "xkb")]
+    XkbGetIndicatorMap(xkb::GetIndicatorMapReply),
+    #[cfg(feature = "xkb")]
+    XkbGetNamedIndicator(xkb::GetNamedIndicatorReply),
+    #[cfg(feature = "xkb")]
+    XkbGetNames(xkb::GetNamesReply),
+    #[cfg(feature = "xkb")]
+    XkbPerClientFlags(xkb::PerClientFlagsReply),
+    #[cfg(feature = "xkb")]
+    XkbListComponents(xkb::ListComponentsReply),
+    #[cfg(feature = "xkb")]
+    XkbGetKbdByName(xkb::GetKbdByNameReply),
+    #[cfg(feature = "xkb")]
+    XkbGetDeviceInfo(xkb::GetDeviceInfoReply),
+    #[cfg(feature = "xkb")]
+    XkbSetDebuggingFlags(xkb::SetDebuggingFlagsReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintQueryVersion(xprint::PrintQueryVersionReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetPrinterList(xprint::PrintGetPrinterListReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetContext(xprint::PrintGetContextReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetScreenOfContext(xprint::PrintGetScreenOfContextReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetDocumentData(xprint::PrintGetDocumentDataReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintInputSelected(xprint::PrintInputSelectedReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetAttributes(xprint::PrintGetAttributesReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetOneAttributes(xprint::PrintGetOneAttributesReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetPageDimensions(xprint::PrintGetPageDimensionsReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintQueryScreens(xprint::PrintQueryScreensReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintSetImageResolution(xprint::PrintSetImageResolutionReply),
+    #[cfg(feature = "xprint")]
+    XprintPrintGetImageResolution(xprint::PrintGetImageResolutionReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxQueryVersion(xselinux::QueryVersionReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetDeviceCreateContext(xselinux::GetDeviceCreateContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetDeviceContext(xselinux::GetDeviceContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetWindowCreateContext(xselinux::GetWindowCreateContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetWindowContext(xselinux::GetWindowContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetPropertyCreateContext(xselinux::GetPropertyCreateContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetPropertyUseContext(xselinux::GetPropertyUseContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetPropertyContext(xselinux::GetPropertyContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetPropertyDataContext(xselinux::GetPropertyDataContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxListProperties(xselinux::ListPropertiesReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetSelectionCreateContext(xselinux::GetSelectionCreateContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetSelectionUseContext(xselinux::GetSelectionUseContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetSelectionContext(xselinux::GetSelectionContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetSelectionDataContext(xselinux::GetSelectionDataContextReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxListSelections(xselinux::ListSelectionsReply),
+    #[cfg(feature = "xselinux")]
+    XselinuxGetClientContext(xselinux::GetClientContextReply),
+    #[cfg(feature = "xtest")]
+    XtestGetVersion(xtest::GetVersionReply),
+    #[cfg(feature = "xtest")]
+    XtestCompareCursor(xtest::CompareCursorReply),
+    #[cfg(feature = "xv")]
+    XvQueryExtension(xv::QueryExtensionReply),
+    #[cfg(feature = "xv")]
+    XvQueryAdaptors(xv::QueryAdaptorsReply),
+    #[cfg(feature = "xv")]
+    XvQueryEncodings(xv::QueryEncodingsReply),
+    #[cfg(feature = "xv")]
+    XvGrabPort(xv::GrabPortReply),
+    #[cfg(feature = "xv")]
+    XvQueryBestSize(xv::QueryBestSizeReply),
+    #[cfg(feature = "xv")]
+    XvGetPortAttribute(xv::GetPortAttributeReply),
+    #[cfg(feature = "xv")]
+    XvQueryPortAttributes(xv::QueryPortAttributesReply),
+    #[cfg(feature = "xv")]
+    XvListImageFormats(xv::ListImageFormatsReply),
+    #[cfg(feature = "xv")]
+    XvQueryImageAttributes(xv::QueryImageAttributesReply),
+    #[cfg(feature = "xvmc")]
+    XvmcQueryVersion(xvmc::QueryVersionReply),
+    #[cfg(feature = "xvmc")]
+    XvmcListSurfaceTypes(xvmc::ListSurfaceTypesReply),
+    #[cfg(feature = "xvmc")]
+    XvmcCreateContext(xvmc::CreateContextReply),
+    #[cfg(feature = "xvmc")]
+    XvmcCreateSurface(xvmc::CreateSurfaceReply),
+    #[cfg(feature = "xvmc")]
+    XvmcCreateSubpicture(xvmc::CreateSubpictureReply),
+    #[cfg(feature = "xvmc")]
+    XvmcListSubpictureTypes(xvmc::ListSubpictureTypesReply),
+}
+
 /// Enumeration of all possible X11 errors.
 #[derive(Debug, Clone)]
 pub enum Error {

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -553,6 +553,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, major_version: u32, minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -768,6 +771,9 @@ impl<'input> PixmapRequest<'input> {
         })
     }
 }
+impl<'input> Request for PixmapRequest<'input> {
+    type Reply = ();
+}
 pub fn pixmap<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, pixmap: xproto::Pixmap, serial: u32, valid: xfixes::Region, update: xfixes::Region, x_off: i16, y_off: i16, target_crtc: randr::Crtc, wait_fence: sync::Fence, idle_fence: sync::Fence, options: u32, target_msc: u64, divisor: u64, remainder: u64, notifies: &'input [Notify]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -887,6 +893,9 @@ impl NotifyMSCRequest {
         })
     }
 }
+impl Request for NotifyMSCRequest {
+    type Reply = ();
+}
 pub fn notify_msc<Conn>(conn: &Conn, window: xproto::Window, serial: u32, target_msc: u64, divisor: u64, remainder: u64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -965,6 +974,9 @@ impl SelectInputRequest {
         })
     }
 }
+impl Request for SelectInputRequest {
+    type Reply = ();
+}
 pub fn select_input<Conn, A>(conn: &Conn, eid: Event, window: xproto::Window, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1024,6 +1036,9 @@ impl QueryCapabilitiesRequest {
             target,
         })
     }
+}
+impl Request for QueryCapabilitiesRequest {
+    type Reply = QueryCapabilitiesReply;
 }
 pub fn query_capabilities<Conn>(conn: &Conn, target: u32) -> Result<Cookie<'_, Conn, QueryCapabilitiesReply>, ConnectionError>
 where

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -554,6 +554,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, major_version: u32, minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -744,6 +747,9 @@ impl SetScreenConfigRequest {
         })
     }
 }
+impl Request for SetScreenConfigRequest {
+    type Reply = SetScreenConfigReply;
+}
 pub fn set_screen_config<Conn, A>(conn: &Conn, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: A, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -932,6 +938,9 @@ impl SelectInputRequest {
         })
     }
 }
+impl Request for SelectInputRequest {
+    type Reply = ();
+}
 pub fn select_input<Conn, A>(conn: &Conn, window: xproto::Window, enable: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -990,6 +999,9 @@ impl GetScreenInfoRequest {
             window,
         })
     }
+}
+impl Request for GetScreenInfoRequest {
+    type Reply = GetScreenInfoReply;
 }
 pub fn get_screen_info<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenInfoReply>, ConnectionError>
 where
@@ -1106,6 +1118,9 @@ impl GetScreenSizeRangeRequest {
         })
     }
 }
+impl Request for GetScreenSizeRangeRequest {
+    type Reply = GetScreenSizeRangeReply;
+}
 pub fn get_screen_size_range<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenSizeRangeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1221,6 +1236,9 @@ impl SetScreenSizeRequest {
             mm_height,
         })
     }
+}
+impl Request for SetScreenSizeRequest {
+    type Reply = ();
 }
 pub fn set_screen_size<Conn>(conn: &Conn, window: xproto::Window, width: u16, height: u16, mm_width: u32, mm_height: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1475,6 +1493,9 @@ impl GetScreenResourcesRequest {
         })
     }
 }
+impl Request for GetScreenResourcesRequest {
+    type Reply = GetScreenResourcesReply;
+}
 pub fn get_screen_resources<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenResourcesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1699,6 +1720,9 @@ impl GetOutputInfoRequest {
         })
     }
 }
+impl Request for GetOutputInfoRequest {
+    type Reply = GetOutputInfoReply;
+}
 pub fn get_output_info<Conn>(conn: &Conn, output: Output, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetOutputInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1864,6 +1888,9 @@ impl ListOutputPropertiesRequest {
         })
     }
 }
+impl Request for ListOutputPropertiesRequest {
+    type Reply = ListOutputPropertiesReply;
+}
 pub fn list_output_properties<Conn>(conn: &Conn, output: Output) -> Result<Cookie<'_, Conn, ListOutputPropertiesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1969,6 +1996,9 @@ impl QueryOutputPropertyRequest {
             property,
         })
     }
+}
+impl Request for QueryOutputPropertyRequest {
+    type Reply = QueryOutputPropertyReply;
 }
 pub fn query_output_property<Conn>(conn: &Conn, output: Output, property: xproto::Atom) -> Result<Cookie<'_, Conn, QueryOutputPropertyReply>, ConnectionError>
 where
@@ -2108,6 +2138,9 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
         })
     }
 }
+impl<'input> Request for ConfigureOutputPropertyRequest<'input> {
+    type Reply = ();
+}
 pub fn configure_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2213,6 +2246,9 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeOutputPropertyRequest<'input> {
+    type Reply = ();
+}
 pub fn change_output_property<'c, 'input, Conn>(conn: &'c Conn, output: Output, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: xproto::PropMode, num_units: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2282,6 +2318,9 @@ impl DeleteOutputPropertyRequest {
             property,
         })
     }
+}
+impl Request for DeleteOutputPropertyRequest {
+    type Reply = ();
 }
 pub fn delete_output_property<Conn>(conn: &Conn, output: Output, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2384,6 +2423,9 @@ impl GetOutputPropertyRequest {
             pending,
         })
     }
+}
+impl Request for GetOutputPropertyRequest {
+    type Reply = GetOutputPropertyReply;
 }
 pub fn get_output_property<Conn, A>(conn: &Conn, output: Output, property: xproto::Atom, type_: A, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetOutputPropertyReply>, ConnectionError>
 where
@@ -2525,6 +2567,9 @@ impl<'input> CreateModeRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateModeRequest<'input> {
+    type Reply = CreateModeReply;
+}
 pub fn create_mode<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode_info: ModeInfo, name: &'input [u8]) -> Result<Cookie<'c, Conn, CreateModeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2609,6 +2654,9 @@ impl DestroyModeRequest {
         })
     }
 }
+impl Request for DestroyModeRequest {
+    type Reply = ();
+}
 pub fn destroy_mode<Conn>(conn: &Conn, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2672,6 +2720,9 @@ impl AddOutputModeRequest {
             mode,
         })
     }
+}
+impl Request for AddOutputModeRequest {
+    type Reply = ();
 }
 pub fn add_output_mode<Conn>(conn: &Conn, output: Output, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2738,6 +2789,9 @@ impl DeleteOutputModeRequest {
         })
     }
 }
+impl Request for DeleteOutputModeRequest {
+    type Reply = ();
+}
 pub fn delete_output_mode<Conn>(conn: &Conn, output: Output, mode: Mode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2802,6 +2856,9 @@ impl GetCrtcInfoRequest {
             config_timestamp,
         })
     }
+}
+impl Request for GetCrtcInfoRequest {
+    type Reply = GetCrtcInfoReply;
 }
 pub fn get_crtc_info<Conn>(conn: &Conn, crtc: Crtc, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetCrtcInfoReply>, ConnectionError>
 where
@@ -2994,6 +3051,9 @@ impl<'input> SetCrtcConfigRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetCrtcConfigRequest<'input> {
+    type Reply = SetCrtcConfigReply;
+}
 pub fn set_crtc_config<'c, 'input, Conn, A>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &'input [Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3087,6 +3147,9 @@ impl GetCrtcGammaSizeRequest {
         })
     }
 }
+impl Request for GetCrtcGammaSizeRequest {
+    type Reply = GetCrtcGammaSizeReply;
+}
 pub fn get_crtc_gamma_size<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcGammaSizeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3168,6 +3231,9 @@ impl GetCrtcGammaRequest {
             crtc,
         })
     }
+}
+impl Request for GetCrtcGammaRequest {
+    type Reply = GetCrtcGammaReply;
 }
 pub fn get_crtc_gamma<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcGammaReply>, ConnectionError>
 where
@@ -3298,6 +3364,9 @@ impl<'input> SetCrtcGammaRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetCrtcGammaRequest<'input> {
+    type Reply = ();
+}
 pub fn set_crtc_gamma<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3356,6 +3425,9 @@ impl GetScreenResourcesCurrentRequest {
             window,
         })
     }
+}
+impl Request for GetScreenResourcesCurrentRequest {
+    type Reply = GetScreenResourcesCurrentReply;
 }
 pub fn get_screen_resources_current<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenResourcesCurrentReply>, ConnectionError>
 where
@@ -3649,6 +3721,9 @@ impl<'input> SetCrtcTransformRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetCrtcTransformRequest<'input> {
+    type Reply = ();
+}
 pub fn set_crtc_transform<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, transform: render::Transform, filter_name: &'input [u8], filter_params: &'input [render::Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3707,6 +3782,9 @@ impl GetCrtcTransformRequest {
             crtc,
         })
     }
+}
+impl Request for GetCrtcTransformRequest {
+    type Reply = GetCrtcTransformReply;
 }
 pub fn get_crtc_transform<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetCrtcTransformReply>, ConnectionError>
 where
@@ -3871,6 +3949,9 @@ impl GetPanningRequest {
             crtc,
         })
     }
+}
+impl Request for GetPanningRequest {
+    type Reply = GetPanningReply;
 }
 pub fn get_panning<Conn>(conn: &Conn, crtc: Crtc) -> Result<Cookie<'_, Conn, GetPanningReply>, ConnectionError>
 where
@@ -4059,6 +4140,9 @@ impl SetPanningRequest {
         })
     }
 }
+impl Request for SetPanningRequest {
+    type Reply = SetPanningReply;
+}
 pub fn set_panning<Conn>(conn: &Conn, crtc: Crtc, timestamp: xproto::Timestamp, left: u16, top: u16, width: u16, height: u16, track_left: u16, track_top: u16, track_width: u16, track_height: u16, border_left: i16, border_top: i16, border_right: i16, border_bottom: i16) -> Result<Cookie<'_, Conn, SetPanningReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4163,6 +4247,9 @@ impl SetOutputPrimaryRequest {
         })
     }
 }
+impl Request for SetOutputPrimaryRequest {
+    type Reply = ();
+}
 pub fn set_output_primary<Conn>(conn: &Conn, window: xproto::Window, output: Output) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4219,6 +4306,9 @@ impl GetOutputPrimaryRequest {
             window,
         })
     }
+}
+impl Request for GetOutputPrimaryRequest {
+    type Reply = GetOutputPrimaryReply;
 }
 pub fn get_output_primary<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetOutputPrimaryReply>, ConnectionError>
 where
@@ -4300,6 +4390,9 @@ impl GetProvidersRequest {
             window,
         })
     }
+}
+impl Request for GetProvidersRequest {
+    type Reply = GetProvidersReply;
 }
 pub fn get_providers<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetProvidersReply>, ConnectionError>
 where
@@ -4478,6 +4571,9 @@ impl GetProviderInfoRequest {
         })
     }
 }
+impl Request for GetProviderInfoRequest {
+    type Reply = GetProviderInfoReply;
+}
 pub fn get_provider_info<Conn>(conn: &Conn, provider: Provider, config_timestamp: xproto::Timestamp) -> Result<Cookie<'_, Conn, GetProviderInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4649,6 +4745,9 @@ impl SetProviderOffloadSinkRequest {
         })
     }
 }
+impl Request for SetProviderOffloadSinkRequest {
+    type Reply = ();
+}
 pub fn set_provider_offload_sink<Conn>(conn: &Conn, provider: Provider, sink_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4723,6 +4822,9 @@ impl SetProviderOutputSourceRequest {
         })
     }
 }
+impl Request for SetProviderOutputSourceRequest {
+    type Reply = ();
+}
 pub fn set_provider_output_source<Conn>(conn: &Conn, provider: Provider, source_provider: Provider, config_timestamp: xproto::Timestamp) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4780,6 +4882,9 @@ impl ListProviderPropertiesRequest {
             provider,
         })
     }
+}
+impl Request for ListProviderPropertiesRequest {
+    type Reply = ListProviderPropertiesReply;
 }
 pub fn list_provider_properties<Conn>(conn: &Conn, provider: Provider) -> Result<Cookie<'_, Conn, ListProviderPropertiesReply>, ConnectionError>
 where
@@ -4886,6 +4991,9 @@ impl QueryProviderPropertyRequest {
             property,
         })
     }
+}
+impl Request for QueryProviderPropertyRequest {
+    type Reply = QueryProviderPropertyReply;
 }
 pub fn query_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom) -> Result<Cookie<'_, Conn, QueryProviderPropertyReply>, ConnectionError>
 where
@@ -5025,6 +5133,9 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
         })
     }
 }
+impl<'input> Request for ConfigureProviderPropertyRequest<'input> {
+    type Reply = ();
+}
 pub fn configure_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, pending: bool, range: bool, values: &'input [i32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5129,6 +5240,9 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeProviderPropertyRequest<'input> {
+    type Reply = ();
+}
 pub fn change_provider_property<'c, 'input, Conn>(conn: &'c Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, format: u8, mode: u8, num_items: u32, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5198,6 +5312,9 @@ impl DeleteProviderPropertyRequest {
             property,
         })
     }
+}
+impl Request for DeleteProviderPropertyRequest {
+    type Reply = ();
 }
 pub fn delete_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -5300,6 +5417,9 @@ impl GetProviderPropertyRequest {
             pending,
         })
     }
+}
+impl Request for GetProviderPropertyRequest {
+    type Reply = GetProviderPropertyReply;
 }
 pub fn get_provider_property<Conn>(conn: &Conn, provider: Provider, property: xproto::Atom, type_: xproto::Atom, long_offset: u32, long_length: u32, delete: bool, pending: bool) -> Result<Cookie<'_, Conn, GetProviderPropertyReply>, ConnectionError>
 where
@@ -6127,6 +6247,9 @@ impl GetMonitorsRequest {
         })
     }
 }
+impl Request for GetMonitorsRequest {
+    type Reply = GetMonitorsReply;
+}
 pub fn get_monitors<Conn>(conn: &Conn, window: xproto::Window, get_active: bool) -> Result<Cookie<'_, Conn, GetMonitorsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6237,6 +6360,9 @@ impl SetMonitorRequest {
         })
     }
 }
+impl Request for SetMonitorRequest {
+    type Reply = ();
+}
 pub fn set_monitor<Conn>(conn: &Conn, window: xproto::Window, monitorinfo: MonitorInfo) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6301,6 +6427,9 @@ impl DeleteMonitorRequest {
             name,
         })
     }
+}
+impl Request for DeleteMonitorRequest {
+    type Reply = ();
 }
 pub fn delete_monitor<Conn>(conn: &Conn, window: xproto::Window, name: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -6388,6 +6517,9 @@ impl<'input> CreateLeaseRequest<'input> {
             outputs: Cow::Owned(outputs),
         })
     }
+}
+impl<'input> Request for CreateLeaseRequest<'input> {
+    type Reply = CreateLeaseReply;
 }
 pub fn create_lease<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, lid: Lease, crtcs: &'input [Crtc], outputs: &'input [Output]) -> Result<CookieWithFds<'c, Conn, CreateLeaseReply>, ConnectionError>
 where
@@ -6484,6 +6616,9 @@ impl FreeLeaseRequest {
             terminate,
         })
     }
+}
+impl Request for FreeLeaseRequest {
+    type Reply = ();
 }
 pub fn free_lease<Conn>(conn: &Conn, lid: Lease, terminate: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -544,6 +544,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, major_version: u16, minor_version: u16) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -663,6 +666,9 @@ impl<'input> CreateContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateContextRequest<'input> {
+    type Reply = ();
+}
 pub fn create_context<'c, 'input, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -757,6 +763,9 @@ impl<'input> RegisterClientsRequest<'input> {
         })
     }
 }
+impl<'input> Request for RegisterClientsRequest<'input> {
+    type Reply = ();
+}
 pub fn register_clients<'c, 'input, Conn>(conn: &'c Conn, context: Context, element_header: ElementHeader, client_specs: &'input [ClientSpec], ranges: &'input [Range]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -830,6 +839,9 @@ impl<'input> UnregisterClientsRequest<'input> {
         })
     }
 }
+impl<'input> Request for UnregisterClientsRequest<'input> {
+    type Reply = ();
+}
 pub fn unregister_clients<'c, 'input, Conn>(conn: &'c Conn, context: Context, client_specs: &'input [ClientSpec]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -886,6 +898,9 @@ impl GetContextRequest {
             context,
         })
     }
+}
+impl Request for GetContextRequest {
+    type Reply = GetContextReply;
 }
 pub fn get_context<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, GetContextReply>, ConnectionError>
 where
@@ -988,6 +1003,9 @@ impl EnableContextRequest {
             context,
         })
     }
+}
+impl Request for EnableContextRequest {
+    type Reply = EnableContextReply;
 }
 pub fn enable_context<Conn>(conn: &Conn, context: Context) -> Result<Cookie<'_, Conn, EnableContextReply>, ConnectionError>
 where
@@ -1099,6 +1117,9 @@ impl DisableContextRequest {
         })
     }
 }
+impl Request for DisableContextRequest {
+    type Reply = ();
+}
 pub fn disable_context<Conn>(conn: &Conn, context: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1154,6 +1175,9 @@ impl FreeContextRequest {
             context,
         })
     }
+}
+impl Request for FreeContextRequest {
+    type Reply = ();
 }
 pub fn free_context<Conn>(conn: &Conn, context: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -1863,6 +1863,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u32, client_minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1938,6 +1941,9 @@ impl QueryPictFormatsRequest {
         Ok(QueryPictFormatsRequest
         )
     }
+}
+impl Request for QueryPictFormatsRequest {
+    type Reply = QueryPictFormatsReply;
 }
 pub fn query_pict_formats<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryPictFormatsReply>, ConnectionError>
 where
@@ -2078,6 +2084,9 @@ impl QueryPictIndexValuesRequest {
             format,
         })
     }
+}
+impl Request for QueryPictIndexValuesRequest {
+    type Reply = QueryPictIndexValuesReply;
 }
 pub fn query_pict_index_values<Conn>(conn: &Conn, format: Pictformat) -> Result<Cookie<'_, Conn, QueryPictIndexValuesReply>, ConnectionError>
 where
@@ -2506,6 +2515,9 @@ impl<'input> CreatePictureRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreatePictureRequest<'input> {
+    type Reply = ();
+}
 pub fn create_picture<'c, 'input, Conn>(conn: &'c Conn, pid: Picture, drawable: xproto::Drawable, format: Pictformat, value_list: &'input CreatePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2878,6 +2890,9 @@ impl<'input> ChangePictureRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangePictureRequest<'input> {
+    type Reply = ();
+}
 pub fn change_picture<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, value_list: &'input ChangePictureAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2961,6 +2976,9 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetPictureClipRectanglesRequest<'input> {
+    type Reply = ();
+}
 pub fn set_picture_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3019,6 +3037,9 @@ impl FreePictureRequest {
             picture,
         })
     }
+}
+impl Request for FreePictureRequest {
+    type Reply = ();
 }
 pub fn free_picture<Conn>(conn: &Conn, picture: Picture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -3150,6 +3171,9 @@ impl CompositeRequest {
         })
     }
 }
+impl Request for CompositeRequest {
+    type Reply = ();
+}
 pub fn composite<Conn, A>(conn: &Conn, op: PictOp, src: Picture, mask: A, dst: Picture, src_x: i16, src_y: i16, mask_x: i16, mask_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3271,6 +3295,9 @@ impl<'input> TrapezoidsRequest<'input> {
         })
     }
 }
+impl<'input> Request for TrapezoidsRequest<'input> {
+    type Reply = ();
+}
 pub fn trapezoids<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, traps: &'input [Trapezoid]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3384,6 +3411,9 @@ impl<'input> TrianglesRequest<'input> {
             triangles: Cow::Owned(triangles),
         })
     }
+}
+impl<'input> Request for TrianglesRequest<'input> {
+    type Reply = ();
 }
 pub fn triangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, triangles: &'input [Triangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -3499,6 +3529,9 @@ impl<'input> TriStripRequest<'input> {
         })
     }
 }
+impl<'input> Request for TriStripRequest<'input> {
+    type Reply = ();
+}
 pub fn tri_strip<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3613,6 +3646,9 @@ impl<'input> TriFanRequest<'input> {
         })
     }
 }
+impl<'input> Request for TriFanRequest<'input> {
+    type Reply = ();
+}
 pub fn tri_fan<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, src_x: i16, src_y: i16, points: &'input [Pointfix]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3683,6 +3719,9 @@ impl CreateGlyphSetRequest {
         })
     }
 }
+impl Request for CreateGlyphSetRequest {
+    type Reply = ();
+}
 pub fn create_glyph_set<Conn>(conn: &Conn, gsid: Glyphset, format: Pictformat) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3748,6 +3787,9 @@ impl ReferenceGlyphSetRequest {
         })
     }
 }
+impl Request for ReferenceGlyphSetRequest {
+    type Reply = ();
+}
 pub fn reference_glyph_set<Conn>(conn: &Conn, gsid: Glyphset, existing: Glyphset) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3804,6 +3846,9 @@ impl FreeGlyphSetRequest {
             glyphset,
         })
     }
+}
+impl Request for FreeGlyphSetRequest {
+    type Reply = ();
 }
 pub fn free_glyph_set<Conn>(conn: &Conn, glyphset: Glyphset) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -3885,6 +3930,9 @@ impl<'input> AddGlyphsRequest<'input> {
         })
     }
 }
+impl<'input> Request for AddGlyphsRequest<'input> {
+    type Reply = ();
+}
 pub fn add_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphids: &'input [u32], glyphs: &'input [Glyphinfo], data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3957,6 +4005,9 @@ impl<'input> FreeGlyphsRequest<'input> {
             glyphs: Cow::Owned(glyphs),
         })
     }
+}
+impl<'input> Request for FreeGlyphsRequest<'input> {
+    type Reply = ();
 }
 pub fn free_glyphs<'c, 'input, Conn>(conn: &'c Conn, glyphset: Glyphset, glyphs: &'input [Glyph]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -4066,6 +4117,9 @@ impl<'input> CompositeGlyphs8Request<'input> {
             glyphcmds,
         })
     }
+}
+impl<'input> Request for CompositeGlyphs8Request<'input> {
+    type Reply = ();
 }
 pub fn composite_glyphs8<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -4182,6 +4236,9 @@ impl<'input> CompositeGlyphs16Request<'input> {
         })
     }
 }
+impl<'input> Request for CompositeGlyphs16Request<'input> {
+    type Reply = ();
+}
 pub fn composite_glyphs16<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4297,6 +4354,9 @@ impl<'input> CompositeGlyphs32Request<'input> {
         })
     }
 }
+impl<'input> Request for CompositeGlyphs32Request<'input> {
+    type Reply = ();
+}
 pub fn composite_glyphs32<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, src: Picture, dst: Picture, mask_format: Pictformat, glyphset: Glyphset, src_x: i16, src_y: i16, glyphcmds: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4396,6 +4456,9 @@ impl<'input> FillRectanglesRequest<'input> {
         })
     }
 }
+impl<'input> Request for FillRectanglesRequest<'input> {
+    type Reply = ();
+}
 pub fn fill_rectangles<'c, 'input, Conn>(conn: &'c Conn, op: PictOp, dst: Picture, color: Color, rects: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4474,6 +4537,9 @@ impl CreateCursorRequest {
             y,
         })
     }
+}
+impl Request for CreateCursorRequest {
+    type Reply = ();
 }
 pub fn create_cursor<Conn>(conn: &Conn, cid: xproto::Cursor, source: Picture, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -4672,6 +4738,9 @@ impl SetPictureTransformRequest {
         })
     }
 }
+impl Request for SetPictureTransformRequest {
+    type Reply = ();
+}
 pub fn set_picture_transform<Conn>(conn: &Conn, picture: Picture, transform: Transform) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4728,6 +4797,9 @@ impl QueryFiltersRequest {
             drawable,
         })
     }
+}
+impl Request for QueryFiltersRequest {
+    type Reply = QueryFiltersReply;
 }
 pub fn query_filters<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, QueryFiltersReply>, ConnectionError>
 where
@@ -4875,6 +4947,9 @@ impl<'input> SetPictureFilterRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetPictureFilterRequest<'input> {
+    type Reply = ();
+}
 pub fn set_picture_filter<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, filter: &'input [u8], values: &'input [Fixed]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -4988,6 +5063,9 @@ impl<'input> CreateAnimCursorRequest<'input> {
             cursors: Cow::Owned(cursors),
         })
     }
+}
+impl<'input> Request for CreateAnimCursorRequest<'input> {
+    type Reply = ();
 }
 pub fn create_anim_cursor<'c, 'input, Conn>(conn: &'c Conn, cid: xproto::Cursor, cursors: &'input [Animcursorelt]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -5180,6 +5258,9 @@ impl<'input> AddTrapsRequest<'input> {
         })
     }
 }
+impl<'input> Request for AddTrapsRequest<'input> {
+    type Reply = ();
+}
 pub fn add_traps<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, x_off: i16, y_off: i16, traps: &'input [Trap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5250,6 +5331,9 @@ impl CreateSolidFillRequest {
             color,
         })
     }
+}
+impl Request for CreateSolidFillRequest {
+    type Reply = ();
 }
 pub fn create_solid_fill<Conn>(conn: &Conn, picture: Picture, color: Color) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -5351,6 +5435,9 @@ impl<'input> CreateLinearGradientRequest<'input> {
             colors: Cow::Owned(colors),
         })
     }
+}
+impl<'input> Request for CreateLinearGradientRequest<'input> {
+    type Reply = ();
 }
 pub fn create_linear_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, p1: Pointfix, p2: Pointfix, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -5472,6 +5559,9 @@ impl<'input> CreateRadialGradientRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateRadialGradientRequest<'input> {
+    type Reply = ();
+}
 pub fn create_radial_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, inner: Pointfix, outer: Pointfix, inner_radius: Fixed, outer_radius: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5573,6 +5663,9 @@ impl<'input> CreateConicalGradientRequest<'input> {
             colors: Cow::Owned(colors),
         })
     }
+}
+impl<'input> Request for CreateConicalGradientRequest<'input> {
+    type Reply = ();
 }
 pub fn create_conical_gradient<'c, 'input, Conn>(conn: &'c Conn, picture: Picture, center: Pointfix, angle: Fixed, stops: &'input [Fixed], colors: &'input [Color]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -479,6 +479,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, client_major: u8, client_minor: u8) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -553,6 +556,9 @@ impl QueryClientsRequest {
         Ok(QueryClientsRequest
         )
     }
+}
+impl Request for QueryClientsRequest {
+    type Reply = QueryClientsReply;
 }
 pub fn query_clients<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryClientsReply>, ConnectionError>
 where
@@ -649,6 +655,9 @@ impl QueryClientResourcesRequest {
             xid,
         })
     }
+}
+impl Request for QueryClientResourcesRequest {
+    type Reply = QueryClientResourcesReply;
 }
 pub fn query_client_resources<Conn>(conn: &Conn, xid: u32) -> Result<Cookie<'_, Conn, QueryClientResourcesReply>, ConnectionError>
 where
@@ -748,6 +757,9 @@ impl QueryClientPixmapBytesRequest {
         })
     }
 }
+impl Request for QueryClientPixmapBytesRequest {
+    type Reply = QueryClientPixmapBytesReply;
+}
 pub fn query_client_pixmap_bytes<Conn>(conn: &Conn, xid: u32) -> Result<Cookie<'_, Conn, QueryClientPixmapBytesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -836,6 +848,9 @@ impl<'input> QueryClientIdsRequest<'input> {
             specs: Cow::Owned(specs),
         })
     }
+}
+impl<'input> Request for QueryClientIdsRequest<'input> {
+    type Reply = QueryClientIdsReply;
 }
 pub fn query_client_ids<'c, 'input, Conn>(conn: &'c Conn, specs: &'input [ClientIdSpec]) -> Result<Cookie<'c, Conn, QueryClientIdsReply>, ConnectionError>
 where
@@ -948,6 +963,9 @@ impl<'input> QueryResourceBytesRequest<'input> {
             specs: Cow::Owned(specs),
         })
     }
+}
+impl<'input> Request for QueryResourceBytesRequest<'input> {
+    type Reply = QueryResourceBytesReply;
 }
 pub fn query_resource_bytes<'c, 'input, Conn>(conn: &'c Conn, client: u32, specs: &'input [ResourceIdSpec]) -> Result<Cookie<'c, Conn, QueryResourceBytesReply>, ConnectionError>
 where

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -280,6 +280,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u8, client_minor_version: u8) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -364,6 +367,9 @@ impl QueryInfoRequest {
             drawable,
         })
     }
+}
+impl Request for QueryInfoRequest {
+    type Reply = QueryInfoReply;
 }
 pub fn query_info<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<Cookie<'_, Conn, QueryInfoReply>, ConnectionError>
 where
@@ -464,6 +470,9 @@ impl SelectInputRequest {
             event_mask,
         })
     }
+}
+impl Request for SelectInputRequest {
+    type Reply = ();
 }
 pub fn select_input<Conn, A>(conn: &Conn, drawable: xproto::Drawable, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -925,6 +934,9 @@ impl<'input> SetAttributesRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetAttributesRequest<'input> {
+    type Reply = ();
+}
 pub fn set_attributes<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: xproto::WindowClass, depth: u8, visual: xproto::Visualid, value_list: &'input SetAttributesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -990,6 +1002,9 @@ impl UnsetAttributesRequest {
         })
     }
 }
+impl Request for UnsetAttributesRequest {
+    type Reply = ();
+}
 pub fn unset_attributes<Conn>(conn: &Conn, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1045,6 +1060,9 @@ impl SuspendRequest {
             suspend,
         })
     }
+}
+impl Request for SuspendRequest {
+    type Reply = ();
 }
 pub fn suspend<Conn>(conn: &Conn, suspend: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -303,6 +303,9 @@ impl QueryVersionRequest {
         )
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -430,6 +433,9 @@ impl<'input> RectanglesRequest<'input> {
         })
     }
 }
+impl<'input> Request for RectanglesRequest<'input> {
+    type Reply = ();
+}
 pub fn rectangles<'c, 'input, Conn>(conn: &'c Conn, operation: SO, destination_kind: SK, ordering: xproto::ClipOrdering, destination_window: xproto::Window, x_offset: i16, y_offset: i16, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -526,6 +532,9 @@ impl MaskRequest {
             source_bitmap,
         })
     }
+}
+impl Request for MaskRequest {
+    type Reply = ();
 }
 pub fn mask<Conn, A>(conn: &Conn, operation: SO, destination_kind: SK, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_bitmap: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -630,6 +639,9 @@ impl CombineRequest {
         })
     }
 }
+impl Request for CombineRequest {
+    type Reply = ();
+}
 pub fn combine<Conn>(conn: &Conn, operation: SO, destination_kind: SK, source_kind: SK, destination_window: xproto::Window, x_offset: i16, y_offset: i16, source_window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -714,6 +726,9 @@ impl OffsetRequest {
         })
     }
 }
+impl Request for OffsetRequest {
+    type Reply = ();
+}
 pub fn offset<Conn>(conn: &Conn, destination_kind: SK, destination_window: xproto::Window, x_offset: i16, y_offset: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -772,6 +787,9 @@ impl QueryExtentsRequest {
             destination_window,
         })
     }
+}
+impl Request for QueryExtentsRequest {
+    type Reply = QueryExtentsReply;
 }
 pub fn query_extents<Conn>(conn: &Conn, destination_window: xproto::Window) -> Result<Cookie<'_, Conn, QueryExtentsReply>, ConnectionError>
 where
@@ -882,6 +900,9 @@ impl SelectInputRequest {
         })
     }
 }
+impl Request for SelectInputRequest {
+    type Reply = ();
+}
 pub fn select_input<Conn>(conn: &Conn, destination_window: xproto::Window, enable: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -938,6 +959,9 @@ impl InputSelectedRequest {
             destination_window,
         })
     }
+}
+impl Request for InputSelectedRequest {
+    type Reply = InputSelectedReply;
 }
 pub fn input_selected<Conn>(conn: &Conn, destination_window: xproto::Window) -> Result<Cookie<'_, Conn, InputSelectedReply>, ConnectionError>
 where
@@ -1028,6 +1052,9 @@ impl GetRectanglesRequest {
             source_kind,
         })
     }
+}
+impl Request for GetRectanglesRequest {
+    type Reply = GetRectanglesReply;
 }
 pub fn get_rectangles<Conn>(conn: &Conn, window: xproto::Window, source_kind: SK) -> Result<Cookie<'_, Conn, GetRectanglesReply>, ConnectionError>
 where

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -161,6 +161,9 @@ impl QueryVersionRequest {
         )
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -267,6 +270,9 @@ impl AttachRequest {
         })
     }
 }
+impl Request for AttachRequest {
+    type Reply = ();
+}
 pub fn attach<Conn>(conn: &Conn, shmseg: Seg, shmid: u32, read_only: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -324,6 +330,9 @@ impl DetachRequest {
             shmseg,
         })
     }
+}
+impl Request for DetachRequest {
+    type Reply = ();
 }
 pub fn detach<Conn>(conn: &Conn, shmseg: Seg) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -470,6 +479,9 @@ impl PutImageRequest {
         })
     }
 }
+impl Request for PutImageRequest {
+    type Reply = ();
+}
 pub fn put_image<Conn>(conn: &Conn, drawable: xproto::Drawable, gc: xproto::Gcontext, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -596,6 +608,9 @@ impl GetImageRequest {
             offset,
         })
     }
+}
+impl Request for GetImageRequest {
+    type Reply = GetImageReply;
 }
 pub fn get_image<Conn>(conn: &Conn, drawable: xproto::Drawable, x: i16, y: i16, width: u16, height: u16, plane_mask: u32, format: u8, shmseg: Seg, offset: u32) -> Result<Cookie<'_, Conn, GetImageReply>, ConnectionError>
 where
@@ -734,6 +749,9 @@ impl CreatePixmapRequest {
         })
     }
 }
+impl Request for CreatePixmapRequest {
+    type Reply = ();
+}
 pub fn create_pixmap<Conn>(conn: &Conn, pid: xproto::Pixmap, drawable: xproto::Drawable, width: u16, height: u16, depth: u8, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -808,6 +826,9 @@ impl AttachFdRequest {
             read_only,
         })
     }
+}
+impl Request for AttachFdRequest {
+    type Reply = ();
 }
 pub fn attach_fd<Conn, A>(conn: &Conn, shmseg: Seg, shm_fd: A, read_only: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -885,6 +906,9 @@ impl CreateSegmentRequest {
             read_only,
         })
     }
+}
+impl Request for CreateSegmentRequest {
+    type Reply = CreateSegmentReply;
 }
 pub fn create_segment<Conn>(conn: &Conn, shmseg: Seg, size: u32, read_only: bool) -> Result<CookieWithFds<'_, Conn, CreateSegmentReply>, ConnectionError>
 where

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -756,6 +756,9 @@ impl InitializeRequest {
         })
     }
 }
+impl Request for InitializeRequest {
+    type Reply = InitializeReply;
+}
 pub fn initialize<Conn>(conn: &Conn, desired_major_version: u8, desired_minor_version: u8) -> Result<Cookie<'_, Conn, InitializeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -831,6 +834,9 @@ impl ListSystemCountersRequest {
         Ok(ListSystemCountersRequest
         )
     }
+}
+impl Request for ListSystemCountersRequest {
+    type Reply = ListSystemCountersReply;
 }
 pub fn list_system_counters<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListSystemCountersReply>, ConnectionError>
 where
@@ -940,6 +946,9 @@ impl CreateCounterRequest {
         })
     }
 }
+impl Request for CreateCounterRequest {
+    type Reply = ();
+}
 pub fn create_counter<Conn>(conn: &Conn, id: Counter, initial_value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -997,6 +1006,9 @@ impl DestroyCounterRequest {
         })
     }
 }
+impl Request for DestroyCounterRequest {
+    type Reply = ();
+}
 pub fn destroy_counter<Conn>(conn: &Conn, counter: Counter) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1052,6 +1064,9 @@ impl QueryCounterRequest {
             counter,
         })
     }
+}
+impl Request for QueryCounterRequest {
+    type Reply = QueryCounterReply;
 }
 pub fn query_counter<Conn>(conn: &Conn, counter: Counter) -> Result<Cookie<'_, Conn, QueryCounterReply>, ConnectionError>
 where
@@ -1140,6 +1155,9 @@ impl<'input> AwaitRequest<'input> {
         })
     }
 }
+impl<'input> Request for AwaitRequest<'input> {
+    type Reply = ();
+}
 pub fn await_<'c, 'input, Conn>(conn: &'c Conn, wait_list: &'input [Waitcondition]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1207,6 +1225,9 @@ impl ChangeCounterRequest {
             amount,
         })
     }
+}
+impl Request for ChangeCounterRequest {
+    type Reply = ();
 }
 pub fn change_counter<Conn>(conn: &Conn, counter: Counter, amount: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1276,6 +1297,9 @@ impl SetCounterRequest {
             value,
         })
     }
+}
+impl Request for SetCounterRequest {
+    type Reply = ();
 }
 pub fn set_counter<Conn>(conn: &Conn, counter: Counter, value: Int64) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1505,6 +1529,9 @@ impl<'input> CreateAlarmRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateAlarmRequest<'input> {
+    type Reply = ();
+}
 pub fn create_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input CreateAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1733,6 +1760,9 @@ impl<'input> ChangeAlarmRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeAlarmRequest<'input> {
+    type Reply = ();
+}
 pub fn change_alarm<'c, 'input, Conn>(conn: &'c Conn, id: Alarm, value_list: &'input ChangeAlarmAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1790,6 +1820,9 @@ impl DestroyAlarmRequest {
         })
     }
 }
+impl Request for DestroyAlarmRequest {
+    type Reply = ();
+}
 pub fn destroy_alarm<Conn>(conn: &Conn, alarm: Alarm) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1845,6 +1878,9 @@ impl QueryAlarmRequest {
             alarm,
         })
     }
+}
+impl Request for QueryAlarmRequest {
+    type Reply = QueryAlarmReply;
 }
 pub fn query_alarm<Conn>(conn: &Conn, alarm: Alarm) -> Result<Cookie<'_, Conn, QueryAlarmReply>, ConnectionError>
 where
@@ -1943,6 +1979,9 @@ impl SetPriorityRequest {
         })
     }
 }
+impl Request for SetPriorityRequest {
+    type Reply = ();
+}
 pub fn set_priority<Conn>(conn: &Conn, id: u32, priority: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1999,6 +2038,9 @@ impl GetPriorityRequest {
             id,
         })
     }
+}
+impl Request for GetPriorityRequest {
+    type Reply = GetPriorityReply;
 }
 pub fn get_priority<Conn>(conn: &Conn, id: u32) -> Result<Cookie<'_, Conn, GetPriorityReply>, ConnectionError>
 where
@@ -2097,6 +2139,9 @@ impl CreateFenceRequest {
         })
     }
 }
+impl Request for CreateFenceRequest {
+    type Reply = ();
+}
 pub fn create_fence<Conn>(conn: &Conn, drawable: xproto::Drawable, fence: Fence, initially_triggered: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2155,6 +2200,9 @@ impl TriggerFenceRequest {
         })
     }
 }
+impl Request for TriggerFenceRequest {
+    type Reply = ();
+}
 pub fn trigger_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2210,6 +2258,9 @@ impl ResetFenceRequest {
             fence,
         })
     }
+}
+impl Request for ResetFenceRequest {
+    type Reply = ();
 }
 pub fn reset_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2267,6 +2318,9 @@ impl DestroyFenceRequest {
         })
     }
 }
+impl Request for DestroyFenceRequest {
+    type Reply = ();
+}
 pub fn destroy_fence<Conn>(conn: &Conn, fence: Fence) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2322,6 +2376,9 @@ impl QueryFenceRequest {
             fence,
         })
     }
+}
+impl Request for QueryFenceRequest {
+    type Reply = QueryFenceReply;
 }
 pub fn query_fence<Conn>(conn: &Conn, fence: Fence) -> Result<Cookie<'_, Conn, QueryFenceReply>, ConnectionError>
 where
@@ -2410,6 +2467,9 @@ impl<'input> AwaitFenceRequest<'input> {
             fence_list: Cow::Owned(fence_list),
         })
     }
+}
+impl<'input> Request for AwaitFenceRequest<'input> {
+    type Reply = ();
 }
 pub fn await_fence<'c, 'input, Conn>(conn: &'c Conn, fence_list: &'input [Fence]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -81,6 +81,9 @@ impl GetVersionRequest {
             client_minor_version,
         })
     }
+}
+impl Request for GetVersionRequest {
+    type Reply = GetVersionReply;
 }
 pub fn get_version<Conn>(conn: &Conn, client_major_version: u16, client_minor_version: u16) -> Result<Cookie<'_, Conn, GetVersionReply>, ConnectionError>
 where
@@ -156,6 +159,9 @@ impl GetXIDRangeRequest {
         Ok(GetXIDRangeRequest
         )
     }
+}
+impl Request for GetXIDRangeRequest {
+    type Reply = GetXIDRangeReply;
 }
 pub fn get_xid_range<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetXIDRangeReply>, ConnectionError>
 where
@@ -237,6 +243,9 @@ impl GetXIDListRequest {
             count,
         })
     }
+}
+impl Request for GetXIDListRequest {
+    type Reply = GetXIDListReply;
 }
 pub fn get_xid_list<Conn>(conn: &Conn, count: u32) -> Result<Cookie<'_, Conn, GetXIDListReply>, ConnectionError>
 where

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -81,6 +81,9 @@ impl QueryVersionRequest {
             client_minor_version,
         })
     }
+}
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
 }
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u16, client_minor_version: u16) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
@@ -167,6 +170,9 @@ impl StartRequest {
         })
     }
 }
+impl Request for StartRequest {
+    type Reply = StartReply;
+}
 pub fn start<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, StartReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -246,6 +252,9 @@ impl EndRequest {
             cmap,
         })
     }
+}
+impl Request for EndRequest {
+    type Reply = EndReply;
 }
 pub fn end<Conn>(conn: &Conn, cmap: u32) -> Result<Cookie<'_, Conn, EndReply>, ConnectionError>
 where
@@ -558,6 +567,9 @@ impl SendRequest {
         })
     }
 }
+impl Request for SendRequest {
+    type Reply = SendReply;
+}
 pub fn send<Conn>(conn: &Conn, event: Event, data_type: u32) -> Result<Cookie<'_, Conn, SendReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -638,6 +650,9 @@ impl SelectInputRequest {
             event_mask,
         })
     }
+}
+impl Request for SelectInputRequest {
+    type Reply = SelectInputReply;
 }
 pub fn select_input<Conn>(conn: &Conn, event_mask: u32) -> Result<Cookie<'_, Conn, SelectInputReply>, ConnectionError>
 where

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -119,6 +119,9 @@ impl QueryVersionRequest {
         )
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -202,6 +205,9 @@ impl QueryDirectRenderingCapableRequest {
         })
     }
 }
+impl Request for QueryDirectRenderingCapableRequest {
+    type Reply = QueryDirectRenderingCapableReply;
+}
 pub fn query_direct_rendering_capable<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, QueryDirectRenderingCapableReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -282,6 +288,9 @@ impl OpenConnectionRequest {
             screen,
         })
     }
+}
+impl Request for OpenConnectionRequest {
+    type Reply = OpenConnectionReply;
 }
 pub fn open_connection<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, OpenConnectionReply>, ConnectionError>
 where
@@ -386,6 +395,9 @@ impl CloseConnectionRequest {
         })
     }
 }
+impl Request for CloseConnectionRequest {
+    type Reply = ();
+}
 pub fn close_connection<Conn>(conn: &Conn, screen: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -441,6 +453,9 @@ impl GetClientDriverNameRequest {
             screen,
         })
     }
+}
+impl Request for GetClientDriverNameRequest {
+    type Reply = GetClientDriverNameReply;
 }
 pub fn get_client_driver_name<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, GetClientDriverNameReply>, ConnectionError>
 where
@@ -563,6 +578,9 @@ impl CreateContextRequest {
         })
     }
 }
+impl Request for CreateContextRequest {
+    type Reply = CreateContextReply;
+}
 pub fn create_context<Conn>(conn: &Conn, screen: u32, visual: u32, context: u32) -> Result<Cookie<'_, Conn, CreateContextReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -654,6 +672,9 @@ impl DestroyContextRequest {
         })
     }
 }
+impl Request for DestroyContextRequest {
+    type Reply = ();
+}
 pub fn destroy_context<Conn>(conn: &Conn, screen: u32, context: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -718,6 +739,9 @@ impl CreateDrawableRequest {
             drawable,
         })
     }
+}
+impl Request for CreateDrawableRequest {
+    type Reply = CreateDrawableReply;
 }
 pub fn create_drawable<Conn>(conn: &Conn, screen: u32, drawable: u32) -> Result<Cookie<'_, Conn, CreateDrawableReply>, ConnectionError>
 where
@@ -809,6 +833,9 @@ impl DestroyDrawableRequest {
         })
     }
 }
+impl Request for DestroyDrawableRequest {
+    type Reply = ();
+}
 pub fn destroy_drawable<Conn>(conn: &Conn, screen: u32, drawable: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -873,6 +900,9 @@ impl GetDrawableInfoRequest {
             drawable,
         })
     }
+}
+impl Request for GetDrawableInfoRequest {
+    type Reply = GetDrawableInfoReply;
 }
 pub fn get_drawable_info<Conn>(conn: &Conn, screen: u32, drawable: u32) -> Result<Cookie<'_, Conn, GetDrawableInfoReply>, ConnectionError>
 where
@@ -1004,6 +1034,9 @@ impl GetDeviceInfoRequest {
         })
     }
 }
+impl Request for GetDeviceInfoRequest {
+    type Reply = GetDeviceInfoReply;
+}
 pub fn get_device_info<Conn>(conn: &Conn, screen: u32) -> Result<Cookie<'_, Conn, GetDeviceInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1118,6 +1151,9 @@ impl AuthConnectionRequest {
             magic,
         })
     }
+}
+impl Request for AuthConnectionRequest {
+    type Reply = AuthConnectionReply;
 }
 pub fn auth_connection<Conn>(conn: &Conn, screen: u32, magic: u32) -> Result<Cookie<'_, Conn, AuthConnectionReply>, ConnectionError>
 where

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -402,6 +402,9 @@ impl QueryVersionRequest {
         )
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -483,6 +486,9 @@ impl GetModeLineRequest {
             screen,
         })
     }
+}
+impl Request for GetModeLineRequest {
+    type Reply = GetModeLineReply;
 }
 pub fn get_mode_line<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetModeLineReply>, ConnectionError>
 where
@@ -697,6 +703,9 @@ impl<'input> ModModeLineRequest<'input> {
         })
     }
 }
+impl<'input> Request for ModModeLineRequest<'input> {
+    type Reply = ();
+}
 pub fn mod_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -770,6 +779,9 @@ impl SwitchModeRequest {
         })
     }
 }
+impl Request for SwitchModeRequest {
+    type Reply = ();
+}
 pub fn switch_mode<Conn>(conn: &Conn, screen: u16, zoom: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -827,6 +839,9 @@ impl GetMonitorRequest {
             screen,
         })
     }
+}
+impl Request for GetMonitorRequest {
+    type Reply = GetMonitorReply;
 }
 pub fn get_monitor<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetMonitorReply>, ConnectionError>
 where
@@ -983,6 +998,9 @@ impl LockModeSwitchRequest {
         })
     }
 }
+impl Request for LockModeSwitchRequest {
+    type Reply = ();
+}
 pub fn lock_mode_switch<Conn>(conn: &Conn, screen: u16, lock: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1040,6 +1058,9 @@ impl GetAllModeLinesRequest {
             screen,
         })
     }
+}
+impl Request for GetAllModeLinesRequest {
+    type Reply = GetAllModeLinesReply;
 }
 pub fn get_all_mode_lines<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetAllModeLinesReply>, ConnectionError>
 where
@@ -1324,6 +1345,9 @@ impl<'input> AddModeLineRequest<'input> {
         })
     }
 }
+impl<'input> Request for AddModeLineRequest<'input> {
+    type Reply = ();
+}
 pub fn add_mode_line<'c, 'input, Conn, A, B>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1506,6 +1530,9 @@ impl<'input> DeleteModeLineRequest<'input> {
         })
     }
 }
+impl<'input> Request for DeleteModeLineRequest<'input> {
+    type Reply = ();
+}
 pub fn delete_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1674,6 +1701,9 @@ impl<'input> ValidateModeLineRequest<'input> {
             private,
         })
     }
+}
+impl<'input> Request for ValidateModeLineRequest<'input> {
+    type Reply = ValidateModeLineReply;
 }
 pub fn validate_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
 where
@@ -1870,6 +1900,9 @@ impl<'input> SwitchToModeRequest<'input> {
         })
     }
 }
+impl<'input> Request for SwitchToModeRequest<'input> {
+    type Reply = ();
+}
 pub fn switch_to_mode<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1940,6 +1973,9 @@ impl GetViewPortRequest {
             screen,
         })
     }
+}
+impl Request for GetViewPortRequest {
+    type Reply = GetViewPortReply;
 }
 pub fn get_view_port<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetViewPortReply>, ConnectionError>
 where
@@ -2042,6 +2078,9 @@ impl SetViewPortRequest {
         })
     }
 }
+impl Request for SetViewPortRequest {
+    type Reply = ();
+}
 pub fn set_view_port<Conn>(conn: &Conn, screen: u16, x: u32, y: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2100,6 +2139,9 @@ impl GetDotClocksRequest {
             screen,
         })
     }
+}
+impl Request for GetDotClocksRequest {
+    type Reply = GetDotClocksReply;
 }
 pub fn get_dot_clocks<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetDotClocksReply>, ConnectionError>
 where
@@ -2192,6 +2234,9 @@ impl SetClientVersionRequest {
             minor,
         })
     }
+}
+impl Request for SetClientVersionRequest {
+    type Reply = ();
 }
 pub fn set_client_version<Conn>(conn: &Conn, major: u16, minor: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2288,6 +2333,9 @@ impl SetGammaRequest {
         })
     }
 }
+impl Request for SetGammaRequest {
+    type Reply = ();
+}
 pub fn set_gamma<Conn>(conn: &Conn, screen: u16, red: u32, green: u32, blue: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2371,6 +2419,9 @@ impl GetGammaRequest {
             screen,
         })
     }
+}
+impl Request for GetGammaRequest {
+    type Reply = GetGammaReply;
 }
 pub fn get_gamma<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetGammaReply>, ConnectionError>
 where
@@ -2461,6 +2512,9 @@ impl GetGammaRampRequest {
             size,
         })
     }
+}
+impl Request for GetGammaRampRequest {
+    type Reply = GetGammaRampReply;
 }
 pub fn get_gamma_ramp<Conn>(conn: &Conn, screen: u16, size: u16) -> Result<Cookie<'_, Conn, GetGammaRampReply>, ConnectionError>
 where
@@ -2575,6 +2629,9 @@ impl<'input> SetGammaRampRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetGammaRampRequest<'input> {
+    type Reply = ();
+}
 pub fn set_gamma_ramp<'c, 'input, Conn>(conn: &'c Conn, screen: u16, size: u16, red: &'input [u16], green: &'input [u16], blue: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2635,6 +2692,9 @@ impl GetGammaRampSizeRequest {
             screen,
         })
     }
+}
+impl Request for GetGammaRampSizeRequest {
+    type Reply = GetGammaRampSizeReply;
 }
 pub fn get_gamma_ramp_size<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetGammaRampSizeReply>, ConnectionError>
 where
@@ -2718,6 +2778,9 @@ impl GetPermissionsRequest {
             screen,
         })
     }
+}
+impl Request for GetPermissionsRequest {
+    type Reply = GetPermissionsReply;
 }
 pub fn get_permissions<Conn>(conn: &Conn, screen: u16) -> Result<Cookie<'_, Conn, GetPermissionsReply>, ConnectionError>
 where

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -88,6 +88,9 @@ impl QueryVersionRequest {
             client_minor_version,
         })
     }
+}
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
 }
 pub fn query_version<Conn>(conn: &Conn, client_major_version: u32, client_minor_version: u32) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
@@ -404,6 +407,9 @@ impl ChangeSaveSetRequest {
         })
     }
 }
+impl Request for ChangeSaveSetRequest {
+    type Reply = ();
+}
 pub fn change_save_set<Conn>(conn: &Conn, mode: SaveSetMode, target: SaveSetTarget, map: SaveSetMapping, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -697,6 +703,9 @@ impl SelectSelectionInputRequest {
         })
     }
 }
+impl Request for SelectSelectionInputRequest {
+    type Reply = ();
+}
 pub fn select_selection_input<Conn, A>(conn: &Conn, window: xproto::Window, selection: xproto::Atom, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -968,6 +977,9 @@ impl SelectCursorInputRequest {
         })
     }
 }
+impl Request for SelectCursorInputRequest {
+    type Reply = ();
+}
 pub fn select_cursor_input<Conn, A>(conn: &Conn, window: xproto::Window, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1017,6 +1029,9 @@ impl GetCursorImageRequest {
         Ok(GetCursorImageRequest
         )
     }
+}
+impl Request for GetCursorImageRequest {
+    type Reply = GetCursorImageReply;
 }
 pub fn get_cursor_image<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetCursorImageReply>, ConnectionError>
 where
@@ -1258,6 +1273,9 @@ impl<'input> CreateRegionRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateRegionRequest<'input> {
+    type Reply = ();
+}
 pub fn create_region<'c, 'input, Conn>(conn: &'c Conn, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1322,6 +1340,9 @@ impl CreateRegionFromBitmapRequest {
             bitmap,
         })
     }
+}
+impl Request for CreateRegionFromBitmapRequest {
+    type Reply = ();
 }
 pub fn create_region_from_bitmap<Conn>(conn: &Conn, region: Region, bitmap: xproto::Pixmap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1398,6 +1419,9 @@ impl CreateRegionFromWindowRequest {
         })
     }
 }
+impl Request for CreateRegionFromWindowRequest {
+    type Reply = ();
+}
 pub fn create_region_from_window<Conn>(conn: &Conn, region: Region, window: xproto::Window, kind: shape::SK) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1464,6 +1488,9 @@ impl CreateRegionFromGCRequest {
         })
     }
 }
+impl Request for CreateRegionFromGCRequest {
+    type Reply = ();
+}
 pub fn create_region_from_gc<Conn>(conn: &Conn, region: Region, gc: xproto::Gcontext) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1529,6 +1556,9 @@ impl CreateRegionFromPictureRequest {
         })
     }
 }
+impl Request for CreateRegionFromPictureRequest {
+    type Reply = ();
+}
 pub fn create_region_from_picture<Conn>(conn: &Conn, region: Region, picture: render::Picture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1585,6 +1615,9 @@ impl DestroyRegionRequest {
             region,
         })
     }
+}
+impl Request for DestroyRegionRequest {
+    type Reply = ();
 }
 pub fn destroy_region<Conn>(conn: &Conn, region: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1656,6 +1689,9 @@ impl<'input> SetRegionRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetRegionRequest<'input> {
+    type Reply = ();
+}
 pub fn set_region<'c, 'input, Conn>(conn: &'c Conn, region: Region, rectangles: &'input [xproto::Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1720,6 +1756,9 @@ impl CopyRegionRequest {
             destination,
         })
     }
+}
+impl Request for CopyRegionRequest {
+    type Reply = ();
 }
 pub fn copy_region<Conn>(conn: &Conn, source: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1793,6 +1832,9 @@ impl UnionRegionRequest {
             destination,
         })
     }
+}
+impl Request for UnionRegionRequest {
+    type Reply = ();
 }
 pub fn union_region<Conn>(conn: &Conn, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1868,6 +1910,9 @@ impl IntersectRegionRequest {
         })
     }
 }
+impl Request for IntersectRegionRequest {
+    type Reply = ();
+}
 pub fn intersect_region<Conn>(conn: &Conn, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1941,6 +1986,9 @@ impl SubtractRegionRequest {
             destination,
         })
     }
+}
+impl Request for SubtractRegionRequest {
+    type Reply = ();
 }
 pub fn subtract_region<Conn>(conn: &Conn, source1: Region, source2: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2020,6 +2068,9 @@ impl InvertRegionRequest {
         })
     }
 }
+impl Request for InvertRegionRequest {
+    type Reply = ();
+}
 pub fn invert_region<Conn>(conn: &Conn, source: Region, bounds: xproto::Rectangle, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2090,6 +2141,9 @@ impl TranslateRegionRequest {
         })
     }
 }
+impl Request for TranslateRegionRequest {
+    type Reply = ();
+}
 pub fn translate_region<Conn>(conn: &Conn, region: Region, dx: i16, dy: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2156,6 +2210,9 @@ impl RegionExtentsRequest {
         })
     }
 }
+impl Request for RegionExtentsRequest {
+    type Reply = ();
+}
 pub fn region_extents<Conn>(conn: &Conn, source: Region, destination: Region) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2212,6 +2269,9 @@ impl FetchRegionRequest {
             region,
         })
     }
+}
+impl Request for FetchRegionRequest {
+    type Reply = FetchRegionReply;
 }
 pub fn fetch_region<Conn>(conn: &Conn, region: Region) -> Result<Cookie<'_, Conn, FetchRegionReply>, ConnectionError>
 where
@@ -2332,6 +2392,9 @@ impl SetGCClipRegionRequest {
         })
     }
 }
+impl Request for SetGCClipRegionRequest {
+    type Reply = ();
+}
 pub fn set_gc_clip_region<Conn, A>(conn: &Conn, gc: xproto::Gcontext, region: A, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2423,6 +2486,9 @@ impl SetWindowShapeRegionRequest {
         })
     }
 }
+impl Request for SetWindowShapeRegionRequest {
+    type Reply = ();
+}
 pub fn set_window_shape_region<Conn, A>(conn: &Conn, dest: xproto::Window, dest_kind: shape::SK, x_offset: i16, y_offset: i16, region: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2505,6 +2571,9 @@ impl SetPictureClipRegionRequest {
         })
     }
 }
+impl Request for SetPictureClipRegionRequest {
+    type Reply = ();
+}
 pub fn set_picture_clip_region<Conn, A>(conn: &Conn, picture: render::Picture, region: A, x_origin: i16, y_origin: i16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2580,6 +2649,9 @@ impl<'input> SetCursorNameRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetCursorNameRequest<'input> {
+    type Reply = ();
+}
 pub fn set_cursor_name<'c, 'input, Conn>(conn: &'c Conn, cursor: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2636,6 +2708,9 @@ impl GetCursorNameRequest {
             cursor,
         })
     }
+}
+impl Request for GetCursorNameRequest {
+    type Reply = GetCursorNameReply;
 }
 pub fn get_cursor_name<Conn>(conn: &Conn, cursor: xproto::Cursor) -> Result<Cookie<'_, Conn, GetCursorNameReply>, ConnectionError>
 where
@@ -2728,6 +2803,9 @@ impl GetCursorImageAndNameRequest {
         Ok(GetCursorImageAndNameRequest
         )
     }
+}
+impl Request for GetCursorImageAndNameRequest {
+    type Reply = GetCursorImageAndNameReply;
 }
 pub fn get_cursor_image_and_name<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetCursorImageAndNameReply>, ConnectionError>
 where
@@ -2852,6 +2930,9 @@ impl ChangeCursorRequest {
         })
     }
 }
+impl Request for ChangeCursorRequest {
+    type Reply = ();
+}
 pub fn change_cursor<Conn>(conn: &Conn, source: xproto::Cursor, destination: xproto::Cursor) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2922,6 +3003,9 @@ impl<'input> ChangeCursorByNameRequest<'input> {
             name,
         })
     }
+}
+impl<'input> Request for ChangeCursorByNameRequest<'input> {
+    type Reply = ();
 }
 pub fn change_cursor_by_name<'c, 'input, Conn>(conn: &'c Conn, src: xproto::Cursor, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -3012,6 +3096,9 @@ impl ExpandRegionRequest {
         })
     }
 }
+impl Request for ExpandRegionRequest {
+    type Reply = ();
+}
 pub fn expand_region<Conn>(conn: &Conn, source: Region, destination: Region, left: u16, right: u16, top: u16, bottom: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3073,6 +3160,9 @@ impl HideCursorRequest {
         })
     }
 }
+impl Request for HideCursorRequest {
+    type Reply = ();
+}
 pub fn hide_cursor<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3128,6 +3218,9 @@ impl ShowCursorRequest {
             window,
         })
     }
+}
+impl Request for ShowCursorRequest {
+    type Reply = ();
 }
 pub fn show_cursor<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -3311,6 +3404,9 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreatePointerBarrierRequest<'input> {
+    type Reply = ();
+}
 pub fn create_pointer_barrier<'c, 'input, Conn, A>(conn: &'c Conn, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3375,6 +3471,9 @@ impl DeletePointerBarrierRequest {
             barrier,
         })
     }
+}
+impl Request for DeletePointerBarrierRequest {
+    type Reply = ();
 }
 pub fn delete_pointer_barrier<Conn>(conn: &Conn, barrier: Barrier) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -133,6 +133,9 @@ impl QueryVersionRequest {
         })
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn, major: u8, minor: u8) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -217,6 +220,9 @@ impl GetStateRequest {
         })
     }
 }
+impl Request for GetStateRequest {
+    type Reply = GetStateReply;
+}
 pub fn get_state<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -298,6 +304,9 @@ impl GetScreenCountRequest {
             window,
         })
     }
+}
+impl Request for GetScreenCountRequest {
+    type Reply = GetScreenCountReply;
 }
 pub fn get_screen_count<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetScreenCountReply>, ConnectionError>
 where
@@ -389,6 +398,9 @@ impl GetScreenSizeRequest {
         })
     }
 }
+impl Request for GetScreenSizeRequest {
+    type Reply = GetScreenSizeReply;
+}
 pub fn get_screen_size<Conn>(conn: &Conn, window: xproto::Window, screen: u32) -> Result<Cookie<'_, Conn, GetScreenSizeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -468,6 +480,9 @@ impl IsActiveRequest {
         )
     }
 }
+impl Request for IsActiveRequest {
+    type Reply = IsActiveReply;
+}
 pub fn is_active<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, IsActiveReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -537,6 +552,9 @@ impl QueryScreensRequest {
         Ok(QueryScreensRequest
         )
     }
+}
+impl Request for QueryScreensRequest {
+    type Reply = QueryScreensReply;
 }
 pub fn query_screens<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryScreensReply>, ConnectionError>
 where

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -135,6 +135,9 @@ impl<'input> GetExtensionVersionRequest<'input> {
             name,
         })
     }
+}
+impl<'input> Request for GetExtensionVersionRequest<'input> {
+    type Reply = GetExtensionVersionReply;
 }
 pub fn get_extension_version<'c, 'input, Conn>(conn: &'c Conn, name: &'input [u8]) -> Result<Cookie<'c, Conn, GetExtensionVersionReply>, ConnectionError>
 where
@@ -992,6 +995,9 @@ impl ListInputDevicesRequest {
         )
     }
 }
+impl Request for ListInputDevicesRequest {
+    type Reply = ListInputDevicesReply;
+}
 pub fn list_input_devices<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListInputDevicesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1138,6 +1144,9 @@ impl OpenDeviceRequest {
         })
     }
 }
+impl Request for OpenDeviceRequest {
+    type Reply = OpenDeviceReply;
+}
 pub fn open_device<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, OpenDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1243,6 +1252,9 @@ impl CloseDeviceRequest {
         })
     }
 }
+impl Request for CloseDeviceRequest {
+    type Reply = ();
+}
 pub fn close_device<Conn>(conn: &Conn, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1304,6 +1316,9 @@ impl SetDeviceModeRequest {
             mode,
         })
     }
+}
+impl Request for SetDeviceModeRequest {
+    type Reply = SetDeviceModeReply;
 }
 pub fn set_device_mode<Conn>(conn: &Conn, device_id: u8, mode: ValuatorMode) -> Result<Cookie<'_, Conn, SetDeviceModeReply>, ConnectionError>
 where
@@ -1405,6 +1420,9 @@ impl<'input> SelectExtensionEventRequest<'input> {
         })
     }
 }
+impl<'input> Request for SelectExtensionEventRequest<'input> {
+    type Reply = ();
+}
 pub fn select_extension_event<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1461,6 +1479,9 @@ impl GetSelectedExtensionEventsRequest {
             window,
         })
     }
+}
+impl Request for GetSelectedExtensionEventsRequest {
+    type Reply = GetSelectedExtensionEventsReply;
 }
 pub fn get_selected_extension_events<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetSelectedExtensionEventsReply>, ConnectionError>
 where
@@ -1667,6 +1688,9 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeDeviceDontPropagateListRequest<'input> {
+    type Reply = ();
+}
 pub fn change_device_dont_propagate_list<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, mode: PropagateMode, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1724,6 +1748,9 @@ impl GetDeviceDontPropagateListRequest {
             window,
         })
     }
+}
+impl Request for GetDeviceDontPropagateListRequest {
+    type Reply = GetDeviceDontPropagateListReply;
 }
 pub fn get_device_dont_propagate_list<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetDeviceDontPropagateListReply>, ConnectionError>
 where
@@ -1869,6 +1896,9 @@ impl GetDeviceMotionEventsRequest {
         })
     }
 }
+impl Request for GetDeviceMotionEventsRequest {
+    type Reply = GetDeviceMotionEventsReply;
+}
 pub fn get_device_motion_events<Conn, A>(conn: &Conn, start: xproto::Timestamp, stop: A, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceMotionEventsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1985,6 +2015,9 @@ impl ChangeKeyboardDeviceRequest {
         })
     }
 }
+impl Request for ChangeKeyboardDeviceRequest {
+    type Reply = ChangeKeyboardDeviceReply;
+}
 pub fn change_keyboard_device<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, ChangeKeyboardDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2077,6 +2110,9 @@ impl ChangePointerDeviceRequest {
             device_id,
         })
     }
+}
+impl Request for ChangePointerDeviceRequest {
+    type Reply = ChangePointerDeviceReply;
 }
 pub fn change_pointer_device<Conn>(conn: &Conn, x_axis: u8, y_axis: u8, device_id: u8) -> Result<Cookie<'_, Conn, ChangePointerDeviceReply>, ConnectionError>
 where
@@ -2209,6 +2245,9 @@ impl<'input> GrabDeviceRequest<'input> {
         })
     }
 }
+impl<'input> Request for GrabDeviceRequest<'input> {
+    type Reply = GrabDeviceReply;
+}
 pub fn grab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, time: A, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, device_id: u8, classes: &'input [EventClass]) -> Result<Cookie<'c, Conn, GrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2309,6 +2348,9 @@ impl UngrabDeviceRequest {
             device_id,
         })
     }
+}
+impl Request for UngrabDeviceRequest {
+    type Reply = ();
 }
 pub fn ungrab_device<Conn, A>(conn: &Conn, time: A, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2481,6 +2523,9 @@ impl<'input> GrabDeviceKeyRequest<'input> {
         })
     }
 }
+impl<'input> Request for GrabDeviceKeyRequest<'input> {
+    type Reply = ();
+}
 pub fn grab_device_key<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2574,6 +2619,9 @@ impl UngrabDeviceKeyRequest {
             grabbed_device,
         })
     }
+}
+impl Request for UngrabDeviceKeyRequest {
+    type Reply = ();
 }
 pub fn ungrab_device_key<Conn, A, B, C>(conn: &Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, key: C, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2694,6 +2742,9 @@ impl<'input> GrabDeviceButtonRequest<'input> {
         })
     }
 }
+impl<'input> Request for GrabDeviceButtonRequest<'input> {
+    type Reply = ();
+}
 pub fn grab_device_button<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2788,6 +2839,9 @@ impl UngrabDeviceButtonRequest {
             grabbed_device,
         })
     }
+}
+impl Request for UngrabDeviceButtonRequest {
+    type Reply = ();
 }
 pub fn ungrab_device_button<Conn, A, B, C>(conn: &Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, button: C, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2943,6 +2997,9 @@ impl AllowDeviceEventsRequest {
         })
     }
 }
+impl Request for AllowDeviceEventsRequest {
+    type Reply = ();
+}
 pub fn allow_device_events<Conn, A>(conn: &Conn, time: A, mode: DeviceInputMode, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3003,6 +3060,9 @@ impl GetDeviceFocusRequest {
             device_id,
         })
     }
+}
+impl Request for GetDeviceFocusRequest {
+    type Reply = GetDeviceFocusReply;
 }
 pub fn get_device_focus<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceFocusReply>, ConnectionError>
 where
@@ -3113,6 +3173,9 @@ impl SetDeviceFocusRequest {
             device_id,
         })
     }
+}
+impl Request for SetDeviceFocusRequest {
+    type Reply = ();
 }
 pub fn set_device_focus<Conn, A, B>(conn: &Conn, focus: A, time: B, revert_to: xproto::InputFocus, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -4199,6 +4262,9 @@ impl GetFeedbackControlRequest {
         })
     }
 }
+impl Request for GetFeedbackControlRequest {
+    type Reply = GetFeedbackControlReply;
+}
 pub fn get_feedback_control<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetFeedbackControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5225,6 +5291,9 @@ impl ChangeFeedbackControlRequest {
         })
     }
 }
+impl Request for ChangeFeedbackControlRequest {
+    type Reply = ();
+}
 pub fn change_feedback_control<Conn, A>(conn: &Conn, mask: A, device_id: u8, feedback_id: u8, feedback: FeedbackCtl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5294,6 +5363,9 @@ impl GetDeviceKeyMappingRequest {
             count,
         })
     }
+}
+impl Request for GetDeviceKeyMappingRequest {
+    type Reply = GetDeviceKeyMappingReply;
 }
 pub fn get_device_key_mapping<Conn>(conn: &Conn, device_id: u8, first_keycode: KeyCode, count: u8) -> Result<Cookie<'_, Conn, GetDeviceKeyMappingReply>, ConnectionError>
 where
@@ -5416,6 +5488,9 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeDeviceKeyMappingRequest<'input> {
+    type Reply = ();
+}
 pub fn change_device_key_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_keycode: KeyCode, keysyms_per_keycode: u8, keycode_count: u8, keysyms: &'input [xproto::Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5476,6 +5551,9 @@ impl GetDeviceModifierMappingRequest {
             device_id,
         })
     }
+}
+impl Request for GetDeviceModifierMappingRequest {
+    type Reply = GetDeviceModifierMappingReply;
 }
 pub fn get_device_modifier_mapping<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceModifierMappingReply>, ConnectionError>
 where
@@ -5589,6 +5667,9 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetDeviceModifierMappingRequest<'input> {
+    type Reply = SetDeviceModifierMappingReply;
+}
 pub fn set_device_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, keymaps: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -5674,6 +5755,9 @@ impl GetDeviceButtonMappingRequest {
             device_id,
         })
     }
+}
+impl Request for GetDeviceButtonMappingRequest {
+    type Reply = GetDeviceButtonMappingReply;
 }
 pub fn get_device_button_mapping<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceButtonMappingReply>, ConnectionError>
 where
@@ -5789,6 +5873,9 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
             map,
         })
     }
+}
+impl<'input> Request for SetDeviceButtonMappingRequest<'input> {
+    type Reply = SetDeviceButtonMappingReply;
 }
 pub fn set_device_button_mapping<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetDeviceButtonMappingReply>, ConnectionError>
 where
@@ -6463,6 +6550,9 @@ impl QueryDeviceStateRequest {
         })
     }
 }
+impl Request for QueryDeviceStateRequest {
+    type Reply = QueryDeviceStateReply;
+}
 pub fn query_device_state<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, QueryDeviceStateReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6574,6 +6664,9 @@ impl DeviceBellRequest {
         })
     }
 }
+impl Request for DeviceBellRequest {
+    type Reply = ();
+}
 pub fn device_bell<Conn>(conn: &Conn, device_id: u8, feedback_id: u8, feedback_class: u8, percent: i8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -6647,6 +6740,9 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
             valuators: Cow::Owned(valuators),
         })
     }
+}
+impl<'input> Request for SetDeviceValuatorsRequest<'input> {
+    type Reply = SetDeviceValuatorsReply;
 }
 pub fn set_device_valuators<'c, 'input, Conn>(conn: &'c Conn, device_id: u8, first_valuator: u8, valuators: &'input [i32]) -> Result<Cookie<'c, Conn, SetDeviceValuatorsReply>, ConnectionError>
 where
@@ -7573,6 +7669,9 @@ impl GetDeviceControlRequest {
         })
     }
 }
+impl Request for GetDeviceControlRequest {
+    type Reply = GetDeviceControlReply;
+}
 pub fn get_device_control<Conn>(conn: &Conn, control_id: DeviceControl, device_id: u8) -> Result<Cookie<'_, Conn, GetDeviceControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8421,6 +8520,9 @@ impl ChangeDeviceControlRequest {
         })
     }
 }
+impl Request for ChangeDeviceControlRequest {
+    type Reply = ChangeDeviceControlReply;
+}
 pub fn change_device_control<Conn>(conn: &Conn, control_id: DeviceControl, device_id: u8, control: DeviceCtl) -> Result<Cookie<'_, Conn, ChangeDeviceControlReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8506,6 +8608,9 @@ impl ListDevicePropertiesRequest {
             device_id,
         })
     }
+}
+impl Request for ListDevicePropertiesRequest {
+    type Reply = ListDevicePropertiesReply;
 }
 pub fn list_device_properties<Conn>(conn: &Conn, device_id: u8) -> Result<Cookie<'_, Conn, ListDevicePropertiesReply>, ConnectionError>
 where
@@ -8816,6 +8921,9 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeDevicePropertyRequest<'input> {
+    type Reply = ();
+}
 pub fn change_device_property<'c, 'input, Conn>(conn: &'c Conn, property: xproto::Atom, type_: xproto::Atom, device_id: u8, mode: xproto::PropMode, num_items: u32, items: &'input ChangeDevicePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8885,6 +8993,9 @@ impl DeleteDevicePropertyRequest {
             device_id,
         })
     }
+}
+impl Request for DeleteDevicePropertyRequest {
+    type Reply = ();
 }
 pub fn delete_device_property<Conn>(conn: &Conn, property: xproto::Atom, device_id: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -8979,6 +9090,9 @@ impl GetDevicePropertyRequest {
             delete,
         })
     }
+}
+impl Request for GetDevicePropertyRequest {
+    type Reply = GetDevicePropertyReply;
 }
 pub fn get_device_property<Conn>(conn: &Conn, property: xproto::Atom, type_: xproto::Atom, offset: u32, len: u32, device_id: u8, delete: bool) -> Result<Cookie<'_, Conn, GetDevicePropertyReply>, ConnectionError>
 where
@@ -9330,6 +9444,9 @@ impl XIQueryPointerRequest {
         })
     }
 }
+impl Request for XIQueryPointerRequest {
+    type Reply = XIQueryPointerReply;
+}
 pub fn xi_query_pointer<Conn, A>(conn: &Conn, window: xproto::Window, deviceid: A) -> Result<Cookie<'_, Conn, XIQueryPointerReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9510,6 +9627,9 @@ impl XIWarpPointerRequest {
         })
     }
 }
+impl Request for XIWarpPointerRequest {
+    type Reply = ();
+}
 pub fn xi_warp_pointer<Conn, A>(conn: &Conn, src_win: xproto::Window, dst_win: xproto::Window, src_x: Fp1616, src_y: Fp1616, src_width: u16, src_height: u16, dst_x: Fp1616, dst_y: Fp1616, deviceid: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9592,6 +9712,9 @@ impl XIChangeCursorRequest {
             deviceid,
         })
     }
+}
+impl Request for XIChangeCursorRequest {
+    type Reply = ();
 }
 pub fn xi_change_cursor<Conn, A>(conn: &Conn, window: xproto::Window, cursor: xproto::Cursor, deviceid: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -10339,6 +10462,9 @@ impl<'input> XIChangeHierarchyRequest<'input> {
         })
     }
 }
+impl<'input> Request for XIChangeHierarchyRequest<'input> {
+    type Reply = ();
+}
 pub fn xi_change_hierarchy<'c, 'input, Conn>(conn: &'c Conn, changes: &'input [HierarchyChange]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10404,6 +10530,9 @@ impl XISetClientPointerRequest {
         })
     }
 }
+impl Request for XISetClientPointerRequest {
+    type Reply = ();
+}
 pub fn xi_set_client_pointer<Conn, A>(conn: &Conn, window: xproto::Window, deviceid: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10462,6 +10591,9 @@ impl XIGetClientPointerRequest {
             window,
         })
     }
+}
+impl Request for XIGetClientPointerRequest {
+    type Reply = XIGetClientPointerReply;
 }
 pub fn xi_get_client_pointer<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, XIGetClientPointerReply>, ConnectionError>
 where
@@ -10717,6 +10849,9 @@ impl<'input> XISelectEventsRequest<'input> {
         })
     }
 }
+impl<'input> Request for XISelectEventsRequest<'input> {
+    type Reply = ();
+}
 pub fn xi_select_events<'c, 'input, Conn>(conn: &'c Conn, window: xproto::Window, masks: &'input [EventMask]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10777,6 +10912,9 @@ impl XIQueryVersionRequest {
             minor_version,
         })
     }
+}
+impl Request for XIQueryVersionRequest {
+    type Reply = XIQueryVersionReply;
 }
 pub fn xi_query_version<Conn>(conn: &Conn, major_version: u16, minor_version: u16) -> Result<Cookie<'_, Conn, XIQueryVersionReply>, ConnectionError>
 where
@@ -12091,6 +12229,9 @@ impl XIQueryDeviceRequest {
         })
     }
 }
+impl Request for XIQueryDeviceRequest {
+    type Reply = XIQueryDeviceReply;
+}
 pub fn xi_query_device<Conn, A>(conn: &Conn, deviceid: A) -> Result<Cookie<'_, Conn, XIQueryDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -12208,6 +12349,9 @@ impl XISetFocusRequest {
         })
     }
 }
+impl Request for XISetFocusRequest {
+    type Reply = ();
+}
 pub fn xi_set_focus<Conn, A, B>(conn: &Conn, window: xproto::Window, time: A, deviceid: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -12270,6 +12414,9 @@ impl XIGetFocusRequest {
             deviceid,
         })
     }
+}
+impl Request for XIGetFocusRequest {
+    type Reply = XIGetFocusReply;
 }
 pub fn xi_get_focus<Conn, A>(conn: &Conn, deviceid: A) -> Result<Cookie<'_, Conn, XIGetFocusReply>, ConnectionError>
 where
@@ -12479,6 +12626,9 @@ impl<'input> XIGrabDeviceRequest<'input> {
         })
     }
 }
+impl<'input> Request for XIGrabDeviceRequest<'input> {
+    type Reply = XIGrabDeviceReply;
+}
 pub fn xi_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, window: xproto::Window, time: A, cursor: xproto::Cursor, deviceid: B, mode: xproto::GrabMode, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32]) -> Result<Cookie<'c, Conn, XIGrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -12581,6 +12731,9 @@ impl XIUngrabDeviceRequest {
             deviceid,
         })
     }
+}
+impl Request for XIUngrabDeviceRequest {
+    type Reply = ();
 }
 pub fn xi_ungrab_device<Conn, A, B>(conn: &Conn, time: A, deviceid: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -12752,6 +12905,9 @@ impl XIAllowEventsRequest {
             grab_window,
         })
     }
+}
+impl Request for XIAllowEventsRequest {
+    type Reply = ();
 }
 pub fn xi_allow_events<Conn, A, B>(conn: &Conn, time: A, deviceid: B, event_mode: EventMode, touchid: u32, grab_window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -13105,6 +13261,9 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
         })
     }
 }
+impl<'input> Request for XIPassiveGrabDeviceRequest<'input> {
+    type Reply = XIPassiveGrabDeviceReply;
+}
 pub fn xi_passive_grab_device<'c, 'input, Conn, A, B>(conn: &'c Conn, time: A, grab_window: xproto::Window, cursor: xproto::Cursor, detail: u32, deviceid: B, grab_type: GrabType, grab_mode: GrabMode22, paired_device_mode: xproto::GrabMode, owner_events: GrabOwner, mask: &'input [u32], modifiers: &'input [u32]) -> Result<Cookie<'c, Conn, XIPassiveGrabDeviceReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -13253,6 +13412,9 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
         })
     }
 }
+impl<'input> Request for XIPassiveUngrabDeviceRequest<'input> {
+    type Reply = ();
+}
 pub fn xi_passive_ungrab_device<'c, 'input, Conn, A>(conn: &'c Conn, grab_window: xproto::Window, detail: u32, deviceid: A, grab_type: GrabType, modifiers: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -13315,6 +13477,9 @@ impl XIListPropertiesRequest {
             deviceid,
         })
     }
+}
+impl Request for XIListPropertiesRequest {
+    type Reply = XIListPropertiesReply;
 }
 pub fn xi_list_properties<Conn, A>(conn: &Conn, deviceid: A) -> Result<Cookie<'_, Conn, XIListPropertiesReply>, ConnectionError>
 where
@@ -13560,6 +13725,9 @@ impl<'input> XIChangePropertyRequest<'input> {
         })
     }
 }
+impl<'input> Request for XIChangePropertyRequest<'input> {
+    type Reply = ();
+}
 pub fn xi_change_property<'c, 'input, Conn, A>(conn: &'c Conn, deviceid: A, mode: xproto::PropMode, property: xproto::Atom, type_: xproto::Atom, num_items: u32, items: &'input XIChangePropertyAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -13631,6 +13799,9 @@ impl XIDeletePropertyRequest {
             property,
         })
     }
+}
+impl Request for XIDeletePropertyRequest {
+    type Reply = ();
 }
 pub fn xi_delete_property<Conn, A>(conn: &Conn, deviceid: A, property: xproto::Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -13727,6 +13898,9 @@ impl XIGetPropertyRequest {
             len,
         })
     }
+}
+impl Request for XIGetPropertyRequest {
+    type Reply = XIGetPropertyReply;
 }
 pub fn xi_get_property<Conn, A>(conn: &Conn, deviceid: A, delete: bool, property: xproto::Atom, type_: xproto::Atom, offset: u32, len: u32) -> Result<Cookie<'_, Conn, XIGetPropertyReply>, ConnectionError>
 where
@@ -13894,6 +14068,9 @@ impl XIGetSelectedEventsRequest {
         })
     }
 }
+impl Request for XIGetSelectedEventsRequest {
+    type Reply = XIGetSelectedEventsReply;
+}
 pub fn xi_get_selected_events<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, XIGetSelectedEventsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -14049,6 +14226,9 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
             barriers: Cow::Owned(barriers),
         })
     }
+}
+impl<'input> Request for XIBarrierReleasePointerRequest<'input> {
+    type Reply = ();
 }
 pub fn xi_barrier_release_pointer<'c, 'input, Conn>(conn: &'c Conn, barriers: &'input [BarrierReleasePointerInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -16995,6 +17175,9 @@ impl<'input> SendExtensionEventRequest<'input> {
             classes: Cow::Owned(classes),
         })
     }
+}
+impl<'input> Request for SendExtensionEventRequest<'input> {
+    type Reply = ();
 }
 pub fn send_extension_event<'c, 'input, Conn>(conn: &'c Conn, destination: xproto::Window, device_id: u8, propagate: bool, events: &'input [EventForSend], classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -6357,6 +6357,9 @@ impl UseExtensionRequest {
         })
     }
 }
+impl Request for UseExtensionRequest {
+    type Reply = UseExtensionReply;
+}
 pub fn use_extension<Conn>(conn: &Conn, wanted_major: u16, wanted_minor: u16) -> Result<Cookie<'_, Conn, UseExtensionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7135,6 +7138,9 @@ impl<'input> SelectEventsRequest<'input> {
         })
     }
 }
+impl<'input> Request for SelectEventsRequest<'input> {
+    type Reply = ();
+}
 pub fn select_events<'c, 'input, Conn, A, B, C, D>(conn: &'c Conn, device_spec: DeviceSpec, clear: A, select_all: B, affect_map: C, map: D, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7262,6 +7268,9 @@ impl BellRequest {
         })
     }
 }
+impl Request for BellRequest {
+    type Reply = ();
+}
 pub fn bell<Conn>(conn: &Conn, device_spec: DeviceSpec, bell_class: BellClassSpec, bell_id: IDSpec, percent: i8, force_sound: bool, event_only: bool, pitch: i16, duration: i16, name: xproto::Atom, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7327,6 +7336,9 @@ impl GetStateRequest {
             device_spec,
         })
     }
+}
+impl Request for GetStateRequest {
+    type Reply = GetStateReply;
 }
 pub fn get_state<Conn>(conn: &Conn, device_spec: DeviceSpec) -> Result<Cookie<'_, Conn, GetStateReply>, ConnectionError>
 where
@@ -7479,6 +7491,9 @@ impl LatchLockStateRequest {
         })
     }
 }
+impl Request for LatchLockStateRequest {
+    type Reply = ();
+}
 pub fn latch_lock_state<Conn, A, B, C>(conn: &Conn, device_spec: DeviceSpec, affect_mod_locks: A, mod_locks: B, lock_group: bool, group_lock: Group, affect_mod_latches: C, latch_group: bool, group_latch: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7548,6 +7563,9 @@ impl GetControlsRequest {
             device_spec,
         })
     }
+}
+impl Request for GetControlsRequest {
+    type Reply = GetControlsReply;
 }
 pub fn get_controls<Conn>(conn: &Conn, device_spec: DeviceSpec) -> Result<Cookie<'_, Conn, GetControlsReply>, ConnectionError>
 where
@@ -7862,6 +7880,9 @@ impl<'input> SetControlsRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetControlsRequest<'input> {
+    type Reply = ();
+}
 pub fn set_controls<'c, 'input, Conn, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(conn: &'c Conn, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8067,6 +8088,9 @@ impl GetMapRequest {
             n_v_mod_map_keys,
         })
     }
+}
+impl Request for GetMapRequest {
+    type Reply = GetMapReply;
 }
 pub fn get_map<Conn, A, B, C>(conn: &Conn, device_spec: DeviceSpec, full: A, partial: B, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: C, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
 where
@@ -8720,6 +8744,9 @@ impl<'input> SetMapRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetMapRequest<'input> {
+    type Reply = ();
+}
 pub fn set_map<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &'input SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -8824,6 +8851,9 @@ impl GetCompatMapRequest {
             n_si,
         })
     }
+}
+impl Request for GetCompatMapRequest {
+    type Reply = GetCompatMapReply;
 }
 pub fn get_compat_map<Conn, A>(conn: &Conn, device_spec: DeviceSpec, groups: A, get_all_si: bool, first_si: u16, n_si: u16) -> Result<Cookie<'_, Conn, GetCompatMapReply>, ConnectionError>
 where
@@ -8981,6 +9011,9 @@ impl<'input> SetCompatMapRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetCompatMapRequest<'input> {
+    type Reply = ();
+}
 pub fn set_compat_map<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9045,6 +9078,9 @@ impl GetIndicatorStateRequest {
             device_spec,
         })
     }
+}
+impl Request for GetIndicatorStateRequest {
+    type Reply = GetIndicatorStateReply;
 }
 pub fn get_indicator_state<Conn>(conn: &Conn, device_spec: DeviceSpec) -> Result<Cookie<'_, Conn, GetIndicatorStateReply>, ConnectionError>
 where
@@ -9137,6 +9173,9 @@ impl GetIndicatorMapRequest {
             which,
         })
     }
+}
+impl Request for GetIndicatorMapRequest {
+    type Reply = GetIndicatorMapReply;
 }
 pub fn get_indicator_map<Conn>(conn: &Conn, device_spec: DeviceSpec, which: u32) -> Result<Cookie<'_, Conn, GetIndicatorMapReply>, ConnectionError>
 where
@@ -9245,6 +9284,9 @@ impl<'input> SetIndicatorMapRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetIndicatorMapRequest<'input> {
+    type Reply = ();
+}
 pub fn set_indicator_map<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, which: u32, maps: &'input [IndicatorMap]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9324,6 +9366,9 @@ impl GetNamedIndicatorRequest {
             indicator,
         })
     }
+}
+impl Request for GetNamedIndicatorRequest {
+    type Reply = GetNamedIndicatorReply;
 }
 pub fn get_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom) -> Result<Cookie<'_, Conn, GetNamedIndicatorReply>, ConnectionError>
 where
@@ -9522,6 +9567,9 @@ impl SetNamedIndicatorRequest {
         })
     }
 }
+impl Request for SetNamedIndicatorRequest {
+    type Reply = ();
+}
 pub fn set_named_indicator<Conn, A, B, C, D, E, F, G, H>(conn: &Conn, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: B, map_which_groups: C, map_groups: D, map_which_mods: E, map_real_mods: F, map_vmods: G, map_ctrls: H) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -9616,6 +9664,9 @@ impl GetNamesRequest {
             which,
         })
     }
+}
+impl Request for GetNamesRequest {
+    type Reply = GetNamesReply;
 }
 pub fn get_names<Conn, A>(conn: &Conn, device_spec: DeviceSpec, which: A) -> Result<Cookie<'_, Conn, GetNamesReply>, ConnectionError>
 where
@@ -10318,6 +10369,9 @@ impl<'input> SetNamesRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetNamesRequest<'input> {
+    type Reply = ();
+}
 pub fn set_names<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10432,6 +10486,9 @@ impl PerClientFlagsRequest {
         })
     }
 }
+impl Request for PerClientFlagsRequest {
+    type Reply = PerClientFlagsReply;
+}
 pub fn per_client_flags<Conn, A, B, C, D, E>(conn: &Conn, device_spec: DeviceSpec, change: A, value: B, ctrls_to_change: C, auto_ctrls: D, auto_ctrls_values: E) -> Result<Cookie<'_, Conn, PerClientFlagsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10539,6 +10596,9 @@ impl ListComponentsRequest {
             max_names,
         })
     }
+}
+impl Request for ListComponentsRequest {
+    type Reply = ListComponentsReply;
 }
 pub fn list_components<Conn>(conn: &Conn, device_spec: DeviceSpec, max_names: u16) -> Result<Cookie<'_, Conn, ListComponentsReply>, ConnectionError>
 where
@@ -10738,6 +10798,9 @@ impl GetKbdByNameRequest {
             load,
         })
     }
+}
+impl Request for GetKbdByNameRequest {
+    type Reply = GetKbdByNameReply;
 }
 pub fn get_kbd_by_name<Conn, A, B>(conn: &Conn, device_spec: DeviceSpec, need: A, want: B, load: bool) -> Result<Cookie<'_, Conn, GetKbdByNameReply>, ConnectionError>
 where
@@ -11475,6 +11538,9 @@ impl GetDeviceInfoRequest {
         })
     }
 }
+impl Request for GetDeviceInfoRequest {
+    type Reply = GetDeviceInfoReply;
+}
 pub fn get_device_info<Conn, A, B>(conn: &Conn, device_spec: DeviceSpec, wanted: A, all_buttons: bool, first_button: u8, n_buttons: u8, led_class: LedClass, led_id: B) -> Result<Cookie<'_, Conn, GetDeviceInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -11674,6 +11740,9 @@ impl<'input> SetDeviceInfoRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetDeviceInfoRequest<'input> {
+    type Reply = ();
+}
 pub fn set_device_info<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -11773,6 +11842,9 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
             message,
         })
     }
+}
+impl<'input> Request for SetDebuggingFlagsRequest<'input> {
+    type Reply = SetDebuggingFlagsReply;
 }
 pub fn set_debugging_flags<'c, 'input, Conn>(conn: &'c Conn, affect_flags: u32, flags: u32, affect_ctrls: u32, ctrls: u32, message: &'input [String8]) -> Result<Cookie<'c, Conn, SetDebuggingFlagsReply>, ConnectionError>
 where

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -440,6 +440,9 @@ impl PrintQueryVersionRequest {
         )
     }
 }
+impl Request for PrintQueryVersionRequest {
+    type Reply = PrintQueryVersionReply;
+}
 pub fn print_query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, PrintQueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -537,6 +540,9 @@ impl<'input> PrintGetPrinterListRequest<'input> {
         })
     }
 }
+impl<'input> Request for PrintGetPrinterListRequest<'input> {
+    type Reply = PrintGetPrinterListReply;
+}
 pub fn print_get_printer_list<'c, 'input, Conn>(conn: &'c Conn, printer_name: &'input [String8], locale: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetPrinterListReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -627,6 +633,9 @@ impl PrintRehashPrinterListRequest {
         )
     }
 }
+impl Request for PrintRehashPrinterListRequest {
+    type Reply = ();
+}
 pub fn print_rehash_printer_list<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -705,6 +714,9 @@ impl<'input> CreateContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateContextRequest<'input> {
+    type Reply = ();
+}
 pub fn create_context<'c, 'input, Conn>(conn: &'c Conn, context_id: u32, printer_name: &'input [String8], locale: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -763,6 +775,9 @@ impl PrintSetContextRequest {
         })
     }
 }
+impl Request for PrintSetContextRequest {
+    type Reply = ();
+}
 pub fn print_set_context<Conn>(conn: &Conn, context: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -809,6 +824,9 @@ impl PrintGetContextRequest {
         Ok(PrintGetContextRequest
         )
     }
+}
+impl Request for PrintGetContextRequest {
+    type Reply = PrintGetContextReply;
 }
 pub fn print_get_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, PrintGetContextReply>, ConnectionError>
 where
@@ -889,6 +907,9 @@ impl PrintDestroyContextRequest {
         })
     }
 }
+impl Request for PrintDestroyContextRequest {
+    type Reply = ();
+}
 pub fn print_destroy_context<Conn>(conn: &Conn, context: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -935,6 +956,9 @@ impl PrintGetScreenOfContextRequest {
         Ok(PrintGetScreenOfContextRequest
         )
     }
+}
+impl Request for PrintGetScreenOfContextRequest {
+    type Reply = PrintGetScreenOfContextReply;
 }
 pub fn print_get_screen_of_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, PrintGetScreenOfContextReply>, ConnectionError>
 where
@@ -1015,6 +1039,9 @@ impl PrintStartJobRequest {
         })
     }
 }
+impl Request for PrintStartJobRequest {
+    type Reply = ();
+}
 pub fn print_start_job<Conn>(conn: &Conn, output_mode: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1070,6 +1097,9 @@ impl PrintEndJobRequest {
             cancel,
         })
     }
+}
+impl Request for PrintEndJobRequest {
+    type Reply = ();
 }
 pub fn print_end_job<Conn>(conn: &Conn, cancel: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1127,6 +1157,9 @@ impl PrintStartDocRequest {
         })
     }
 }
+impl Request for PrintStartDocRequest {
+    type Reply = ();
+}
 pub fn print_start_doc<Conn>(conn: &Conn, driver_mode: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1182,6 +1215,9 @@ impl PrintEndDocRequest {
             cancel,
         })
     }
+}
+impl Request for PrintEndDocRequest {
+    type Reply = ();
 }
 pub fn print_end_doc<Conn>(conn: &Conn, cancel: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1270,6 +1306,9 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
         })
     }
 }
+impl<'input> Request for PrintPutDocumentDataRequest<'input> {
+    type Reply = ();
+}
 pub fn print_put_document_data<'c, 'input, Conn>(conn: &'c Conn, drawable: xproto::Drawable, data: &'input [u8], doc_format: &'input [String8], options: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1336,6 +1375,9 @@ impl PrintGetDocumentDataRequest {
             max_bytes,
         })
     }
+}
+impl Request for PrintGetDocumentDataRequest {
+    type Reply = PrintGetDocumentDataReply;
 }
 pub fn print_get_document_data<Conn>(conn: &Conn, context: Pcontext, max_bytes: u32) -> Result<Cookie<'_, Conn, PrintGetDocumentDataReply>, ConnectionError>
 where
@@ -1441,6 +1483,9 @@ impl PrintStartPageRequest {
         })
     }
 }
+impl Request for PrintStartPageRequest {
+    type Reply = ();
+}
 pub fn print_start_page<Conn>(conn: &Conn, window: xproto::Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1497,6 +1542,9 @@ impl PrintEndPageRequest {
             cancel,
         })
     }
+}
+impl Request for PrintEndPageRequest {
+    type Reply = ();
 }
 pub fn print_end_page<Conn>(conn: &Conn, cancel: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -1562,6 +1610,9 @@ impl PrintSelectInputRequest {
         })
     }
 }
+impl Request for PrintSelectInputRequest {
+    type Reply = ();
+}
 pub fn print_select_input<Conn>(conn: &Conn, context: Pcontext, event_mask: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1618,6 +1669,9 @@ impl PrintInputSelectedRequest {
             context,
         })
     }
+}
+impl Request for PrintInputSelectedRequest {
+    type Reply = PrintInputSelectedReply;
 }
 pub fn print_input_selected<Conn>(conn: &Conn, context: Pcontext) -> Result<Cookie<'_, Conn, PrintInputSelectedReply>, ConnectionError>
 where
@@ -1710,6 +1764,9 @@ impl PrintGetAttributesRequest {
             pool,
         })
     }
+}
+impl Request for PrintGetAttributesRequest {
+    type Reply = PrintGetAttributesReply;
 }
 pub fn print_get_attributes<Conn>(conn: &Conn, context: Pcontext, pool: u8) -> Result<Cookie<'_, Conn, PrintGetAttributesReply>, ConnectionError>
 where
@@ -1832,6 +1889,9 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
             name,
         })
     }
+}
+impl<'input> Request for PrintGetOneAttributesRequest<'input> {
+    type Reply = PrintGetOneAttributesReply;
 }
 pub fn print_get_one_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, pool: u8, name: &'input [String8]) -> Result<Cookie<'c, Conn, PrintGetOneAttributesReply>, ConnectionError>
 where
@@ -1961,6 +2021,9 @@ impl<'input> PrintSetAttributesRequest<'input> {
         })
     }
 }
+impl<'input> Request for PrintSetAttributesRequest<'input> {
+    type Reply = ();
+}
 pub fn print_set_attributes<'c, 'input, Conn>(conn: &'c Conn, context: Pcontext, string_len: u32, pool: u8, rule: u8, attributes: &'input [String8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2020,6 +2083,9 @@ impl PrintGetPageDimensionsRequest {
             context,
         })
     }
+}
+impl Request for PrintGetPageDimensionsRequest {
+    type Reply = PrintGetPageDimensionsReply;
 }
 pub fn print_get_page_dimensions<Conn>(conn: &Conn, context: Pcontext) -> Result<Cookie<'_, Conn, PrintGetPageDimensionsReply>, ConnectionError>
 where
@@ -2102,6 +2168,9 @@ impl PrintQueryScreensRequest {
         Ok(PrintQueryScreensRequest
         )
     }
+}
+impl Request for PrintQueryScreensRequest {
+    type Reply = PrintQueryScreensReply;
 }
 pub fn print_query_screens<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, PrintQueryScreensReply>, ConnectionError>
 where
@@ -2207,6 +2276,9 @@ impl PrintSetImageResolutionRequest {
         })
     }
 }
+impl Request for PrintSetImageResolutionRequest {
+    type Reply = PrintSetImageResolutionReply;
+}
 pub fn print_set_image_resolution<Conn>(conn: &Conn, context: Pcontext, image_resolution: u16) -> Result<Cookie<'_, Conn, PrintSetImageResolutionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2289,6 +2361,9 @@ impl PrintGetImageResolutionRequest {
             context,
         })
     }
+}
+impl Request for PrintGetImageResolutionRequest {
+    type Reply = PrintGetImageResolutionReply;
 }
 pub fn print_get_image_resolution<Conn>(conn: &Conn, context: Pcontext) -> Result<Cookie<'_, Conn, PrintGetImageResolutionReply>, ConnectionError>
 where

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -22,7 +22,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -6260,6 +6260,9 @@ impl<'input> CreateWindowRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateWindowRequest<'input> {
+    type Reply = ();
+}
 /// Creates a window.
 ///
 /// Creates an unmapped window as child of the specified `parent` window. A
@@ -6755,6 +6758,9 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeWindowAttributesRequest<'input> {
+    type Reply = ();
+}
 /// change window attributes.
 ///
 /// Changes the attributes specified by `value_mask` for the specified `window`.
@@ -6911,6 +6917,9 @@ impl GetWindowAttributesRequest {
             window,
         })
     }
+}
+impl Request for GetWindowAttributesRequest {
+    type Reply = GetWindowAttributesReply;
 }
 /// Gets window attributes.
 ///
@@ -7078,6 +7087,9 @@ impl DestroyWindowRequest {
         })
     }
 }
+impl Request for DestroyWindowRequest {
+    type Reply = ();
+}
 /// Destroys a window.
 ///
 /// Destroys the specified window and all of its subwindows. A DestroyNotify event
@@ -7157,6 +7169,9 @@ impl DestroySubwindowsRequest {
             window,
         })
     }
+}
+impl Request for DestroySubwindowsRequest {
+    type Reply = ();
 }
 pub fn destroy_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -7312,6 +7327,9 @@ impl ChangeSaveSetRequest {
         })
     }
 }
+impl Request for ChangeSaveSetRequest {
+    type Reply = ();
+}
 /// Changes a client's save set.
 ///
 /// TODO: explain what the save set is for.
@@ -7445,6 +7463,9 @@ impl ReparentWindowRequest {
         })
     }
 }
+impl Request for ReparentWindowRequest {
+    type Reply = ();
+}
 /// Reparents a window.
 ///
 /// Makes the specified window a child of the specified parent window. If the
@@ -7573,6 +7594,9 @@ impl MapWindowRequest {
         })
     }
 }
+impl Request for MapWindowRequest {
+    type Reply = ();
+}
 /// Makes a window visible.
 ///
 /// Maps the specified window. This means making the window visible (as long as its
@@ -7666,6 +7690,9 @@ impl MapSubwindowsRequest {
         })
     }
 }
+impl Request for MapSubwindowsRequest {
+    type Reply = ();
+}
 pub fn map_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -7745,6 +7772,9 @@ impl UnmapWindowRequest {
         })
     }
 }
+impl Request for UnmapWindowRequest {
+    type Reply = ();
+}
 /// Makes a window invisible.
 ///
 /// Unmaps the specified window. This means making the window invisible (and all
@@ -7823,6 +7853,9 @@ impl UnmapSubwindowsRequest {
             window,
         })
     }
+}
+impl Request for UnmapSubwindowsRequest {
+    type Reply = ();
 }
 pub fn unmap_subwindows<Conn>(conn: &Conn, window: Window) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -8273,6 +8306,9 @@ impl<'input> ConfigureWindowRequest<'input> {
         })
     }
 }
+impl<'input> Request for ConfigureWindowRequest<'input> {
+    type Reply = ();
+}
 /// Configures window attributes.
 ///
 /// Configures a window's size, position, border width and stacking order.
@@ -8473,6 +8509,9 @@ impl CirculateWindowRequest {
         })
     }
 }
+impl Request for CirculateWindowRequest {
+    type Reply = ();
+}
 /// Change window stacking order.
 ///
 /// If `direction` is `XCB_CIRCULATE_RAISE_LOWEST`, the lowest mapped child (if
@@ -8584,6 +8623,9 @@ impl GetGeometryRequest {
             drawable,
         })
     }
+}
+impl Request for GetGeometryRequest {
+    type Reply = GetGeometryReply;
 }
 /// Get current window geometry.
 ///
@@ -8765,6 +8807,9 @@ impl QueryTreeRequest {
             window,
         })
     }
+}
+impl Request for QueryTreeRequest {
+    type Reply = QueryTreeReply;
 }
 /// query the window tree.
 ///
@@ -8966,6 +9011,9 @@ impl<'input> InternAtomRequest<'input> {
         })
     }
 }
+impl<'input> Request for InternAtomRequest<'input> {
+    type Reply = InternAtomReply;
+}
 /// Get atom identifier by name.
 ///
 /// Retrieves the identifier (xcb_atom_t TODO) for the atom with the specified
@@ -9094,6 +9142,9 @@ impl GetAtomNameRequest {
             atom,
         })
     }
+}
+impl Request for GetAtomNameRequest {
+    type Reply = GetAtomNameReply;
 }
 pub fn get_atom_name<Conn>(conn: &Conn, atom: Atom) -> Result<Cookie<'_, Conn, GetAtomNameReply>, ConnectionError>
 where
@@ -9365,6 +9416,9 @@ impl<'input> ChangePropertyRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangePropertyRequest<'input> {
+    type Reply = ();
+}
 /// Changes a window property.
 ///
 /// Sets or updates a property on the specified `window`. Properties are for
@@ -9491,6 +9545,9 @@ impl DeletePropertyRequest {
             property,
         })
     }
+}
+impl Request for DeletePropertyRequest {
+    type Reply = ();
 }
 pub fn delete_property<Conn>(conn: &Conn, window: Window, property: Atom) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -9712,6 +9769,9 @@ impl GetPropertyRequest {
             long_length,
         })
     }
+}
+impl Request for GetPropertyRequest {
+    type Reply = GetPropertyReply;
 }
 /// Gets a window property.
 ///
@@ -10055,6 +10115,9 @@ impl ListPropertiesRequest {
         })
     }
 }
+impl Request for ListPropertiesRequest {
+    type Reply = ListPropertiesReply;
+}
 pub fn list_properties<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -10200,6 +10263,9 @@ impl SetSelectionOwnerRequest {
         })
     }
 }
+impl Request for SetSelectionOwnerRequest {
+    type Reply = ();
+}
 /// Sets the owner of a selection.
 ///
 /// Makes `window` the owner of the selection `selection` and updates the
@@ -10309,6 +10375,9 @@ impl GetSelectionOwnerRequest {
             selection,
         })
     }
+}
+impl Request for GetSelectionOwnerRequest {
+    type Reply = GetSelectionOwnerReply;
 }
 /// Gets the owner of a selection.
 ///
@@ -10444,6 +10513,9 @@ impl ConvertSelectionRequest {
             time,
         })
     }
+}
+impl Request for ConvertSelectionRequest {
+    type Reply = ();
 }
 pub fn convert_selection<Conn, A, B>(conn: &Conn, requestor: Window, selection: Atom, target: Atom, property: A, time: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -10669,6 +10741,9 @@ impl<'input> SendEventRequest<'input> {
             event,
         })
     }
+}
+impl<'input> Request for SendEventRequest<'input> {
+    type Reply = ();
 }
 /// send an event.
 ///
@@ -11133,6 +11208,9 @@ impl GrabPointerRequest {
         })
     }
 }
+impl Request for GrabPointerRequest {
+    type Reply = GrabPointerReply;
+}
 /// Grab the pointer.
 ///
 /// Actively grabs control of the pointer. Further pointer events are reported only to the grabbing client. Overrides any active pointer grab by this client.
@@ -11324,6 +11402,9 @@ impl UngrabPointerRequest {
             time,
         })
     }
+}
+impl Request for UngrabPointerRequest {
+    type Reply = ();
 }
 /// release the pointer.
 ///
@@ -11608,6 +11689,9 @@ impl GrabButtonRequest {
         })
     }
 }
+impl Request for GrabButtonRequest {
+    type Reply = ();
+}
 /// Grab pointer button(s).
 ///
 /// This request establishes a passive grab. The pointer is actively grabbed as
@@ -11762,6 +11846,9 @@ impl UngrabButtonRequest {
         })
     }
 }
+impl Request for UngrabButtonRequest {
+    type Reply = ();
+}
 pub fn ungrab_button<Conn, A>(conn: &Conn, button: ButtonIndex, grab_window: Window, modifiers: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -11840,6 +11927,9 @@ impl ChangeActivePointerGrabRequest {
             event_mask,
         })
     }
+}
+impl Request for ChangeActivePointerGrabRequest {
+    type Reply = ();
 }
 pub fn change_active_pointer_grab<Conn, A, B, C>(conn: &Conn, cursor: A, time: B, event_mask: C) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -11995,6 +12085,9 @@ impl GrabKeyboardRequest {
         })
     }
 }
+impl Request for GrabKeyboardRequest {
+    type Reply = GrabKeyboardReply;
+}
 /// Grab the keyboard.
 ///
 /// Actively grabs control of the keyboard and generates FocusIn and FocusOut
@@ -12145,6 +12238,9 @@ impl UngrabKeyboardRequest {
             time,
         })
     }
+}
+impl Request for UngrabKeyboardRequest {
+    type Reply = ();
 }
 pub fn ungrab_keyboard<Conn, A>(conn: &Conn, time: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -12355,6 +12451,9 @@ impl GrabKeyRequest {
         })
     }
 }
+impl Request for GrabKeyRequest {
+    type Reply = ();
+}
 /// Grab keyboard key(s).
 ///
 /// Establishes a passive grab on the keyboard. In the future, the keyboard is
@@ -12518,6 +12617,9 @@ impl UngrabKeyRequest {
             modifiers,
         })
     }
+}
+impl Request for UngrabKeyRequest {
+    type Reply = ();
 }
 /// release a key combination.
 ///
@@ -12769,6 +12871,9 @@ impl AllowEventsRequest {
         })
     }
 }
+impl Request for AllowEventsRequest {
+    type Reply = ();
+}
 /// release queued events.
 ///
 /// Releases queued events if the client has caused a device (pointer/keyboard) to
@@ -12839,6 +12944,9 @@ impl GrabServerRequest {
         )
     }
 }
+impl Request for GrabServerRequest {
+    type Reply = ();
+}
 pub fn grab_server<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -12885,6 +12993,9 @@ impl UngrabServerRequest {
         Ok(UngrabServerRequest
         )
     }
+}
+impl Request for UngrabServerRequest {
+    type Reply = ();
 }
 pub fn ungrab_server<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -12954,6 +13065,9 @@ impl QueryPointerRequest {
             window,
         })
     }
+}
+impl Request for QueryPointerRequest {
+    type Reply = QueryPointerReply;
 }
 /// get pointer coordinates.
 ///
@@ -13146,6 +13260,9 @@ impl GetMotionEventsRequest {
         })
     }
 }
+impl Request for GetMotionEventsRequest {
+    type Reply = GetMotionEventsReply;
+}
 pub fn get_motion_events<Conn, A, B>(conn: &Conn, window: Window, start: A, stop: B) -> Result<Cookie<'_, Conn, GetMotionEventsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -13271,6 +13388,9 @@ impl TranslateCoordinatesRequest {
             src_y,
         })
     }
+}
+impl Request for TranslateCoordinatesRequest {
+    type Reply = TranslateCoordinatesReply;
 }
 pub fn translate_coordinates<Conn>(conn: &Conn, src_window: Window, dst_window: Window, src_x: i16, src_y: i16) -> Result<Cookie<'_, Conn, TranslateCoordinatesReply>, ConnectionError>
 where
@@ -13438,6 +13558,9 @@ impl WarpPointerRequest {
             dst_y,
         })
     }
+}
+impl Request for WarpPointerRequest {
+    type Reply = ();
 }
 /// move mouse pointer.
 ///
@@ -13664,6 +13787,9 @@ impl SetInputFocusRequest {
         })
     }
 }
+impl Request for SetInputFocusRequest {
+    type Reply = ();
+}
 /// Sets input focus.
 ///
 /// Changes the input focus and the last-focus-change time. If the specified `time`
@@ -13754,6 +13880,9 @@ impl GetInputFocusRequest {
         )
     }
 }
+impl Request for GetInputFocusRequest {
+    type Reply = GetInputFocusReply;
+}
 pub fn get_input_focus<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetInputFocusReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -13827,6 +13956,9 @@ impl QueryKeymapRequest {
         Ok(QueryKeymapRequest
         )
     }
+}
+impl Request for QueryKeymapRequest {
+    type Reply = QueryKeymapReply;
 }
 pub fn query_keymap<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryKeymapReply>, ConnectionError>
 where
@@ -13944,6 +14076,9 @@ impl<'input> OpenFontRequest<'input> {
         })
     }
 }
+impl<'input> Request for OpenFontRequest<'input> {
+    type Reply = ();
+}
 /// opens a font.
 ///
 /// Opens any X core font matching the given `name` (for example "-misc-fixed-*").
@@ -14022,6 +14157,9 @@ impl CloseFontRequest {
             font,
         })
     }
+}
+impl Request for CloseFontRequest {
+    type Reply = ();
 }
 pub fn close_font<Conn>(conn: &Conn, font: Font) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -14262,6 +14400,9 @@ impl QueryFontRequest {
         })
     }
 }
+impl Request for QueryFontRequest {
+    type Reply = QueryFontReply;
+}
 /// query font metrics.
 ///
 /// Queries information associated with the font.
@@ -14478,6 +14619,9 @@ impl<'input> QueryTextExtentsRequest<'input> {
         })
     }
 }
+impl<'input> Request for QueryTextExtentsRequest<'input> {
+    type Reply = QueryTextExtentsReply;
+}
 /// get text extents.
 ///
 /// Query text extents from the X11 server. This request returns the bounding box
@@ -14680,6 +14824,9 @@ impl<'input> ListFontsRequest<'input> {
         })
     }
 }
+impl<'input> Request for ListFontsRequest<'input> {
+    type Reply = ListFontsReply;
+}
 /// get matching font names.
 ///
 /// Gets a list of available font names which match the given `pattern`.
@@ -14818,6 +14965,9 @@ impl<'input> ListFontsWithInfoRequest<'input> {
             pattern,
         })
     }
+}
+impl<'input> Request for ListFontsWithInfoRequest<'input> {
+    type Reply = ListFontsWithInfoReply;
 }
 /// get matching font names and information.
 ///
@@ -14998,6 +15148,9 @@ impl<'input> SetFontPathRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetFontPathRequest<'input> {
+    type Reply = ();
+}
 pub fn set_font_path<'c, 'input, Conn>(conn: &'c Conn, font: &'input [Str]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -15046,6 +15199,9 @@ impl GetFontPathRequest {
         Ok(GetFontPathRequest
         )
     }
+}
+impl Request for GetFontPathRequest {
+    type Reply = GetFontPathReply;
 }
 pub fn get_font_path<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetFontPathReply>, ConnectionError>
 where
@@ -15191,6 +15347,9 @@ impl CreatePixmapRequest {
         })
     }
 }
+impl Request for CreatePixmapRequest {
+    type Reply = ();
+}
 /// Creates a pixmap.
 ///
 /// Creates a pixmap. The pixmap can only be used on the same screen as `drawable`
@@ -15287,6 +15446,9 @@ impl FreePixmapRequest {
             pixmap,
         })
     }
+}
+impl Request for FreePixmapRequest {
+    type Reply = ();
 }
 /// Destroys a pixmap.
 ///
@@ -16682,6 +16844,9 @@ impl<'input> CreateGCRequest<'input> {
         })
     }
 }
+impl<'input> Request for CreateGCRequest<'input> {
+    type Reply = ();
+}
 /// Creates a graphics context.
 ///
 /// Creates a graphics context. The graphics context can be used with any drawable
@@ -17327,6 +17492,9 @@ impl<'input> ChangeGCRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeGCRequest<'input> {
+    type Reply = ();
+}
 /// change graphics context components.
 ///
 /// Changes the components specified by `value_mask` for the specified graphics context.
@@ -17447,6 +17615,9 @@ impl CopyGCRequest {
         })
     }
 }
+impl Request for CopyGCRequest {
+    type Reply = ();
+}
 pub fn copy_gc<Conn, A>(conn: &Conn, src_gc: Gcontext, dst_gc: Gcontext, value_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -17525,6 +17696,9 @@ impl<'input> SetDashesRequest<'input> {
             dashes,
         })
     }
+}
+impl<'input> Request for SetDashesRequest<'input> {
+    type Reply = ();
 }
 pub fn set_dashes<'c, 'input, Conn>(conn: &'c Conn, gc: Gcontext, dash_offset: u16, dashes: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -17684,6 +17858,9 @@ impl<'input> SetClipRectanglesRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetClipRectanglesRequest<'input> {
+    type Reply = ();
+}
 pub fn set_clip_rectangles<'c, 'input, Conn>(conn: &'c Conn, ordering: ClipOrdering, gc: Gcontext, clip_x_origin: i16, clip_y_origin: i16, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -17756,6 +17933,9 @@ impl FreeGCRequest {
             gc,
         })
     }
+}
+impl Request for FreeGCRequest {
+    type Reply = ();
 }
 /// Destroys a graphics context.
 ///
@@ -17852,6 +18032,9 @@ impl ClearAreaRequest {
             height,
         })
     }
+}
+impl Request for ClearAreaRequest {
+    type Reply = ();
 }
 pub fn clear_area<Conn>(conn: &Conn, exposures: bool, window: Window, x: i16, y: i16, width: u16, height: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -17988,6 +18171,9 @@ impl CopyAreaRequest {
             height,
         })
     }
+}
+impl Request for CopyAreaRequest {
+    type Reply = ();
 }
 /// copy areas.
 ///
@@ -18135,6 +18321,9 @@ impl CopyPlaneRequest {
             bit_plane,
         })
     }
+}
+impl Request for CopyPlaneRequest {
+    type Reply = ();
 }
 pub fn copy_plane<Conn>(conn: &Conn, src_drawable: Drawable, dst_drawable: Drawable, gc: Gcontext, src_x: i16, src_y: i16, dst_x: i16, dst_y: i16, width: u16, height: u16, bit_plane: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -18303,6 +18492,9 @@ impl<'input> PolyPointRequest<'input> {
         })
     }
 }
+impl<'input> Request for PolyPointRequest<'input> {
+    type Reply = ();
+}
 pub fn poly_point<'c, 'input, Conn>(conn: &'c Conn, coordinate_mode: CoordMode, drawable: Drawable, gc: Gcontext, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -18428,6 +18620,9 @@ impl<'input> PolyLineRequest<'input> {
             points: Cow::Owned(points),
         })
     }
+}
+impl<'input> Request for PolyLineRequest<'input> {
+    type Reply = ();
 }
 /// draw lines.
 ///
@@ -18627,6 +18822,9 @@ impl<'input> PolySegmentRequest<'input> {
         })
     }
 }
+impl<'input> Request for PolySegmentRequest<'input> {
+    type Reply = ();
+}
 /// draw lines.
 ///
 /// Draws multiple, unconnected lines. For each segment, a line is drawn between
@@ -18735,6 +18933,9 @@ impl<'input> PolyRectangleRequest<'input> {
         })
     }
 }
+impl<'input> Request for PolyRectangleRequest<'input> {
+    type Reply = ();
+}
 pub fn poly_rectangle<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, rectangles: &'input [Rectangle]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -18816,6 +19017,9 @@ impl<'input> PolyArcRequest<'input> {
             arcs: Cow::Owned(arcs),
         })
     }
+}
+impl<'input> Request for PolyArcRequest<'input> {
+    type Reply = ();
 }
 pub fn poly_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -18979,6 +19183,9 @@ impl<'input> FillPolyRequest<'input> {
         })
     }
 }
+impl<'input> Request for FillPolyRequest<'input> {
+    type Reply = ();
+}
 pub fn fill_poly<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, shape: PolyShape, coordinate_mode: CoordMode, points: &'input [Point]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -19088,6 +19295,9 @@ impl<'input> PolyFillRectangleRequest<'input> {
         })
     }
 }
+impl<'input> Request for PolyFillRectangleRequest<'input> {
+    type Reply = ();
+}
 /// Fills rectangles.
 ///
 /// Fills the specified rectangle(s) in the order listed in the array. For any
@@ -19194,6 +19404,9 @@ impl<'input> PolyFillArcRequest<'input> {
             arcs: Cow::Owned(arcs),
         })
     }
+}
+impl<'input> Request for PolyFillArcRequest<'input> {
+    type Reply = ();
 }
 pub fn poly_fill_arc<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, arcs: &'input [Arc]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -19375,6 +19588,9 @@ impl<'input> PutImageRequest<'input> {
         })
     }
 }
+impl<'input> Request for PutImageRequest<'input> {
+    type Reply = ();
+}
 pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, format: ImageFormat, drawable: Drawable, gc: Gcontext, width: u16, height: u16, dst_x: i16, dst_y: i16, left_pad: u8, depth: u8, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -19477,6 +19693,9 @@ impl GetImageRequest {
             plane_mask,
         })
     }
+}
+impl Request for GetImageRequest {
+    type Reply = GetImageReply;
 }
 pub fn get_image<Conn>(conn: &Conn, format: ImageFormat, drawable: Drawable, x: i16, y: i16, width: u16, height: u16, plane_mask: u32) -> Result<Cookie<'_, Conn, GetImageReply>, ConnectionError>
 where
@@ -19613,6 +19832,9 @@ impl<'input> PolyText8Request<'input> {
         })
     }
 }
+impl<'input> Request for PolyText8Request<'input> {
+    type Reply = ();
+}
 pub fn poly_text8<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -19700,6 +19922,9 @@ impl<'input> PolyText16Request<'input> {
             items,
         })
     }
+}
+impl<'input> Request for PolyText16Request<'input> {
+    type Reply = ();
 }
 pub fn poly_text16<'c, 'input, Conn>(conn: &'c Conn, drawable: Drawable, gc: Gcontext, x: i16, y: i16, items: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -19824,6 +20049,9 @@ impl<'input> ImageText8Request<'input> {
             string,
         })
     }
+}
+impl<'input> Request for ImageText8Request<'input> {
+    type Reply = ();
 }
 /// Draws text.
 ///
@@ -19984,6 +20212,9 @@ impl<'input> ImageText16Request<'input> {
             string: Cow::Owned(string),
         })
     }
+}
+impl<'input> Request for ImageText16Request<'input> {
+    type Reply = ();
 }
 /// Draws text.
 ///
@@ -20172,6 +20403,9 @@ impl CreateColormapRequest {
         })
     }
 }
+impl Request for CreateColormapRequest {
+    type Reply = ();
+}
 pub fn create_colormap<Conn>(conn: &Conn, alloc: ColormapAlloc, mid: Colormap, window: Window, visual: Visualid) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -20232,6 +20466,9 @@ impl FreeColormapRequest {
             cmap,
         })
     }
+}
+impl Request for FreeColormapRequest {
+    type Reply = ();
 }
 pub fn free_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -20299,6 +20536,9 @@ impl CopyColormapAndFreeRequest {
         })
     }
 }
+impl Request for CopyColormapAndFreeRequest {
+    type Reply = ();
+}
 pub fn copy_colormap_and_free<Conn>(conn: &Conn, mid: Colormap, src_cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -20358,6 +20598,9 @@ impl InstallColormapRequest {
         })
     }
 }
+impl Request for InstallColormapRequest {
+    type Reply = ();
+}
 pub fn install_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -20416,6 +20659,9 @@ impl UninstallColormapRequest {
         })
     }
 }
+impl Request for UninstallColormapRequest {
+    type Reply = ();
+}
 pub fn uninstall_colormap<Conn>(conn: &Conn, cmap: Colormap) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -20473,6 +20719,9 @@ impl ListInstalledColormapsRequest {
             window,
         })
     }
+}
+impl Request for ListInstalledColormapsRequest {
+    type Reply = ListInstalledColormapsReply;
 }
 pub fn list_installed_colormaps<Conn>(conn: &Conn, window: Window) -> Result<Cookie<'_, Conn, ListInstalledColormapsReply>, ConnectionError>
 where
@@ -20613,6 +20862,9 @@ impl AllocColorRequest {
         })
     }
 }
+impl Request for AllocColorRequest {
+    type Reply = AllocColorReply;
+}
 /// Allocate a color.
 ///
 /// Allocates a read-only colormap entry corresponding to the closest RGB value
@@ -20738,6 +20990,9 @@ impl<'input> AllocNamedColorRequest<'input> {
         })
     }
 }
+impl<'input> Request for AllocNamedColorRequest<'input> {
+    type Reply = AllocNamedColorReply;
+}
 pub fn alloc_named_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, AllocNamedColorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -20848,6 +21103,9 @@ impl AllocColorCellsRequest {
             planes,
         })
     }
+}
+impl Request for AllocColorCellsRequest {
+    type Reply = AllocColorCellsReply;
 }
 pub fn alloc_color_cells<Conn>(conn: &Conn, contiguous: bool, cmap: Colormap, colors: u16, planes: u16) -> Result<Cookie<'_, Conn, AllocColorCellsReply>, ConnectionError>
 where
@@ -20995,6 +21253,9 @@ impl AllocColorPlanesRequest {
         })
     }
 }
+impl Request for AllocColorPlanesRequest {
+    type Reply = AllocColorPlanesReply;
+}
 pub fn alloc_color_planes<Conn>(conn: &Conn, contiguous: bool, cmap: Colormap, colors: u16, reds: u16, greens: u16, blues: u16) -> Result<Cookie<'_, Conn, AllocColorPlanesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -21128,6 +21389,9 @@ impl<'input> FreeColorsRequest<'input> {
             pixels: Cow::Owned(pixels),
         })
     }
+}
+impl<'input> Request for FreeColorsRequest<'input> {
+    type Reply = ();
 }
 pub fn free_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, plane_mask: u32, pixels: &'input [u32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -21329,6 +21593,9 @@ impl<'input> StoreColorsRequest<'input> {
         })
     }
 }
+impl<'input> Request for StoreColorsRequest<'input> {
+    type Reply = ();
+}
 pub fn store_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, items: &'input [Coloritem]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -21412,6 +21679,9 @@ impl<'input> StoreNamedColorRequest<'input> {
             name,
         })
     }
+}
+impl<'input> Request for StoreNamedColorRequest<'input> {
+    type Reply = ();
 }
 pub fn store_named_color<'c, 'input, Conn, A>(conn: &'c Conn, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -21538,6 +21808,9 @@ impl<'input> QueryColorsRequest<'input> {
         })
     }
 }
+impl<'input> Request for QueryColorsRequest<'input> {
+    type Reply = QueryColorsReply;
+}
 pub fn query_colors<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, pixels: &'input [u32]) -> Result<Cookie<'c, Conn, QueryColorsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -21652,6 +21925,9 @@ impl<'input> LookupColorRequest<'input> {
             name,
         })
     }
+}
+impl<'input> Request for LookupColorRequest<'input> {
+    type Reply = LookupColorReply;
 }
 pub fn lookup_color<'c, 'input, Conn>(conn: &'c Conn, cmap: Colormap, name: &'input [u8]) -> Result<Cookie<'c, Conn, LookupColorReply>, ConnectionError>
 where
@@ -21869,6 +22145,9 @@ impl CreateCursorRequest {
             y,
         })
     }
+}
+impl Request for CreateCursorRequest {
+    type Reply = ();
 }
 pub fn create_cursor<Conn, A>(conn: &Conn, cid: Cursor, source: Pixmap, mask: A, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -22096,6 +22375,9 @@ impl CreateGlyphCursorRequest {
         })
     }
 }
+impl Request for CreateGlyphCursorRequest {
+    type Reply = ();
+}
 /// create cursor.
 ///
 /// Creates a cursor from a font glyph. X provides a set of standard cursor shapes
@@ -22211,6 +22493,9 @@ impl FreeCursorRequest {
         })
     }
 }
+impl Request for FreeCursorRequest {
+    type Reply = ();
+}
 /// Deletes a cursor.
 ///
 /// Deletes the association between the cursor resource ID and the specified
@@ -22316,6 +22601,9 @@ impl RecolorCursorRequest {
             back_blue,
         })
     }
+}
+impl Request for RecolorCursorRequest {
+    type Reply = ();
 }
 pub fn recolor_cursor<Conn>(conn: &Conn, cursor: Cursor, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -22462,6 +22750,9 @@ impl QueryBestSizeRequest {
         })
     }
 }
+impl Request for QueryBestSizeRequest {
+    type Reply = QueryBestSizeReply;
+}
 pub fn query_best_size<Conn>(conn: &Conn, class: QueryShapeOf, drawable: Drawable, width: u16, height: u16) -> Result<Cookie<'_, Conn, QueryBestSizeReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -22578,6 +22869,9 @@ impl<'input> QueryExtensionRequest<'input> {
         })
     }
 }
+impl<'input> Request for QueryExtensionRequest<'input> {
+    type Reply = QueryExtensionReply;
+}
 /// check if extension is present.
 ///
 /// Determines if the specified extension is present on this X11 server.
@@ -22685,6 +22979,9 @@ impl ListExtensionsRequest {
         Ok(ListExtensionsRequest
         )
     }
+}
+impl Request for ListExtensionsRequest {
+    type Reply = ListExtensionsReply;
 }
 pub fn list_extensions<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListExtensionsReply>, ConnectionError>
 where
@@ -22799,6 +23096,9 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeKeyboardMappingRequest<'input> {
+    type Reply = ();
+}
 pub fn change_keyboard_mapping<'c, 'input, Conn>(conn: &'c Conn, keycode_count: u8, first_keycode: Keycode, keysyms_per_keycode: u8, keysyms: &'input [Keysym]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -22863,6 +23163,9 @@ impl GetKeyboardMappingRequest {
             count,
         })
     }
+}
+impl Request for GetKeyboardMappingRequest {
+    type Reply = GetKeyboardMappingReply;
 }
 pub fn get_keyboard_mapping<Conn>(conn: &Conn, first_keycode: Keycode, count: u8) -> Result<Cookie<'_, Conn, GetKeyboardMappingReply>, ConnectionError>
 where
@@ -23383,6 +23686,9 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeKeyboardControlRequest<'input> {
+    type Reply = ();
+}
 pub fn change_keyboard_control<'c, 'input, Conn>(conn: &'c Conn, value_list: &'input ChangeKeyboardControlAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -23431,6 +23737,9 @@ impl GetKeyboardControlRequest {
         Ok(GetKeyboardControlRequest
         )
     }
+}
+impl Request for GetKeyboardControlRequest {
+    type Reply = GetKeyboardControlReply;
 }
 pub fn get_keyboard_control<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetKeyboardControlReply>, ConnectionError>
 where
@@ -23522,6 +23831,9 @@ impl BellRequest {
         })
     }
 }
+impl Request for BellRequest {
+    type Reply = ();
+}
 pub fn bell<Conn>(conn: &Conn, percent: i8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -23600,6 +23912,9 @@ impl ChangePointerControlRequest {
         })
     }
 }
+impl Request for ChangePointerControlRequest {
+    type Reply = ();
+}
 pub fn change_pointer_control<Conn>(conn: &Conn, acceleration_numerator: i16, acceleration_denominator: i16, threshold: i16, do_acceleration: bool, do_threshold: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -23652,6 +23967,9 @@ impl GetPointerControlRequest {
         Ok(GetPointerControlRequest
         )
     }
+}
+impl Request for GetPointerControlRequest {
+    type Reply = GetPointerControlReply;
 }
 pub fn get_pointer_control<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetPointerControlReply>, ConnectionError>
 where
@@ -23887,6 +24205,9 @@ impl SetScreenSaverRequest {
         })
     }
 }
+impl Request for SetScreenSaverRequest {
+    type Reply = ();
+}
 pub fn set_screen_saver<Conn>(conn: &Conn, timeout: i16, interval: i16, prefer_blanking: Blanking, allow_exposures: Exposures) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -23938,6 +24259,9 @@ impl GetScreenSaverRequest {
         Ok(GetScreenSaverRequest
         )
     }
+}
+impl Request for GetScreenSaverRequest {
+    type Reply = GetScreenSaverReply;
 }
 pub fn get_screen_saver<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetScreenSaverReply>, ConnectionError>
 where
@@ -24185,6 +24509,9 @@ impl<'input> ChangeHostsRequest<'input> {
         })
     }
 }
+impl<'input> Request for ChangeHostsRequest<'input> {
+    type Reply = ();
+}
 pub fn change_hosts<'c, 'input, Conn>(conn: &'c Conn, mode: HostMode, family: Family, address: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -24296,6 +24623,9 @@ impl ListHostsRequest {
         Ok(ListHostsRequest
         )
     }
+}
+impl Request for ListHostsRequest {
+    type Reply = ListHostsReply;
 }
 pub fn list_hosts<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListHostsReply>, ConnectionError>
 where
@@ -24463,6 +24793,9 @@ impl SetAccessControlRequest {
         })
     }
 }
+impl Request for SetAccessControlRequest {
+    type Reply = ();
+}
 pub fn set_access_control<Conn>(conn: &Conn, mode: AccessControl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -24581,6 +24914,9 @@ impl SetCloseDownModeRequest {
             mode,
         })
     }
+}
+impl Request for SetCloseDownModeRequest {
+    type Reply = ();
 }
 pub fn set_close_down_mode<Conn>(conn: &Conn, mode: CloseDown) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -24718,6 +25054,9 @@ impl KillClientRequest {
         })
     }
 }
+impl Request for KillClientRequest {
+    type Reply = ();
+}
 /// kills a client.
 ///
 /// Forces a close down of the client that created the specified `resource`.
@@ -24814,6 +25153,9 @@ impl<'input> RotatePropertiesRequest<'input> {
             atoms: Cow::Owned(atoms),
         })
     }
+}
+impl<'input> Request for RotatePropertiesRequest<'input> {
+    type Reply = ();
 }
 pub fn rotate_properties<'c, 'input, Conn>(conn: &'c Conn, window: Window, delta: i16, atoms: &'input [Atom]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
@@ -24941,6 +25283,9 @@ impl ForceScreenSaverRequest {
         })
     }
 }
+impl Request for ForceScreenSaverRequest {
+    type Reply = ();
+}
 pub fn force_screen_saver<Conn>(conn: &Conn, mode: ScreenSaver) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -25064,6 +25409,9 @@ impl<'input> SetPointerMappingRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetPointerMappingRequest<'input> {
+    type Reply = SetPointerMappingReply;
+}
 pub fn set_pointer_mapping<'c, 'input, Conn>(conn: &'c Conn, map: &'input [u8]) -> Result<Cookie<'c, Conn, SetPointerMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -25137,6 +25485,9 @@ impl GetPointerMappingRequest {
         Ok(GetPointerMappingRequest
         )
     }
+}
+impl Request for GetPointerMappingRequest {
+    type Reply = GetPointerMappingReply;
 }
 pub fn get_pointer_mapping<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetPointerMappingReply>, ConnectionError>
 where
@@ -25317,6 +25668,9 @@ impl<'input> SetModifierMappingRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetModifierMappingRequest<'input> {
+    type Reply = SetModifierMappingReply;
+}
 pub fn set_modifier_mapping<'c, 'input, Conn>(conn: &'c Conn, keycodes: &'input [Keycode]) -> Result<Cookie<'c, Conn, SetModifierMappingReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -25390,6 +25744,9 @@ impl GetModifierMappingRequest {
         Ok(GetModifierMappingRequest
         )
     }
+}
+impl Request for GetModifierMappingRequest {
+    type Reply = GetModifierMappingReply;
 }
 pub fn get_modifier_mapping<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetModifierMappingReply>, ConnectionError>
 where
@@ -25480,6 +25837,9 @@ impl NoOperationRequest {
         Ok(NoOperationRequest
         )
     }
+}
+impl Request for NoOperationRequest {
+    type Reply = ();
 }
 pub fn no_operation<Conn>(conn: &Conn) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -82,6 +82,9 @@ impl QueryVersionRequest {
             client_minor,
         })
     }
+}
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
 }
 pub fn query_version<Conn>(conn: &Conn, client_major: u8, client_minor: u8) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
@@ -172,6 +175,9 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetDeviceCreateContextRequest<'input> {
+    type Reply = ();
+}
 pub fn set_device_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -218,6 +224,9 @@ impl GetDeviceCreateContextRequest {
         Ok(GetDeviceCreateContextRequest
         )
     }
+}
+impl Request for GetDeviceCreateContextRequest {
+    type Reply = GetDeviceCreateContextReply;
 }
 pub fn get_device_create_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetDeviceCreateContextReply>, ConnectionError>
 where
@@ -329,6 +338,9 @@ impl<'input> SetDeviceContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetDeviceContextRequest<'input> {
+    type Reply = ();
+}
 pub fn set_device_context<'c, 'input, Conn>(conn: &'c Conn, device: u32, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -385,6 +397,9 @@ impl GetDeviceContextRequest {
             device,
         })
     }
+}
+impl Request for GetDeviceContextRequest {
+    type Reply = GetDeviceContextReply;
 }
 pub fn get_device_context<Conn>(conn: &Conn, device: u32) -> Result<Cookie<'_, Conn, GetDeviceContextReply>, ConnectionError>
 where
@@ -490,6 +505,9 @@ impl<'input> SetWindowCreateContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetWindowCreateContextRequest<'input> {
+    type Reply = ();
+}
 pub fn set_window_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -536,6 +554,9 @@ impl GetWindowCreateContextRequest {
         Ok(GetWindowCreateContextRequest
         )
     }
+}
+impl Request for GetWindowCreateContextRequest {
+    type Reply = GetWindowCreateContextReply;
 }
 pub fn get_window_create_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetWindowCreateContextReply>, ConnectionError>
 where
@@ -633,6 +654,9 @@ impl GetWindowContextRequest {
             window,
         })
     }
+}
+impl Request for GetWindowContextRequest {
+    type Reply = GetWindowContextReply;
 }
 pub fn get_window_context<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, GetWindowContextReply>, ConnectionError>
 where
@@ -821,6 +845,9 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetPropertyCreateContextRequest<'input> {
+    type Reply = ();
+}
 pub fn set_property_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -867,6 +894,9 @@ impl GetPropertyCreateContextRequest {
         Ok(GetPropertyCreateContextRequest
         )
     }
+}
+impl Request for GetPropertyCreateContextRequest {
+    type Reply = GetPropertyCreateContextReply;
 }
 pub fn get_property_create_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetPropertyCreateContextReply>, ConnectionError>
 where
@@ -970,6 +1000,9 @@ impl<'input> SetPropertyUseContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetPropertyUseContextRequest<'input> {
+    type Reply = ();
+}
 pub fn set_property_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1016,6 +1049,9 @@ impl GetPropertyUseContextRequest {
         Ok(GetPropertyUseContextRequest
         )
     }
+}
+impl Request for GetPropertyUseContextRequest {
+    type Reply = GetPropertyUseContextReply;
 }
 pub fn get_property_use_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetPropertyUseContextReply>, ConnectionError>
 where
@@ -1121,6 +1157,9 @@ impl GetPropertyContextRequest {
             property,
         })
     }
+}
+impl Request for GetPropertyContextRequest {
+    type Reply = GetPropertyContextReply;
 }
 pub fn get_property_context<Conn>(conn: &Conn, window: xproto::Window, property: xproto::Atom) -> Result<Cookie<'_, Conn, GetPropertyContextReply>, ConnectionError>
 where
@@ -1230,6 +1269,9 @@ impl GetPropertyDataContextRequest {
         })
     }
 }
+impl Request for GetPropertyDataContextRequest {
+    type Reply = GetPropertyDataContextReply;
+}
 pub fn get_property_data_context<Conn>(conn: &Conn, window: xproto::Window, property: xproto::Atom) -> Result<Cookie<'_, Conn, GetPropertyDataContextReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1329,6 +1371,9 @@ impl ListPropertiesRequest {
             window,
         })
     }
+}
+impl Request for ListPropertiesRequest {
+    type Reply = ListPropertiesReply;
 }
 pub fn list_properties<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, ListPropertiesReply>, ConnectionError>
 where
@@ -1433,6 +1478,9 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetSelectionCreateContextRequest<'input> {
+    type Reply = ();
+}
 pub fn set_selection_create_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1479,6 +1527,9 @@ impl GetSelectionCreateContextRequest {
         Ok(GetSelectionCreateContextRequest
         )
     }
+}
+impl Request for GetSelectionCreateContextRequest {
+    type Reply = GetSelectionCreateContextReply;
 }
 pub fn get_selection_create_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetSelectionCreateContextReply>, ConnectionError>
 where
@@ -1582,6 +1633,9 @@ impl<'input> SetSelectionUseContextRequest<'input> {
         })
     }
 }
+impl<'input> Request for SetSelectionUseContextRequest<'input> {
+    type Reply = ();
+}
 pub fn set_selection_use_context<'c, 'input, Conn>(conn: &'c Conn, context: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1628,6 +1682,9 @@ impl GetSelectionUseContextRequest {
         Ok(GetSelectionUseContextRequest
         )
     }
+}
+impl Request for GetSelectionUseContextRequest {
+    type Reply = GetSelectionUseContextReply;
 }
 pub fn get_selection_use_context<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, GetSelectionUseContextReply>, ConnectionError>
 where
@@ -1725,6 +1782,9 @@ impl GetSelectionContextRequest {
             selection,
         })
     }
+}
+impl Request for GetSelectionContextRequest {
+    type Reply = GetSelectionContextReply;
 }
 pub fn get_selection_context<Conn>(conn: &Conn, selection: xproto::Atom) -> Result<Cookie<'_, Conn, GetSelectionContextReply>, ConnectionError>
 where
@@ -1825,6 +1885,9 @@ impl GetSelectionDataContextRequest {
         })
     }
 }
+impl Request for GetSelectionDataContextRequest {
+    type Reply = GetSelectionDataContextReply;
+}
 pub fn get_selection_data_context<Conn>(conn: &Conn, selection: xproto::Atom) -> Result<Cookie<'_, Conn, GetSelectionDataContextReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1914,6 +1977,9 @@ impl ListSelectionsRequest {
         Ok(ListSelectionsRequest
         )
     }
+}
+impl Request for ListSelectionsRequest {
+    type Reply = ListSelectionsReply;
 }
 pub fn list_selections<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, ListSelectionsReply>, ConnectionError>
 where
@@ -2010,6 +2076,9 @@ impl GetClientContextRequest {
             resource,
         })
     }
+}
+impl Request for GetClientContextRequest {
+    type Reply = GetClientContextReply;
 }
 pub fn get_client_context<Conn>(conn: &Conn, resource: u32) -> Result<Cookie<'_, Conn, GetClientContextReply>, ConnectionError>
 where

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -83,6 +83,9 @@ impl GetVersionRequest {
             minor_version,
         })
     }
+}
+impl Request for GetVersionRequest {
+    type Reply = GetVersionReply;
 }
 pub fn get_version<Conn>(conn: &Conn, major_version: u8, minor_version: u16) -> Result<Cookie<'_, Conn, GetVersionReply>, ConnectionError>
 where
@@ -245,6 +248,9 @@ impl CompareCursorRequest {
         })
     }
 }
+impl Request for CompareCursorRequest {
+    type Reply = CompareCursorReply;
+}
 pub fn compare_cursor<Conn>(conn: &Conn, window: xproto::Window, cursor: xproto::Cursor) -> Result<Cookie<'_, Conn, CompareCursorReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -381,6 +387,9 @@ impl FakeInputRequest {
         })
     }
 }
+impl Request for FakeInputRequest {
+    type Reply = ();
+}
 pub fn fake_input<Conn>(conn: &Conn, type_: u8, detail: u8, time: u32, root: xproto::Window, root_x: i16, root_y: i16, deviceid: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -443,6 +452,9 @@ impl GrabControlRequest {
             impervious,
         })
     }
+}
+impl Request for GrabControlRequest {
+    type Reply = ();
 }
 pub fn grab_control<Conn>(conn: &Conn, impervious: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -1582,6 +1582,9 @@ impl QueryExtensionRequest {
         )
     }
 }
+impl Request for QueryExtensionRequest {
+    type Reply = QueryExtensionReply;
+}
 pub fn query_extension<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryExtensionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1662,6 +1665,9 @@ impl QueryAdaptorsRequest {
             window,
         })
     }
+}
+impl Request for QueryAdaptorsRequest {
+    type Reply = QueryAdaptorsReply;
 }
 pub fn query_adaptors<Conn>(conn: &Conn, window: xproto::Window) -> Result<Cookie<'_, Conn, QueryAdaptorsReply>, ConnectionError>
 where
@@ -1760,6 +1766,9 @@ impl QueryEncodingsRequest {
             port,
         })
     }
+}
+impl Request for QueryEncodingsRequest {
+    type Reply = QueryEncodingsReply;
 }
 pub fn query_encodings<Conn>(conn: &Conn, port: Port) -> Result<Cookie<'_, Conn, QueryEncodingsReply>, ConnectionError>
 where
@@ -1867,6 +1876,9 @@ impl GrabPortRequest {
         })
     }
 }
+impl Request for GrabPortRequest {
+    type Reply = GrabPortReply;
+}
 pub fn grab_port<Conn, A>(conn: &Conn, port: Port, time: A) -> Result<Cookie<'_, Conn, GrabPortReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -1958,6 +1970,9 @@ impl UngrabPortRequest {
             time,
         })
     }
+}
+impl Request for UngrabPortRequest {
+    type Reply = ();
 }
 pub fn ungrab_port<Conn, A>(conn: &Conn, port: Port, time: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2081,6 +2096,9 @@ impl PutVideoRequest {
             drw_h,
         })
     }
+}
+impl Request for PutVideoRequest {
+    type Reply = ();
 }
 pub fn put_video<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2212,6 +2230,9 @@ impl PutStillRequest {
         })
     }
 }
+impl Request for PutStillRequest {
+    type Reply = ();
+}
 pub fn put_still<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2341,6 +2362,9 @@ impl GetVideoRequest {
             drw_h,
         })
     }
+}
+impl Request for GetVideoRequest {
+    type Reply = ();
 }
 pub fn get_video<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2472,6 +2496,9 @@ impl GetStillRequest {
         })
     }
 }
+impl Request for GetStillRequest {
+    type Reply = ();
+}
 pub fn get_still<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, vid_x: i16, vid_y: i16, vid_w: u16, vid_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2546,6 +2573,9 @@ impl StopVideoRequest {
         })
     }
 }
+impl Request for StopVideoRequest {
+    type Reply = ();
+}
 pub fn stop_video<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2612,6 +2642,9 @@ impl SelectVideoNotifyRequest {
         })
     }
 }
+impl Request for SelectVideoNotifyRequest {
+    type Reply = ();
+}
 pub fn select_video_notify<Conn>(conn: &Conn, drawable: xproto::Drawable, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2677,6 +2710,9 @@ impl SelectPortNotifyRequest {
             onoff,
         })
     }
+}
+impl Request for SelectPortNotifyRequest {
+    type Reply = ();
 }
 pub fn select_port_notify<Conn>(conn: &Conn, port: Port, onoff: bool) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -2767,6 +2803,9 @@ impl QueryBestSizeRequest {
             motion,
         })
     }
+}
+impl Request for QueryBestSizeRequest {
+    type Reply = QueryBestSizeReply;
 }
 pub fn query_best_size<Conn>(conn: &Conn, port: Port, vid_w: u16, vid_h: u16, drw_w: u16, drw_h: u16, motion: bool) -> Result<Cookie<'_, Conn, QueryBestSizeReply>, ConnectionError>
 where
@@ -2872,6 +2911,9 @@ impl SetPortAttributeRequest {
         })
     }
 }
+impl Request for SetPortAttributeRequest {
+    type Reply = ();
+}
 pub fn set_port_attribute<Conn>(conn: &Conn, port: Port, attribute: xproto::Atom, value: i32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -2937,6 +2979,9 @@ impl GetPortAttributeRequest {
             attribute,
         })
     }
+}
+impl Request for GetPortAttributeRequest {
+    type Reply = GetPortAttributeReply;
 }
 pub fn get_port_attribute<Conn>(conn: &Conn, port: Port, attribute: xproto::Atom) -> Result<Cookie<'_, Conn, GetPortAttributeReply>, ConnectionError>
 where
@@ -3019,6 +3064,9 @@ impl QueryPortAttributesRequest {
             port,
         })
     }
+}
+impl Request for QueryPortAttributesRequest {
+    type Reply = QueryPortAttributesReply;
 }
 pub fn query_port_attributes<Conn>(conn: &Conn, port: Port) -> Result<Cookie<'_, Conn, QueryPortAttributesReply>, ConnectionError>
 where
@@ -3119,6 +3167,9 @@ impl ListImageFormatsRequest {
             port,
         })
     }
+}
+impl Request for ListImageFormatsRequest {
+    type Reply = ListImageFormatsReply;
 }
 pub fn list_image_formats<Conn>(conn: &Conn, port: Port) -> Result<Cookie<'_, Conn, ListImageFormatsReply>, ConnectionError>
 where
@@ -3237,6 +3288,9 @@ impl QueryImageAttributesRequest {
             height,
         })
     }
+}
+impl Request for QueryImageAttributesRequest {
+    type Reply = QueryImageAttributesReply;
 }
 pub fn query_image_attributes<Conn>(conn: &Conn, port: Port, id: u32, width: u16, height: u16) -> Result<Cookie<'_, Conn, QueryImageAttributesReply>, ConnectionError>
 where
@@ -3437,6 +3491,9 @@ impl<'input> PutImageRequest<'input> {
         })
     }
 }
+impl<'input> Request for PutImageRequest<'input> {
+    type Reply = ();
+}
 pub fn put_image<'c, 'input, Conn>(conn: &'c Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, id: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, data: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -3615,6 +3672,9 @@ impl ShmPutImageRequest {
             send_event,
         })
     }
+}
+impl Request for ShmPutImageRequest {
+    type Reply = ();
 }
 pub fn shm_put_image<Conn>(conn: &Conn, port: Port, drawable: xproto::Drawable, gc: xproto::Gcontext, shmseg: shm::Seg, id: u32, offset: u32, src_x: i16, src_y: i16, src_w: u16, src_h: u16, drw_x: i16, drw_y: i16, drw_w: u16, drw_h: u16, width: u16, height: u16, send_event: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::RawFdContainer;
 #[allow(unused_imports)]
-use crate::x11_utils::{RequestHeader, Serialize, TryParse};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -162,6 +162,9 @@ impl QueryVersionRequest {
         )
     }
 }
+impl Request for QueryVersionRequest {
+    type Reply = QueryVersionReply;
+}
 pub fn query_version<Conn>(conn: &Conn) -> Result<Cookie<'_, Conn, QueryVersionReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -242,6 +245,9 @@ impl ListSurfaceTypesRequest {
             port_id,
         })
     }
+}
+impl Request for ListSurfaceTypesRequest {
+    type Reply = ListSurfaceTypesReply;
 }
 pub fn list_surface_types<Conn>(conn: &Conn, port_id: xv::Port) -> Result<Cookie<'_, Conn, ListSurfaceTypesReply>, ConnectionError>
 where
@@ -377,6 +383,9 @@ impl CreateContextRequest {
         })
     }
 }
+impl Request for CreateContextRequest {
+    type Reply = CreateContextReply;
+}
 pub fn create_context<Conn>(conn: &Conn, context_id: Context, port_id: xv::Port, surface_id: Surface, width: u16, height: u16, flags: u32) -> Result<Cookie<'_, Conn, CreateContextReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -484,6 +493,9 @@ impl DestroyContextRequest {
         })
     }
 }
+impl Request for DestroyContextRequest {
+    type Reply = ();
+}
 pub fn destroy_context<Conn>(conn: &Conn, context_id: Context) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -547,6 +559,9 @@ impl CreateSurfaceRequest {
             context_id,
         })
     }
+}
+impl Request for CreateSurfaceRequest {
+    type Reply = CreateSurfaceReply;
 }
 pub fn create_surface<Conn>(conn: &Conn, surface_id: Surface, context_id: Context) -> Result<Cookie<'_, Conn, CreateSurfaceReply>, ConnectionError>
 where
@@ -645,6 +660,9 @@ impl DestroySurfaceRequest {
         })
     }
 }
+impl Request for DestroySurfaceRequest {
+    type Reply = ();
+}
 pub fn destroy_surface<Conn>(conn: &Conn, surface_id: Surface) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -728,6 +746,9 @@ impl CreateSubpictureRequest {
             height,
         })
     }
+}
+impl Request for CreateSubpictureRequest {
+    type Reply = CreateSubpictureReply;
 }
 pub fn create_subpicture<Conn>(conn: &Conn, subpicture_id: Subpicture, context: Context, xvimage_id: u32, width: u16, height: u16) -> Result<Cookie<'_, Conn, CreateSubpictureReply>, ConnectionError>
 where
@@ -840,6 +861,9 @@ impl DestroySubpictureRequest {
         })
     }
 }
+impl Request for DestroySubpictureRequest {
+    type Reply = ();
+}
 pub fn destroy_subpicture<Conn>(conn: &Conn, subpicture_id: Subpicture) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -903,6 +927,9 @@ impl ListSubpictureTypesRequest {
             surface_id,
         })
     }
+}
+impl Request for ListSubpictureTypesRequest {
+    type Reply = ListSubpictureTypesReply;
 }
 pub fn list_subpicture_types<Conn>(conn: &Conn, port_id: xv::Port, surface_id: Surface) -> Result<Cookie<'_, Conn, ListSubpictureTypesReply>, ConnectionError>
 where

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -94,6 +94,11 @@ pub fn parse_request_header(
     ))
 }
 
+/// A type implementing this trait is an X11 request.
+pub trait Request {
+    type Reply: Into<crate::protocol::Reply>;
+}
+
 /// A type implementing this trait can be serialized into X11 raw bytes.
 pub trait Serialize {
     /// The value returned by `serialize`.


### PR DESCRIPTION
The information about which replies a given request generates are currently only encoded in the helper functions. This adds a `Request` trait that contains that information as an associated type, and machinery for working with it.