### PR TITLE
Fix BigRequests support

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -549,8 +549,10 @@ pub fn compute_length_field<'b>(
         return Err(ConnectionError::MaximumRequestLengthExceeded);
     }
 
-    // Okay, we need to use big requests.
+    // Okay, we need to use big requests (thus four extra bytes, "+1" below)
     let wire_length: u32 = wire_length
+        .checked_add(1)
+        .ok_or(ConnectionError::MaximumRequestLengthExceeded)?
         .try_into()
         .expect("X11 request larger than 2^34 bytes?!?");
     let wire_length = wire_length.to_ne_bytes();

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -205,7 +205,8 @@ fn test_big_requests() -> Result<(), ConnectionError> {
     let x: i16 = 21;
     let y: i16 = 7;
     let padding = 3; // big_buffer's size rounded up to a multiple of 4
-    let length: u32 = (16 + big_buffer.len() as u32 + padding) / 4;
+    let big_request_length_field = 4;
+    let length: u32 = (16 + big_request_length_field + big_buffer.len() as u32 + padding) / 4;
     conn.poly_text16(drawable, gc, x, y, &big_buffer)?;
 
     let mut expected = Vec::new();


### PR DESCRIPTION
The length field in requests has 16 bit. For larger requests, the big
requests extension was invented. This sets the 16 bit length field to
zero, which indicates that a new 32 bit length field comes immediately
next.

x11rb transparently uses the BigRequests extension were needed. However,
up to now, it did this incorrectly. Because of the extra 32 bit length
field, the request is now four bytes larger. Since the length field
counts the length of the request in four byte units, this means that we
need to increase the length field by one.

This commit does exactly that.

Fixes: https://github.com/psychon/x11rb/issues/480
Signed-off-by: Uli Schlachter <psychon@znc.in>