### PR TITLE
Disable clippy's unnested_or_patterns lint

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -9,6 +9,10 @@
 )]
 #![forbid(unsafe_code)]
 
+// Or patterns are not available in Rust 1.37.0. I am not quite sure when (and if) they went
+// stable.
+#![allow(clippy::unnested_or_patterns)]
+
 use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,6 @@
 // is Rust 1.37.0, just disable the lint.
 #![allow(clippy::option_as_ref_deref)]
 
-// Or patterns are not available in Rust 1.37.0. I am not quite sure when (and if) they went
-// stable.
-#![allow(clippy::unnested_or_patterns)]
-
 #![deny(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,11 @@
 // This lint suggests a function that was added in Rust 1.40.0. Since our minimum supported version
 // is Rust 1.37.0, just disable the lint.
 #![allow(clippy::option_as_ref_deref)]
+
+// Or patterns are not available in Rust 1.37.0. I am not quite sure when (and if) they went
+// stable.
+#![allow(clippy::unnested_or_patterns)]
+
 #![deny(
     missing_copy_implementations,
     missing_debug_implementations,


### PR DESCRIPTION
This is something that is not available in Rust 1.37.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

So far, this only makes the nightly CI build fail, but before this reaches stable and suddenly breaks the build, let's just deal with this already.