### PR TITLE
Add some more assertions to the generated code

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2602,7 +2602,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         if external_params.is_empty() {
             outln!(out, "impl Serialize for {} {{", name);
         } else {
-            outln!(out, "#[allow(dead_code, unused_variables)]");
             outln!(out, "impl {} {{", name);
         }
         out.indented(|out| {
@@ -2694,12 +2693,13 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         if external_params.is_empty() {
             outln!(out, "impl Serialize for {} {{", name);
         } else {
-            outln!(out, "#[allow(dead_code, unused_variables)]");
             outln!(out, "impl {} {{", name);
         }
         out.indented(|out| {
             if external_params.is_empty() {
                 outln!(out, "type Bytes = Vec<u8>;");
+            } else {
+                outln!(out, "#[allow(dead_code)]");
             }
             outln!(
                 out,
@@ -3332,7 +3332,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         if external_params.is_empty() {
             outln!(out, "impl Serialize for {} {{", name);
         } else {
-            outln!(out, "#[allow(dead_code, unused_variables)]");
             outln!(out, "impl {} {{", name);
         }
         out.indented(|out| {
@@ -3474,12 +3473,13 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         if external_params.is_empty() {
             outln!(out, "impl Serialize for {} {{", name);
         } else {
-            outln!(out, "#[allow(dead_code, unused_variables)]");
             outln!(out, "impl {} {{", name);
         }
         out.indented(|out| {
             if external_params.is_empty() {
                 outln!(out, "type Bytes = Vec<u8>;");
+            } else {
+                outln!(out, "#[allow(dead_code)]");
             }
             outln!(
                 out,

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -4317,31 +4317,16 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         parent_deducible_fields: &HashMap<String, DeducibleField>,
         out: &mut Output,
     ) {
-        let needs_expr_assert =
-            !parent_deducible_fields
-                .values()
-                .any(|deducible_field| match deducible_field {
-                    DeducibleField::CaseSwitchExpr(switch_name, _) => *switch_name == switch.name,
-                    DeducibleField::BitCaseSwitchExpr(switch_name, DeducibleFieldOp::None) => {
-                        *switch_name == switch.name
-                    }
-                    DeducibleField::BitCaseSwitchExpr(_, _) | DeducibleField::LengthOf(_, _) => {
-                        false
-                    }
-                });
-
-        if needs_expr_assert {
-            let rust_field_name = to_rust_variable_name(&switch.name);
-            let switch_expr_str =
-                self.expr_to_str(&switch.expr, to_rust_variable_name, true, true, false);
-            outln!(
-                out,
-                "assert_eq!(self.switch_expr(), {}, \"switch `{}` has an inconsistent \
-                 discriminant\");",
-                switch_expr_str,
-                rust_field_name,
-            );
-        }
+        let rust_field_name = to_rust_variable_name(&switch.name);
+        let switch_expr_str =
+            self.expr_to_str(&switch.expr, to_rust_variable_name, true, true, false);
+        outln!(
+            out,
+            "assert_eq!(self.switch_expr(), {}, \"switch `{}` has an inconsistent \
+             discriminant\");",
+            switch_expr_str,
+            rust_field_name,
+        );
     }
 
     fn emit_value_serialize(

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -438,12 +438,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             if let Some(aux_start_align) = switch_fields[0].required_start_align {
                 assert_eq!(aux_start_align.offset(), 0);
             }
-            self.generate_aux(
-                request_def,
-                switch_fields[0],
-                &function_name,
-                out,
-            );
+            self.generate_aux(request_def, switch_fields[0], &function_name, out);
         }
 
         outln!(out, "/// Opcode for the {} request", name);
@@ -547,27 +542,14 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         let aux_name = format!("{}Aux", request_def.name);
 
         if switch_field.kind == xcbdefs::SwitchKind::Case {
-            self.emit_switch_type(
-                switch_field,
-                &aux_name,
-                true,
-                true,
-                None,
-                out,
-            );
+            self.emit_switch_type(switch_field, &aux_name, true, true, None, out);
         } else {
             let doc = format!(
                 "Auxiliary and optional information for the `{}` function",
                 function_name,
             );
-            let cases_infos = self.emit_switch_type(
-                switch_field,
-                &aux_name,
-                true,
-                true,
-                Some(&doc),
-                out,
-            );
+            let cases_infos =
+                self.emit_switch_type(switch_field, &aux_name, true, true, Some(&doc), out);
 
             outln!(out, "impl {} {{", aux_name);
             out.indented(|out| {
@@ -2990,20 +2972,9 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
         if generate_serialize {
             if let Some(size) = switch.size() {
-                self.emit_fixed_size_switch_serialize(
-                    switch,
-                    name,
-                    &case_infos,
-                    size,
-                    out,
-                );
+                self.emit_fixed_size_switch_serialize(switch, name, &case_infos, size, out);
             } else {
-                self.emit_variable_size_switch_serialize(
-                    switch,
-                    name,
-                    &case_infos,
-                    out,
-                );
+                self.emit_variable_size_switch_serialize(switch, name, &case_infos, out);
             }
         }
 
@@ -4296,11 +4267,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     }
 
     /// Emits an assert that checks the consistency of switch expressions
-    fn emit_assert_for_switch_serialize(
-        &self,
-        switch: &xcbdefs::SwitchField,
-        out: &mut Output,
-    ) {
+    fn emit_assert_for_switch_serialize(&self, switch: &xcbdefs::SwitchField, out: &mut Output) {
         let rust_field_name = to_rust_variable_name(&switch.name);
         let switch_expr_str =
             self.expr_to_str(&switch.expr, to_rust_variable_name, true, true, false);

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -440,7 +440,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             }
             self.generate_aux(
                 request_def,
-                &deducible_fields,
                 switch_fields[0],
                 &function_name,
                 out,
@@ -541,7 +540,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn generate_aux(
         &self,
         request_def: &xcbdefs::RequestDef,
-        deducible_fields: &HashMap<String, DeducibleField>,
         switch_field: &xcbdefs::SwitchField,
         function_name: &str,
         out: &mut Output,
@@ -552,7 +550,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             self.emit_switch_type(
                 switch_field,
                 &aux_name,
-                deducible_fields,
                 true,
                 true,
                 None,
@@ -566,7 +563,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             let cases_infos = self.emit_switch_type(
                 switch_field,
                 &aux_name,
-                deducible_fields,
                 true,
                 true,
                 Some(&doc),
@@ -2276,7 +2272,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         name_prefix: &str,
         fields: &[xcbdefs::FieldDef],
-        parent_deducible_fields: &HashMap<String, DeducibleField>,
         generate_try_parse: bool,
         generate_serialize: bool,
         out: &mut Output,
@@ -2286,7 +2281,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 self.generate_switch(
                     name_prefix,
                     switch_field,
-                    parent_deducible_fields,
                     generate_try_parse,
                     generate_serialize,
                     out,
@@ -2299,7 +2293,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         name_prefix: &str,
         switch: &xcbdefs::SwitchField,
-        parent_deducible_fields: &HashMap<String, DeducibleField>,
         generate_try_parse: bool,
         generate_serialize: bool,
         out: &mut Output,
@@ -2308,7 +2301,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         self.emit_switch_type(
             switch,
             &switch_name,
-            parent_deducible_fields,
             generate_try_parse,
             generate_serialize,
             None,
@@ -2339,7 +2331,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         self.generate_switches_for_fields(
             switch_prefix,
             fields,
-            &deducible_fields,
             generate_try_parse,
             fields_need_serialize,
             out,
@@ -2781,7 +2772,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         switch: &xcbdefs::SwitchField,
         name: &str,
-        parent_deducible_fields: &HashMap<String, DeducibleField>,
         generate_try_parse: bool,
         generate_serialize: bool,
         doc: Option<&str>,
@@ -2834,7 +2824,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     self.generate_switch(
                         name,
                         switch_field,
-                        &case_deducible_fields,
                         generate_try_parse,
                         generate_serialize,
                         out,
@@ -3004,7 +2993,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 self.emit_fixed_size_switch_serialize(
                     switch,
                     name,
-                    parent_deducible_fields,
                     &case_infos,
                     size,
                     out,
@@ -3013,7 +3001,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 self.emit_variable_size_switch_serialize(
                     switch,
                     name,
-                    parent_deducible_fields,
                     &case_infos,
                     out,
                 );
@@ -3331,7 +3318,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         switch: &xcbdefs::SwitchField,
         name: &str,
-        parent_deducible_fields: &HashMap<String, DeducibleField>,
         case_infos: &[CaseInfo],
         size: u32,
         out: &mut Output,
@@ -3360,7 +3346,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 size,
             );
             out.indented(|out| {
-                self.emit_assert_for_switch_serialize(switch, parent_deducible_fields, out);
+                self.emit_assert_for_switch_serialize(switch, out);
                 outln!(out, "match self {{");
                 out.indented(|out| {
                     for (case, case_info) in switch.cases.iter().zip(case_infos.iter()) {
@@ -3477,7 +3463,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         switch: &xcbdefs::SwitchField,
         name: &str,
-        parent_deducible_fields: &HashMap<String, DeducibleField>,
         case_infos: &[CaseInfo],
         out: &mut Output,
     ) {
@@ -3517,7 +3502,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 ext_params_arg_defs
             );
             out.indented(|out| {
-                self.emit_assert_for_switch_serialize(switch, parent_deducible_fields, out);
+                self.emit_assert_for_switch_serialize(switch, out);
                 if switch.kind == xcbdefs::SwitchKind::BitCase {
                     for (case, case_info) in switch.cases.iter().zip(case_infos.iter()) {
                         match case_info {
@@ -4314,7 +4299,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     fn emit_assert_for_switch_serialize(
         &self,
         switch: &xcbdefs::SwitchField,
-        parent_deducible_fields: &HashMap<String, DeducibleField>,
         out: &mut Output,
     ) {
         let rust_field_name = to_rust_variable_name(&switch.name);

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -2283,6 +2283,7 @@ impl CreatePictureAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(repeat) = self.repeat {
             u32::from(repeat).serialize_into(bytes);
         }
@@ -2674,6 +2675,7 @@ impl ChangePictureAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(repeat) = self.repeat {
             u32::from(repeat).serialize_into(bytes);
         }

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -2275,8 +2275,8 @@ impl CreatePictureAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl CreatePictureAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);
@@ -2667,8 +2667,8 @@ impl ChangePictureAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl ChangePictureAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -647,6 +647,7 @@ impl SetAttributesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -639,8 +639,8 @@ impl SetAttributesAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl SetAttributesAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -1382,8 +1382,8 @@ impl CreateAlarmAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl CreateAlarmAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);
@@ -1614,8 +1614,8 @@ impl ChangeAlarmAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl ChangeAlarmAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -1390,6 +1390,7 @@ impl CreateAlarmAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(counter) = self.counter {
             counter.serialize_into(bytes);
         }
@@ -1621,6 +1622,7 @@ impl ChangeAlarmAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(counter) = self.counter {
             counter.serialize_into(bytes);
         }

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -858,6 +858,7 @@ impl InputInfoInfo {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
+        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `info` has an inconsistent discriminant");
         match self {
             InputInfoInfo::Key(key) => key.serialize_into(bytes),
             InputInfoInfo::Button(button) => button.serialize_into(bytes),
@@ -4155,6 +4156,7 @@ impl FeedbackStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
+        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackStateData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackStateData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -5103,6 +5105,7 @@ impl FeedbackCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
+        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackCtlData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackCtlData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -6452,6 +6455,7 @@ impl InputStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
+        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             InputStateData::Key(key) => key.serialize_into(bytes),
             InputStateData::Button(button) => button.serialize_into(bytes),
@@ -7558,6 +7562,7 @@ impl DeviceStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
+        assert_eq!(self.switch_expr(), u32::from(control_id), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceStateData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceStateData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -8402,6 +8407,7 @@ impl DeviceCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
+        assert_eq!(self.switch_expr(), u32::from(control_id), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceCtlData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceCtlData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -8809,6 +8815,7 @@ impl ChangeDevicePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
+        assert_eq!(self.switch_expr(), u32::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             ChangeDevicePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -10356,6 +10363,7 @@ impl HierarchyChangeData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
+        assert_eq!(self.switch_expr(), u32::from(type_), "switch `data` has an inconsistent discriminant");
         match self {
             HierarchyChangeData::AddMaster(add_master) => add_master.serialize_into(bytes),
             HierarchyChangeData::RemoveMaster(remove_master) => remove_master.serialize_into(bytes),
@@ -12035,6 +12043,7 @@ impl DeviceClassData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
+        assert_eq!(self.switch_expr(), u32::from(type_), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceClassData::Key(key) => key.serialize_into(bytes),
             DeviceClassData::Button(button) => button.serialize_into(bytes),
@@ -13614,6 +13623,7 @@ impl XIChangePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
+        assert_eq!(self.switch_expr(), u32::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             XIChangePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -850,8 +850,8 @@ impl InputInfoInfo {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl InputInfoInfo {
+    #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, class_id);
@@ -1822,8 +1822,8 @@ impl DeviceTimeCoord {
     }
 }
 // Skipping TryFrom implementations because of unresolved members
-#[allow(dead_code, unused_variables)]
 impl DeviceTimeCoord {
+    #[allow(dead_code)]
     fn serialize(&self, num_axes: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, num_axes);
@@ -4148,8 +4148,8 @@ impl FeedbackStateData {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl FeedbackStateData {
+    #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, class_id);
@@ -5097,8 +5097,8 @@ impl FeedbackCtlData {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl FeedbackCtlData {
+    #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, class_id);
@@ -6447,8 +6447,8 @@ impl InputStateData {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl InputStateData {
+    #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, class_id);
@@ -7554,8 +7554,8 @@ impl DeviceStateData {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl DeviceStateData {
+    #[allow(dead_code)]
     fn serialize(&self, control_id: u16) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, control_id);
@@ -8399,8 +8399,8 @@ impl DeviceCtlData {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl DeviceCtlData {
+    #[allow(dead_code)]
     fn serialize(&self, control_id: u16) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, control_id);
@@ -8807,8 +8807,8 @@ impl ChangeDevicePropertyAux {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl ChangeDevicePropertyAux {
+    #[allow(dead_code)]
     fn serialize(&self, format: u8, num_items: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, format, num_items);
@@ -10355,8 +10355,8 @@ impl HierarchyChangeData {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl HierarchyChangeData {
+    #[allow(dead_code)]
     fn serialize(&self, type_: u16) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, type_);
@@ -12035,8 +12035,8 @@ impl DeviceClassData {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl DeviceClassData {
+    #[allow(dead_code)]
     fn serialize(&self, type_: u16) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, type_);
@@ -13615,8 +13615,8 @@ impl XIChangePropertyAux {
         }
     }
 }
-#[allow(dead_code, unused_variables)]
 impl XIChangePropertyAux {
+    #[allow(dead_code)]
     fn serialize(&self, format: u8, num_items: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, format, num_items);

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6915,8 +6915,8 @@ impl SelectEventsAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl SelectEventsAux {
+    #[allow(dead_code)]
     fn serialize(&self, affect_which: u16, clear: u16, select_all: u16) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, affect_which, clear, select_all);
@@ -8343,8 +8343,8 @@ impl SetMapAuxBitcase3 {
     }
 }
 // Skipping TryFrom implementations because of unresolved members
-#[allow(dead_code, unused_variables)]
 impl SetMapAuxBitcase3 {
+    #[allow(dead_code)]
     fn serialize(&self, n_key_actions: u8, total_actions: u16) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, n_key_actions, total_actions);
@@ -8447,8 +8447,8 @@ impl SetMapAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl SetMapAux {
+    #[allow(dead_code)]
     fn serialize(&self, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys);
@@ -9911,8 +9911,8 @@ impl SetNamesAuxBitcase8 {
     }
 }
 // Skipping TryFrom implementations because of unresolved members
-#[allow(dead_code, unused_variables)]
 impl SetNamesAuxBitcase8 {
+    #[allow(dead_code)]
     fn serialize(&self, n_types: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, n_types);
@@ -10063,8 +10063,8 @@ impl SetNamesAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl SetNamesAux {
+    #[allow(dead_code)]
     fn serialize(&self, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups);

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -8455,6 +8455,7 @@ impl SetMapAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
+        assert_eq!(self.switch_expr(), u32::from(present), "switch `values` has an inconsistent discriminant");
         if let Some(ref types) = self.types {
             assert_eq!(types.len(), usize::try_from(n_types).unwrap(), "`types` has an incorrect length");
             types.serialize_into(bytes);
@@ -10070,6 +10071,7 @@ impl SetNamesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
+        assert_eq!(self.switch_expr(), which, "switch `values` has an inconsistent discriminant");
         if let Some(keycodes_name) = self.keycodes_name {
             keycodes_name.serialize_into(bytes);
         }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -5910,6 +5910,7 @@ impl CreateWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }
@@ -6497,6 +6498,7 @@ impl ChangeWindowAttributesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }
@@ -8103,6 +8105,7 @@ impl ConfigureWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u16) {
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(x) = self.x {
             x.serialize_into(bytes);
         }
@@ -16485,6 +16488,7 @@ impl CreateGCAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(function) = self.function {
             u32::from(function).serialize_into(bytes);
         }
@@ -17119,6 +17123,7 @@ impl ChangeGCAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(function) = self.function {
             u32::from(function).serialize_into(bytes);
         }
@@ -23531,6 +23536,7 @@ impl ChangeKeyboardControlAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(key_click_percent) = self.key_click_percent {
             key_click_percent.serialize_into(bytes);
         }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -5902,8 +5902,8 @@ impl CreateWindowAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl CreateWindowAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);
@@ -6490,8 +6490,8 @@ impl ChangeWindowAttributesAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl ChangeWindowAttributesAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);
@@ -8097,8 +8097,8 @@ impl ConfigureWindowAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl ConfigureWindowAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u16) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);
@@ -16480,8 +16480,8 @@ impl CreateGCAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl CreateGCAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);
@@ -17115,8 +17115,8 @@ impl ChangeGCAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl ChangeGCAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);
@@ -23528,8 +23528,8 @@ impl ChangeKeyboardControlAux {
         Ok((result, outer_remaining))
     }
 }
-#[allow(dead_code, unused_variables)]
 impl ChangeKeyboardControlAux {
+    #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
         self.serialize_into(&mut result, value_mask);


### PR DESCRIPTION
This started by me wanting to add some more assertions to the generated code. The changes to the code generator then allowed to get rid of some function arguments and made some `#[allow]`s in the generated code no longer necessary.

Oh and I stumbled upon #473 while trying to figure out how to change the code generator (but that's pretty much unrelated to this PR).