### PR TITLE
Pad all response parsing to 32 bytes and also round replies to 4 byte boundaries

### DIFF
--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -89,7 +89,8 @@ pub struct EnableReply {
     pub maximum_request_length: u32,
 }
 impl TryParse for EnableReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -99,6 +100,9 @@ impl TryParse for EnableReply {
             return Err(ParseError::ParseError);
         }
         let result = EnableReply { sequence, length, maximum_request_length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -182,7 +182,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -194,6 +195,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -686,7 +690,8 @@ pub struct GetOverlayWindowReply {
     pub overlay_win: xproto::Window,
 }
 impl TryParse for GetOverlayWindowReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -697,6 +702,9 @@ impl TryParse for GetOverlayWindowReply {
             return Err(ParseError::ParseError);
         }
         let result = GetOverlayWindowReply { sequence, length, overlay_win };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -114,7 +114,8 @@ pub struct BadDamageError {
     pub sequence: u16,
 }
 impl TryParse for BadDamageError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -122,6 +123,9 @@ impl TryParse for BadDamageError {
             return Err(ParseError::ParseError);
         }
         let result = BadDamageError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -255,7 +259,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -267,6 +272,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -578,7 +586,8 @@ pub struct NotifyEvent {
     pub geometry: xproto::Rectangle,
 }
 impl TryParse for NotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (level, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -589,6 +598,9 @@ impl TryParse for NotifyEvent {
         let (geometry, remaining) = xproto::Rectangle::try_parse(remaining)?;
         let level = level.try_into()?;
         let result = NotifyEvent { response_type, level, sequence, drawable, damage, timestamp, area, geometry };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -106,7 +106,8 @@ pub struct GetVersionReply {
     pub server_minor_version: u16,
 }
 impl TryParse for GetVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -117,6 +118,9 @@ impl TryParse for GetVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = GetVersionReply { sequence, length, server_major_version, server_minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -182,7 +186,8 @@ pub struct CapableReply {
     pub capable: bool,
 }
 impl TryParse for CapableReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -193,6 +198,9 @@ impl TryParse for CapableReply {
             return Err(ParseError::ParseError);
         }
         let result = CapableReply { sequence, length, capable };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -260,7 +268,8 @@ pub struct GetTimeoutsReply {
     pub off_timeout: u16,
 }
 impl TryParse for GetTimeoutsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -273,6 +282,9 @@ impl TryParse for GetTimeoutsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTimeoutsReply { sequence, length, standby_timeout, suspend_timeout, off_timeout };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -636,7 +648,8 @@ pub struct InfoReply {
     pub state: bool,
 }
 impl TryParse for InfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -649,6 +662,9 @@ impl TryParse for InfoReply {
         }
         let power_level = power_level.try_into()?;
         let result = InfoReply { sequence, length, power_level, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -446,7 +446,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -457,6 +458,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -545,7 +549,8 @@ pub struct ConnectReply {
     pub device_name: Vec<u8>,
 }
 impl TryParse for ConnectReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -563,6 +568,9 @@ impl TryParse for ConnectReply {
             return Err(ParseError::ParseError);
         }
         let result = ConnectReply { sequence, length, driver_name, alignment_pad, device_name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -676,7 +684,8 @@ pub struct AuthenticateReply {
     pub authenticated: u32,
 }
 impl TryParse for AuthenticateReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -686,6 +695,9 @@ impl TryParse for AuthenticateReply {
             return Err(ParseError::ParseError);
         }
         let result = AuthenticateReply { sequence, length, authenticated };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -914,7 +926,8 @@ pub struct GetBuffersReply {
     pub buffers: Vec<DRI2Buffer>,
 }
 impl TryParse for GetBuffersReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -928,6 +941,9 @@ impl TryParse for GetBuffersReply {
             return Err(ParseError::ParseError);
         }
         let result = GetBuffersReply { sequence, length, width, height, buffers };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1045,7 +1061,8 @@ pub struct CopyRegionReply {
     pub length: u32,
 }
 impl TryParse for CopyRegionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1054,6 +1071,9 @@ impl TryParse for CopyRegionReply {
             return Err(ParseError::ParseError);
         }
         let result = CopyRegionReply { sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1164,7 +1184,8 @@ pub struct GetBuffersWithFormatReply {
     pub buffers: Vec<DRI2Buffer>,
 }
 impl TryParse for GetBuffersWithFormatReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1178,6 +1199,9 @@ impl TryParse for GetBuffersWithFormatReply {
             return Err(ParseError::ParseError);
         }
         let result = GetBuffersWithFormatReply { sequence, length, width, height, buffers };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1324,7 +1348,8 @@ pub struct SwapBuffersReply {
     pub swap_lo: u32,
 }
 impl TryParse for SwapBuffersReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1335,6 +1360,9 @@ impl TryParse for SwapBuffersReply {
             return Err(ParseError::ParseError);
         }
         let result = SwapBuffersReply { sequence, length, swap_hi, swap_lo };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1416,7 +1444,8 @@ pub struct GetMSCReply {
     pub sbc_lo: u32,
 }
 impl TryParse for GetMSCReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1431,6 +1460,9 @@ impl TryParse for GetMSCReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMSCReply { sequence, length, ust_hi, ust_lo, msc_hi, msc_lo, sbc_hi, sbc_lo };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1566,7 +1598,8 @@ pub struct WaitMSCReply {
     pub sbc_lo: u32,
 }
 impl TryParse for WaitMSCReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1581,6 +1614,9 @@ impl TryParse for WaitMSCReply {
             return Err(ParseError::ParseError);
         }
         let result = WaitMSCReply { sequence, length, ust_hi, ust_lo, msc_hi, msc_lo, sbc_hi, sbc_lo };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1680,7 +1716,8 @@ pub struct WaitSBCReply {
     pub sbc_lo: u32,
 }
 impl TryParse for WaitSBCReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1695,6 +1732,9 @@ impl TryParse for WaitSBCReply {
             return Err(ParseError::ParseError);
         }
         let result = WaitSBCReply { sequence, length, ust_hi, ust_lo, msc_hi, msc_lo, sbc_hi, sbc_lo };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1850,7 +1890,8 @@ pub struct GetParamReply {
     pub value_lo: u32,
 }
 impl TryParse for GetParamReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (is_param_recognized, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1861,6 +1902,9 @@ impl TryParse for GetParamReply {
             return Err(ParseError::ParseError);
         }
         let result = GetParamReply { is_param_recognized, sequence, length, value_hi, value_lo };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1886,7 +1930,8 @@ pub struct BufferSwapCompleteEvent {
     pub sbc: u32,
 }
 impl TryParse for BufferSwapCompleteEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1900,6 +1945,9 @@ impl TryParse for BufferSwapCompleteEvent {
         let (sbc, remaining) = u32::try_parse(remaining)?;
         let event_type = event_type.try_into()?;
         let result = BufferSwapCompleteEvent { response_type, sequence, event_type, drawable, ust_hi, ust_lo, msc_hi, msc_lo, sbc };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1971,12 +2019,16 @@ pub struct InvalidateBuffersEvent {
     pub drawable: xproto::Drawable,
 }
 impl TryParse for InvalidateBuffersEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
         let result = InvalidateBuffersEvent { response_type, sequence, drawable };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -111,7 +111,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -122,6 +123,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -208,7 +212,8 @@ pub struct OpenReply {
     pub device_fd: RawFdContainer,
 }
 impl TryParseFd for OpenReply {
-    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+    fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (nfd, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -220,6 +225,9 @@ impl TryParseFd for OpenReply {
             return Err(ParseError::ParseError);
         }
         let result = OpenReply { nfd, sequence, length, device_fd };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -421,7 +429,8 @@ pub struct BufferFromPixmapReply {
     pub pixmap_fd: RawFdContainer,
 }
 impl TryParseFd for BufferFromPixmapReply {
-    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+    fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (nfd, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -439,6 +448,9 @@ impl TryParseFd for BufferFromPixmapReply {
             return Err(ParseError::ParseError);
         }
         let result = BufferFromPixmapReply { nfd, sequence, length, size, width, height, stride, depth, bpp, pixmap_fd };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -611,7 +623,8 @@ pub struct FDFromFenceReply {
     pub fence_fd: RawFdContainer,
 }
 impl TryParseFd for FDFromFenceReply {
-    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+    fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (nfd, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -623,6 +636,9 @@ impl TryParseFd for FDFromFenceReply {
             return Err(ParseError::ParseError);
         }
         let result = FDFromFenceReply { nfd, sequence, length, fence_fd };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -716,7 +732,8 @@ pub struct GetSupportedModifiersReply {
     pub screen_modifiers: Vec<u64>,
 }
 impl TryParse for GetSupportedModifiersReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -730,6 +747,9 @@ impl TryParse for GetSupportedModifiersReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSupportedModifiersReply { sequence, length, window_modifiers, screen_modifiers };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1038,7 +1058,8 @@ pub struct BuffersFromPixmapReply {
     pub buffers: Vec<RawFdContainer>,
 }
 impl TryParseFd for BuffersFromPixmapReply {
-    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+    fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (nfd, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1060,6 +1081,9 @@ impl TryParseFd for BuffersFromPixmapReply {
             return Err(ParseError::ParseError);
         }
         let result = BuffersFromPixmapReply { sequence, length, width, height, modifier, depth, bpp, strides, offsets, buffers };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -106,7 +106,8 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -118,6 +119,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -64,7 +64,8 @@ pub struct GenericError {
     pub major_opcode: u8,
 }
 impl TryParse for GenericError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -76,6 +77,9 @@ impl TryParse for GenericError {
             return Err(ParseError::ParseError);
         }
         let result = GenericError { error_code, sequence, bad_value, minor_opcode, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -209,7 +213,8 @@ pub struct PbufferClobberEvent {
     pub count: u16,
 }
 impl TryParse for PbufferClobberEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -225,6 +230,9 @@ impl TryParse for PbufferClobberEvent {
         let (count, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = PbufferClobberEvent { response_type, sequence, event_type, draw_type, drawable, b_mask, aux_buffer, x, y, width, height, count };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -305,7 +313,8 @@ pub struct BufferSwapCompleteEvent {
     pub sbc: u32,
 }
 impl TryParse for BufferSwapCompleteEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -318,6 +327,9 @@ impl TryParse for BufferSwapCompleteEvent {
         let (msc_lo, remaining) = u32::try_parse(remaining)?;
         let (sbc, remaining) = u32::try_parse(remaining)?;
         let result = BufferSwapCompleteEvent { response_type, sequence, event_type, drawable, ust_hi, ust_lo, msc_hi, msc_lo, sbc };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -880,7 +892,8 @@ pub struct MakeCurrentReply {
     pub context_tag: ContextTag,
 }
 impl TryParse for MakeCurrentReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -891,6 +904,9 @@ impl TryParse for MakeCurrentReply {
             return Err(ParseError::ParseError);
         }
         let result = MakeCurrentReply { sequence, length, context_tag };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -967,7 +983,8 @@ pub struct IsDirectReply {
     pub is_direct: bool,
 }
 impl TryParse for IsDirectReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -978,6 +995,9 @@ impl TryParse for IsDirectReply {
             return Err(ParseError::ParseError);
         }
         let result = IsDirectReply { sequence, length, is_direct };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1064,7 +1084,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1076,6 +1097,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1694,7 +1718,8 @@ pub struct GetVisualConfigsReply {
     pub property_list: Vec<u32>,
 }
 impl TryParse for GetVisualConfigsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1707,6 +1732,9 @@ impl TryParse for GetVisualConfigsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetVisualConfigsReply { sequence, num_visuals, num_properties, property_list };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1965,7 +1993,8 @@ pub struct VendorPrivateWithReplyReply {
     pub data2: Vec<u8>,
 }
 impl TryParse for VendorPrivateWithReplyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1979,6 +2008,9 @@ impl TryParse for VendorPrivateWithReplyReply {
             return Err(ParseError::ParseError);
         }
         let result = VendorPrivateWithReplyReply { sequence, retval, data1, data2 };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2071,7 +2103,8 @@ pub struct QueryExtensionsStringReply {
     pub n: u32,
 }
 impl TryParse for QueryExtensionsStringReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2083,6 +2116,9 @@ impl TryParse for QueryExtensionsStringReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryExtensionsStringReply { sequence, length, n };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2168,7 +2204,8 @@ pub struct QueryServerStringReply {
     pub string: Vec<u8>,
 }
 impl TryParse for QueryServerStringReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2182,6 +2219,9 @@ impl TryParse for QueryServerStringReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryServerStringReply { sequence, length, string };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2364,7 +2404,8 @@ pub struct GetFBConfigsReply {
     pub property_list: Vec<u32>,
 }
 impl TryParse for GetFBConfigsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2377,6 +2418,9 @@ impl TryParse for GetFBConfigsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetFBConfigsReply { sequence, num_fb_configs, num_properties, property_list };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2744,7 +2788,8 @@ pub struct QueryContextReply {
     pub attribs: Vec<u32>,
 }
 impl TryParse for QueryContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2756,6 +2801,9 @@ impl TryParse for QueryContextReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryContextReply { sequence, length, attribs };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2875,7 +2923,8 @@ pub struct MakeContextCurrentReply {
     pub context_tag: ContextTag,
 }
 impl TryParse for MakeContextCurrentReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2886,6 +2935,9 @@ impl TryParse for MakeContextCurrentReply {
             return Err(ParseError::ParseError);
         }
         let result = MakeContextCurrentReply { sequence, length, context_tag };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3123,7 +3175,8 @@ pub struct GetDrawableAttributesReply {
     pub attribs: Vec<u32>,
 }
 impl TryParse for GetDrawableAttributesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3135,6 +3188,9 @@ impl TryParse for GetDrawableAttributesReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDrawableAttributesReply { sequence, length, attribs };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4061,7 +4117,8 @@ pub struct GenListsReply {
     pub ret_val: u32,
 }
 impl TryParse for GenListsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4071,6 +4128,9 @@ impl TryParse for GenListsReply {
             return Err(ParseError::ParseError);
         }
         let result = GenListsReply { sequence, length, ret_val };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4303,7 +4363,8 @@ pub struct RenderModeReply {
     pub data: Vec<u32>,
 }
 impl TryParse for RenderModeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4317,6 +4378,9 @@ impl TryParse for RenderModeReply {
             return Err(ParseError::ParseError);
         }
         let result = RenderModeReply { sequence, length, ret_val, new_mode, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4457,7 +4521,8 @@ pub struct FinishReply {
     pub length: u32,
 }
 impl TryParse for FinishReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4466,6 +4531,9 @@ impl TryParse for FinishReply {
             return Err(ParseError::ParseError);
         }
         let result = FinishReply { sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4763,7 +4831,8 @@ pub struct ReadPixelsReply {
     pub data: Vec<u8>,
 }
 impl TryParse for ReadPixelsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4775,6 +4844,9 @@ impl TryParse for ReadPixelsReply {
             return Err(ParseError::ParseError);
         }
         let result = ReadPixelsReply { sequence, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4877,7 +4949,8 @@ pub struct GetBooleanvReply {
     pub data: Vec<bool>,
 }
 impl TryParse for GetBooleanvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4891,6 +4964,9 @@ impl TryParse for GetBooleanvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetBooleanvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4990,7 +5066,8 @@ pub struct GetClipPlaneReply {
     pub data: Vec<Float64>,
 }
 impl TryParse for GetClipPlaneReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5001,6 +5078,9 @@ impl TryParse for GetClipPlaneReply {
             return Err(ParseError::ParseError);
         }
         let result = GetClipPlaneReply { sequence, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5103,7 +5183,8 @@ pub struct GetDoublevReply {
     pub data: Vec<Float64>,
 }
 impl TryParse for GetDoublevReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5117,6 +5198,9 @@ impl TryParse for GetDoublevReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDoublevReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5208,7 +5292,8 @@ pub struct GetErrorReply {
     pub error: i32,
 }
 impl TryParse for GetErrorReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5218,6 +5303,9 @@ impl TryParse for GetErrorReply {
             return Err(ParseError::ParseError);
         }
         let result = GetErrorReply { sequence, length, error };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5304,7 +5392,8 @@ pub struct GetFloatvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetFloatvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5318,6 +5407,9 @@ impl TryParse for GetFloatvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetFloatvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5419,7 +5511,8 @@ pub struct GetIntegervReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetIntegervReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5433,6 +5526,9 @@ impl TryParse for GetIntegervReply {
             return Err(ParseError::ParseError);
         }
         let result = GetIntegervReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5543,7 +5639,8 @@ pub struct GetLightfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetLightfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5557,6 +5654,9 @@ impl TryParse for GetLightfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetLightfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5667,7 +5767,8 @@ pub struct GetLightivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetLightivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5681,6 +5782,9 @@ impl TryParse for GetLightivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetLightivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5791,7 +5895,8 @@ pub struct GetMapdvReply {
     pub data: Vec<Float64>,
 }
 impl TryParse for GetMapdvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5805,6 +5910,9 @@ impl TryParse for GetMapdvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMapdvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5915,7 +6023,8 @@ pub struct GetMapfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetMapfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5929,6 +6038,9 @@ impl TryParse for GetMapfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMapfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6039,7 +6151,8 @@ pub struct GetMapivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetMapivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6053,6 +6166,9 @@ impl TryParse for GetMapivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMapivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6163,7 +6279,8 @@ pub struct GetMaterialfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetMaterialfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6177,6 +6294,9 @@ impl TryParse for GetMaterialfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMaterialfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6287,7 +6407,8 @@ pub struct GetMaterialivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetMaterialivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6301,6 +6422,9 @@ impl TryParse for GetMaterialivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMaterialivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6402,7 +6526,8 @@ pub struct GetPixelMapfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetPixelMapfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6416,6 +6541,9 @@ impl TryParse for GetPixelMapfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPixelMapfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6517,7 +6645,8 @@ pub struct GetPixelMapuivReply {
     pub data: Vec<u32>,
 }
 impl TryParse for GetPixelMapuivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6531,6 +6660,9 @@ impl TryParse for GetPixelMapuivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPixelMapuivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6632,7 +6764,8 @@ pub struct GetPixelMapusvReply {
     pub data: Vec<u16>,
 }
 impl TryParse for GetPixelMapusvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6646,6 +6779,9 @@ impl TryParse for GetPixelMapusvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPixelMapusvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6745,7 +6881,8 @@ pub struct GetPolygonStippleReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetPolygonStippleReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6757,6 +6894,9 @@ impl TryParse for GetPolygonStippleReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPolygonStippleReply { sequence, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6858,7 +6998,8 @@ pub struct GetStringReply {
     pub string: Vec<u8>,
 }
 impl TryParse for GetStringReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6872,6 +7013,9 @@ impl TryParse for GetStringReply {
             return Err(ParseError::ParseError);
         }
         let result = GetStringReply { sequence, length, string };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6982,7 +7126,8 @@ pub struct GetTexEnvfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetTexEnvfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6996,6 +7141,9 @@ impl TryParse for GetTexEnvfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexEnvfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7106,7 +7254,8 @@ pub struct GetTexEnvivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetTexEnvivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7120,6 +7269,9 @@ impl TryParse for GetTexEnvivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexEnvivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7230,7 +7382,8 @@ pub struct GetTexGendvReply {
     pub data: Vec<Float64>,
 }
 impl TryParse for GetTexGendvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7244,6 +7397,9 @@ impl TryParse for GetTexGendvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexGendvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7354,7 +7510,8 @@ pub struct GetTexGenfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetTexGenfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7368,6 +7525,9 @@ impl TryParse for GetTexGenfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexGenfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7478,7 +7638,8 @@ pub struct GetTexGenivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetTexGenivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7492,6 +7653,9 @@ impl TryParse for GetTexGenivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexGenivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7630,7 +7794,8 @@ pub struct GetTexImageReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetTexImageReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7646,6 +7811,9 @@ impl TryParse for GetTexImageReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexImageReply { sequence, width, height, depth, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7757,7 +7925,8 @@ pub struct GetTexParameterfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetTexParameterfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7771,6 +7940,9 @@ impl TryParse for GetTexParameterfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexParameterfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7881,7 +8053,8 @@ pub struct GetTexParameterivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetTexParameterivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7895,6 +8068,9 @@ impl TryParse for GetTexParameterivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexParameterivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8014,7 +8190,8 @@ pub struct GetTexLevelParameterfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetTexLevelParameterfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8028,6 +8205,9 @@ impl TryParse for GetTexLevelParameterfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexLevelParameterfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8147,7 +8327,8 @@ pub struct GetTexLevelParameterivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetTexLevelParameterivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8161,6 +8342,9 @@ impl TryParse for GetTexLevelParameterivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetTexLevelParameterivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8261,7 +8445,8 @@ pub struct IsEnabledReply {
     pub ret_val: Bool32,
 }
 impl TryParse for IsEnabledReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8271,6 +8456,9 @@ impl TryParse for IsEnabledReply {
             return Err(ParseError::ParseError);
         }
         let result = IsEnabledReply { sequence, length, ret_val };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8356,7 +8544,8 @@ pub struct IsListReply {
     pub ret_val: Bool32,
 }
 impl TryParse for IsListReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8366,6 +8555,9 @@ impl TryParse for IsListReply {
             return Err(ParseError::ParseError);
         }
         let result = IsListReply { sequence, length, ret_val };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8523,7 +8715,8 @@ pub struct AreTexturesResidentReply {
     pub data: Vec<bool>,
 }
 impl TryParse for AreTexturesResidentReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8535,6 +8728,9 @@ impl TryParse for AreTexturesResidentReply {
             return Err(ParseError::ParseError);
         }
         let result = AreTexturesResidentReply { sequence, ret_val, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8716,7 +8912,8 @@ pub struct GenTexturesReply {
     pub data: Vec<u32>,
 }
 impl TryParse for GenTexturesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8727,6 +8924,9 @@ impl TryParse for GenTexturesReply {
             return Err(ParseError::ParseError);
         }
         let result = GenTexturesReply { sequence, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8827,7 +9027,8 @@ pub struct IsTextureReply {
     pub ret_val: Bool32,
 }
 impl TryParse for IsTextureReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8837,6 +9038,9 @@ impl TryParse for IsTextureReply {
             return Err(ParseError::ParseError);
         }
         let result = IsTextureReply { sequence, length, ret_val };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8949,7 +9153,8 @@ pub struct GetColorTableReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetColorTableReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8963,6 +9168,9 @@ impl TryParse for GetColorTableReply {
             return Err(ParseError::ParseError);
         }
         let result = GetColorTableReply { sequence, width, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9074,7 +9282,8 @@ pub struct GetColorTableParameterfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetColorTableParameterfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9088,6 +9297,9 @@ impl TryParse for GetColorTableParameterfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetColorTableParameterfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9198,7 +9410,8 @@ pub struct GetColorTableParameterivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetColorTableParameterivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9212,6 +9425,9 @@ impl TryParse for GetColorTableParameterivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetColorTableParameterivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9340,7 +9556,8 @@ pub struct GetConvolutionFilterReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetConvolutionFilterReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9355,6 +9572,9 @@ impl TryParse for GetConvolutionFilterReply {
             return Err(ParseError::ParseError);
         }
         let result = GetConvolutionFilterReply { sequence, width, height, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9466,7 +9686,8 @@ pub struct GetConvolutionParameterfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetConvolutionParameterfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9480,6 +9701,9 @@ impl TryParse for GetConvolutionParameterfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetConvolutionParameterfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9590,7 +9814,8 @@ pub struct GetConvolutionParameterivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetConvolutionParameterivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9604,6 +9829,9 @@ impl TryParse for GetConvolutionParameterivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetConvolutionParameterivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9732,7 +9960,8 @@ pub struct GetSeparableFilterReply {
     pub rows_and_cols: Vec<u8>,
 }
 impl TryParse for GetSeparableFilterReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9747,6 +9976,9 @@ impl TryParse for GetSeparableFilterReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSeparableFilterReply { sequence, row_w, col_h, rows_and_cols };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9880,7 +10112,8 @@ pub struct GetHistogramReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetHistogramReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9894,6 +10127,9 @@ impl TryParse for GetHistogramReply {
             return Err(ParseError::ParseError);
         }
         let result = GetHistogramReply { sequence, width, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10005,7 +10241,8 @@ pub struct GetHistogramParameterfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetHistogramParameterfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10019,6 +10256,9 @@ impl TryParse for GetHistogramParameterfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetHistogramParameterfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10129,7 +10369,8 @@ pub struct GetHistogramParameterivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetHistogramParameterivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10143,6 +10384,9 @@ impl TryParse for GetHistogramParameterivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetHistogramParameterivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10274,7 +10518,8 @@ pub struct GetMinmaxReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetMinmaxReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10286,6 +10531,9 @@ impl TryParse for GetMinmaxReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMinmaxReply { sequence, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10397,7 +10645,8 @@ pub struct GetMinmaxParameterfvReply {
     pub data: Vec<Float32>,
 }
 impl TryParse for GetMinmaxParameterfvReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10411,6 +10660,9 @@ impl TryParse for GetMinmaxParameterfvReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMinmaxParameterfvReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10521,7 +10773,8 @@ pub struct GetMinmaxParameterivReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetMinmaxParameterivReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10535,6 +10788,9 @@ impl TryParse for GetMinmaxParameterivReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMinmaxParameterivReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10644,7 +10900,8 @@ pub struct GetCompressedTexImageARBReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetCompressedTexImageARBReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10658,6 +10915,9 @@ impl TryParse for GetCompressedTexImageARBReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCompressedTexImageARBReply { sequence, size, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10839,7 +11099,8 @@ pub struct GenQueriesARBReply {
     pub data: Vec<u32>,
 }
 impl TryParse for GenQueriesARBReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10850,6 +11111,9 @@ impl TryParse for GenQueriesARBReply {
             return Err(ParseError::ParseError);
         }
         let result = GenQueriesARBReply { sequence, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10950,7 +11214,8 @@ pub struct IsQueryARBReply {
     pub ret_val: Bool32,
 }
 impl TryParse for IsQueryARBReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10960,6 +11225,9 @@ impl TryParse for IsQueryARBReply {
             return Err(ParseError::ParseError);
         }
         let result = IsQueryARBReply { sequence, length, ret_val };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -11055,7 +11323,8 @@ pub struct GetQueryivARBReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetQueryivARBReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -11069,6 +11338,9 @@ impl TryParse for GetQueryivARBReply {
             return Err(ParseError::ParseError);
         }
         let result = GetQueryivARBReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -11179,7 +11451,8 @@ pub struct GetQueryObjectivARBReply {
     pub data: Vec<i32>,
 }
 impl TryParse for GetQueryObjectivARBReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -11193,6 +11466,9 @@ impl TryParse for GetQueryObjectivARBReply {
             return Err(ParseError::ParseError);
         }
         let result = GetQueryObjectivARBReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -11303,7 +11579,8 @@ pub struct GetQueryObjectuivARBReply {
     pub data: Vec<u32>,
 }
 impl TryParse for GetQueryObjectuivARBReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -11317,6 +11594,9 @@ impl TryParse for GetQueryObjectuivARBReply {
             return Err(ParseError::ParseError);
         }
         let result = GetQueryObjectuivARBReply { sequence, length, datum, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -577,7 +577,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -588,6 +589,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1081,7 +1085,8 @@ pub struct QueryCapabilitiesReply {
     pub capabilities: u32,
 }
 impl TryParse for QueryCapabilitiesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1091,6 +1096,9 @@ impl TryParse for QueryCapabilitiesReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryCapabilitiesReply { sequence, length, capabilities };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1113,7 +1121,8 @@ pub struct GenericEvent {
     pub event: Event,
 }
 impl TryParse for GenericEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1122,6 +1131,9 @@ impl TryParse for GenericEvent {
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let (event, remaining) = Event::try_parse(remaining)?;
         let result = GenericEvent { response_type, extension, sequence, length, evtype, event };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1204,7 +1216,8 @@ pub struct ConfigureNotifyEvent {
     pub pixmap_flags: u32,
 }
 impl TryParse for ConfigureNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1223,6 +1236,9 @@ impl TryParse for ConfigureNotifyEvent {
         let (pixmap_height, remaining) = u16::try_parse(remaining)?;
         let (pixmap_flags, remaining) = u32::try_parse(remaining)?;
         let result = ConfigureNotifyEvent { response_type, extension, sequence, length, event_type, event, window, x, y, width, height, off_x, off_y, pixmap_width, pixmap_height, pixmap_flags };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1251,7 +1267,8 @@ pub struct CompleteNotifyEvent {
     pub msc: u64,
 }
 impl TryParse for CompleteNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1267,6 +1284,9 @@ impl TryParse for CompleteNotifyEvent {
         let kind = kind.try_into()?;
         let mode = mode.try_into()?;
         let result = CompleteNotifyEvent { response_type, extension, sequence, length, event_type, kind, mode, event, window, serial, ust, msc };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1293,7 +1313,8 @@ pub struct IdleNotifyEvent {
     pub idle_fence: sync::Fence,
 }
 impl TryParse for IdleNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1306,6 +1327,9 @@ impl TryParse for IdleNotifyEvent {
         let (pixmap, remaining) = xproto::Pixmap::try_parse(remaining)?;
         let (idle_fence, remaining) = sync::Fence::try_parse(remaining)?;
         let result = IdleNotifyEvent { response_type, extension, sequence, length, event_type, event, window, serial, pixmap, idle_fence };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1347,7 +1371,8 @@ pub struct RedirectNotifyEvent {
     pub notifies: Vec<Notify>,
 }
 impl TryParse for RedirectNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1383,6 +1408,9 @@ impl TryParse for RedirectNotifyEvent {
             notifies.push(v);
         }
         let result = RedirectNotifyEvent { response_type, extension, sequence, length, event_type, update_window, event, event_window, window, pixmap, serial, valid_region, update_region, valid_rect, update_rect, x_off, y_off, target_crtc, wait_fence, idle_fence, options, target_msc, divisor, remainder, notifies };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -54,7 +54,8 @@ pub struct BadOutputError {
     pub sequence: u16,
 }
 impl TryParse for BadOutputError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -62,6 +63,9 @@ impl TryParse for BadOutputError {
             return Err(ParseError::ParseError);
         }
         let result = BadOutputError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -127,7 +131,8 @@ pub struct BadCrtcError {
     pub sequence: u16,
 }
 impl TryParse for BadCrtcError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -135,6 +140,9 @@ impl TryParse for BadCrtcError {
             return Err(ParseError::ParseError);
         }
         let result = BadCrtcError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -200,7 +208,8 @@ pub struct BadModeError {
     pub sequence: u16,
 }
 impl TryParse for BadModeError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -208,6 +217,9 @@ impl TryParse for BadModeError {
             return Err(ParseError::ParseError);
         }
         let result = BadModeError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -273,7 +285,8 @@ pub struct BadProviderError {
     pub sequence: u16,
 }
 impl TryParse for BadProviderError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -281,6 +294,9 @@ impl TryParse for BadProviderError {
             return Err(ParseError::ParseError);
         }
         let result = BadProviderError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -586,7 +602,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -598,6 +615,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -790,7 +810,8 @@ pub struct SetScreenConfigReply {
     pub subpixel_order: render::SubPixel,
 }
 impl TryParse for SetScreenConfigReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -806,6 +827,9 @@ impl TryParse for SetScreenConfigReply {
         let status = status.try_into()?;
         let subpixel_order = subpixel_order.try_into()?;
         let result = SetScreenConfigReply { status, sequence, length, new_timestamp, config_timestamp, root, subpixel_order };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1043,7 +1067,8 @@ pub struct GetScreenInfoReply {
     pub rates: Vec<RefreshRates>,
 }
 impl TryParse for GetScreenInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (rotations, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1063,6 +1088,9 @@ impl TryParse for GetScreenInfoReply {
             return Err(ParseError::ParseError);
         }
         let result = GetScreenInfoReply { rotations, sequence, length, root, timestamp, config_timestamp, size_id, rotation, rate, n_info, sizes, rates };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1157,7 +1185,8 @@ pub struct GetScreenSizeRangeReply {
     pub max_height: u16,
 }
 impl TryParse for GetScreenSizeRangeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1171,6 +1200,9 @@ impl TryParse for GetScreenSizeRangeReply {
             return Err(ParseError::ParseError);
         }
         let result = GetScreenSizeRangeReply { sequence, length, min_width, min_height, max_width, max_height };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1536,7 +1568,8 @@ pub struct GetScreenResourcesReply {
     pub names: Vec<u8>,
 }
 impl TryParse for GetScreenResourcesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1557,6 +1590,9 @@ impl TryParse for GetScreenResourcesReply {
             return Err(ParseError::ParseError);
         }
         let result = GetScreenResourcesReply { sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1772,7 +1808,8 @@ pub struct GetOutputInfoReply {
     pub name: Vec<u8>,
 }
 impl TryParse for GetOutputInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1800,6 +1837,9 @@ impl TryParse for GetOutputInfoReply {
         let connection = connection.try_into()?;
         let subpixel_order = subpixel_order.try_into()?;
         let result = GetOutputInfoReply { status, sequence, length, timestamp, crtc, mm_width, mm_height, connection, subpixel_order, num_preferred, crtcs, modes, clones, name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1930,7 +1970,8 @@ pub struct ListOutputPropertiesReply {
     pub atoms: Vec<xproto::Atom>,
 }
 impl TryParse for ListOutputPropertiesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1942,6 +1983,9 @@ impl TryParse for ListOutputPropertiesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListOutputPropertiesReply { sequence, length, atoms };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2044,7 +2088,8 @@ pub struct QueryOutputPropertyReply {
     pub valid_values: Vec<i32>,
 }
 impl TryParse for QueryOutputPropertyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2058,6 +2103,9 @@ impl TryParse for QueryOutputPropertyReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryOutputPropertyReply { sequence, pending, range, immutable, valid_values };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2504,7 +2552,8 @@ pub struct GetOutputPropertyReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetOutputPropertyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2519,6 +2568,9 @@ impl TryParse for GetOutputPropertyReply {
             return Err(ParseError::ParseError);
         }
         let result = GetOutputPropertyReply { format, sequence, length, type_, bytes_after, num_items, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2647,7 +2699,8 @@ pub struct CreateModeReply {
     pub mode: Mode,
 }
 impl TryParse for CreateModeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2658,6 +2711,9 @@ impl TryParse for CreateModeReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateModeReply { sequence, length, mode };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2948,7 +3004,8 @@ pub struct GetCrtcInfoReply {
     pub possible: Vec<Output>,
 }
 impl TryParse for GetCrtcInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2970,6 +3027,9 @@ impl TryParse for GetCrtcInfoReply {
         }
         let status = status.try_into()?;
         let result = GetCrtcInfoReply { status, sequence, length, timestamp, x, y, width, height, mode, rotation, rotations, outputs, possible };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3156,7 +3216,8 @@ pub struct SetCrtcConfigReply {
     pub timestamp: xproto::Timestamp,
 }
 impl TryParse for SetCrtcConfigReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3168,6 +3229,9 @@ impl TryParse for SetCrtcConfigReply {
         }
         let status = status.try_into()?;
         let result = SetCrtcConfigReply { status, sequence, length, timestamp };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3244,7 +3308,8 @@ pub struct GetCrtcGammaSizeReply {
     pub size: u16,
 }
 impl TryParse for GetCrtcGammaSizeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3255,6 +3320,9 @@ impl TryParse for GetCrtcGammaSizeReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCrtcGammaSizeReply { sequence, length, size };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3333,7 +3401,8 @@ pub struct GetCrtcGammaReply {
     pub blue: Vec<u16>,
 }
 impl TryParse for GetCrtcGammaReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3347,6 +3416,9 @@ impl TryParse for GetCrtcGammaReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCrtcGammaReply { sequence, length, red, green, blue };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3541,7 +3613,8 @@ pub struct GetScreenResourcesCurrentReply {
     pub names: Vec<u8>,
 }
 impl TryParse for GetScreenResourcesCurrentReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3562,6 +3635,9 @@ impl TryParse for GetScreenResourcesCurrentReply {
             return Err(ParseError::ParseError);
         }
         let result = GetScreenResourcesCurrentReply { sequence, length, timestamp, config_timestamp, crtcs, outputs, modes, names };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3910,7 +3986,8 @@ pub struct GetCrtcTransformReply {
     pub current_params: Vec<render::Fixed>,
 }
 impl TryParse for GetCrtcTransformReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let value = remaining;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
@@ -3943,6 +4020,9 @@ impl TryParse for GetCrtcTransformReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCrtcTransformReply { sequence, length, pending_transform, has_transforms, current_transform, pending_filter_name, pending_params, current_filter_name, current_params };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4086,7 +4166,8 @@ pub struct GetPanningReply {
     pub border_bottom: i16,
 }
 impl TryParse for GetPanningReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4109,6 +4190,9 @@ impl TryParse for GetPanningReply {
         }
         let status = status.try_into()?;
         let result = GetPanningReply { status, sequence, length, timestamp, left, top, width, height, track_left, track_top, track_width, track_height, border_left, border_top, border_right, border_bottom };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4279,7 +4363,8 @@ pub struct SetPanningReply {
     pub timestamp: xproto::Timestamp,
 }
 impl TryParse for SetPanningReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4290,6 +4375,9 @@ impl TryParse for SetPanningReply {
         }
         let status = status.try_into()?;
         let result = SetPanningReply { status, sequence, length, timestamp };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4434,7 +4522,8 @@ pub struct GetOutputPrimaryReply {
     pub output: Output,
 }
 impl TryParse for GetOutputPrimaryReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4444,6 +4533,9 @@ impl TryParse for GetOutputPrimaryReply {
             return Err(ParseError::ParseError);
         }
         let result = GetOutputPrimaryReply { sequence, length, output };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4521,7 +4613,8 @@ pub struct GetProvidersReply {
     pub providers: Vec<Provider>,
 }
 impl TryParse for GetProvidersReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4534,6 +4627,9 @@ impl TryParse for GetProvidersReply {
             return Err(ParseError::ParseError);
         }
         let result = GetProvidersReply { sequence, length, timestamp, providers };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4710,7 +4806,8 @@ pub struct GetProviderInfoReply {
     pub name: Vec<u8>,
 }
 impl TryParse for GetProviderInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4732,6 +4829,9 @@ impl TryParse for GetProviderInfoReply {
             return Err(ParseError::ParseError);
         }
         let result = GetProviderInfoReply { status, sequence, length, timestamp, capabilities, crtcs, outputs, associated_providers, associated_capability, name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5016,7 +5116,8 @@ pub struct ListProviderPropertiesReply {
     pub atoms: Vec<xproto::Atom>,
 }
 impl TryParse for ListProviderPropertiesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5028,6 +5129,9 @@ impl TryParse for ListProviderPropertiesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListProviderPropertiesReply { sequence, length, atoms };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5130,7 +5234,8 @@ pub struct QueryProviderPropertyReply {
     pub valid_values: Vec<i32>,
 }
 impl TryParse for QueryProviderPropertyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5144,6 +5249,9 @@ impl TryParse for QueryProviderPropertyReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryProviderPropertyReply { sequence, pending, range, immutable, valid_values };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5587,7 +5695,8 @@ pub struct GetProviderPropertyReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetProviderPropertyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5602,6 +5711,9 @@ impl TryParse for GetProviderPropertyReply {
             return Err(ParseError::ParseError);
         }
         let result = GetProviderPropertyReply { format, sequence, length, type_, bytes_after, num_items, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5631,7 +5743,8 @@ pub struct ScreenChangeNotifyEvent {
     pub mheight: u16,
 }
 impl TryParse for ScreenChangeNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (rotation, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5647,6 +5760,9 @@ impl TryParse for ScreenChangeNotifyEvent {
         let (mheight, remaining) = u16::try_parse(remaining)?;
         let subpixel_order = subpixel_order.try_into()?;
         let result = ScreenChangeNotifyEvent { response_type, rotation, sequence, timestamp, config_timestamp, root, request_window, size_id, subpixel_order, width, height, mwidth, mheight };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6411,7 +6527,8 @@ pub struct GetMonitorsReply {
     pub monitors: Vec<MonitorInfo>,
 }
 impl TryParse for GetMonitorsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6425,6 +6542,9 @@ impl TryParse for GetMonitorsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMonitorsReply { sequence, length, timestamp, n_outputs, monitors };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6694,7 +6814,8 @@ pub struct CreateLeaseReply {
     pub master_fd: RawFdContainer,
 }
 impl TryParseFd for CreateLeaseReply {
-    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+    fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (nfd, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6706,6 +6827,9 @@ impl TryParseFd for CreateLeaseReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateLeaseReply { nfd, sequence, length, master_fd };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6989,13 +7113,17 @@ pub struct NotifyEvent {
     pub u: NotifyData,
 }
 impl TryParse for NotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (sub_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (u, remaining) = NotifyData::try_parse(remaining)?;
         let sub_code = sub_code.try_into()?;
         let result = NotifyEvent { response_type, sub_code, sequence, u };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -431,7 +431,8 @@ pub struct BadContextError {
     pub invalid_record: u32,
 }
 impl TryParse for BadContextError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -440,6 +441,9 @@ impl TryParse for BadContextError {
             return Err(ParseError::ParseError);
         }
         let result = BadContextError { error_code, sequence, invalid_record };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -570,7 +574,8 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -581,6 +586,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -952,7 +960,8 @@ pub struct GetContextReply {
     pub intercepted_clients: Vec<ClientInfo>,
 }
 impl TryParse for GetContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (enabled, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -966,6 +975,9 @@ impl TryParse for GetContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetContextReply { enabled, sequence, length, element_header, intercepted_clients };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1062,7 +1074,8 @@ pub struct EnableContextReply {
     pub data: Vec<u8>,
 }
 impl TryParse for EnableContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (category, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1080,6 +1093,9 @@ impl TryParse for EnableContextReply {
             return Err(ParseError::ParseError);
         }
         let result = EnableContextReply { category, sequence, element_header, client_swapped, xid_base, server_time, rec_sequence_num, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -759,7 +759,8 @@ pub struct PictFormatError {
     pub sequence: u16,
 }
 impl TryParse for PictFormatError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -767,6 +768,9 @@ impl TryParse for PictFormatError {
             return Err(ParseError::ParseError);
         }
         let result = PictFormatError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -832,7 +836,8 @@ pub struct PictureError {
     pub sequence: u16,
 }
 impl TryParse for PictureError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -840,6 +845,9 @@ impl TryParse for PictureError {
             return Err(ParseError::ParseError);
         }
         let result = PictureError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -905,7 +913,8 @@ pub struct PictOpError {
     pub sequence: u16,
 }
 impl TryParse for PictOpError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -913,6 +922,9 @@ impl TryParse for PictOpError {
             return Err(ParseError::ParseError);
         }
         let result = PictOpError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -978,7 +990,8 @@ pub struct GlyphSetError {
     pub sequence: u16,
 }
 impl TryParse for GlyphSetError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -986,6 +999,9 @@ impl TryParse for GlyphSetError {
             return Err(ParseError::ParseError);
         }
         let result = GlyphSetError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1051,7 +1067,8 @@ pub struct GlyphError {
     pub sequence: u16,
 }
 impl TryParse for GlyphError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1059,6 +1076,9 @@ impl TryParse for GlyphError {
             return Err(ParseError::ParseError);
         }
         let result = GlyphError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1897,7 +1917,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1909,6 +1930,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1978,7 +2002,8 @@ pub struct QueryPictFormatsReply {
     pub subpixels: Vec<SubPixel>,
 }
 impl TryParse for QueryPictFormatsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2004,6 +2029,9 @@ impl TryParse for QueryPictFormatsReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryPictFormatsReply { sequence, length, num_depths, num_visuals, formats, screens, subpixels };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2121,7 +2149,8 @@ pub struct QueryPictIndexValuesReply {
     pub values: Vec<Indexvalue>,
 }
 impl TryParse for QueryPictIndexValuesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2133,6 +2162,9 @@ impl TryParse for QueryPictIndexValuesReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryPictIndexValuesReply { sequence, length, values };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4976,7 +5008,8 @@ pub struct QueryFiltersReply {
     pub filters: Vec<xproto::Str>,
 }
 impl TryParse for QueryFiltersReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4990,6 +5023,9 @@ impl TryParse for QueryFiltersReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryFiltersReply { sequence, length, aliases, filters };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -503,7 +503,8 @@ pub struct QueryVersionReply {
     pub server_minor: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -514,6 +515,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, server_major, server_minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -579,7 +583,8 @@ pub struct QueryClientsReply {
     pub clients: Vec<Client>,
 }
 impl TryParse for QueryClientsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -591,6 +596,9 @@ impl TryParse for QueryClientsReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryClientsReply { sequence, length, clients };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -682,7 +690,8 @@ pub struct QueryClientResourcesReply {
     pub types: Vec<Type>,
 }
 impl TryParse for QueryClientResourcesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -694,6 +703,9 @@ impl TryParse for QueryClientResourcesReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryClientResourcesReply { sequence, length, types };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -786,7 +798,8 @@ pub struct QueryClientPixmapBytesReply {
     pub bytes_overflow: u32,
 }
 impl TryParse for QueryClientPixmapBytesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -797,6 +810,9 @@ impl TryParse for QueryClientPixmapBytesReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryClientPixmapBytesReply { sequence, length, bytes, bytes_overflow };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -885,7 +901,8 @@ pub struct QueryClientIdsReply {
     pub ids: Vec<ClientIdValue>,
 }
 impl TryParse for QueryClientIdsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -897,6 +914,9 @@ impl TryParse for QueryClientIdsReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryClientIdsReply { sequence, length, ids };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1010,7 +1030,8 @@ pub struct QueryResourceBytesReply {
     pub sizes: Vec<ResourceSizeValue>,
 }
 impl TryParse for QueryResourceBytesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1022,6 +1043,9 @@ impl TryParse for QueryResourceBytesReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryResourceBytesReply { sequence, length, sizes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -304,7 +304,8 @@ pub struct QueryVersionReply {
     pub server_minor_version: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -316,6 +317,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, server_major_version, server_minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -397,7 +401,8 @@ pub struct QueryInfoReply {
     pub kind: Kind,
 }
 impl TryParse for QueryInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -413,6 +418,9 @@ impl TryParse for QueryInfoReply {
         }
         let kind = kind.try_into()?;
         let result = QueryInfoReply { state, sequence, length, saver_window, ms_until_server, ms_since_user_input, event_mask, kind };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1110,7 +1118,8 @@ pub struct NotifyEvent {
     pub forced: bool,
 }
 impl TryParse for NotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1123,6 +1132,9 @@ impl TryParse for NotifyEvent {
         let state = state.try_into()?;
         let kind = kind.try_into()?;
         let result = NotifyEvent { response_type, state, sequence, time, root, window, kind, forced };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -191,7 +191,8 @@ pub struct NotifyEvent {
     pub shaped: bool,
 }
 impl TryParse for NotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (shape_kind, remaining) = Kind::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -205,6 +206,9 @@ impl TryParse for NotifyEvent {
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let shape_kind = shape_kind.try_into()?;
         let result = NotifyEvent { response_type, shape_kind, sequence, affected_window, extents_x, extents_y, extents_width, extents_height, server_time, shaped };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -324,7 +328,8 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -335,6 +340,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -833,7 +841,8 @@ pub struct QueryExtentsReply {
     pub clip_shape_extents_height: u16,
 }
 impl TryParse for QueryExtentsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -853,6 +862,9 @@ impl TryParse for QueryExtentsReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryExtentsReply { sequence, length, bounding_shaped, clip_shaped, bounding_shape_extents_x, bounding_shape_extents_y, bounding_shape_extents_width, bounding_shape_extents_height, clip_shape_extents_x, clip_shape_extents_y, clip_shape_extents_width, clip_shape_extents_height };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -998,7 +1010,8 @@ pub struct InputSelectedReply {
     pub length: u32,
 }
 impl TryParse for InputSelectedReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (enabled, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1007,6 +1020,9 @@ impl TryParse for InputSelectedReply {
             return Err(ParseError::ParseError);
         }
         let result = InputSelectedReply { enabled, sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1095,7 +1111,8 @@ pub struct GetRectanglesReply {
     pub rectangles: Vec<xproto::Rectangle>,
 }
 impl TryParse for GetRectanglesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (ordering, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1108,6 +1125,9 @@ impl TryParse for GetRectanglesReply {
         }
         let ordering = ordering.try_into()?;
         let result = GetRectanglesReply { ordering, sequence, length, rectangles };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -50,7 +50,8 @@ pub struct CompletionEvent {
     pub offset: u32,
 }
 impl TryParse for CompletionEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -61,6 +62,9 @@ impl TryParse for CompletionEvent {
         let (shmseg, remaining) = Seg::try_parse(remaining)?;
         let (offset, remaining) = u32::try_parse(remaining)?;
         let result = CompletionEvent { response_type, sequence, drawable, minor_event, major_event, shmseg, offset };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -186,7 +190,8 @@ pub struct QueryVersionReply {
     pub pixmap_format: u8,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (shared_pixmaps, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -201,6 +206,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { shared_pixmaps, sequence, length, major_version, minor_version, uid, gid, pixmap_format };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -643,7 +651,8 @@ pub struct GetImageReply {
     pub size: u32,
 }
 impl TryParse for GetImageReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -654,6 +663,9 @@ impl TryParse for GetImageReply {
             return Err(ParseError::ParseError);
         }
         let result = GetImageReply { depth, sequence, length, visual, size };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -936,7 +948,8 @@ pub struct CreateSegmentReply {
     pub shm_fd: RawFdContainer,
 }
 impl TryParseFd for CreateSegmentReply {
-    fn try_parse_fd<'a>(remaining: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+    fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (nfd, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -948,6 +961,9 @@ impl TryParseFd for CreateSegmentReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateSegmentReply { nfd, sequence, length, shm_fd };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -559,7 +559,8 @@ pub struct CounterError {
     pub major_opcode: u8,
 }
 impl TryParse for CounterError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -570,6 +571,9 @@ impl TryParse for CounterError {
             return Err(ParseError::ParseError);
         }
         let result = CounterError { error_code, sequence, bad_counter, minor_opcode, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -641,7 +645,8 @@ pub struct AlarmError {
     pub major_opcode: u8,
 }
 impl TryParse for AlarmError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -652,6 +657,9 @@ impl TryParse for AlarmError {
             return Err(ParseError::ParseError);
         }
         let result = AlarmError { error_code, sequence, bad_alarm, minor_opcode, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -784,7 +792,8 @@ pub struct InitializeReply {
     pub minor_version: u8,
 }
 impl TryParse for InitializeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -796,6 +805,9 @@ impl TryParse for InitializeReply {
             return Err(ParseError::ParseError);
         }
         let result = InitializeReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -861,7 +873,8 @@ pub struct ListSystemCountersReply {
     pub counters: Vec<Systemcounter>,
 }
 impl TryParse for ListSystemCountersReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -873,6 +886,9 @@ impl TryParse for ListSystemCountersReply {
             return Err(ParseError::ParseError);
         }
         let result = ListSystemCountersReply { sequence, length, counters };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1095,7 +1111,8 @@ pub struct QueryCounterReply {
     pub counter_value: Int64,
 }
 impl TryParse for QueryCounterReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1105,6 +1122,9 @@ impl TryParse for QueryCounterReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryCounterReply { sequence, length, counter_value };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1936,7 +1956,8 @@ pub struct QueryAlarmReply {
     pub state: ALARMSTATE,
 }
 impl TryParse for QueryAlarmReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1951,6 +1972,9 @@ impl TryParse for QueryAlarmReply {
         }
         let state = state.try_into()?;
         let result = QueryAlarmReply { sequence, length, trigger, delta, events, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2095,7 +2119,8 @@ pub struct GetPriorityReply {
     pub priority: i32,
 }
 impl TryParse for GetPriorityReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2105,6 +2130,9 @@ impl TryParse for GetPriorityReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPriorityReply { sequence, length, priority };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2435,7 +2463,8 @@ pub struct QueryFenceReply {
     pub triggered: bool,
 }
 impl TryParse for QueryFenceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2446,6 +2475,9 @@ impl TryParse for QueryFenceReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryFenceReply { sequence, length, triggered };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2542,7 +2574,8 @@ pub struct CounterNotifyEvent {
     pub destroyed: bool,
 }
 impl TryParse for CounterNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2554,6 +2587,9 @@ impl TryParse for CounterNotifyEvent {
         let (destroyed, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = CounterNotifyEvent { response_type, kind, sequence, counter, wait_value, counter_value, timestamp, count, destroyed };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2630,7 +2666,8 @@ pub struct AlarmNotifyEvent {
     pub state: ALARMSTATE,
 }
 impl TryParse for AlarmNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (kind, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2642,6 +2679,9 @@ impl TryParse for AlarmNotifyEvent {
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
         let result = AlarmNotifyEvent { response_type, kind, sequence, alarm, counter_value, alarm_value, timestamp, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -106,7 +106,8 @@ pub struct GetVersionReply {
     pub server_minor_version: u16,
 }
 impl TryParse for GetVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -117,6 +118,9 @@ impl TryParse for GetVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = GetVersionReply { sequence, length, server_major_version, server_minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -183,7 +187,8 @@ pub struct GetXIDRangeReply {
     pub count: u32,
 }
 impl TryParse for GetXIDRangeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -194,6 +199,9 @@ impl TryParse for GetXIDRangeReply {
             return Err(ParseError::ParseError);
         }
         let result = GetXIDRangeReply { sequence, length, start_id, count };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -270,7 +278,8 @@ pub struct GetXIDListReply {
     pub ids: Vec<u32>,
 }
 impl TryParse for GetXIDListReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -282,6 +291,9 @@ impl TryParse for GetXIDListReply {
             return Err(ParseError::ParseError);
         }
         let result = GetXIDListReply { sequence, length, ids };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -106,7 +106,8 @@ pub struct QueryVersionReply {
     pub server_minor_version: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -118,6 +119,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, server_major_version, server_minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -193,7 +197,8 @@ pub struct StartReply {
     pub length: u32,
 }
 impl TryParse for StartReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -203,6 +208,9 @@ impl TryParse for StartReply {
             return Err(ParseError::ParseError);
         }
         let result = StartReply { sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -278,7 +286,8 @@ pub struct EndReply {
     pub length: u32,
 }
 impl TryParse for EndReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -288,6 +297,9 @@ impl TryParse for EndReply {
             return Err(ParseError::ParseError);
         }
         let result = EndReply { sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -595,7 +607,8 @@ pub struct SendReply {
     pub length: u32,
 }
 impl TryParse for SendReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -605,6 +618,9 @@ impl TryParse for SendReply {
             return Err(ParseError::ParseError);
         }
         let result = SendReply { sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -680,7 +696,8 @@ pub struct SelectInputReply {
     pub length: u32,
 }
 impl TryParse for SelectInputReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -690,6 +707,9 @@ impl TryParse for SelectInputReply {
             return Err(ParseError::ParseError);
         }
         let result = SelectInputReply { sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -141,7 +141,8 @@ pub struct QueryVersionReply {
     pub dri_minor_patch: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -153,6 +154,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, dri_major_version, dri_minor_version, dri_minor_patch };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -229,7 +233,8 @@ pub struct QueryDirectRenderingCapableReply {
     pub is_capable: bool,
 }
 impl TryParse for QueryDirectRenderingCapableReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -239,6 +244,9 @@ impl TryParse for QueryDirectRenderingCapableReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryDirectRenderingCapableReply { sequence, length, is_capable };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -317,7 +325,8 @@ pub struct OpenConnectionReply {
     pub bus_id: Vec<u8>,
 }
 impl TryParse for OpenConnectionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -332,6 +341,9 @@ impl TryParse for OpenConnectionReply {
             return Err(ParseError::ParseError);
         }
         let result = OpenConnectionReply { sequence, length, sarea_handle_low, sarea_handle_high, bus_id };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -485,7 +497,8 @@ pub struct GetClientDriverNameReply {
     pub client_driver_name: Vec<u8>,
 }
 impl TryParse for GetClientDriverNameReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -501,6 +514,9 @@ impl TryParse for GetClientDriverNameReply {
             return Err(ParseError::ParseError);
         }
         let result = GetClientDriverNameReply { sequence, length, client_driver_major_version, client_driver_minor_version, client_driver_patch_version, client_driver_name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -610,7 +626,8 @@ pub struct CreateContextReply {
     pub hw_context: u32,
 }
 impl TryParse for CreateContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -620,6 +637,9 @@ impl TryParse for CreateContextReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateContextReply { sequence, length, hw_context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -773,7 +793,8 @@ pub struct CreateDrawableReply {
     pub hw_drawable_handle: u32,
 }
 impl TryParse for CreateDrawableReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -783,6 +804,9 @@ impl TryParse for CreateDrawableReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateDrawableReply { sequence, length, hw_drawable_handle };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -945,7 +969,8 @@ pub struct GetDrawableInfoReply {
     pub back_clip_rects: Vec<DrmClipRect>,
 }
 impl TryParse for GetDrawableInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -966,6 +991,9 @@ impl TryParse for GetDrawableInfoReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDrawableInfoReply { sequence, length, drawable_table_index, drawable_table_stamp, drawable_origin_x, drawable_origin_y, drawable_size_w, drawable_size_h, back_x, back_y, clip_rects, back_clip_rects };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1075,7 +1103,8 @@ pub struct GetDeviceInfoReply {
     pub device_private: Vec<u32>,
 }
 impl TryParse for GetDeviceInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1091,6 +1120,9 @@ impl TryParse for GetDeviceInfoReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceInfoReply { sequence, length, framebuffer_handle_low, framebuffer_handle_high, framebuffer_origin_offset, framebuffer_size, framebuffer_stride, device_private };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1191,7 +1223,8 @@ pub struct AuthConnectionReply {
     pub authenticated: u32,
 }
 impl TryParse for AuthConnectionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1201,6 +1234,9 @@ impl TryParse for AuthConnectionReply {
             return Err(ParseError::ParseError);
         }
         let result = AuthConnectionReply { sequence, length, authenticated };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -423,7 +423,8 @@ pub struct QueryVersionReply {
     pub minor_version: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -434,6 +435,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -522,7 +526,8 @@ pub struct GetModeLineReply {
     pub private: Vec<u8>,
 }
 impl TryParse for GetModeLineReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -547,6 +552,9 @@ impl TryParse for GetModeLineReply {
             return Err(ParseError::ParseError);
         }
         let result = GetModeLineReply { sequence, length, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -887,7 +895,8 @@ pub struct GetMonitorReply {
     pub model: Vec<u8>,
 }
 impl TryParse for GetMonitorReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -909,6 +918,9 @@ impl TryParse for GetMonitorReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMonitorReply { sequence, length, hsync, vsync, vendor, alignment_pad, model };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1104,7 +1116,8 @@ pub struct GetAllModeLinesReply {
     pub modeinfo: Vec<ModeInfo>,
 }
 impl TryParse for GetAllModeLinesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1116,6 +1129,9 @@ impl TryParse for GetAllModeLinesReply {
             return Err(ParseError::ParseError);
         }
         let result = GetAllModeLinesReply { sequence, length, modeinfo };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1828,7 +1844,8 @@ pub struct ValidateModeLineReply {
     pub status: u32,
 }
 impl TryParse for ValidateModeLineReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1839,6 +1856,9 @@ impl TryParse for ValidateModeLineReply {
             return Err(ParseError::ParseError);
         }
         let result = ValidateModeLineReply { sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2107,7 +2127,8 @@ pub struct GetViewPortReply {
     pub y: u32,
 }
 impl TryParse for GetViewPortReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2119,6 +2140,9 @@ impl TryParse for GetViewPortReply {
             return Err(ParseError::ParseError);
         }
         let result = GetViewPortReply { sequence, length, x, y };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2277,7 +2301,8 @@ pub struct GetDotClocksReply {
     pub clock: Vec<u32>,
 }
 impl TryParse for GetDotClocksReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2291,6 +2316,9 @@ impl TryParse for GetDotClocksReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDotClocksReply { sequence, length, flags, clocks, maxclocks, clock };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2558,7 +2586,8 @@ pub struct GetGammaReply {
     pub blue: u32,
 }
 impl TryParse for GetGammaReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2571,6 +2600,9 @@ impl TryParse for GetGammaReply {
             return Err(ParseError::ParseError);
         }
         let result = GetGammaReply { sequence, length, red, green, blue };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2655,7 +2687,8 @@ pub struct GetGammaRampReply {
     pub blue: Vec<u16>,
 }
 impl TryParse for GetGammaRampReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2669,6 +2702,9 @@ impl TryParse for GetGammaRampReply {
             return Err(ParseError::ParseError);
         }
         let result = GetGammaRampReply { sequence, length, size, red, green, blue };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2843,7 +2879,8 @@ pub struct GetGammaRampSizeReply {
     pub size: u16,
 }
 impl TryParse for GetGammaRampSizeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2854,6 +2891,9 @@ impl TryParse for GetGammaRampSizeReply {
             return Err(ParseError::ParseError);
         }
         let result = GetGammaRampSizeReply { sequence, length, size };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2931,7 +2971,8 @@ pub struct GetPermissionsReply {
     pub permissions: u32,
 }
 impl TryParse for GetPermissionsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2942,6 +2983,9 @@ impl TryParse for GetPermissionsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPermissionsReply { sequence, length, permissions };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2960,7 +3004,8 @@ pub struct BadClockError {
     pub sequence: u16,
 }
 impl TryParse for BadClockError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2968,6 +3013,9 @@ impl TryParse for BadClockError {
             return Err(ParseError::ParseError);
         }
         let result = BadClockError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3033,7 +3081,8 @@ pub struct BadHTimingsError {
     pub sequence: u16,
 }
 impl TryParse for BadHTimingsError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3041,6 +3090,9 @@ impl TryParse for BadHTimingsError {
             return Err(ParseError::ParseError);
         }
         let result = BadHTimingsError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3106,7 +3158,8 @@ pub struct BadVTimingsError {
     pub sequence: u16,
 }
 impl TryParse for BadVTimingsError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3114,6 +3167,9 @@ impl TryParse for BadVTimingsError {
             return Err(ParseError::ParseError);
         }
         let result = BadVTimingsError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3179,7 +3235,8 @@ pub struct ModeUnsuitableError {
     pub sequence: u16,
 }
 impl TryParse for ModeUnsuitableError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3187,6 +3244,9 @@ impl TryParse for ModeUnsuitableError {
             return Err(ParseError::ParseError);
         }
         let result = ModeUnsuitableError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3252,7 +3312,8 @@ pub struct ExtensionDisabledError {
     pub sequence: u16,
 }
 impl TryParse for ExtensionDisabledError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3260,6 +3321,9 @@ impl TryParse for ExtensionDisabledError {
             return Err(ParseError::ParseError);
         }
         let result = ExtensionDisabledError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3325,7 +3389,8 @@ pub struct ClientNotLocalError {
     pub sequence: u16,
 }
 impl TryParse for ClientNotLocalError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3333,6 +3398,9 @@ impl TryParse for ClientNotLocalError {
             return Err(ParseError::ParseError);
         }
         let result = ClientNotLocalError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3398,7 +3466,8 @@ pub struct ZoomLockedError {
     pub sequence: u16,
 }
 impl TryParse for ZoomLockedError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3406,6 +3475,9 @@ impl TryParse for ZoomLockedError {
             return Err(ParseError::ParseError);
         }
         let result = ZoomLockedError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -113,7 +113,8 @@ pub struct QueryVersionReply {
     pub minor_version: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -125,6 +126,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -572,7 +576,8 @@ pub struct SelectionNotifyEvent {
     pub selection_timestamp: xproto::Timestamp,
 }
 impl TryParse for SelectionNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (subtype, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -584,6 +589,9 @@ impl TryParse for SelectionNotifyEvent {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let subtype = subtype.try_into()?;
         let result = SelectionNotifyEvent { response_type, subtype, sequence, window, owner, selection, timestamp, selection_timestamp };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -856,7 +864,8 @@ pub struct CursorNotifyEvent {
     pub name: xproto::Atom,
 }
 impl TryParse for CursorNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (subtype, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -867,6 +876,9 @@ impl TryParse for CursorNotifyEvent {
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let subtype = subtype.try_into()?;
         let result = CursorNotifyEvent { response_type, subtype, sequence, window, cursor_serial, timestamp, name };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1059,7 +1071,8 @@ pub struct GetCursorImageReply {
     pub cursor_image: Vec<u32>,
 }
 impl TryParse for GetCursorImageReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1077,6 +1090,9 @@ impl TryParse for GetCursorImageReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCursorImageReply { sequence, length, x, y, width, height, xhot, yhot, cursor_serial, cursor_image };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1097,7 +1113,8 @@ pub struct BadRegionError {
     pub sequence: u16,
 }
 impl TryParse for BadRegionError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1105,6 +1122,9 @@ impl TryParse for BadRegionError {
             return Err(ParseError::ParseError);
         }
         let result = BadRegionError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2312,7 +2332,8 @@ pub struct FetchRegionReply {
     pub rectangles: Vec<xproto::Rectangle>,
 }
 impl TryParse for FetchRegionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2324,6 +2345,9 @@ impl TryParse for FetchRegionReply {
             return Err(ParseError::ParseError);
         }
         let result = FetchRegionReply { sequence, extents, rectangles };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2761,7 +2785,8 @@ pub struct GetCursorNameReply {
     pub name: Vec<u8>,
 }
 impl TryParse for GetCursorNameReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2775,6 +2800,9 @@ impl TryParse for GetCursorNameReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCursorNameReply { sequence, length, atom, name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2864,7 +2892,8 @@ pub struct GetCursorImageAndNameReply {
     pub name: Vec<u8>,
 }
 impl TryParse for GetCursorImageAndNameReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2886,6 +2915,9 @@ impl TryParse for GetCursorImageAndNameReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCursorImageAndNameReply { sequence, length, x, y, width, height, xhot, yhot, cursor_serial, cursor_atom, cursor_image, name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -157,7 +157,8 @@ pub struct QueryVersionReply {
     pub minor: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -168,6 +169,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major, minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -245,7 +249,8 @@ pub struct GetStateReply {
     pub window: xproto::Window,
 }
 impl TryParse for GetStateReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -255,6 +260,9 @@ impl TryParse for GetStateReply {
             return Err(ParseError::ParseError);
         }
         let result = GetStateReply { state, sequence, length, window };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -332,7 +340,8 @@ pub struct GetScreenCountReply {
     pub window: xproto::Window,
 }
 impl TryParse for GetScreenCountReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (screen_count, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -342,6 +351,9 @@ impl TryParse for GetScreenCountReply {
             return Err(ParseError::ParseError);
         }
         let result = GetScreenCountReply { screen_count, sequence, length, window };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -430,7 +442,8 @@ pub struct GetScreenSizeReply {
     pub screen: u32,
 }
 impl TryParse for GetScreenSizeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -443,6 +456,9 @@ impl TryParse for GetScreenSizeReply {
             return Err(ParseError::ParseError);
         }
         let result = GetScreenSizeReply { sequence, length, width, height, window, screen };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -508,7 +524,8 @@ pub struct IsActiveReply {
     pub state: u32,
 }
 impl TryParse for IsActiveReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -518,6 +535,9 @@ impl TryParse for IsActiveReply {
             return Err(ParseError::ParseError);
         }
         let result = IsActiveReply { sequence, length, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -583,7 +603,8 @@ pub struct QueryScreensReply {
     pub screen_info: Vec<ScreenInfo>,
 }
 impl TryParse for QueryScreensReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -595,6 +616,9 @@ impl TryParse for QueryScreensReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryScreensReply { sequence, length, screen_info };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -167,7 +167,8 @@ pub struct GetExtensionVersionReply {
     pub present: bool,
 }
 impl TryParse for GetExtensionVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -180,6 +181,9 @@ impl TryParse for GetExtensionVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = GetExtensionVersionReply { xi_reply_type, sequence, length, server_major, server_minor, present };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1027,7 +1031,8 @@ pub struct ListInputDevicesReply {
     pub names: Vec<xproto::Str>,
 }
 impl TryParse for ListInputDevicesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let value = remaining;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
@@ -1046,6 +1051,9 @@ impl TryParse for ListInputDevicesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListInputDevicesReply { xi_reply_type, sequence, length, devices, infos, names };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1178,7 +1186,8 @@ pub struct OpenDeviceReply {
     pub class_info: Vec<InputClassInfo>,
 }
 impl TryParse for OpenDeviceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let value = remaining;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
@@ -1195,6 +1204,9 @@ impl TryParse for OpenDeviceReply {
             return Err(ParseError::ParseError);
         }
         let result = OpenDeviceReply { xi_reply_type, sequence, length, class_info };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1354,7 +1366,8 @@ pub struct SetDeviceModeReply {
     pub status: xproto::GrabStatus,
 }
 impl TryParse for SetDeviceModeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1366,6 +1379,9 @@ impl TryParse for SetDeviceModeReply {
         }
         let status = status.try_into()?;
         let result = SetDeviceModeReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1526,7 +1542,8 @@ pub struct GetSelectedExtensionEventsReply {
     pub all_classes: Vec<EventClass>,
 }
 impl TryParse for GetSelectedExtensionEventsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1540,6 +1557,9 @@ impl TryParse for GetSelectedExtensionEventsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSelectedExtensionEventsReply { xi_reply_type, sequence, length, this_classes, all_classes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1804,7 +1824,8 @@ pub struct GetDeviceDontPropagateListReply {
     pub classes: Vec<EventClass>,
 }
 impl TryParse for GetDeviceDontPropagateListReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1816,6 +1837,9 @@ impl TryParse for GetDeviceDontPropagateListReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceDontPropagateListReply { xi_reply_type, sequence, length, classes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1959,7 +1983,8 @@ pub struct GetDeviceMotionEventsReply {
     pub events: Vec<DeviceTimeCoord>,
 }
 impl TryParse for GetDeviceMotionEventsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1981,6 +2006,9 @@ impl TryParse for GetDeviceMotionEventsReply {
         }
         let device_mode = device_mode.try_into()?;
         let result = GetDeviceMotionEventsReply { xi_reply_type, sequence, length, num_axes, device_mode, events };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2074,7 +2102,8 @@ pub struct ChangeKeyboardDeviceReply {
     pub status: xproto::GrabStatus,
 }
 impl TryParse for ChangeKeyboardDeviceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2086,6 +2115,9 @@ impl TryParse for ChangeKeyboardDeviceReply {
         }
         let status = status.try_into()?;
         let result = ChangeKeyboardDeviceReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2174,7 +2206,8 @@ pub struct ChangePointerDeviceReply {
     pub status: xproto::GrabStatus,
 }
 impl TryParse for ChangePointerDeviceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2186,6 +2219,9 @@ impl TryParse for ChangePointerDeviceReply {
         }
         let status = status.try_into()?;
         let result = ChangePointerDeviceReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2328,7 +2364,8 @@ pub struct GrabDeviceReply {
     pub status: xproto::GrabStatus,
 }
 impl TryParse for GrabDeviceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2340,6 +2377,9 @@ impl TryParse for GrabDeviceReply {
         }
         let status = status.try_into()?;
         let result = GrabDeviceReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3168,7 +3208,8 @@ pub struct GetDeviceFocusReply {
     pub revert_to: xproto::InputFocus,
 }
 impl TryParse for GetDeviceFocusReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3182,6 +3223,9 @@ impl TryParse for GetDeviceFocusReply {
         }
         let revert_to = revert_to.try_into()?;
         let result = GetDeviceFocusReply { xi_reply_type, sequence, length, focus, time, revert_to };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4370,7 +4414,8 @@ pub struct GetFeedbackControlReply {
     pub feedbacks: Vec<FeedbackState>,
 }
 impl TryParse for GetFeedbackControlReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4382,6 +4427,9 @@ impl TryParse for GetFeedbackControlReply {
             return Err(ParseError::ParseError);
         }
         let result = GetFeedbackControlReply { xi_reply_type, sequence, length, feedbacks };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5477,7 +5525,8 @@ pub struct GetDeviceKeyMappingReply {
     pub keysyms: Vec<xproto::Keysym>,
 }
 impl TryParse for GetDeviceKeyMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5489,6 +5538,9 @@ impl TryParse for GetDeviceKeyMappingReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceKeyMappingReply { xi_reply_type, sequence, keysyms_per_keycode, keysyms };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5675,7 +5727,8 @@ pub struct GetDeviceModifierMappingReply {
     pub keymaps: Vec<u8>,
 }
 impl TryParse for GetDeviceModifierMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5688,6 +5741,9 @@ impl TryParse for GetDeviceModifierMappingReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceModifierMappingReply { xi_reply_type, sequence, length, keymaps };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5800,7 +5856,8 @@ pub struct SetDeviceModifierMappingReply {
     pub status: xproto::MappingStatus,
 }
 impl TryParse for SetDeviceModifierMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5812,6 +5869,9 @@ impl TryParse for SetDeviceModifierMappingReply {
         }
         let status = status.try_into()?;
         let result = SetDeviceModifierMappingReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5890,7 +5950,8 @@ pub struct GetDeviceButtonMappingReply {
     pub map: Vec<u8>,
 }
 impl TryParse for GetDeviceButtonMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let value = remaining;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
@@ -5908,6 +5969,9 @@ impl TryParse for GetDeviceButtonMappingReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceButtonMappingReply { xi_reply_type, sequence, length, map };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6018,7 +6082,8 @@ pub struct SetDeviceButtonMappingReply {
     pub status: xproto::MappingStatus,
 }
 impl TryParse for SetDeviceButtonMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6030,6 +6095,9 @@ impl TryParse for SetDeviceButtonMappingReply {
         }
         let status = status.try_into()?;
         let result = SetDeviceButtonMappingReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6696,7 +6764,8 @@ pub struct QueryDeviceStateReply {
     pub classes: Vec<InputState>,
 }
 impl TryParse for QueryDeviceStateReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6708,6 +6777,9 @@ impl TryParse for QueryDeviceStateReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryDeviceStateReply { xi_reply_type, sequence, length, classes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6899,7 +6971,8 @@ pub struct SetDeviceValuatorsReply {
     pub status: xproto::GrabStatus,
 }
 impl TryParse for SetDeviceValuatorsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6911,6 +6984,9 @@ impl TryParse for SetDeviceValuatorsReply {
         }
         let status = status.try_into()?;
         let result = SetDeviceValuatorsReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7830,7 +7906,8 @@ pub struct GetDeviceControlReply {
     pub control: DeviceState,
 }
 impl TryParse for GetDeviceControlReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7842,6 +7919,9 @@ impl TryParse for GetDeviceControlReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceControlReply { xi_reply_type, sequence, length, status, control };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8684,7 +8764,8 @@ pub struct ChangeDeviceControlReply {
     pub status: u8,
 }
 impl TryParse for ChangeDeviceControlReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8695,6 +8776,9 @@ impl TryParse for ChangeDeviceControlReply {
             return Err(ParseError::ParseError);
         }
         let result = ChangeDeviceControlReply { xi_reply_type, sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8773,7 +8857,8 @@ pub struct ListDevicePropertiesReply {
     pub atoms: Vec<xproto::Atom>,
 }
 impl TryParse for ListDevicePropertiesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8785,6 +8870,9 @@ impl TryParse for ListDevicePropertiesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListDevicePropertiesReply { xi_reply_type, sequence, length, atoms };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9348,7 +9436,8 @@ pub struct GetDevicePropertyReply {
     pub items: GetDevicePropertyItems,
 }
 impl TryParse for GetDevicePropertyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xi_reply_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9364,6 +9453,9 @@ impl TryParse for GetDevicePropertyReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDevicePropertyReply { xi_reply_type, sequence, length, type_, bytes_after, num_items, device_id, items };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9635,7 +9727,8 @@ pub struct XIQueryPointerReply {
     pub buttons: Vec<u32>,
 }
 impl TryParse for XIQueryPointerReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9656,6 +9749,9 @@ impl TryParse for XIQueryPointerReply {
             return Err(ParseError::ParseError);
         }
         let result = XIQueryPointerReply { sequence, length, root, child, root_x, root_y, win_x, win_y, same_screen, mods, group, buttons };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10781,7 +10877,8 @@ pub struct XIGetClientPointerReply {
     pub deviceid: DeviceId,
 }
 impl TryParse for XIGetClientPointerReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10794,6 +10891,9 @@ impl TryParse for XIGetClientPointerReply {
             return Err(ParseError::ParseError);
         }
         let result = XIGetClientPointerReply { sequence, length, set, deviceid };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -11112,7 +11212,8 @@ pub struct XIQueryVersionReply {
     pub minor_version: u16,
 }
 impl TryParse for XIQueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -11124,6 +11225,9 @@ impl TryParse for XIQueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = XIQueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12431,7 +12535,8 @@ pub struct XIQueryDeviceReply {
     pub infos: Vec<XIDeviceInfo>,
 }
 impl TryParse for XIQueryDeviceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12443,6 +12548,9 @@ impl TryParse for XIQueryDeviceReply {
             return Err(ParseError::ParseError);
         }
         let result = XIQueryDeviceReply { sequence, length, infos };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12619,7 +12727,8 @@ pub struct XIGetFocusReply {
     pub focus: xproto::Window,
 }
 impl TryParse for XIGetFocusReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12630,6 +12739,9 @@ impl TryParse for XIGetFocusReply {
             return Err(ParseError::ParseError);
         }
         let result = XIGetFocusReply { sequence, length, focus };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12854,7 +12966,8 @@ pub struct XIGrabDeviceReply {
     pub status: xproto::GrabStatus,
 }
 impl TryParse for XIGrabDeviceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12866,6 +12979,9 @@ impl TryParse for XIGrabDeviceReply {
         }
         let status = status.try_into()?;
         let result = XIGrabDeviceReply { sequence, length, status };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13510,7 +13626,8 @@ pub struct XIPassiveGrabDeviceReply {
     pub modifiers: Vec<GrabModifierInfo>,
 }
 impl TryParse for XIPassiveGrabDeviceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13522,6 +13639,9 @@ impl TryParse for XIPassiveGrabDeviceReply {
             return Err(ParseError::ParseError);
         }
         let result = XIPassiveGrabDeviceReply { sequence, length, modifiers };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13727,7 +13847,8 @@ pub struct XIListPropertiesReply {
     pub properties: Vec<xproto::Atom>,
 }
 impl TryParse for XIListPropertiesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13739,6 +13860,9 @@ impl TryParse for XIListPropertiesReply {
             return Err(ParseError::ParseError);
         }
         let result = XIListPropertiesReply { sequence, length, properties };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14240,7 +14364,8 @@ pub struct XIGetPropertyReply {
     pub items: XIGetPropertyItems,
 }
 impl TryParse for XIGetPropertyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14255,6 +14380,9 @@ impl TryParse for XIGetPropertyReply {
             return Err(ParseError::ParseError);
         }
         let result = XIGetPropertyReply { sequence, length, type_, bytes_after, num_items, items };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14331,7 +14459,8 @@ pub struct XIGetSelectedEventsReply {
     pub masks: Vec<EventMask>,
 }
 impl TryParse for XIGetSelectedEventsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14343,6 +14472,9 @@ impl TryParse for XIGetSelectedEventsReply {
             return Err(ParseError::ParseError);
         }
         let result = XIGetSelectedEventsReply { sequence, length, masks };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14504,7 +14636,8 @@ pub struct DeviceValuatorEvent {
     pub valuators: [i32; 6],
 }
 impl TryParse for DeviceValuatorEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14526,6 +14659,9 @@ impl TryParse for DeviceValuatorEvent {
             valuators_5,
         ];
         let result = DeviceValuatorEvent { response_type, device_id, sequence, device_state, num_valuators, first_valuator, valuators };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14671,7 +14807,8 @@ pub struct DeviceKeyPressEvent {
     pub device_id: u8,
 }
 impl TryParse for DeviceKeyPressEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14687,6 +14824,9 @@ impl TryParse for DeviceKeyPressEvent {
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let result = DeviceKeyPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14783,7 +14923,8 @@ pub struct DeviceFocusInEvent {
     pub device_id: u8,
 }
 impl TryParse for DeviceFocusInEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14795,6 +14936,9 @@ impl TryParse for DeviceFocusInEvent {
         let detail = detail.try_into()?;
         let mode = mode.try_into()?;
         let result = DeviceFocusInEvent { response_type, detail, sequence, time, window, mode, device_id };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14956,7 +15100,8 @@ pub struct DeviceStateNotifyEvent {
     pub valuators: [u32; 3],
 }
 impl TryParse for DeviceStateNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14978,6 +15123,9 @@ impl TryParse for DeviceStateNotifyEvent {
             valuators_2,
         ];
         let result = DeviceStateNotifyEvent { response_type, device_id, sequence, time, num_keys, num_buttons, num_valuators, classes_reported, buttons, keys, valuators };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15055,7 +15203,8 @@ pub struct DeviceMappingNotifyEvent {
     pub time: xproto::Timestamp,
 }
 impl TryParse for DeviceMappingNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15067,6 +15216,9 @@ impl TryParse for DeviceMappingNotifyEvent {
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let request = request.try_into()?;
         let result = DeviceMappingNotifyEvent { response_type, device_id, sequence, request, first_keycode, count, time };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15208,7 +15360,8 @@ pub struct ChangeDeviceNotifyEvent {
     pub request: ChangeDevice,
 }
 impl TryParse for ChangeDeviceNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15217,6 +15370,9 @@ impl TryParse for ChangeDeviceNotifyEvent {
         let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
         let request = request.try_into()?;
         let result = ChangeDeviceNotifyEvent { response_type, device_id, sequence, time, request };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15285,13 +15441,17 @@ pub struct DeviceKeyStateNotifyEvent {
     pub keys: [u8; 28],
 }
 impl TryParse for DeviceKeyStateNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
         let keys = <[u8; 28]>::try_from(keys).unwrap();
         let result = DeviceKeyStateNotifyEvent { response_type, device_id, sequence, keys };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15358,13 +15518,17 @@ pub struct DeviceButtonStateNotifyEvent {
     pub buttons: [u8; 28],
 }
 impl TryParse for DeviceButtonStateNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
         let buttons = <[u8; 28]>::try_from(buttons).unwrap();
         let result = DeviceButtonStateNotifyEvent { response_type, device_id, sequence, buttons };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15507,7 +15671,8 @@ pub struct DevicePresenceNotifyEvent {
     pub control: u16,
 }
 impl TryParse for DevicePresenceNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15518,6 +15683,9 @@ impl TryParse for DevicePresenceNotifyEvent {
         let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
         let devchange = devchange.try_into()?;
         let result = DevicePresenceNotifyEvent { response_type, sequence, time, devchange, device_id, control };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15589,7 +15757,8 @@ pub struct DevicePropertyNotifyEvent {
     pub device_id: u8,
 }
 impl TryParse for DevicePropertyNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (state, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15599,6 +15768,9 @@ impl TryParse for DevicePropertyNotifyEvent {
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let state = state.try_into()?;
         let result = DevicePropertyNotifyEvent { response_type, state, sequence, time, property, device_id };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15736,7 +15908,8 @@ pub struct DeviceChangedEvent {
     pub classes: Vec<DeviceClass>,
 }
 impl TryParse for DeviceChangedEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15751,6 +15924,9 @@ impl TryParse for DeviceChangedEvent {
         let (classes, remaining) = crate::x11_utils::parse_list::<DeviceClass>(remaining, num_classes.try_into().or(Err(ParseError::ParseError))?)?;
         let reason = reason.try_into()?;
         let result = DeviceChangedEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, reason, classes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15832,7 +16008,8 @@ pub struct KeyPressEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl TryParse for KeyPressEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15859,6 +16036,9 @@ impl TryParse for KeyPressEvent {
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
         let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = KeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15957,7 +16137,8 @@ pub struct ButtonPressEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl TryParse for ButtonPressEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15984,6 +16165,9 @@ impl TryParse for ButtonPressEvent {
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
         let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = ButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16212,7 +16396,8 @@ pub struct EnterEvent {
     pub buttons: Vec<u32>,
 }
 impl TryParse for EnterEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16239,6 +16424,9 @@ impl TryParse for EnterEvent {
         let mode = mode.try_into()?;
         let detail = detail.try_into()?;
         let result = EnterEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, mode, detail, root, event, child, root_x, root_y, event_x, event_y, same_screen, focus, mods, group, buttons };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16433,7 +16621,8 @@ pub struct HierarchyEvent {
     pub infos: Vec<HierarchyInfo>,
 }
 impl TryParse for HierarchyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16446,6 +16635,9 @@ impl TryParse for HierarchyEvent {
         let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
         let (infos, remaining) = crate::x11_utils::parse_list::<HierarchyInfo>(remaining, num_infos.try_into().or(Err(ParseError::ParseError))?)?;
         let result = HierarchyEvent { response_type, extension, sequence, length, event_type, deviceid, time, flags, infos };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16551,7 +16743,8 @@ pub struct PropertyEvent {
     pub what: PropertyFlag,
 }
 impl TryParse for PropertyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16564,6 +16757,9 @@ impl TryParse for PropertyEvent {
         let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
         let what = what.try_into()?;
         let result = PropertyEvent { response_type, extension, sequence, length, event_type, deviceid, time, property, what };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16593,7 +16789,8 @@ pub struct RawKeyPressEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl TryParse for RawKeyPressEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16610,6 +16807,9 @@ impl TryParse for RawKeyPressEvent {
         let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = RawKeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16658,7 +16858,8 @@ pub struct RawButtonPressEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl TryParse for RawButtonPressEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16675,6 +16876,9 @@ impl TryParse for RawButtonPressEvent {
         let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = RawButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16767,7 +16971,8 @@ pub struct TouchBeginEvent {
     pub axisvalues: Vec<Fp3232>,
 }
 impl TryParse for TouchBeginEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16794,6 +16999,9 @@ impl TryParse for TouchBeginEvent {
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
         let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = TouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16918,7 +17126,8 @@ pub struct TouchOwnershipEvent {
     pub flags: TouchOwnershipFlags,
 }
 impl TryParse for TouchOwnershipEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16936,6 +17145,9 @@ impl TryParse for TouchOwnershipEvent {
         let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
         let flags = flags.try_into()?;
         let result = TouchOwnershipEvent { response_type, extension, sequence, length, event_type, deviceid, time, touchid, root, event, child, sourceid, flags };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -16965,7 +17177,8 @@ pub struct RawTouchBeginEvent {
     pub axisvalues_raw: Vec<Fp3232>,
 }
 impl TryParse for RawTouchBeginEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -16982,6 +17195,9 @@ impl TryParse for RawTouchBeginEvent {
         let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
         let result = RawTouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -17102,7 +17318,8 @@ pub struct BarrierHitEvent {
     pub dy: Fp3232,
 }
 impl TryParse for BarrierHitEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -17123,6 +17340,9 @@ impl TryParse for BarrierHitEvent {
         let (dx, remaining) = Fp3232::try_parse(remaining)?;
         let (dy, remaining) = Fp3232::try_parse(remaining)?;
         let result = BarrierHitEvent { response_type, extension, sequence, length, event_type, deviceid, time, eventid, root, event, barrier, dtime, flags, sourceid, root_x, root_y, dx, dy };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -17462,7 +17682,8 @@ pub struct DeviceError {
     pub sequence: u16,
 }
 impl TryParse for DeviceError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -17470,6 +17691,9 @@ impl TryParse for DeviceError {
             return Err(ParseError::ParseError);
         }
         let result = DeviceError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -17535,7 +17759,8 @@ pub struct EventError {
     pub sequence: u16,
 }
 impl TryParse for EventError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -17543,6 +17768,9 @@ impl TryParse for EventError {
             return Err(ParseError::ParseError);
         }
         let result = EventError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -17608,7 +17836,8 @@ pub struct ModeError {
     pub sequence: u16,
 }
 impl TryParse for ModeError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -17616,6 +17845,9 @@ impl TryParse for ModeError {
             return Err(ParseError::ParseError);
         }
         let result = ModeError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -17681,7 +17913,8 @@ pub struct DeviceBusyError {
     pub sequence: u16,
 }
 impl TryParse for DeviceBusyError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -17689,6 +17922,9 @@ impl TryParse for DeviceBusyError {
             return Err(ParseError::ParseError);
         }
         let result = DeviceBusyError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -17754,7 +17990,8 @@ pub struct ClassError {
     pub sequence: u16,
 }
 impl TryParse for ClassError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -17762,6 +17999,9 @@ impl TryParse for ClassError {
             return Err(ParseError::ParseError);
         }
         let result = ClassError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -4110,7 +4110,8 @@ pub struct KeyboardError {
     pub major_opcode: u8,
 }
 impl TryParse for KeyboardError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4122,6 +4123,9 @@ impl TryParse for KeyboardError {
             return Err(ParseError::ParseError);
         }
         let result = KeyboardError { error_code, sequence, value, minor_opcode, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -6384,7 +6388,8 @@ pub struct UseExtensionReply {
     pub server_minor: u16,
 }
 impl TryParse for UseExtensionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (supported, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -6396,6 +6401,9 @@ impl TryParse for UseExtensionReply {
             return Err(ParseError::ParseError);
         }
         let result = UseExtensionReply { supported, sequence, length, server_major, server_minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7388,7 +7396,8 @@ pub struct GetStateReply {
     pub ptr_btn_state: u16,
 }
 impl TryParse for GetStateReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7415,6 +7424,9 @@ impl TryParse for GetStateReply {
         let group = group.try_into()?;
         let locked_group = locked_group.try_into()?;
         let result = GetStateReply { device_id, sequence, length, mods, base_mods, latched_mods, locked_mods, group, locked_group, base_group, latched_group, compat_state, grab_mods, compat_grab_mods, lookup_mods, compat_lookup_mods, ptr_btn_state };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7629,7 +7641,8 @@ pub struct GetControlsReply {
     pub per_key_repeat: [u8; 32],
 }
 impl TryParse for GetControlsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7667,6 +7680,9 @@ impl TryParse for GetControlsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetControlsReply { device_id, sequence, length, mouse_keys_dflt_btn, num_groups, groups_wrap, internal_mods_mask, ignore_lock_mods_mask, internal_mods_real_mods, ignore_lock_mods_real_mods, internal_mods_vmods, ignore_lock_mods_vmods, repeat_delay, repeat_interval, slow_keys_delay, debounce_delay, mouse_keys_delay, mouse_keys_interval, mouse_keys_time_to_max, mouse_keys_max_speed, mouse_keys_curve, access_x_option, access_x_timeout, access_x_timeout_options_mask, access_x_timeout_options_values, access_x_timeout_mask, access_x_timeout_values, enabled_controls, per_key_repeat };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8332,7 +8348,8 @@ pub struct GetMapReply {
     pub map: GetMapMap,
 }
 impl TryParse for GetMapReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8369,6 +8386,9 @@ impl TryParse for GetMapReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMapReply { device_id, sequence, length, min_key_code, max_key_code, first_type, n_types, total_types, first_key_sym, total_syms, n_key_syms, first_key_action, total_actions, n_key_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, map };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8973,7 +8993,8 @@ pub struct GetCompatMapReply {
     pub group_rtrn: Vec<ModDef>,
 }
 impl TryParse for GetCompatMapReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8990,6 +9011,9 @@ impl TryParse for GetCompatMapReply {
             return Err(ParseError::ParseError);
         }
         let result = GetCompatMapReply { device_id, sequence, length, groups_rtrn, first_si_rtrn, n_total_si, si_rtrn, group_rtrn };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9204,7 +9228,8 @@ pub struct GetIndicatorStateReply {
     pub state: u32,
 }
 impl TryParse for GetIndicatorStateReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9215,6 +9240,9 @@ impl TryParse for GetIndicatorStateReply {
             return Err(ParseError::ParseError);
         }
         let result = GetIndicatorStateReply { device_id, sequence, length, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9305,7 +9333,8 @@ pub struct GetIndicatorMapReply {
     pub maps: Vec<IndicatorMap>,
 }
 impl TryParse for GetIndicatorMapReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9319,6 +9348,9 @@ impl TryParse for GetIndicatorMapReply {
             return Err(ParseError::ParseError);
         }
         let result = GetIndicatorMapReply { device_id, sequence, length, which, real_indicators, n_indicators, maps };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9522,7 +9554,8 @@ pub struct GetNamedIndicatorReply {
     pub supported: bool,
 }
 impl TryParse for GetNamedIndicatorReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9546,6 +9579,9 @@ impl TryParse for GetNamedIndicatorReply {
             return Err(ParseError::ParseError);
         }
         let result = GetNamedIndicatorReply { device_id, sequence, length, indicator, found, on, real_indicator, ndx, map_flags, map_which_groups, map_groups, map_which_mods, map_mods, map_real_mods, map_vmod, map_ctrls, supported };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9975,7 +10011,8 @@ pub struct GetNamesReply {
     pub value_list: GetNamesValueList,
 }
 impl TryParse for GetNamesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9998,6 +10035,9 @@ impl TryParse for GetNamesReply {
             return Err(ParseError::ParseError);
         }
         let result = GetNamesReply { device_id, sequence, length, min_key_code, max_key_code, n_types, group_names, virtual_mods, first_key, n_keys, indicators, n_radio_groups, n_key_aliases, n_kt_levels, value_list };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10665,7 +10705,8 @@ pub struct PerClientFlagsReply {
     pub auto_ctrls_values: u32,
 }
 impl TryParse for PerClientFlagsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10679,6 +10720,9 @@ impl TryParse for PerClientFlagsReply {
             return Err(ParseError::ParseError);
         }
         let result = PerClientFlagsReply { device_id, sequence, length, supported, value, auto_ctrls, auto_ctrls_values };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10767,7 +10811,8 @@ pub struct ListComponentsReply {
     pub geometries: Vec<Listing>,
 }
 impl TryParse for ListComponentsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10790,6 +10835,9 @@ impl TryParse for ListComponentsReply {
             return Err(ParseError::ParseError);
         }
         let result = ListComponentsReply { device_id, sequence, length, extra, keymaps, keycodes, types, compat_maps, symbols, geometries };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -11577,7 +11625,8 @@ pub struct GetKbdByNameReply {
     pub replies: GetKbdByNameReplies,
 }
 impl TryParse for GetKbdByNameReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -11594,6 +11643,9 @@ impl TryParse for GetKbdByNameReply {
             return Err(ParseError::ParseError);
         }
         let result = GetKbdByNameReply { device_id, sequence, length, min_key_code, max_key_code, loaded, new_keyboard, found, reported, replies };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -11728,7 +11780,8 @@ pub struct GetDeviceInfoReply {
     pub leds: Vec<DeviceLedInfo>,
 }
 impl TryParse for GetDeviceInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let value = remaining;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
@@ -11761,6 +11814,9 @@ impl TryParse for GetDeviceInfoReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceInfoReply { device_id, sequence, length, present, supported, unsupported, first_btn_wanted, n_btns_wanted, first_btn_rtrn, total_btns, has_own_state, dflt_kbd_fb, dflt_led_fb, dev_type, name, btn_actions, leds };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12038,7 +12094,8 @@ pub struct SetDebuggingFlagsReply {
     pub supported_ctrls: u32,
 }
 impl TryParse for SetDebuggingFlagsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12052,6 +12109,9 @@ impl TryParse for SetDebuggingFlagsReply {
             return Err(ParseError::ParseError);
         }
         let result = SetDebuggingFlagsReply { sequence, length, current_flags, current_ctrls, supported_flags, supported_ctrls };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12081,7 +12141,8 @@ pub struct NewKeyboardNotifyEvent {
     pub changed: u16,
 }
 impl TryParse for NewKeyboardNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12097,6 +12158,9 @@ impl TryParse for NewKeyboardNotifyEvent {
         let (changed, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
         let result = NewKeyboardNotifyEvent { response_type, xkb_type, sequence, time, device_id, old_device_id, min_key_code, max_key_code, old_min_key_code, old_max_key_code, request_major, request_minor, changed };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12193,7 +12257,8 @@ pub struct MapNotifyEvent {
     pub virtual_mods: u16,
 }
 impl TryParse for MapNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12220,6 +12285,9 @@ impl TryParse for MapNotifyEvent {
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = MapNotifyEvent { response_type, xkb_type, sequence, time, device_id, ptr_btn_actions, changed, min_key_code, max_key_code, first_type, n_types, first_key_sym, n_key_syms, first_key_act, n_key_acts, first_key_behavior, n_key_behavior, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, virtual_mods };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12327,7 +12395,8 @@ pub struct StateNotifyEvent {
     pub request_minor: u8,
 }
 impl TryParse for StateNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12355,6 +12424,9 @@ impl TryParse for StateNotifyEvent {
         let group = group.try_into()?;
         let locked_group = locked_group.try_into()?;
         let result = StateNotifyEvent { response_type, xkb_type, sequence, time, device_id, mods, base_mods, latched_mods, locked_mods, group, base_group, latched_group, locked_group, compat_state, grab_mods, compat_grab_mods, lookup_mods, compat_loockup_mods, ptr_btn_state, changed, keycode, event_type, request_major, request_minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12451,7 +12523,8 @@ pub struct ControlsNotifyEvent {
     pub request_minor: u8,
 }
 impl TryParse for ControlsNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12468,6 +12541,9 @@ impl TryParse for ControlsNotifyEvent {
         let (request_minor, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = ControlsNotifyEvent { response_type, xkb_type, sequence, time, device_id, num_groups, changed_controls, enabled_controls, enabled_control_changes, keycode, event_type, request_major, request_minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12547,7 +12623,8 @@ pub struct IndicatorStateNotifyEvent {
     pub state_changed: u32,
 }
 impl TryParse for IndicatorStateNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12558,6 +12635,9 @@ impl TryParse for IndicatorStateNotifyEvent {
         let (state_changed, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let result = IndicatorStateNotifyEvent { response_type, xkb_type, sequence, time, device_id, state, state_changed };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12631,7 +12711,8 @@ pub struct IndicatorMapNotifyEvent {
     pub map_changed: u32,
 }
 impl TryParse for IndicatorMapNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12642,6 +12723,9 @@ impl TryParse for IndicatorMapNotifyEvent {
         let (map_changed, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
         let result = IndicatorMapNotifyEvent { response_type, xkb_type, sequence, time, device_id, state, map_changed };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12725,7 +12809,8 @@ pub struct NamesNotifyEvent {
     pub changed_indicators: u32,
 }
 impl TryParse for NamesNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12747,6 +12832,9 @@ impl TryParse for NamesNotifyEvent {
         let (changed_indicators, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
         let result = NamesNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed, first_type, n_types, first_level_name, n_level_names, n_radio_groups, n_key_aliases, changed_group_names, changed_virtual_mods, first_key, n_keys, changed_indicators };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12832,7 +12920,8 @@ pub struct CompatMapNotifyEvent {
     pub n_total_si: u16,
 }
 impl TryParse for CompatMapNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12844,6 +12933,9 @@ impl TryParse for CompatMapNotifyEvent {
         let (n_total_si, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = CompatMapNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed_groups, first_si, n_si, n_total_si };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12925,7 +13017,8 @@ pub struct BellNotifyEvent {
     pub event_only: bool,
 }
 impl TryParse for BellNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12942,6 +13035,9 @@ impl TryParse for BellNotifyEvent {
         let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
         let bell_class = bell_class.try_into()?;
         let result = BellNotifyEvent { response_type, xkb_type, sequence, time, device_id, bell_class, bell_id, percent, pitch, duration, name, window, event_only };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13025,7 +13121,8 @@ pub struct ActionMessageEvent {
     pub message: [String8; 8],
 }
 impl TryParse for ActionMessageEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13041,6 +13138,9 @@ impl TryParse for ActionMessageEvent {
         let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
         let group = group.try_into()?;
         let result = ActionMessageEvent { response_type, xkb_type, sequence, time, device_id, keycode, press, key_event_follows, mods, group, message };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13119,7 +13219,8 @@ pub struct AccessXNotifyEvent {
     pub debounce_delay: u16,
 }
 impl TryParse for AccessXNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13131,6 +13232,9 @@ impl TryParse for AccessXNotifyEvent {
         let (debounce_delay, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
         let result = AccessXNotifyEvent { response_type, xkb_type, sequence, time, device_id, keycode, detailt, slow_keys_delay, debounce_delay };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13213,7 +13317,8 @@ pub struct ExtensionDeviceNotifyEvent {
     pub unsupported: u16,
 }
 impl TryParse for ExtensionDeviceNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (xkb_type, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13232,6 +13337,9 @@ impl TryParse for ExtensionDeviceNotifyEvent {
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let led_class = led_class.try_into()?;
         let result = ExtensionDeviceNotifyEvent { response_type, xkb_type, sequence, time, device_id, reason, led_class, led_id, leds_defined, led_state, first_button, n_buttons, supported, unsupported };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -461,7 +461,8 @@ pub struct PrintQueryVersionReply {
     pub minor_version: u16,
 }
 impl TryParse for PrintQueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -472,6 +473,9 @@ impl TryParse for PrintQueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintQueryVersionReply { sequence, length, major_version, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -572,7 +576,8 @@ pub struct PrintGetPrinterListReply {
     pub printers: Vec<Printer>,
 }
 impl TryParse for PrintGetPrinterListReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -584,6 +589,9 @@ impl TryParse for PrintGetPrinterListReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetPrinterListReply { sequence, length, printers };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -864,7 +872,8 @@ pub struct PrintGetContextReply {
     pub context: u32,
 }
 impl TryParse for PrintGetContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -874,6 +883,9 @@ impl TryParse for PrintGetContextReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -998,7 +1010,8 @@ pub struct PrintGetScreenOfContextReply {
     pub root: xproto::Window,
 }
 impl TryParse for PrintGetScreenOfContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1008,6 +1021,9 @@ impl TryParse for PrintGetScreenOfContextReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetScreenOfContextReply { sequence, length, root };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1433,7 +1449,8 @@ pub struct PrintGetDocumentDataReply {
     pub data: Vec<u8>,
 }
 impl TryParse for PrintGetDocumentDataReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1448,6 +1465,9 @@ impl TryParse for PrintGetDocumentDataReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetDocumentDataReply { sequence, length, status_code, finished_flag, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1727,7 +1747,8 @@ pub struct PrintInputSelectedReply {
     pub all_events_mask: u32,
 }
 impl TryParse for PrintInputSelectedReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1738,6 +1759,9 @@ impl TryParse for PrintInputSelectedReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintInputSelectedReply { sequence, length, event_mask, all_events_mask };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1824,7 +1848,8 @@ pub struct PrintGetAttributesReply {
     pub attributes: Vec<String8>,
 }
 impl TryParse for PrintGetAttributesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1837,6 +1862,9 @@ impl TryParse for PrintGetAttributesReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetAttributesReply { sequence, length, attributes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1960,7 +1988,8 @@ pub struct PrintGetOneAttributesReply {
     pub value: Vec<String8>,
 }
 impl TryParse for PrintGetOneAttributesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1973,6 +2002,9 @@ impl TryParse for PrintGetOneAttributesReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetOneAttributesReply { sequence, length, value };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2169,7 +2201,8 @@ pub struct PrintGetPageDimensionsReply {
     pub reproducible_height: u16,
 }
 impl TryParse for PrintGetPageDimensionsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2184,6 +2217,9 @@ impl TryParse for PrintGetPageDimensionsReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetPageDimensionsReply { sequence, length, width, height, offset_x, offset_y, reproducible_width, reproducible_height };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2249,7 +2285,8 @@ pub struct PrintQueryScreensReply {
     pub roots: Vec<xproto::Window>,
 }
 impl TryParse for PrintQueryScreensReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2261,6 +2298,9 @@ impl TryParse for PrintQueryScreensReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintQueryScreensReply { sequence, length, roots };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2362,7 +2402,8 @@ pub struct PrintSetImageResolutionReply {
     pub previous_resolutions: u16,
 }
 impl TryParse for PrintSetImageResolutionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2372,6 +2413,9 @@ impl TryParse for PrintSetImageResolutionReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintSetImageResolutionReply { status, sequence, length, previous_resolutions };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2448,7 +2492,8 @@ pub struct PrintGetImageResolutionReply {
     pub image_resolution: u16,
 }
 impl TryParse for PrintGetImageResolutionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2458,6 +2503,9 @@ impl TryParse for PrintGetImageResolutionReply {
             return Err(ParseError::ParseError);
         }
         let result = PrintGetImageResolutionReply { sequence, length, image_resolution };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2479,13 +2527,17 @@ pub struct NotifyEvent {
     pub cancel: bool,
 }
 impl TryParse for NotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (context, remaining) = Pcontext::try_parse(remaining)?;
         let (cancel, remaining) = bool::try_parse(remaining)?;
         let result = NotifyEvent { response_type, detail, sequence, context, cancel };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2555,12 +2607,16 @@ pub struct AttributNotifyEvent {
     pub context: Pcontext,
 }
 impl TryParse for AttributNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (context, remaining) = Pcontext::try_parse(remaining)?;
         let result = AttributNotifyEvent { response_type, detail, sequence, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2627,7 +2683,8 @@ pub struct BadContextError {
     pub sequence: u16,
 }
 impl TryParse for BadContextError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2635,6 +2692,9 @@ impl TryParse for BadContextError {
             return Err(ParseError::ParseError);
         }
         let result = BadContextError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2700,7 +2760,8 @@ pub struct BadSequenceError {
     pub sequence: u16,
 }
 impl TryParse for BadSequenceError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2708,6 +2769,9 @@ impl TryParse for BadSequenceError {
             return Err(ParseError::ParseError);
         }
         let result = BadSequenceError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -1441,7 +1441,8 @@ pub struct KeyPressEvent {
     pub same_screen: bool,
 }
 impl TryParse for KeyPressEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = Keycode::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1457,6 +1458,9 @@ impl TryParse for KeyPressEvent {
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = KeyPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1629,7 +1633,8 @@ pub struct ButtonPressEvent {
     pub same_screen: bool,
 }
 impl TryParse for ButtonPressEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = Button::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1645,6 +1650,9 @@ impl TryParse for ButtonPressEvent {
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ButtonPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1828,7 +1836,8 @@ pub struct MotionNotifyEvent {
     pub same_screen: bool,
 }
 impl TryParse for MotionNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1845,6 +1854,9 @@ impl TryParse for MotionNotifyEvent {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let detail = detail.try_into()?;
         let result = MotionNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2094,7 +2106,8 @@ pub struct EnterNotifyEvent {
     pub same_screen_focus: u8,
 }
 impl TryParse for EnterNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2112,6 +2125,9 @@ impl TryParse for EnterNotifyEvent {
         let detail = detail.try_into()?;
         let mode = mode.try_into()?;
         let result = EnterNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, mode, same_screen_focus };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2202,7 +2218,8 @@ pub struct FocusInEvent {
     pub mode: NotifyMode,
 }
 impl TryParse for FocusInEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (detail, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2212,6 +2229,9 @@ impl TryParse for FocusInEvent {
         let detail = detail.try_into()?;
         let mode = mode.try_into()?;
         let result = FocusInEvent { response_type, detail, sequence, event, mode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2283,11 +2303,15 @@ pub struct KeymapNotifyEvent {
     pub keys: [u8; 31],
 }
 impl TryParse for KeymapNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 31)?;
         let keys = <[u8; 31]>::try_from(keys).unwrap();
         let result = KeymapNotifyEvent { response_type, keys };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2371,7 +2395,8 @@ pub struct ExposeEvent {
     pub count: u16,
 }
 impl TryParse for ExposeEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2383,6 +2408,9 @@ impl TryParse for ExposeEvent {
         let (count, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let result = ExposeEvent { response_type, sequence, window, x, y, width, height, count };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2461,7 +2489,8 @@ pub struct GraphicsExposureEvent {
     pub major_opcode: u8,
 }
 impl TryParse for GraphicsExposureEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2475,6 +2504,9 @@ impl TryParse for GraphicsExposureEvent {
         let (major_opcode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = GraphicsExposureEvent { response_type, sequence, drawable, x, y, width, height, minor_opcode, count, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2550,7 +2582,8 @@ pub struct NoExposureEvent {
     pub major_opcode: u8,
 }
 impl TryParse for NoExposureEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2559,6 +2592,9 @@ impl TryParse for NoExposureEvent {
         let (major_opcode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = NoExposureEvent { response_type, sequence, drawable, minor_opcode, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2693,7 +2729,8 @@ pub struct VisibilityNotifyEvent {
     pub state: Visibility,
 }
 impl TryParse for VisibilityNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2702,6 +2739,9 @@ impl TryParse for VisibilityNotifyEvent {
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
         let result = VisibilityNotifyEvent { response_type, sequence, window, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2776,7 +2816,8 @@ pub struct CreateNotifyEvent {
     pub override_redirect: bool,
 }
 impl TryParse for CreateNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2790,6 +2831,9 @@ impl TryParse for CreateNotifyEvent {
         let (override_redirect, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = CreateNotifyEvent { response_type, sequence, parent, window, x, y, width, height, border_width, override_redirect };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2875,13 +2919,17 @@ pub struct DestroyNotifyEvent {
     pub window: Window,
 }
 impl TryParse for DestroyNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (event, remaining) = Window::try_parse(remaining)?;
         let (window, remaining) = Window::try_parse(remaining)?;
         let result = DestroyNotifyEvent { response_type, sequence, event, window };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2964,7 +3012,8 @@ pub struct UnmapNotifyEvent {
     pub from_configure: bool,
 }
 impl TryParse for UnmapNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2973,6 +3022,9 @@ impl TryParse for UnmapNotifyEvent {
         let (from_configure, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = UnmapNotifyEvent { response_type, sequence, event, window, from_configure };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3055,7 +3107,8 @@ pub struct MapNotifyEvent {
     pub override_redirect: bool,
 }
 impl TryParse for MapNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3064,6 +3117,9 @@ impl TryParse for MapNotifyEvent {
         let (override_redirect, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = MapNotifyEvent { response_type, sequence, event, window, override_redirect };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3143,13 +3199,17 @@ pub struct MapRequestEvent {
     pub window: Window,
 }
 impl TryParse for MapRequestEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (parent, remaining) = Window::try_parse(remaining)?;
         let (window, remaining) = Window::try_parse(remaining)?;
         let result = MapRequestEvent { response_type, sequence, parent, window };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3222,7 +3282,8 @@ pub struct ReparentNotifyEvent {
     pub override_redirect: bool,
 }
 impl TryParse for ReparentNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3234,6 +3295,9 @@ impl TryParse for ReparentNotifyEvent {
         let (override_redirect, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let result = ReparentNotifyEvent { response_type, sequence, event, window, parent, x, y, override_redirect };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3335,7 +3399,8 @@ pub struct ConfigureNotifyEvent {
     pub override_redirect: bool,
 }
 impl TryParse for ConfigureNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3350,6 +3415,9 @@ impl TryParse for ConfigureNotifyEvent {
         let (override_redirect, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let result = ConfigureNotifyEvent { response_type, sequence, event, window, above_sibling, x, y, width, height, border_width, override_redirect };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3433,7 +3501,8 @@ pub struct ConfigureRequestEvent {
     pub value_mask: u16,
 }
 impl TryParse for ConfigureRequestEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (stack_mode, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3448,6 +3517,9 @@ impl TryParse for ConfigureRequestEvent {
         let (value_mask, remaining) = u16::try_parse(remaining)?;
         let stack_mode = stack_mode.try_into()?;
         let result = ConfigureRequestEvent { response_type, stack_mode, sequence, parent, window, sibling, x, y, width, height, border_width, value_mask };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3526,7 +3598,8 @@ pub struct GravityNotifyEvent {
     pub y: i16,
 }
 impl TryParse for GravityNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3535,6 +3608,9 @@ impl TryParse for GravityNotifyEvent {
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
         let result = GravityNotifyEvent { response_type, sequence, event, window, x, y };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3606,7 +3682,8 @@ pub struct ResizeRequestEvent {
     pub height: u16,
 }
 impl TryParse for ResizeRequestEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3614,6 +3691,9 @@ impl TryParse for ResizeRequestEvent {
         let (width, remaining) = u16::try_parse(remaining)?;
         let (height, remaining) = u16::try_parse(remaining)?;
         let result = ResizeRequestEvent { response_type, sequence, window, width, height };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3770,7 +3850,8 @@ pub struct CirculateNotifyEvent {
     pub place: Place,
 }
 impl TryParse for CirculateNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3781,6 +3862,9 @@ impl TryParse for CirculateNotifyEvent {
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let place = place.try_into()?;
         let result = CirculateNotifyEvent { response_type, sequence, event, window, place };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3938,7 +4022,8 @@ pub struct PropertyNotifyEvent {
     pub state: Property,
 }
 impl TryParse for PropertyNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3949,6 +4034,9 @@ impl TryParse for PropertyNotifyEvent {
         let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
         let result = PropertyNotifyEvent { response_type, sequence, window, atom, time, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4020,7 +4108,8 @@ pub struct SelectionClearEvent {
     pub selection: Atom,
 }
 impl TryParse for SelectionClearEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4028,6 +4117,9 @@ impl TryParse for SelectionClearEvent {
         let (owner, remaining) = Window::try_parse(remaining)?;
         let (selection, remaining) = Atom::try_parse(remaining)?;
         let result = SelectionClearEvent { response_type, sequence, time, owner, selection };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4336,7 +4428,8 @@ pub struct SelectionRequestEvent {
     pub property: Atom,
 }
 impl TryParse for SelectionRequestEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4347,6 +4440,9 @@ impl TryParse for SelectionRequestEvent {
         let (target, remaining) = Atom::try_parse(remaining)?;
         let (property, remaining) = Atom::try_parse(remaining)?;
         let result = SelectionRequestEvent { response_type, sequence, time, owner, requestor, selection, target, property };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4422,7 +4518,8 @@ pub struct SelectionNotifyEvent {
     pub property: Atom,
 }
 impl TryParse for SelectionNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4432,6 +4529,9 @@ impl TryParse for SelectionNotifyEvent {
         let (target, remaining) = Atom::try_parse(remaining)?;
         let (property, remaining) = Atom::try_parse(remaining)?;
         let result = SelectionNotifyEvent { response_type, sequence, time, requestor, selection, target, property };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4651,7 +4751,8 @@ pub struct ColormapNotifyEvent {
     pub state: ColormapState,
 }
 impl TryParse for ColormapNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4662,6 +4763,9 @@ impl TryParse for ColormapNotifyEvent {
         let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
         let state = state.try_into()?;
         let result = ColormapNotifyEvent { response_type, sequence, window, colormap, new, state };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -4906,7 +5010,8 @@ pub struct ClientMessageEvent {
     pub data: ClientMessageData,
 }
 impl TryParse for ClientMessageEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -4914,6 +5019,9 @@ impl TryParse for ClientMessageEvent {
         let (type_, remaining) = Atom::try_parse(remaining)?;
         let (data, remaining) = ClientMessageData::try_parse(remaining)?;
         let result = ClientMessageEvent { response_type, format, sequence, window, type_, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5056,7 +5164,8 @@ pub struct MappingNotifyEvent {
     pub count: u8,
 }
 impl TryParse for MappingNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5066,6 +5175,9 @@ impl TryParse for MappingNotifyEvent {
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let request = request.try_into()?;
         let result = MappingNotifyEvent { response_type, sequence, request, first_keycode, count };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5143,7 +5255,8 @@ pub struct GeGenericEvent {
     pub event_type: u16,
 }
 impl TryParse for GeGenericEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (extension, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5151,6 +5264,9 @@ impl TryParse for GeGenericEvent {
         let (event_type, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
         let result = GeGenericEvent { response_type, extension, sequence, length, event_type };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5172,7 +5288,8 @@ pub struct RequestError {
     pub major_opcode: u8,
 }
 impl TryParse for RequestError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5184,6 +5301,9 @@ impl TryParse for RequestError {
             return Err(ParseError::ParseError);
         }
         let result = RequestError { error_code, sequence, bad_value, minor_opcode, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -5255,7 +5375,8 @@ pub struct ValueError {
     pub major_opcode: u8,
 }
 impl TryParse for ValueError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -5267,6 +5388,9 @@ impl TryParse for ValueError {
             return Err(ParseError::ParseError);
         }
         let result = ValueError { error_code, sequence, bad_value, minor_opcode, major_opcode };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -7011,7 +7135,8 @@ pub struct GetWindowAttributesReply {
     pub do_not_propagate_mask: u16,
 }
 impl TryParse for GetWindowAttributesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (backing_store, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -7040,6 +7165,9 @@ impl TryParse for GetWindowAttributesReply {
         let win_gravity = Gravity::try_from(win_gravity, Gravity::WinUnmap)?;
         let map_state = map_state.try_into()?;
         let result = GetWindowAttributesReply { backing_store, sequence, length, visual, class, bit_gravity, win_gravity, backing_planes, backing_pixel, save_under, map_is_installed, map_state, override_redirect, colormap, all_event_masks, your_event_mask, do_not_propagate_mask };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8740,7 +8868,8 @@ pub struct GetGeometryReply {
     pub border_width: u16,
 }
 impl TryParse for GetGeometryReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8756,6 +8885,9 @@ impl TryParse for GetGeometryReply {
             return Err(ParseError::ParseError);
         }
         let result = GetGeometryReply { depth, sequence, length, root, x, y, width, height, border_width };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -8915,7 +9047,8 @@ pub struct QueryTreeReply {
     pub children: Vec<Window>,
 }
 impl TryParse for QueryTreeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -8929,6 +9062,9 @@ impl TryParse for QueryTreeReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryTreeReply { sequence, length, root, parent, children };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9129,7 +9265,8 @@ pub struct InternAtomReply {
     pub atom: Atom,
 }
 impl TryParse for InternAtomReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9139,6 +9276,9 @@ impl TryParse for InternAtomReply {
             return Err(ParseError::ParseError);
         }
         let result = InternAtomReply { sequence, length, atom };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -9217,7 +9357,8 @@ pub struct GetAtomNameReply {
     pub name: Vec<u8>,
 }
 impl TryParse for GetAtomNameReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -9230,6 +9371,9 @@ impl TryParse for GetAtomNameReply {
             return Err(ParseError::ParseError);
         }
         let result = GetAtomNameReply { sequence, length, name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10106,7 +10250,8 @@ pub struct GetPropertyReply {
     pub value: Vec<u8>,
 }
 impl TryParse for GetPropertyReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10121,6 +10266,9 @@ impl TryParse for GetPropertyReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPropertyReply { format, sequence, length, type_, bytes_after, value_len, value };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10199,7 +10347,8 @@ pub struct ListPropertiesReply {
     pub atoms: Vec<Atom>,
 }
 impl TryParse for ListPropertiesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10211,6 +10360,9 @@ impl TryParse for ListPropertiesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListPropertiesReply { sequence, length, atoms };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -10482,7 +10634,8 @@ pub struct GetSelectionOwnerReply {
     pub owner: Window,
 }
 impl TryParse for GetSelectionOwnerReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -10492,6 +10645,9 @@ impl TryParse for GetSelectionOwnerReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSelectionOwnerReply { sequence, length, owner };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -11390,7 +11546,8 @@ pub struct GrabPointerReply {
     pub length: u32,
 }
 impl TryParse for GrabPointerReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -11400,6 +11557,9 @@ impl TryParse for GrabPointerReply {
         }
         let status = status.try_into()?;
         let result = GrabPointerReply { status, sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -12251,7 +12411,8 @@ pub struct GrabKeyboardReply {
     pub length: u32,
 }
 impl TryParse for GrabKeyboardReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -12261,6 +12422,9 @@ impl TryParse for GrabKeyboardReply {
         }
         let status = status.try_into()?;
         let result = GrabKeyboardReply { status, sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13205,7 +13369,8 @@ pub struct QueryPointerReply {
     pub mask: u16,
 }
 impl TryParse for QueryPointerReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13222,6 +13387,9 @@ impl TryParse for QueryPointerReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryPointerReply { same_screen, sequence, length, root, child, root_x, root_y, win_x, win_y, mask };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13368,7 +13536,8 @@ pub struct GetMotionEventsReply {
     pub events: Vec<Timecoord>,
 }
 impl TryParse for GetMotionEventsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13380,6 +13549,9 @@ impl TryParse for GetMotionEventsReply {
             return Err(ParseError::ParseError);
         }
         let result = GetMotionEventsReply { sequence, length, events };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13499,7 +13671,8 @@ pub struct TranslateCoordinatesReply {
     pub dst_y: i16,
 }
 impl TryParse for TranslateCoordinatesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13511,6 +13684,9 @@ impl TryParse for TranslateCoordinatesReply {
             return Err(ParseError::ParseError);
         }
         let result = TranslateCoordinatesReply { same_screen, sequence, length, child, dst_x, dst_y };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -13985,7 +14161,8 @@ pub struct GetInputFocusReply {
     pub focus: Window,
 }
 impl TryParse for GetInputFocusReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (revert_to, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -13996,6 +14173,9 @@ impl TryParse for GetInputFocusReply {
         }
         let revert_to = revert_to.try_into()?;
         let result = GetInputFocusReply { revert_to, sequence, length, focus };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14063,7 +14243,8 @@ pub struct QueryKeymapReply {
     pub keys: [u8; 32],
 }
 impl TryParse for QueryKeymapReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14074,6 +14255,9 @@ impl TryParse for QueryKeymapReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryKeymapReply { sequence, length, keys };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14548,7 +14732,8 @@ pub struct QueryFontReply {
     pub char_infos: Vec<Charinfo>,
 }
 impl TryParse for QueryFontReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14575,6 +14760,9 @@ impl TryParse for QueryFontReply {
         }
         let draw_direction = draw_direction.try_into()?;
         let result = QueryFontReply { sequence, length, min_bounds, max_bounds, min_char_or_byte2, max_char_or_byte2, default_char, draw_direction, min_byte1, max_byte1, all_chars_exist, font_ascent, font_descent, properties, char_infos };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14787,7 +14975,8 @@ pub struct QueryTextExtentsReply {
     pub overall_right: i32,
 }
 impl TryParse for QueryTextExtentsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (draw_direction, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14804,6 +14993,9 @@ impl TryParse for QueryTextExtentsReply {
         }
         let draw_direction = draw_direction.try_into()?;
         let result = QueryTextExtentsReply { draw_direction, sequence, length, font_ascent, font_descent, overall_ascent, overall_descent, overall_width, overall_left, overall_right };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -14976,7 +15168,8 @@ pub struct ListFontsReply {
     pub names: Vec<Str>,
 }
 impl TryParse for ListFontsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -14988,6 +15181,9 @@ impl TryParse for ListFontsReply {
             return Err(ParseError::ParseError);
         }
         let result = ListFontsReply { sequence, length, names };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15153,7 +15349,8 @@ pub struct ListFontsWithInfoReply {
     pub name: Vec<u8>,
 }
 impl TryParse for ListFontsWithInfoReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (name_len, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15181,6 +15378,9 @@ impl TryParse for ListFontsWithInfoReply {
         }
         let draw_direction = draw_direction.try_into()?;
         let result = ListFontsWithInfoReply { sequence, length, min_bounds, max_bounds, min_char_or_byte2, max_char_or_byte2, default_char, draw_direction, min_byte1, max_byte1, all_chars_exist, font_ascent, font_descent, replies_hint, properties, name };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -15350,7 +15550,8 @@ pub struct GetFontPathReply {
     pub path: Vec<Str>,
 }
 impl TryParse for GetFontPathReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -15362,6 +15563,9 @@ impl TryParse for GetFontPathReply {
             return Err(ParseError::ParseError);
         }
         let result = GetFontPathReply { sequence, length, path };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -19973,7 +20177,8 @@ pub struct GetImageReply {
     pub data: Vec<u8>,
 }
 impl TryParse for GetImageReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -19986,6 +20191,9 @@ impl TryParse for GetImageReply {
             return Err(ParseError::ParseError);
         }
         let result = GetImageReply { depth, sequence, visual, data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -21034,7 +21242,8 @@ pub struct ListInstalledColormapsReply {
     pub cmaps: Vec<Colormap>,
 }
 impl TryParse for ListInstalledColormapsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -21046,6 +21255,9 @@ impl TryParse for ListInstalledColormapsReply {
             return Err(ParseError::ParseError);
         }
         let result = ListInstalledColormapsReply { sequence, length, cmaps };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -21202,7 +21414,8 @@ pub struct AllocColorReply {
     pub pixel: u32,
 }
 impl TryParse for AllocColorReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -21216,6 +21429,9 @@ impl TryParse for AllocColorReply {
             return Err(ParseError::ParseError);
         }
         let result = AllocColorReply { sequence, length, red, green, blue, pixel };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -21322,7 +21538,8 @@ pub struct AllocNamedColorReply {
     pub visual_blue: u16,
 }
 impl TryParse for AllocNamedColorReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -21338,6 +21555,9 @@ impl TryParse for AllocNamedColorReply {
             return Err(ParseError::ParseError);
         }
         let result = AllocNamedColorReply { sequence, length, pixel, exact_red, exact_green, exact_blue, visual_red, visual_green, visual_blue };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -21435,7 +21655,8 @@ pub struct AllocColorCellsReply {
     pub masks: Vec<u32>,
 }
 impl TryParse for AllocColorCellsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -21449,6 +21670,9 @@ impl TryParse for AllocColorCellsReply {
             return Err(ParseError::ParseError);
         }
         let result = AllocColorCellsReply { sequence, length, pixels, masks };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -21590,7 +21814,8 @@ pub struct AllocColorPlanesReply {
     pub pixels: Vec<u32>,
 }
 impl TryParse for AllocColorPlanesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -21606,6 +21831,9 @@ impl TryParse for AllocColorPlanesReply {
             return Err(ParseError::ParseError);
         }
         let result = AllocColorPlanesReply { sequence, length, red_mask, green_mask, blue_mask, pixels };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -22171,7 +22399,8 @@ pub struct QueryColorsReply {
     pub colors: Vec<Rgb>,
 }
 impl TryParse for QueryColorsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -22183,6 +22412,9 @@ impl TryParse for QueryColorsReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryColorsReply { sequence, length, colors };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -22303,7 +22535,8 @@ pub struct LookupColorReply {
     pub visual_blue: u16,
 }
 impl TryParse for LookupColorReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -22318,6 +22551,9 @@ impl TryParse for LookupColorReply {
             return Err(ParseError::ParseError);
         }
         let result = LookupColorReply { sequence, length, exact_red, exact_green, exact_blue, visual_red, visual_green, visual_blue };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -23127,7 +23363,8 @@ pub struct QueryBestSizeReply {
     pub height: u16,
 }
 impl TryParse for QueryBestSizeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -23138,6 +23375,9 @@ impl TryParse for QueryBestSizeReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryBestSizeReply { sequence, length, width, height };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -23281,7 +23521,8 @@ pub struct QueryExtensionReply {
     pub first_error: u8,
 }
 impl TryParse for QueryExtensionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -23294,6 +23535,9 @@ impl TryParse for QueryExtensionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryExtensionReply { sequence, length, present, major_opcode, first_event, first_error };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -23361,7 +23605,8 @@ pub struct ListExtensionsReply {
     pub names: Vec<Str>,
 }
 impl TryParse for ListExtensionsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (names_len, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -23372,6 +23617,9 @@ impl TryParse for ListExtensionsReply {
             return Err(ParseError::ParseError);
         }
         let result = ListExtensionsReply { sequence, length, names };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -23559,7 +23807,8 @@ pub struct GetKeyboardMappingReply {
     pub keysyms: Vec<Keysym>,
 }
 impl TryParse for GetKeyboardMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (keysyms_per_keycode, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -23570,6 +23819,9 @@ impl TryParse for GetKeyboardMappingReply {
             return Err(ParseError::ParseError);
         }
         let result = GetKeyboardMappingReply { keysyms_per_keycode, sequence, keysyms };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -24145,7 +24397,8 @@ pub struct GetKeyboardControlReply {
     pub auto_repeats: [u8; 32],
 }
 impl TryParse for GetKeyboardControlReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (global_auto_repeat, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -24163,6 +24416,9 @@ impl TryParse for GetKeyboardControlReply {
         }
         let global_auto_repeat = global_auto_repeat.try_into()?;
         let result = GetKeyboardControlReply { global_auto_repeat, sequence, length, led_mask, key_click_percent, bell_percent, bell_pitch, bell_duration, auto_repeats };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -24373,7 +24629,8 @@ pub struct GetPointerControlReply {
     pub threshold: u16,
 }
 impl TryParse for GetPointerControlReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -24386,6 +24643,9 @@ impl TryParse for GetPointerControlReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPointerControlReply { sequence, length, acceleration_numerator, acceleration_denominator, threshold };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -24668,7 +24928,8 @@ pub struct GetScreenSaverReply {
     pub allow_exposures: Exposures,
 }
 impl TryParse for GetScreenSaverReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -24684,6 +24945,9 @@ impl TryParse for GetScreenSaverReply {
         let prefer_blanking = prefer_blanking.try_into()?;
         let allow_exposures = allow_exposures.try_into()?;
         let result = GetScreenSaverReply { sequence, length, timeout, interval, prefer_blanking, allow_exposures };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -25040,7 +25304,8 @@ pub struct ListHostsReply {
     pub hosts: Vec<Host>,
 }
 impl TryParse for ListHostsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -25053,6 +25318,9 @@ impl TryParse for ListHostsReply {
         }
         let mode = mode.try_into()?;
         let result = ListHostsReply { mode, sequence, length, hosts };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -25842,7 +26110,8 @@ pub struct SetPointerMappingReply {
     pub length: u32,
 }
 impl TryParse for SetPointerMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -25852,6 +26121,9 @@ impl TryParse for SetPointerMappingReply {
         }
         let status = status.try_into()?;
         let result = SetPointerMappingReply { status, sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -25919,7 +26191,8 @@ pub struct GetPointerMappingReply {
     pub map: Vec<u8>,
 }
 impl TryParse for GetPointerMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (map_len, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -25931,6 +26204,9 @@ impl TryParse for GetPointerMappingReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPointerMappingReply { sequence, length, map };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -26111,7 +26387,8 @@ pub struct SetModifierMappingReply {
     pub length: u32,
 }
 impl TryParse for SetModifierMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (status, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -26121,6 +26398,9 @@ impl TryParse for SetModifierMappingReply {
         }
         let status = status.try_into()?;
         let result = SetModifierMappingReply { status, sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -26188,7 +26468,8 @@ pub struct GetModifierMappingReply {
     pub keycodes: Vec<Keycode>,
 }
 impl TryParse for GetModifierMappingReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (keycodes_per_modifier, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -26200,6 +26481,9 @@ impl TryParse for GetModifierMappingReply {
             return Err(ParseError::ParseError);
         }
         let result = GetModifierMappingReply { sequence, length, keycodes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -107,7 +107,8 @@ pub struct QueryVersionReply {
     pub server_minor: u16,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -118,6 +119,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, server_major, server_minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -253,7 +257,8 @@ pub struct GetDeviceCreateContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetDeviceCreateContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -266,6 +271,9 @@ impl TryParse for GetDeviceCreateContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceCreateContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -437,7 +445,8 @@ pub struct GetDeviceContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetDeviceContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -450,6 +459,9 @@ impl TryParse for GetDeviceContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetDeviceContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -600,7 +612,8 @@ pub struct GetWindowCreateContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetWindowCreateContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -613,6 +626,9 @@ impl TryParse for GetWindowCreateContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetWindowCreateContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -704,7 +720,8 @@ pub struct GetWindowContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetWindowContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -717,6 +734,9 @@ impl TryParse for GetWindowContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetWindowContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -950,7 +970,8 @@ pub struct GetPropertyCreateContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetPropertyCreateContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -963,6 +984,9 @@ impl TryParse for GetPropertyCreateContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPropertyCreateContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1113,7 +1137,8 @@ pub struct GetPropertyUseContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetPropertyUseContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1126,6 +1151,9 @@ impl TryParse for GetPropertyUseContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPropertyUseContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1226,7 +1254,8 @@ pub struct GetPropertyContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetPropertyContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1239,6 +1268,9 @@ impl TryParse for GetPropertyContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPropertyContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1339,7 +1371,8 @@ pub struct GetPropertyDataContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetPropertyDataContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1352,6 +1385,9 @@ impl TryParse for GetPropertyDataContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPropertyDataContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1443,7 +1479,8 @@ pub struct ListPropertiesReply {
     pub properties: Vec<ListItem>,
 }
 impl TryParse for ListPropertiesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1455,6 +1492,9 @@ impl TryParse for ListPropertiesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListPropertiesReply { sequence, length, properties };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1605,7 +1645,8 @@ pub struct GetSelectionCreateContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetSelectionCreateContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1618,6 +1659,9 @@ impl TryParse for GetSelectionCreateContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSelectionCreateContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1768,7 +1812,8 @@ pub struct GetSelectionUseContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetSelectionUseContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1781,6 +1826,9 @@ impl TryParse for GetSelectionUseContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSelectionUseContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1872,7 +1920,8 @@ pub struct GetSelectionContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetSelectionContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1885,6 +1934,9 @@ impl TryParse for GetSelectionContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSelectionContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1976,7 +2028,8 @@ pub struct GetSelectionDataContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetSelectionDataContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1989,6 +2042,9 @@ impl TryParse for GetSelectionDataContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetSelectionDataContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2069,7 +2125,8 @@ pub struct ListSelectionsReply {
     pub selections: Vec<ListItem>,
 }
 impl TryParse for ListSelectionsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2081,6 +2138,9 @@ impl TryParse for ListSelectionsReply {
             return Err(ParseError::ParseError);
         }
         let result = ListSelectionsReply { sequence, length, selections };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2172,7 +2232,8 @@ pub struct GetClientContextReply {
     pub context: Vec<u8>,
 }
 impl TryParse for GetClientContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2185,6 +2246,9 @@ impl TryParse for GetClientContextReply {
             return Err(ParseError::ParseError);
         }
         let result = GetClientContextReply { sequence, length, context };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -108,7 +108,8 @@ pub struct GetVersionReply {
     pub minor_version: u16,
 }
 impl TryParse for GetVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (major_version, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -118,6 +119,9 @@ impl TryParse for GetVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = GetVersionReply { major_version, sequence, length, minor_version };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -273,7 +277,8 @@ pub struct CompareCursorReply {
     pub length: u32,
 }
 impl TryParse for CompareCursorReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (same, remaining) = bool::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -282,6 +287,9 @@ impl TryParse for CompareCursorReply {
             return Err(ParseError::ParseError);
         }
         let result = CompareCursorReply { same, sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -1180,7 +1180,8 @@ pub struct BadPortError {
     pub sequence: u16,
 }
 impl TryParse for BadPortError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1188,6 +1189,9 @@ impl TryParse for BadPortError {
             return Err(ParseError::ParseError);
         }
         let result = BadPortError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1253,7 +1257,8 @@ pub struct BadEncodingError {
     pub sequence: u16,
 }
 impl TryParse for BadEncodingError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1261,6 +1266,9 @@ impl TryParse for BadEncodingError {
             return Err(ParseError::ParseError);
         }
         let result = BadEncodingError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1326,7 +1334,8 @@ pub struct BadControlError {
     pub sequence: u16,
 }
 impl TryParse for BadControlError {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1334,6 +1343,9 @@ impl TryParse for BadControlError {
             return Err(ParseError::ParseError);
         }
         let result = BadControlError { error_code, sequence };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1403,7 +1415,8 @@ pub struct VideoNotifyEvent {
     pub port: Port,
 }
 impl TryParse for VideoNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (reason, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1412,6 +1425,9 @@ impl TryParse for VideoNotifyEvent {
         let (port, remaining) = Port::try_parse(remaining)?;
         let reason = reason.try_into()?;
         let result = VideoNotifyEvent { response_type, reason, sequence, time, drawable, port };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1484,7 +1500,8 @@ pub struct PortNotifyEvent {
     pub value: i32,
 }
 impl TryParse for PortNotifyEvent {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1493,6 +1510,9 @@ impl TryParse for PortNotifyEvent {
         let (attribute, remaining) = xproto::Atom::try_parse(remaining)?;
         let (value, remaining) = i32::try_parse(remaining)?;
         let result = PortNotifyEvent { response_type, sequence, time, port, attribute, value };
+        let _ = remaining;
+        let remaining = initial_value.get(32..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1609,7 +1629,8 @@ pub struct QueryExtensionReply {
     pub minor: u16,
 }
 impl TryParse for QueryExtensionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1620,6 +1641,9 @@ impl TryParse for QueryExtensionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryExtensionReply { sequence, length, major, minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1696,7 +1720,8 @@ pub struct QueryAdaptorsReply {
     pub info: Vec<AdaptorInfo>,
 }
 impl TryParse for QueryAdaptorsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1708,6 +1733,9 @@ impl TryParse for QueryAdaptorsReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryAdaptorsReply { sequence, length, info };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1799,7 +1827,8 @@ pub struct QueryEncodingsReply {
     pub info: Vec<EncodingInfo>,
 }
 impl TryParse for QueryEncodingsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1811,6 +1840,9 @@ impl TryParse for QueryEncodingsReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryEncodingsReply { sequence, length, info };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -1913,7 +1945,8 @@ pub struct GrabPortReply {
     pub length: u32,
 }
 impl TryParse for GrabPortReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (result, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -1923,6 +1956,9 @@ impl TryParse for GrabPortReply {
         }
         let result = result.try_into()?;
         let result = GrabPortReply { result, sequence, length };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -2846,7 +2882,8 @@ pub struct QueryBestSizeReply {
     pub actual_height: u16,
 }
 impl TryParse for QueryBestSizeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -2857,6 +2894,9 @@ impl TryParse for QueryBestSizeReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryBestSizeReply { sequence, length, actual_width, actual_height };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3019,7 +3059,8 @@ pub struct GetPortAttributeReply {
     pub value: i32,
 }
 impl TryParse for GetPortAttributeReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3029,6 +3070,9 @@ impl TryParse for GetPortAttributeReply {
             return Err(ParseError::ParseError);
         }
         let result = GetPortAttributeReply { sequence, length, value };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3106,7 +3150,8 @@ pub struct QueryPortAttributesReply {
     pub attributes: Vec<AttributeInfo>,
 }
 impl TryParse for QueryPortAttributesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3119,6 +3164,9 @@ impl TryParse for QueryPortAttributesReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryPortAttributesReply { sequence, length, text_size, attributes };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3210,7 +3258,8 @@ pub struct ListImageFormatsReply {
     pub format: Vec<ImageFormatInfo>,
 }
 impl TryParse for ListImageFormatsReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3222,6 +3271,9 @@ impl TryParse for ListImageFormatsReply {
             return Err(ParseError::ParseError);
         }
         let result = ListImageFormatsReply { sequence, length, format };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -3340,7 +3392,8 @@ pub struct QueryImageAttributesReply {
     pub offsets: Vec<u32>,
 }
 impl TryParse for QueryImageAttributesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -3356,6 +3409,9 @@ impl TryParse for QueryImageAttributesReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryImageAttributesReply { sequence, length, data_size, width, height, pitches, offsets };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -183,7 +183,8 @@ pub struct QueryVersionReply {
     pub minor: u32,
 }
 impl TryParse for QueryVersionReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -194,6 +195,9 @@ impl TryParse for QueryVersionReply {
             return Err(ParseError::ParseError);
         }
         let result = QueryVersionReply { sequence, length, major, minor };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -270,7 +274,8 @@ pub struct ListSurfaceTypesReply {
     pub surfaces: Vec<SurfaceInfo>,
 }
 impl TryParse for ListSurfaceTypesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -282,6 +287,9 @@ impl TryParse for ListSurfaceTypesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListSurfaceTypesReply { sequence, length, surfaces };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -416,7 +424,8 @@ pub struct CreateContextReply {
     pub priv_data: Vec<u32>,
 }
 impl TryParse for CreateContextReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -430,6 +439,9 @@ impl TryParse for CreateContextReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateContextReply { sequence, width_actual, height_actual, flags_return, priv_data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -588,7 +600,8 @@ pub struct CreateSurfaceReply {
     pub priv_data: Vec<u32>,
 }
 impl TryParse for CreateSurfaceReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -599,6 +612,9 @@ impl TryParse for CreateSurfaceReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateSurfaceReply { sequence, priv_data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -785,7 +801,8 @@ pub struct CreateSubpictureReply {
     pub priv_data: Vec<u32>,
 }
 impl TryParse for CreateSubpictureReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -802,6 +819,9 @@ impl TryParse for CreateSubpictureReply {
             return Err(ParseError::ParseError);
         }
         let result = CreateSubpictureReply { sequence, width_actual, height_actual, num_palette_entries, entry_bytes, component_order, priv_data };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }
@@ -961,7 +981,8 @@ pub struct ListSubpictureTypesReply {
     pub types: Vec<xv::ImageFormatInfo>,
 }
 impl TryParse for ListSubpictureTypesReply {
-    fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+    fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
+        let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
@@ -973,6 +994,9 @@ impl TryParse for ListSubpictureTypesReply {
             return Err(ParseError::ParseError);
         }
         let result = ListSubpictureTypesReply { sequence, length, types };
+        let _ = remaining;
+        let remaining = initial_value.get(32 + length as usize * 4..)
+            .ok_or(ParseError::ParseError)?;
         Ok((result, remaining))
     }
 }


### PR DESCRIPTION
This is important for errors and events and not so much for replies (because they don't return the continuation of the buffer when they are parsed) but I added them as well.