### PR TITLE
cairo-example: Support true transparency

### DIFF
--- a/cairo-example/Cargo.toml
+++ b/cairo-example/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies.x11rb]
 path = "../"
-features = ["allow-unsafe-code"]
+features = ["allow-unsafe-code", "render"]
 
 [dependencies.cairo-rs]
 version = "0.8"


### PR DESCRIPTION
This commit makes the cairo example support true transparency. Just because. The result looks like this ontop of its own source code:

![foo](https://user-images.githubusercontent.com/89482/83964974-b275da80-a8b0-11ea-8c8e-303fda10d2c6.png)

After having written some code that uses the render extension, I wonder if it makes sense to add something like libxcb-render-util even though I concluded in #316 that it is not necessary. After reading and understanding `choose_visual`, the interested reviewer can tell me if this needs to be simplified with some helper functions. `xcb_render_util_find_standard_format` would simplify this code a bit. :-)