### PR TITLE
Change Request::parse signature to be more ergonomic.

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -32,8 +32,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String
     outln!(main_out, "use crate::utils::RawFdContainer;");
     outln!(
         main_out,
-        "use crate::x11_utils::{{parse_request_header, BigRequests, ExtInfoProvider, \
-         RequestHeader}};"
+        "use crate::x11_utils::{{ExtInfoProvider, RequestHeader}};"
     );
     outln!(main_out, "");
 

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -76,10 +76,12 @@ pub(super) fn generate_request_reply_enum(
             "#[allow(clippy::cognitive_complexity, clippy::single_match)]"
         );
         outln!(out, "pub fn parse(");
-        outln!(out.indent(), "request: &'input [u8],");
-        outln!(out.indent(), "fds: &mut Vec<RawFdContainer>,");
-        outln!(out.indent(), "big_requests_enabled: BigRequests,");
-        outln!(out.indent(), "ext_info_provider: &dyn ExtInfoProvider,");
+        out.indented(|out| {
+            outln!(out, "header: RequestHeader,");
+            outln!(out, "body: &'input [u8],");
+            outln!(out, "fds: &mut Vec<RawFdContainer>,");
+            outln!(out, "ext_info_provider: &dyn ExtInfoProvider,");
+        });
         outln!(out, ") -> Result<Self, ParseError> {{");
         out.indented(|out| {
             outln!(
@@ -93,10 +95,7 @@ pub(super) fn generate_request_reply_enum(
             );
             outln!(out, "#[allow(unused_variables)]");
             outln!(out, "let fds = fds;");
-            outln!(
-                out,
-                "let (header, remaining) = parse_request_header(request, big_requests_enabled)?;"
-            );
+            outln!(out, "let remaining = body;");
             outln!(out, "// Check if this is a core protocol request.");
             outln!(out, "match header.major_opcode {{");
             out.indented(|out| {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -9,7 +9,7 @@
 use std::convert::{TryFrom, TryInto};
 use crate::errors::ParseError;
 use crate::utils::RawFdContainer;
-use crate::x11_utils::{parse_request_header, BigRequests, ExtInfoProvider, RequestHeader};
+use crate::x11_utils::{ExtInfoProvider, RequestHeader};
 
 pub mod xproto;
 pub mod bigreq;
@@ -1260,16 +1260,16 @@ impl<'input> Request<'input> {
     // Parse a X11 request into a concrete type
     #[allow(clippy::cognitive_complexity, clippy::single_match)]
     pub fn parse(
-        request: &'input [u8],
+        header: RequestHeader,
+        body: &'input [u8],
         fds: &mut Vec<RawFdContainer>,
-        big_requests_enabled: BigRequests,
         ext_info_provider: &dyn ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         // Might not be used if none of the extensions that use FD passing is enabled
         // The `allow` is not in the function argument because it is not stable in Rust 1.37
         #[allow(unused_variables)]
         let fds = fds;
-        let (header, remaining) = parse_request_header(request, big_requests_enabled)?;
+        let remaining = body;
         // Check if this is a core protocol request.
         match header.major_opcode {
             xproto::CREATE_WINDOW_REQUEST => return Ok(Request::CreateWindow(xproto::CreateWindowRequest::try_parse_request(header, remaining)?)),


### PR DESCRIPTION
The caller has to parse the header anyways to make sure there are enough bytes for the entire request, so rather than parsing it again just ask the caller to pass in the RequestHeader.

I was aware of this when we were implementing the parsing stuff but somehow forgot about the signature here. :/