### PR TITLE
Update the changelog in preparation of the next release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x11rb"
-version = "0.5.0"
+version = "0.6.0"
 description = "Rust bindings to X11"
 authors = [
     "Uli Schlachter <psychon@znc.in>",


### PR DESCRIPTION
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

Related to #484 

On one hand, the following items seem "too short", because a lot of work went into them. On the other hand, they seem "long enough" since the intermediate steps and parts are not really relevant for the changelog. Is the version that I settled with okay? (Items 2 and 3 talk about the same thing because one is under `Fixes` while the other is under `Breaking changes`)

* Added `struct`s for X11 requests and added infrastructure for parsing
  requests.
* Use nonblocking reads and writes for all interactions with the X11 server.
  This fixes a theoretical deadlock with the X11 server that was never seen in
  practice. Bindings for `poll()` are now required.
* The whole code around `rust_connection`'s low level stream abstraction was
  redesigned. This now uses an abstraction over the `poll()` function from libc
  (and requires similar support for all alternative transport implementations).
