### PR TITLE
Add a PollMode enumeration

### DIFF
--- a/src/rust_connection/write_buffer.rs
+++ b/src/rust_connection/write_buffer.rs
@@ -161,14 +161,14 @@ impl WriteBuffer {
 mod test {
     use std::io::{Error, ErrorKind, IoSlice, Result};
 
-    use super::super::Stream;
+    use super::super::{PollMode, Stream};
     use super::WriteBuffer;
     use crate::utils::RawFdContainer;
 
     struct WouldBlockWriter;
 
     impl Stream for WouldBlockWriter {
-        fn poll(&self, _read: bool, _write: bool) -> Result<()> {
+        fn poll(&self, _mode: PollMode) -> Result<()> {
             unimplemented!();
         }
 

--- a/tests/multithread_test.rs
+++ b/tests/multithread_test.rs
@@ -65,7 +65,7 @@ mod fake_stream {
     use x11rb::protocol::xproto::{
         ImageOrder, Setup, CLIENT_MESSAGE_EVENT, GET_INPUT_FOCUS_REQUEST, SEND_EVENT_REQUEST,
     };
-    use x11rb::rust_connection::{RustConnection, Stream};
+    use x11rb::rust_connection::{PollMode, RustConnection, Stream};
     use x11rb::utils::RawFdContainer;
 
     /// Create a new `RustConnection` connected to a fake stream
@@ -163,12 +163,8 @@ mod fake_stream {
     }
 
     impl Stream for FakeStream {
-        fn poll(&self, read: bool, write: bool) -> std::io::Result<()> {
-            assert!(
-                read || write,
-                "at least one of `read` and `write` must be true",
-            );
-            if write {
+        fn poll(&self, mode: PollMode) -> std::io::Result<()> {
+            if mode.writable() {
                 Ok(())
             } else {
                 let mut inner = self.inner.lock().unwrap();


### PR DESCRIPTION
Before this, Stream::poll() got two booleans as argument that describe
if we want to poll for readability/writability. The combination
false,false was forbidden.

This commit adds a PollMode enumeration. This makes it impossible to
represent the forbidden combination. Also, this is more readable in
callers, since one does not have to remember what the meaning of each of
the booleans is.

Signed-off-by: Uli Schlachter <psychon@znc.in>