### PR TITLE
Change return type of VoidCookie::check()

### DIFF
--- a/examples/check_unchecked_requests.rs
+++ b/examples/check_unchecked_requests.rs
@@ -8,6 +8,7 @@
 extern crate x11rb;
 
 use x11rb::connection::Connection;
+use x11rb::errors::ReplyError;
 use x11rb::protocol::xproto::ConnectionExt as _;
 use x11rb::protocol::Event;
 use x11rb::wrapper::ConnectionExt as _;
@@ -46,8 +47,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // For requests without responses, there are three possibilities
 
     // We can check for errors explicitly
-    let res = conn.destroy_window(INVALID_WINDOW)?.check()?;
-    assert!(res.is_some());
+    match conn.destroy_window(INVALID_WINDOW)?.check() {
+        Err(ReplyError::X11Error(_)) => {}
+        e => panic!("{:?} unexpected", e),
+    }
 
     // We can silently ignore the error
     conn.destroy_window(INVALID_WINDOW)?.ignore_error();

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -321,19 +321,14 @@ fn become_wm<C: Connection>(conn: &C, screen: &Screen) -> Result<(), ReplyError>
     let change = ChangeWindowAttributesAux::default().event_mask(
         EventMask::SubstructureRedirect | EventMask::SubstructureNotify | EventMask::EnterWindow,
     );
-    let error = conn
+    let res = conn
         .change_window_attributes(screen.root, &change)?
-        .check()?;
-    if let Some(error) = error {
-        match error {
-            Error::Access(_) => {
-                eprintln!("Another WM is already running.");
-                exit(1);
-            }
-            error => Err(ReplyError::X11Error(error)),
-        }
+        .check();
+    if let Err(ReplyError::X11Error(Error::Access(_))) = res {
+        eprintln!("Another WM is already running.");
+        exit(1);
     } else {
-        Ok(())
+        res
     }
 }
 

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -321,9 +321,7 @@ fn become_wm<C: Connection>(conn: &C, screen: &Screen) -> Result<(), ReplyError>
     let change = ChangeWindowAttributesAux::default().event_mask(
         EventMask::SubstructureRedirect | EventMask::SubstructureNotify | EventMask::EnterWindow,
     );
-    let res = conn
-        .change_window_attributes(screen.root, &change)?
-        .check();
+    let res = conn.change_window_attributes(screen.root, &change)?.check();
     if let Err(ReplyError::X11Error(Error::Access(_))) = res {
         eprintln!("Another WM is already running.");
         exit(1);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -271,10 +271,11 @@ pub trait RequestConnection {
     /// The given sequence number identifies the request for which the check should be performed.
     ///
     /// Users of this library will most likely not want to use this function directly.
-    fn check_for_error(&self, sequence: SequenceNumber) -> Result<Option<Error>, ConnectionError> {
-        let res = self.check_for_raw_error(sequence)?;
-        let res = res.map(|e| self.parse_error(e.as_ref())).transpose()?;
-        Ok(res)
+    fn check_for_error(&self, sequence: SequenceNumber) -> Result<(), ReplyError> {
+        match self.check_for_raw_error(sequence)? {
+            Some(err) => Err(self.parse_error(err.as_ref())?.into()),
+            None => Ok(()),
+        }
     }
 
     /// Check whether a request that does not have a reply caused an X11 error.

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -6,7 +6,6 @@ use std::marker::PhantomData;
 use crate::connection::{BufWithFds, DiscardMode, RequestConnection, RequestKind, SequenceNumber};
 use crate::errors::{ConnectionError, ParseError, ReplyError};
 use crate::protocol::xproto::ListFontsWithInfoReply;
-use crate::protocol::Error;
 use crate::utils::RawFdContainer;
 
 /// A handle to a possible error from the X11 server.
@@ -49,7 +48,7 @@ where
     }
 
     /// Check if the original request caused an X11 error.
-    pub fn check(self) -> Result<Option<Error>, ConnectionError> {
+    pub fn check(self) -> Result<(), ReplyError> {
         let (connection, sequence) = self.consume();
         connection.check_for_error(sequence)
     }


### PR DESCRIPTION
When checking whether a request without a reply succeeded, there are
three possible outcomes:
1. it succeeded
2. it failed with an X11 error
3. it failed with a ConnectionError (e.g. I/O error)

Before this commit, check() returns a Result<Option<Error>>. Case 1 is
represented as Ok(None), case 2 as as Ok(Some(err)), and case 3 as
Err(err).

This API emphasises the difference between an X11 error and a
ConnectionError. Also, it makes it harder to "bubble up" errors via ?,
because an X11 error is not an error in the Rust sense (does not
implement std's Error trait).

This commit changes check() to return Result<(), ReplyError>. Case 1 is
represented as Ok(()) and cases 2 and 3 are both an Err. This seems more
consistent.

Fixes: https://github.com/psychon/x11rb/issues/466
Signed-off-by: Uli Schlachter <psychon@znc.in>

---

I'm still not sure if this is a good idea or not. So, feel free to complain about this and reject it. This should at least simplify usage with `anyhow::Error`.