### PR TITLE
UGLY CODE SIZE HACK

### DIFF
--- a/generator/src/generator/error_events.rs
+++ b/generator/src/generator/error_events.rs
@@ -312,7 +312,7 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
                     }
                     outln!(
                         out,
-                        "xproto::{}_EVENT => return Ok(Self::{}(event.try_into()?)),",
+                        "xproto::{}_EVENT => return xproto::{}Event::ugly_hack(event),",
                         super::camel_case_to_upper_snake(event_name),
                         event_name,
                     );
@@ -367,10 +367,10 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
                             }
                             outln!(
                                 out.indent(),
-                                "{}::{}_EVENT => Ok(Self::{}{}(event.try_into()?)),",
+                                "{}::{}_EVENT => {}::{}Event::ugly_hack(event),",
                                 ns.header,
                                 super::camel_case_to_upper_snake(event_def.name()),
-                                get_ns_name_prefix(ns),
+                                ns.header,
                                 event_def.name(),
                             );
                         }
@@ -424,10 +424,10 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
                             }
                             outln!(
                                 out.indent(),
-                                "{}::{}_EVENT => Ok(Self::{}{}(event.try_into()?)),",
+                                "{}::{}_EVENT => {}::{}Event::ugly_hack(event),",
                                 ns.header,
                                 super::camel_case_to_upper_snake(event_def.name()),
-                                get_ns_name_prefix(ns),
+                                ns.header,
                                 event_def.name(),
                             );
                         }

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -661,6 +661,22 @@ impl From<NotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl NotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (level, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
+        let (damage, remaining) = Damage::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (area, remaining) = xproto::Rectangle::try_parse(remaining)?;
+        let (geometry, remaining) = xproto::Rectangle::try_parse(remaining)?;
+        let level = level.try_into()?;
+        let _ = remaining;
+        let result = NotifyEvent { response_type, level, sequence, drawable, damage, timestamp, area, geometry };
+        Ok(super::Event::DamageNotify(result))
+    }
+}
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -2009,6 +2009,25 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl BufferSwapCompleteEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
+        let (ust_hi, remaining) = u32::try_parse(remaining)?;
+        let (ust_lo, remaining) = u32::try_parse(remaining)?;
+        let (msc_hi, remaining) = u32::try_parse(remaining)?;
+        let (msc_lo, remaining) = u32::try_parse(remaining)?;
+        let (sbc, remaining) = u32::try_parse(remaining)?;
+        let event_type = event_type.try_into()?;
+        let _ = remaining;
+        let result = BufferSwapCompleteEvent { response_type, sequence, event_type, drawable, ust_hi, ust_lo, msc_hi, msc_lo, sbc };
+        Ok(super::Event::Dri2BufferSwapComplete(result))
+    }
+}
 
 /// Opcode for the InvalidateBuffers event
 pub const INVALIDATE_BUFFERS_EVENT: u8 = 1;
@@ -2083,6 +2102,17 @@ impl From<&InvalidateBuffersEvent> for [u8; 32] {
 impl From<InvalidateBuffersEvent> for [u8; 32] {
     fn from(input: InvalidateBuffersEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl InvalidateBuffersEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
+        let _ = remaining;
+        let result = InvalidateBuffersEvent { response_type, sequence, drawable };
+        Ok(super::Event::Dri2InvalidateBuffers(result))
     }
 }
 

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -297,6 +297,27 @@ impl From<PbufferClobberEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl PbufferClobberEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (draw_type, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (b_mask, remaining) = u32::try_parse(remaining)?;
+        let (aux_buffer, remaining) = u16::try_parse(remaining)?;
+        let (x, remaining) = u16::try_parse(remaining)?;
+        let (y, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = PbufferClobberEvent { response_type, sequence, event_type, draw_type, drawable, b_mask, aux_buffer, x, y, width, height, count };
+        Ok(super::Event::GlxPbufferClobber(result))
+    }
+}
 
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 1;
@@ -389,6 +410,24 @@ impl From<&BufferSwapCompleteEvent> for [u8; 32] {
 impl From<BufferSwapCompleteEvent> for [u8; 32] {
     fn from(input: BufferSwapCompleteEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl BufferSwapCompleteEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (ust_hi, remaining) = u32::try_parse(remaining)?;
+        let (ust_lo, remaining) = u32::try_parse(remaining)?;
+        let (msc_hi, remaining) = u32::try_parse(remaining)?;
+        let (msc_lo, remaining) = u32::try_parse(remaining)?;
+        let (sbc, remaining) = u32::try_parse(remaining)?;
+        let _ = remaining;
+        let result = BufferSwapCompleteEvent { response_type, sequence, event_type, drawable, ust_hi, ust_lo, msc_hi, msc_lo, sbc };
+        Ok(super::Event::GlxBufferSwapComplete(result))
     }
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -7702,39 +7702,39 @@ impl Event {
         // Check if this is a core protocol event or error, or from the generic event extension
         match event_code {
             0 => return Ok(Self::Error(Error::parse(event, ext_info_provider)?)),
-            xproto::BUTTON_PRESS_EVENT => return Ok(Self::ButtonPress(event.try_into()?)),
-            xproto::BUTTON_RELEASE_EVENT => return Ok(Self::ButtonRelease(event.try_into()?)),
-            xproto::CIRCULATE_NOTIFY_EVENT => return Ok(Self::CirculateNotify(event.try_into()?)),
-            xproto::CIRCULATE_REQUEST_EVENT => return Ok(Self::CirculateRequest(event.try_into()?)),
-            xproto::CLIENT_MESSAGE_EVENT => return Ok(Self::ClientMessage(event.try_into()?)),
-            xproto::COLORMAP_NOTIFY_EVENT => return Ok(Self::ColormapNotify(event.try_into()?)),
-            xproto::CONFIGURE_NOTIFY_EVENT => return Ok(Self::ConfigureNotify(event.try_into()?)),
-            xproto::CONFIGURE_REQUEST_EVENT => return Ok(Self::ConfigureRequest(event.try_into()?)),
-            xproto::CREATE_NOTIFY_EVENT => return Ok(Self::CreateNotify(event.try_into()?)),
-            xproto::DESTROY_NOTIFY_EVENT => return Ok(Self::DestroyNotify(event.try_into()?)),
-            xproto::ENTER_NOTIFY_EVENT => return Ok(Self::EnterNotify(event.try_into()?)),
-            xproto::EXPOSE_EVENT => return Ok(Self::Expose(event.try_into()?)),
-            xproto::FOCUS_IN_EVENT => return Ok(Self::FocusIn(event.try_into()?)),
-            xproto::FOCUS_OUT_EVENT => return Ok(Self::FocusOut(event.try_into()?)),
-            xproto::GRAPHICS_EXPOSURE_EVENT => return Ok(Self::GraphicsExposure(event.try_into()?)),
-            xproto::GRAVITY_NOTIFY_EVENT => return Ok(Self::GravityNotify(event.try_into()?)),
-            xproto::KEY_PRESS_EVENT => return Ok(Self::KeyPress(event.try_into()?)),
-            xproto::KEY_RELEASE_EVENT => return Ok(Self::KeyRelease(event.try_into()?)),
-            xproto::KEYMAP_NOTIFY_EVENT => return Ok(Self::KeymapNotify(event.try_into()?)),
-            xproto::LEAVE_NOTIFY_EVENT => return Ok(Self::LeaveNotify(event.try_into()?)),
-            xproto::MAP_NOTIFY_EVENT => return Ok(Self::MapNotify(event.try_into()?)),
-            xproto::MAP_REQUEST_EVENT => return Ok(Self::MapRequest(event.try_into()?)),
-            xproto::MAPPING_NOTIFY_EVENT => return Ok(Self::MappingNotify(event.try_into()?)),
-            xproto::MOTION_NOTIFY_EVENT => return Ok(Self::MotionNotify(event.try_into()?)),
-            xproto::NO_EXPOSURE_EVENT => return Ok(Self::NoExposure(event.try_into()?)),
-            xproto::PROPERTY_NOTIFY_EVENT => return Ok(Self::PropertyNotify(event.try_into()?)),
-            xproto::REPARENT_NOTIFY_EVENT => return Ok(Self::ReparentNotify(event.try_into()?)),
-            xproto::RESIZE_REQUEST_EVENT => return Ok(Self::ResizeRequest(event.try_into()?)),
-            xproto::SELECTION_CLEAR_EVENT => return Ok(Self::SelectionClear(event.try_into()?)),
-            xproto::SELECTION_NOTIFY_EVENT => return Ok(Self::SelectionNotify(event.try_into()?)),
-            xproto::SELECTION_REQUEST_EVENT => return Ok(Self::SelectionRequest(event.try_into()?)),
-            xproto::UNMAP_NOTIFY_EVENT => return Ok(Self::UnmapNotify(event.try_into()?)),
-            xproto::VISIBILITY_NOTIFY_EVENT => return Ok(Self::VisibilityNotify(event.try_into()?)),
+            xproto::BUTTON_PRESS_EVENT => return xproto::ButtonPressEvent::ugly_hack(event),
+            xproto::BUTTON_RELEASE_EVENT => return xproto::ButtonReleaseEvent::ugly_hack(event),
+            xproto::CIRCULATE_NOTIFY_EVENT => return xproto::CirculateNotifyEvent::ugly_hack(event),
+            xproto::CIRCULATE_REQUEST_EVENT => return xproto::CirculateRequestEvent::ugly_hack(event),
+            xproto::CLIENT_MESSAGE_EVENT => return xproto::ClientMessageEvent::ugly_hack(event),
+            xproto::COLORMAP_NOTIFY_EVENT => return xproto::ColormapNotifyEvent::ugly_hack(event),
+            xproto::CONFIGURE_NOTIFY_EVENT => return xproto::ConfigureNotifyEvent::ugly_hack(event),
+            xproto::CONFIGURE_REQUEST_EVENT => return xproto::ConfigureRequestEvent::ugly_hack(event),
+            xproto::CREATE_NOTIFY_EVENT => return xproto::CreateNotifyEvent::ugly_hack(event),
+            xproto::DESTROY_NOTIFY_EVENT => return xproto::DestroyNotifyEvent::ugly_hack(event),
+            xproto::ENTER_NOTIFY_EVENT => return xproto::EnterNotifyEvent::ugly_hack(event),
+            xproto::EXPOSE_EVENT => return xproto::ExposeEvent::ugly_hack(event),
+            xproto::FOCUS_IN_EVENT => return xproto::FocusInEvent::ugly_hack(event),
+            xproto::FOCUS_OUT_EVENT => return xproto::FocusOutEvent::ugly_hack(event),
+            xproto::GRAPHICS_EXPOSURE_EVENT => return xproto::GraphicsExposureEvent::ugly_hack(event),
+            xproto::GRAVITY_NOTIFY_EVENT => return xproto::GravityNotifyEvent::ugly_hack(event),
+            xproto::KEY_PRESS_EVENT => return xproto::KeyPressEvent::ugly_hack(event),
+            xproto::KEY_RELEASE_EVENT => return xproto::KeyReleaseEvent::ugly_hack(event),
+            xproto::KEYMAP_NOTIFY_EVENT => return xproto::KeymapNotifyEvent::ugly_hack(event),
+            xproto::LEAVE_NOTIFY_EVENT => return xproto::LeaveNotifyEvent::ugly_hack(event),
+            xproto::MAP_NOTIFY_EVENT => return xproto::MapNotifyEvent::ugly_hack(event),
+            xproto::MAP_REQUEST_EVENT => return xproto::MapRequestEvent::ugly_hack(event),
+            xproto::MAPPING_NOTIFY_EVENT => return xproto::MappingNotifyEvent::ugly_hack(event),
+            xproto::MOTION_NOTIFY_EVENT => return xproto::MotionNotifyEvent::ugly_hack(event),
+            xproto::NO_EXPOSURE_EVENT => return xproto::NoExposureEvent::ugly_hack(event),
+            xproto::PROPERTY_NOTIFY_EVENT => return xproto::PropertyNotifyEvent::ugly_hack(event),
+            xproto::REPARENT_NOTIFY_EVENT => return xproto::ReparentNotifyEvent::ugly_hack(event),
+            xproto::RESIZE_REQUEST_EVENT => return xproto::ResizeRequestEvent::ugly_hack(event),
+            xproto::SELECTION_CLEAR_EVENT => return xproto::SelectionClearEvent::ugly_hack(event),
+            xproto::SELECTION_NOTIFY_EVENT => return xproto::SelectionNotifyEvent::ugly_hack(event),
+            xproto::SELECTION_REQUEST_EVENT => return xproto::SelectionRequestEvent::ugly_hack(event),
+            xproto::UNMAP_NOTIFY_EVENT => return xproto::UnmapNotifyEvent::ugly_hack(event),
+            xproto::VISIBILITY_NOTIFY_EVENT => return xproto::VisibilityNotifyEvent::ugly_hack(event),
             xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, ext_info_provider),
             _ => {}
         }
@@ -7744,98 +7744,98 @@ impl Event {
             #[cfg(feature = "damage")]
             Some((damage::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    damage::NOTIFY_EVENT => Ok(Self::DamageNotify(event.try_into()?)),
+                    damage::NOTIFY_EVENT => damage::NotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "dri2")]
             Some((dri2::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    dri2::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::Dri2BufferSwapComplete(event.try_into()?)),
-                    dri2::INVALIDATE_BUFFERS_EVENT => Ok(Self::Dri2InvalidateBuffers(event.try_into()?)),
+                    dri2::BUFFER_SWAP_COMPLETE_EVENT => dri2::BufferSwapCompleteEvent::ugly_hack(event),
+                    dri2::INVALIDATE_BUFFERS_EVENT => dri2::InvalidateBuffersEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "glx")]
             Some((glx::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    glx::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::GlxBufferSwapComplete(event.try_into()?)),
-                    glx::PBUFFER_CLOBBER_EVENT => Ok(Self::GlxPbufferClobber(event.try_into()?)),
+                    glx::BUFFER_SWAP_COMPLETE_EVENT => glx::BufferSwapCompleteEvent::ugly_hack(event),
+                    glx::PBUFFER_CLOBBER_EVENT => glx::PbufferClobberEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "present")]
             Some((present::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    present::GENERIC_EVENT => Ok(Self::PresentGeneric(event.try_into()?)),
+                    present::GENERIC_EVENT => present::GenericEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "randr")]
             Some((randr::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    randr::NOTIFY_EVENT => Ok(Self::RandrNotify(event.try_into()?)),
-                    randr::SCREEN_CHANGE_NOTIFY_EVENT => Ok(Self::RandrScreenChangeNotify(event.try_into()?)),
+                    randr::NOTIFY_EVENT => randr::NotifyEvent::ugly_hack(event),
+                    randr::SCREEN_CHANGE_NOTIFY_EVENT => randr::ScreenChangeNotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "screensaver")]
             Some((screensaver::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    screensaver::NOTIFY_EVENT => Ok(Self::ScreensaverNotify(event.try_into()?)),
+                    screensaver::NOTIFY_EVENT => screensaver::NotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "shape")]
             Some((shape::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    shape::NOTIFY_EVENT => Ok(Self::ShapeNotify(event.try_into()?)),
+                    shape::NOTIFY_EVENT => shape::NotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "shm")]
             Some((shm::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    shm::COMPLETION_EVENT => Ok(Self::ShmCompletion(event.try_into()?)),
+                    shm::COMPLETION_EVENT => shm::CompletionEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "sync")]
             Some((sync::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    sync::ALARM_NOTIFY_EVENT => Ok(Self::SyncAlarmNotify(event.try_into()?)),
-                    sync::COUNTER_NOTIFY_EVENT => Ok(Self::SyncCounterNotify(event.try_into()?)),
+                    sync::ALARM_NOTIFY_EVENT => sync::AlarmNotifyEvent::ugly_hack(event),
+                    sync::COUNTER_NOTIFY_EVENT => sync::CounterNotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xfixes")]
             Some((xfixes::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xfixes::CURSOR_NOTIFY_EVENT => Ok(Self::XfixesCursorNotify(event.try_into()?)),
-                    xfixes::SELECTION_NOTIFY_EVENT => Ok(Self::XfixesSelectionNotify(event.try_into()?)),
+                    xfixes::CURSOR_NOTIFY_EVENT => xfixes::CursorNotifyEvent::ugly_hack(event),
+                    xfixes::SELECTION_NOTIFY_EVENT => xfixes::SelectionNotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xinput")]
             Some((xinput::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xinput::CHANGE_DEVICE_NOTIFY_EVENT => Ok(Self::XinputChangeDeviceNotify(event.try_into()?)),
-                    xinput::DEVICE_BUTTON_PRESS_EVENT => Ok(Self::XinputDeviceButtonPress(event.try_into()?)),
-                    xinput::DEVICE_BUTTON_RELEASE_EVENT => Ok(Self::XinputDeviceButtonRelease(event.try_into()?)),
-                    xinput::DEVICE_BUTTON_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceButtonStateNotify(event.try_into()?)),
-                    xinput::DEVICE_FOCUS_IN_EVENT => Ok(Self::XinputDeviceFocusIn(event.try_into()?)),
-                    xinput::DEVICE_FOCUS_OUT_EVENT => Ok(Self::XinputDeviceFocusOut(event.try_into()?)),
-                    xinput::DEVICE_KEY_PRESS_EVENT => Ok(Self::XinputDeviceKeyPress(event.try_into()?)),
-                    xinput::DEVICE_KEY_RELEASE_EVENT => Ok(Self::XinputDeviceKeyRelease(event.try_into()?)),
-                    xinput::DEVICE_KEY_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceKeyStateNotify(event.try_into()?)),
-                    xinput::DEVICE_MAPPING_NOTIFY_EVENT => Ok(Self::XinputDeviceMappingNotify(event.try_into()?)),
-                    xinput::DEVICE_MOTION_NOTIFY_EVENT => Ok(Self::XinputDeviceMotionNotify(event.try_into()?)),
-                    xinput::DEVICE_PRESENCE_NOTIFY_EVENT => Ok(Self::XinputDevicePresenceNotify(event.try_into()?)),
-                    xinput::DEVICE_PROPERTY_NOTIFY_EVENT => Ok(Self::XinputDevicePropertyNotify(event.try_into()?)),
-                    xinput::DEVICE_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceStateNotify(event.try_into()?)),
-                    xinput::DEVICE_VALUATOR_EVENT => Ok(Self::XinputDeviceValuator(event.try_into()?)),
-                    xinput::PROXIMITY_IN_EVENT => Ok(Self::XinputProximityIn(event.try_into()?)),
-                    xinput::PROXIMITY_OUT_EVENT => Ok(Self::XinputProximityOut(event.try_into()?)),
+                    xinput::CHANGE_DEVICE_NOTIFY_EVENT => xinput::ChangeDeviceNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_BUTTON_PRESS_EVENT => xinput::DeviceButtonPressEvent::ugly_hack(event),
+                    xinput::DEVICE_BUTTON_RELEASE_EVENT => xinput::DeviceButtonReleaseEvent::ugly_hack(event),
+                    xinput::DEVICE_BUTTON_STATE_NOTIFY_EVENT => xinput::DeviceButtonStateNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_FOCUS_IN_EVENT => xinput::DeviceFocusInEvent::ugly_hack(event),
+                    xinput::DEVICE_FOCUS_OUT_EVENT => xinput::DeviceFocusOutEvent::ugly_hack(event),
+                    xinput::DEVICE_KEY_PRESS_EVENT => xinput::DeviceKeyPressEvent::ugly_hack(event),
+                    xinput::DEVICE_KEY_RELEASE_EVENT => xinput::DeviceKeyReleaseEvent::ugly_hack(event),
+                    xinput::DEVICE_KEY_STATE_NOTIFY_EVENT => xinput::DeviceKeyStateNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_MAPPING_NOTIFY_EVENT => xinput::DeviceMappingNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_MOTION_NOTIFY_EVENT => xinput::DeviceMotionNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_PRESENCE_NOTIFY_EVENT => xinput::DevicePresenceNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_PROPERTY_NOTIFY_EVENT => xinput::DevicePropertyNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_STATE_NOTIFY_EVENT => xinput::DeviceStateNotifyEvent::ugly_hack(event),
+                    xinput::DEVICE_VALUATOR_EVENT => xinput::DeviceValuatorEvent::ugly_hack(event),
+                    xinput::PROXIMITY_IN_EVENT => xinput::ProximityInEvent::ugly_hack(event),
+                    xinput::PROXIMITY_OUT_EVENT => xinput::ProximityOutEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
@@ -7845,34 +7845,34 @@ impl Event {
                     return Ok(Self::Unknown(event.to_vec()));
                 }
                 match *event.get(1).ok_or(ParseError::ParseError)? {
-                    xkb::ACCESS_X_NOTIFY_EVENT => Ok(Self::XkbAccessXNotify(event.try_into()?)),
-                    xkb::ACTION_MESSAGE_EVENT => Ok(Self::XkbActionMessage(event.try_into()?)),
-                    xkb::BELL_NOTIFY_EVENT => Ok(Self::XkbBellNotify(event.try_into()?)),
-                    xkb::COMPAT_MAP_NOTIFY_EVENT => Ok(Self::XkbCompatMapNotify(event.try_into()?)),
-                    xkb::CONTROLS_NOTIFY_EVENT => Ok(Self::XkbControlsNotify(event.try_into()?)),
-                    xkb::EXTENSION_DEVICE_NOTIFY_EVENT => Ok(Self::XkbExtensionDeviceNotify(event.try_into()?)),
-                    xkb::INDICATOR_MAP_NOTIFY_EVENT => Ok(Self::XkbIndicatorMapNotify(event.try_into()?)),
-                    xkb::INDICATOR_STATE_NOTIFY_EVENT => Ok(Self::XkbIndicatorStateNotify(event.try_into()?)),
-                    xkb::MAP_NOTIFY_EVENT => Ok(Self::XkbMapNotify(event.try_into()?)),
-                    xkb::NAMES_NOTIFY_EVENT => Ok(Self::XkbNamesNotify(event.try_into()?)),
-                    xkb::NEW_KEYBOARD_NOTIFY_EVENT => Ok(Self::XkbNewKeyboardNotify(event.try_into()?)),
-                    xkb::STATE_NOTIFY_EVENT => Ok(Self::XkbStateNotify(event.try_into()?)),
+                    xkb::ACCESS_X_NOTIFY_EVENT => xkb::AccessXNotifyEvent::ugly_hack(event),
+                    xkb::ACTION_MESSAGE_EVENT => xkb::ActionMessageEvent::ugly_hack(event),
+                    xkb::BELL_NOTIFY_EVENT => xkb::BellNotifyEvent::ugly_hack(event),
+                    xkb::COMPAT_MAP_NOTIFY_EVENT => xkb::CompatMapNotifyEvent::ugly_hack(event),
+                    xkb::CONTROLS_NOTIFY_EVENT => xkb::ControlsNotifyEvent::ugly_hack(event),
+                    xkb::EXTENSION_DEVICE_NOTIFY_EVENT => xkb::ExtensionDeviceNotifyEvent::ugly_hack(event),
+                    xkb::INDICATOR_MAP_NOTIFY_EVENT => xkb::IndicatorMapNotifyEvent::ugly_hack(event),
+                    xkb::INDICATOR_STATE_NOTIFY_EVENT => xkb::IndicatorStateNotifyEvent::ugly_hack(event),
+                    xkb::MAP_NOTIFY_EVENT => xkb::MapNotifyEvent::ugly_hack(event),
+                    xkb::NAMES_NOTIFY_EVENT => xkb::NamesNotifyEvent::ugly_hack(event),
+                    xkb::NEW_KEYBOARD_NOTIFY_EVENT => xkb::NewKeyboardNotifyEvent::ugly_hack(event),
+                    xkb::STATE_NOTIFY_EVENT => xkb::StateNotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xprint")]
             Some((xprint::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xprint::ATTRIBUT_NOTIFY_EVENT => Ok(Self::XprintAttributNotify(event.try_into()?)),
-                    xprint::NOTIFY_EVENT => Ok(Self::XprintNotify(event.try_into()?)),
+                    xprint::ATTRIBUT_NOTIFY_EVENT => xprint::AttributNotifyEvent::ugly_hack(event),
+                    xprint::NOTIFY_EVENT => xprint::NotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xv")]
             Some((xv::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xv::PORT_NOTIFY_EVENT => Ok(Self::XvPortNotify(event.try_into()?)),
-                    xv::VIDEO_NOTIFY_EVENT => Ok(Self::XvVideoNotify(event.try_into()?)),
+                    xv::PORT_NOTIFY_EVENT => xv::PortNotifyEvent::ugly_hack(event),
+                    xv::VIDEO_NOTIFY_EVENT => xv::VideoNotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
@@ -7893,42 +7893,42 @@ impl Event {
             #[cfg(feature = "present")]
             Some(present::X11_EXTENSION_NAME) => {
                 match ge_event.event_type {
-                    present::COMPLETE_NOTIFY_EVENT => Ok(Self::PresentCompleteNotify(event.try_into()?)),
-                    present::CONFIGURE_NOTIFY_EVENT => Ok(Self::PresentConfigureNotify(event.try_into()?)),
-                    present::IDLE_NOTIFY_EVENT => Ok(Self::PresentIdleNotify(event.try_into()?)),
-                    present::REDIRECT_NOTIFY_EVENT => Ok(Self::PresentRedirectNotify(event.try_into()?)),
+                    present::COMPLETE_NOTIFY_EVENT => present::CompleteNotifyEvent::ugly_hack(event),
+                    present::CONFIGURE_NOTIFY_EVENT => present::ConfigureNotifyEvent::ugly_hack(event),
+                    present::IDLE_NOTIFY_EVENT => present::IdleNotifyEvent::ugly_hack(event),
+                    present::REDIRECT_NOTIFY_EVENT => present::RedirectNotifyEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xinput")]
             Some(xinput::X11_EXTENSION_NAME) => {
                 match ge_event.event_type {
-                    xinput::BARRIER_HIT_EVENT => Ok(Self::XinputBarrierHit(event.try_into()?)),
-                    xinput::BARRIER_LEAVE_EVENT => Ok(Self::XinputBarrierLeave(event.try_into()?)),
-                    xinput::BUTTON_PRESS_EVENT => Ok(Self::XinputButtonPress(event.try_into()?)),
-                    xinput::BUTTON_RELEASE_EVENT => Ok(Self::XinputButtonRelease(event.try_into()?)),
-                    xinput::DEVICE_CHANGED_EVENT => Ok(Self::XinputDeviceChanged(event.try_into()?)),
-                    xinput::ENTER_EVENT => Ok(Self::XinputEnter(event.try_into()?)),
-                    xinput::FOCUS_IN_EVENT => Ok(Self::XinputFocusIn(event.try_into()?)),
-                    xinput::FOCUS_OUT_EVENT => Ok(Self::XinputFocusOut(event.try_into()?)),
-                    xinput::HIERARCHY_EVENT => Ok(Self::XinputHierarchy(event.try_into()?)),
-                    xinput::KEY_PRESS_EVENT => Ok(Self::XinputKeyPress(event.try_into()?)),
-                    xinput::KEY_RELEASE_EVENT => Ok(Self::XinputKeyRelease(event.try_into()?)),
-                    xinput::LEAVE_EVENT => Ok(Self::XinputLeave(event.try_into()?)),
-                    xinput::MOTION_EVENT => Ok(Self::XinputMotion(event.try_into()?)),
-                    xinput::PROPERTY_EVENT => Ok(Self::XinputProperty(event.try_into()?)),
-                    xinput::RAW_BUTTON_PRESS_EVENT => Ok(Self::XinputRawButtonPress(event.try_into()?)),
-                    xinput::RAW_BUTTON_RELEASE_EVENT => Ok(Self::XinputRawButtonRelease(event.try_into()?)),
-                    xinput::RAW_KEY_PRESS_EVENT => Ok(Self::XinputRawKeyPress(event.try_into()?)),
-                    xinput::RAW_KEY_RELEASE_EVENT => Ok(Self::XinputRawKeyRelease(event.try_into()?)),
-                    xinput::RAW_MOTION_EVENT => Ok(Self::XinputRawMotion(event.try_into()?)),
-                    xinput::RAW_TOUCH_BEGIN_EVENT => Ok(Self::XinputRawTouchBegin(event.try_into()?)),
-                    xinput::RAW_TOUCH_END_EVENT => Ok(Self::XinputRawTouchEnd(event.try_into()?)),
-                    xinput::RAW_TOUCH_UPDATE_EVENT => Ok(Self::XinputRawTouchUpdate(event.try_into()?)),
-                    xinput::TOUCH_BEGIN_EVENT => Ok(Self::XinputTouchBegin(event.try_into()?)),
-                    xinput::TOUCH_END_EVENT => Ok(Self::XinputTouchEnd(event.try_into()?)),
-                    xinput::TOUCH_OWNERSHIP_EVENT => Ok(Self::XinputTouchOwnership(event.try_into()?)),
-                    xinput::TOUCH_UPDATE_EVENT => Ok(Self::XinputTouchUpdate(event.try_into()?)),
+                    xinput::BARRIER_HIT_EVENT => xinput::BarrierHitEvent::ugly_hack(event),
+                    xinput::BARRIER_LEAVE_EVENT => xinput::BarrierLeaveEvent::ugly_hack(event),
+                    xinput::BUTTON_PRESS_EVENT => xinput::ButtonPressEvent::ugly_hack(event),
+                    xinput::BUTTON_RELEASE_EVENT => xinput::ButtonReleaseEvent::ugly_hack(event),
+                    xinput::DEVICE_CHANGED_EVENT => xinput::DeviceChangedEvent::ugly_hack(event),
+                    xinput::ENTER_EVENT => xinput::EnterEvent::ugly_hack(event),
+                    xinput::FOCUS_IN_EVENT => xinput::FocusInEvent::ugly_hack(event),
+                    xinput::FOCUS_OUT_EVENT => xinput::FocusOutEvent::ugly_hack(event),
+                    xinput::HIERARCHY_EVENT => xinput::HierarchyEvent::ugly_hack(event),
+                    xinput::KEY_PRESS_EVENT => xinput::KeyPressEvent::ugly_hack(event),
+                    xinput::KEY_RELEASE_EVENT => xinput::KeyReleaseEvent::ugly_hack(event),
+                    xinput::LEAVE_EVENT => xinput::LeaveEvent::ugly_hack(event),
+                    xinput::MOTION_EVENT => xinput::MotionEvent::ugly_hack(event),
+                    xinput::PROPERTY_EVENT => xinput::PropertyEvent::ugly_hack(event),
+                    xinput::RAW_BUTTON_PRESS_EVENT => xinput::RawButtonPressEvent::ugly_hack(event),
+                    xinput::RAW_BUTTON_RELEASE_EVENT => xinput::RawButtonReleaseEvent::ugly_hack(event),
+                    xinput::RAW_KEY_PRESS_EVENT => xinput::RawKeyPressEvent::ugly_hack(event),
+                    xinput::RAW_KEY_RELEASE_EVENT => xinput::RawKeyReleaseEvent::ugly_hack(event),
+                    xinput::RAW_MOTION_EVENT => xinput::RawMotionEvent::ugly_hack(event),
+                    xinput::RAW_TOUCH_BEGIN_EVENT => xinput::RawTouchBeginEvent::ugly_hack(event),
+                    xinput::RAW_TOUCH_END_EVENT => xinput::RawTouchEndEvent::ugly_hack(event),
+                    xinput::RAW_TOUCH_UPDATE_EVENT => xinput::RawTouchUpdateEvent::ugly_hack(event),
+                    xinput::TOUCH_BEGIN_EVENT => xinput::TouchBeginEvent::ugly_hack(event),
+                    xinput::TOUCH_END_EVENT => xinput::TouchEndEvent::ugly_hack(event),
+                    xinput::TOUCH_OWNERSHIP_EVENT => xinput::TouchOwnershipEvent::ugly_hack(event),
+                    xinput::TOUCH_UPDATE_EVENT => xinput::TouchUpdateEvent::ugly_hack(event),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -1193,6 +1193,20 @@ impl From<GenericEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl GenericEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (evtype, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let _ = remaining;
+        let result = GenericEvent { response_type, extension, sequence, length, evtype, event };
+        Ok(super::Event::PresentGeneric(result))
+    }
+}
 
 /// Opcode for the ConfigureNotify event
 pub const CONFIGURE_NOTIFY_EVENT: u16 = 0;
@@ -1248,6 +1262,30 @@ impl TryFrom<&[u8]> for ConfigureNotifyEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl ConfigureNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (off_x, remaining) = i16::try_parse(remaining)?;
+        let (off_y, remaining) = i16::try_parse(remaining)?;
+        let (pixmap_width, remaining) = u16::try_parse(remaining)?;
+        let (pixmap_height, remaining) = u16::try_parse(remaining)?;
+        let (pixmap_flags, remaining) = u32::try_parse(remaining)?;
+        let _ = remaining;
+        let result = ConfigureNotifyEvent { response_type, extension, sequence, length, event_type, event, window, x, y, width, height, off_x, off_y, pixmap_width, pixmap_height, pixmap_flags };
+        Ok(super::Event::PresentConfigureNotify(result))
+    }
+}
 
 /// Opcode for the CompleteNotify event
 pub const COMPLETE_NOTIFY_EVENT: u16 = 1;
@@ -1296,6 +1334,27 @@ impl TryFrom<&[u8]> for CompleteNotifyEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl CompleteNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (serial, remaining) = u32::try_parse(remaining)?;
+        let (ust, remaining) = u64::try_parse(remaining)?;
+        let (msc, remaining) = u64::try_parse(remaining)?;
+        let kind = kind.try_into()?;
+        let mode = mode.try_into()?;
+        let _ = remaining;
+        let result = CompleteNotifyEvent { response_type, extension, sequence, length, event_type, kind, mode, event, window, serial, ust, msc };
+        Ok(super::Event::PresentCompleteNotify(result))
+    }
+}
 
 /// Opcode for the IdleNotify event
 pub const IDLE_NOTIFY_EVENT: u16 = 2;
@@ -1337,6 +1396,24 @@ impl TryFrom<&[u8]> for IdleNotifyEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl IdleNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (serial, remaining) = u32::try_parse(remaining)?;
+        let (pixmap, remaining) = xproto::Pixmap::try_parse(remaining)?;
+        let (idle_fence, remaining) = sync::Fence::try_parse(remaining)?;
+        let _ = remaining;
+        let result = IdleNotifyEvent { response_type, extension, sequence, length, event_type, event, window, serial, pixmap, idle_fence };
+        Ok(super::Event::PresentIdleNotify(result))
     }
 }
 
@@ -1418,6 +1495,47 @@ impl TryFrom<&[u8]> for RedirectNotifyEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl RedirectNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (update_window, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (event, remaining) = Event::try_parse(remaining)?;
+        let (event_window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (pixmap, remaining) = xproto::Pixmap::try_parse(remaining)?;
+        let (serial, remaining) = u32::try_parse(remaining)?;
+        let (valid_region, remaining) = xfixes::Region::try_parse(remaining)?;
+        let (update_region, remaining) = xfixes::Region::try_parse(remaining)?;
+        let (valid_rect, remaining) = xproto::Rectangle::try_parse(remaining)?;
+        let (update_rect, remaining) = xproto::Rectangle::try_parse(remaining)?;
+        let (x_off, remaining) = i16::try_parse(remaining)?;
+        let (y_off, remaining) = i16::try_parse(remaining)?;
+        let (target_crtc, remaining) = randr::Crtc::try_parse(remaining)?;
+        let (wait_fence, remaining) = sync::Fence::try_parse(remaining)?;
+        let (idle_fence, remaining) = sync::Fence::try_parse(remaining)?;
+        let (options, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (target_msc, remaining) = u64::try_parse(remaining)?;
+        let (divisor, remaining) = u64::try_parse(remaining)?;
+        let (remainder, remaining) = u64::try_parse(remaining)?;
+        let mut remaining = remaining;
+        // Length is 'everything left in the input'
+        let mut notifies = Vec::new();
+        while !remaining.is_empty() {
+            let (v, new_remaining) = Notify::try_parse(remaining)?;
+            remaining = new_remaining;
+            notifies.push(v);
+        }
+        let _ = remaining;
+        let result = RedirectNotifyEvent { response_type, extension, sequence, length, event_type, update_window, event, event_window, window, pixmap, serial, valid_region, update_region, valid_rect, update_rect, x_off, y_off, target_crtc, wait_fence, idle_fence, options, target_msc, divisor, remainder, notifies };
+        Ok(super::Event::PresentRedirectNotify(result))
     }
 }
 

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -5828,6 +5828,27 @@ impl From<ScreenChangeNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ScreenChangeNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (rotation, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (request_window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (size_id, remaining) = u16::try_parse(remaining)?;
+        let (subpixel_order, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (mwidth, remaining) = u16::try_parse(remaining)?;
+        let (mheight, remaining) = u16::try_parse(remaining)?;
+        let subpixel_order = subpixel_order.try_into()?;
+        let _ = remaining;
+        let result = ScreenChangeNotifyEvent { response_type, rotation, sequence, timestamp, config_timestamp, root, request_window, size_id, subpixel_order, width, height, mwidth, mheight };
+        Ok(super::Event::RandrScreenChangeNotify(result))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -7178,6 +7199,18 @@ impl From<&NotifyEvent> for [u8; 32] {
 impl From<NotifyEvent> for [u8; 32] {
     fn from(input: NotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl NotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (sub_code, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (u, remaining) = NotifyData::try_parse(remaining)?;
+        let sub_code = sub_code.try_into()?;
+        let _ = remaining;
+        let result = NotifyEvent { response_type, sub_code, sequence, u };
+        Ok(super::Event::RandrNotify(result))
     }
 }
 

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -271,6 +271,25 @@ impl From<NotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl NotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (shape_kind, remaining) = Kind::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (affected_window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (extents_x, remaining) = i16::try_parse(remaining)?;
+        let (extents_y, remaining) = i16::try_parse(remaining)?;
+        let (extents_width, remaining) = u16::try_parse(remaining)?;
+        let (extents_height, remaining) = u16::try_parse(remaining)?;
+        let (server_time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (shaped, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
+        let shape_kind = shape_kind.try_into()?;
+        let _ = remaining;
+        let result = NotifyEvent { response_type, shape_kind, sequence, affected_window, extents_x, extents_y, extents_width, extents_height, server_time, shaped };
+        Ok(super::Event::ShapeNotify(result))
+    }
+}
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -125,6 +125,22 @@ impl From<CompletionEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl CompletionEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
+        let (minor_event, remaining) = u16::try_parse(remaining)?;
+        let (major_event, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (shmseg, remaining) = Seg::try_parse(remaining)?;
+        let (offset, remaining) = u32::try_parse(remaining)?;
+        let _ = remaining;
+        let result = CompletionEvent { response_type, sequence, drawable, minor_event, major_event, shmseg, offset };
+        Ok(super::Event::ShmCompletion(result))
+    }
+}
 
 /// Opcode for the BadSeg error
 pub const BAD_SEG_ERROR: u8 = 0;

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -2651,6 +2651,23 @@ impl From<CounterNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl CounterNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (counter, remaining) = Counter::try_parse(remaining)?;
+        let (wait_value, remaining) = Int64::try_parse(remaining)?;
+        let (counter_value, remaining) = Int64::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let (destroyed, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = CounterNotifyEvent { response_type, kind, sequence, counter, wait_value, counter_value, timestamp, count, destroyed };
+        Ok(super::Event::SyncCounterNotify(result))
+    }
+}
 
 /// Opcode for the AlarmNotify event
 pub const ALARM_NOTIFY_EVENT: u8 = 1;
@@ -2740,6 +2757,23 @@ impl From<&AlarmNotifyEvent> for [u8; 32] {
 impl From<AlarmNotifyEvent> for [u8; 32] {
     fn from(input: AlarmNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl AlarmNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (kind, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (alarm, remaining) = Alarm::try_parse(remaining)?;
+        let (counter_value, remaining) = Int64::try_parse(remaining)?;
+        let (alarm_value, remaining) = Int64::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let state = state.try_into()?;
+        let _ = remaining;
+        let result = AlarmNotifyEvent { response_type, kind, sequence, alarm, counter_value, alarm_value, timestamp, state };
+        Ok(super::Event::SyncAlarmNotify(result))
     }
 }
 

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -652,6 +652,23 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl SelectionNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (subtype, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (owner, remaining) = xproto::Window::try_parse(remaining)?;
+        let (selection, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (selection_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let subtype = subtype.try_into()?;
+        let _ = remaining;
+        let result = SelectionNotifyEvent { response_type, subtype, sequence, window, owner, selection, timestamp, selection_timestamp };
+        Ok(super::Event::XfixesSelectionNotify(result))
+    }
+}
 
 /// Opcode for the SelectSelectionInput request
 pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
@@ -936,6 +953,22 @@ impl From<&CursorNotifyEvent> for [u8; 32] {
 impl From<CursorNotifyEvent> for [u8; 32] {
     fn from(input: CursorNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl CursorNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (subtype, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (cursor_serial, remaining) = u32::try_parse(remaining)?;
+        let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let subtype = subtype.try_into()?;
+        let _ = remaining;
+        let result = CursorNotifyEvent { response_type, subtype, sequence, window, cursor_serial, timestamp, name };
+        Ok(super::Event::XfixesCursorNotify(result))
     }
 }
 

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -14726,6 +14726,33 @@ impl From<DeviceValuatorEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl DeviceValuatorEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (device_state, remaining) = u16::try_parse(remaining)?;
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let (first_valuator, remaining) = u8::try_parse(remaining)?;
+        let (valuators_0, remaining) = i32::try_parse(remaining)?;
+        let (valuators_1, remaining) = i32::try_parse(remaining)?;
+        let (valuators_2, remaining) = i32::try_parse(remaining)?;
+        let (valuators_3, remaining) = i32::try_parse(remaining)?;
+        let (valuators_4, remaining) = i32::try_parse(remaining)?;
+        let (valuators_5, remaining) = i32::try_parse(remaining)?;
+        let valuators = [
+            valuators_0,
+            valuators_1,
+            valuators_2,
+            valuators_3,
+            valuators_4,
+            valuators_5,
+        ];
+        let _ = remaining;
+        let result = DeviceValuatorEvent { response_type, device_id, sequence, device_state, num_valuators, first_valuator, valuators };
+        Ok(super::Event::XinputDeviceValuator(result))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -14893,6 +14920,27 @@ impl From<DeviceKeyPressEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl DeviceKeyPressEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event, remaining) = xproto::Window::try_parse(remaining)?;
+        let (child, remaining) = xproto::Window::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let _ = remaining;
+        let result = DeviceKeyPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen, device_id };
+        Ok(super::Event::XinputDeviceKeyPress(result))
+    }
+}
 
 /// Opcode for the DeviceKeyRelease event
 pub const DEVICE_KEY_RELEASE_EVENT: u8 = 2;
@@ -14996,6 +15044,23 @@ impl From<&DeviceFocusInEvent> for [u8; 32] {
 impl From<DeviceFocusInEvent> for [u8; 32] {
     fn from(input: DeviceFocusInEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl DeviceFocusInEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(18..).ok_or(ParseError::ParseError)?;
+        let detail = detail.try_into()?;
+        let mode = mode.try_into()?;
+        let _ = remaining;
+        let result = DeviceFocusInEvent { response_type, detail, sequence, time, window, mode, device_id };
+        Ok(super::Event::XinputDeviceFocusIn(result))
     }
 }
 
@@ -15189,6 +15254,33 @@ impl From<DeviceStateNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl DeviceStateNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (num_keys, remaining) = u8::try_parse(remaining)?;
+        let (num_buttons, remaining) = u8::try_parse(remaining)?;
+        let (num_valuators, remaining) = u8::try_parse(remaining)?;
+        let (classes_reported, remaining) = u8::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let buttons = <[u8; 4]>::try_from(buttons).unwrap();
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
+        let keys = <[u8; 4]>::try_from(keys).unwrap();
+        let (valuators_0, remaining) = u32::try_parse(remaining)?;
+        let (valuators_1, remaining) = u32::try_parse(remaining)?;
+        let (valuators_2, remaining) = u32::try_parse(remaining)?;
+        let valuators = [
+            valuators_0,
+            valuators_1,
+            valuators_2,
+        ];
+        let _ = remaining;
+        let result = DeviceStateNotifyEvent { response_type, device_id, sequence, time, num_keys, num_buttons, num_valuators, classes_reported, buttons, keys, valuators };
+        Ok(super::Event::XinputDeviceStateNotify(result))
+    }
+}
 
 /// Opcode for the DeviceMappingNotify event
 pub const DEVICE_MAPPING_NOTIFY_EVENT: u8 = 11;
@@ -15276,6 +15368,23 @@ impl From<&DeviceMappingNotifyEvent> for [u8; 32] {
 impl From<DeviceMappingNotifyEvent> for [u8; 32] {
     fn from(input: DeviceMappingNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl DeviceMappingNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (request, remaining) = u8::try_parse(remaining)?;
+        let (first_keycode, remaining) = KeyCode::try_parse(remaining)?;
+        let (count, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let request = request.try_into()?;
+        let _ = remaining;
+        let result = DeviceMappingNotifyEvent { response_type, device_id, sequence, request, first_keycode, count, time };
+        Ok(super::Event::XinputDeviceMappingNotify(result))
     }
 }
 
@@ -15430,6 +15539,20 @@ impl From<ChangeDeviceNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ChangeDeviceNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (request, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(23..).ok_or(ParseError::ParseError)?;
+        let request = request.try_into()?;
+        let _ = remaining;
+        let result = ChangeDeviceNotifyEvent { response_type, device_id, sequence, time, request };
+        Ok(super::Event::XinputChangeDeviceNotify(result))
+    }
+}
 
 /// Opcode for the DeviceKeyStateNotify event
 pub const DEVICE_KEY_STATE_NOTIFY_EVENT: u8 = 13;
@@ -15507,6 +15630,18 @@ impl From<DeviceKeyStateNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl DeviceKeyStateNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
+        let keys = <[u8; 28]>::try_from(keys).unwrap();
+        let _ = remaining;
+        let result = DeviceKeyStateNotifyEvent { response_type, device_id, sequence, keys };
+        Ok(super::Event::XinputDeviceKeyStateNotify(result))
+    }
+}
 
 /// Opcode for the DeviceButtonStateNotify event
 pub const DEVICE_BUTTON_STATE_NOTIFY_EVENT: u8 = 14;
@@ -15582,6 +15717,18 @@ impl From<&DeviceButtonStateNotifyEvent> for [u8; 32] {
 impl From<DeviceButtonStateNotifyEvent> for [u8; 32] {
     fn from(input: DeviceButtonStateNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl DeviceButtonStateNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
+        let buttons = <[u8; 28]>::try_from(buttons).unwrap();
+        let _ = remaining;
+        let result = DeviceButtonStateNotifyEvent { response_type, device_id, sequence, buttons };
+        Ok(super::Event::XinputDeviceButtonStateNotify(result))
     }
 }
 
@@ -15744,6 +15891,22 @@ impl From<DevicePresenceNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl DevicePresenceNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (devchange, remaining) = u8::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (control, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(20..).ok_or(ParseError::ParseError)?;
+        let devchange = devchange.try_into()?;
+        let _ = remaining;
+        let result = DevicePresenceNotifyEvent { response_type, sequence, time, devchange, device_id, control };
+        Ok(super::Event::XinputDevicePresenceNotify(result))
+    }
+}
 
 /// Opcode for the DevicePropertyNotify event
 pub const DEVICE_PROPERTY_NOTIFY_EVENT: u8 = 16;
@@ -15827,6 +15990,21 @@ impl From<&DevicePropertyNotifyEvent> for [u8; 32] {
 impl From<DevicePropertyNotifyEvent> for [u8; 32] {
     fn from(input: DevicePropertyNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl DevicePropertyNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (property, remaining) = xproto::Atom::try_parse(remaining)?;
+        let remaining = remaining.get(19..).ok_or(ParseError::ParseError)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let state = state.try_into()?;
+        let _ = remaining;
+        let result = DevicePropertyNotifyEvent { response_type, state, sequence, time, property, device_id };
+        Ok(super::Event::XinputDevicePropertyNotify(result))
     }
 }
 
@@ -15949,6 +16127,26 @@ impl DeviceChangedEvent {
     pub fn num_classes(&self) -> u16 {
         self.classes.len()
             .try_into().unwrap()
+    }
+}
+impl DeviceChangedEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (num_classes, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (reason, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
+        let (classes, remaining) = crate::x11_utils::parse_list::<DeviceClass>(remaining, num_classes.try_into().or(Err(ParseError::ParseError))?)?;
+        let reason = reason.try_into()?;
+        let _ = remaining;
+        let result = DeviceChangedEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, reason, classes };
+        Ok(super::Event::XinputDeviceChanged(result))
     }
 }
 
@@ -16074,6 +16272,38 @@ impl KeyPressEvent {
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
+    }
+}
+impl KeyPressEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event, remaining) = xproto::Window::try_parse(remaining)?;
+        let (child, remaining) = xproto::Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let _ = remaining;
+        let result = KeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
+        Ok(super::Event::XinputKeyPress(result))
     }
 }
 
@@ -16203,6 +16433,38 @@ impl ButtonPressEvent {
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
+    }
+}
+impl ButtonPressEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event, remaining) = xproto::Window::try_parse(remaining)?;
+        let (child, remaining) = xproto::Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let _ = remaining;
+        let result = ButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
+        Ok(super::Event::XinputButtonPress(result))
     }
 }
 
@@ -16451,6 +16713,38 @@ impl EnterEvent {
             .try_into().unwrap()
     }
 }
+impl EnterEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event, remaining) = xproto::Window::try_parse(remaining)?;
+        let (child, remaining) = xproto::Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let (focus, remaining) = bool::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (buttons, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let mode = mode.try_into()?;
+        let detail = detail.try_into()?;
+        let _ = remaining;
+        let result = EnterEvent { response_type, extension, sequence, length, event_type, deviceid, time, sourceid, mode, detail, root, event, child, root_x, root_y, event_x, event_y, same_screen, focus, mods, group, buttons };
+        Ok(super::Event::XinputEnter(result))
+    }
+}
 
 /// Opcode for the Leave event
 pub const LEAVE_EVENT: u16 = 8;
@@ -16662,6 +16956,24 @@ impl HierarchyEvent {
             .try_into().unwrap()
     }
 }
+impl HierarchyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (num_infos, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
+        let (infos, remaining) = crate::x11_utils::parse_list::<HierarchyInfo>(remaining, num_infos.try_into().or(Err(ParseError::ParseError))?)?;
+        let _ = remaining;
+        let result = HierarchyEvent { response_type, extension, sequence, length, event_type, deviceid, time, flags, infos };
+        Ok(super::Event::XinputHierarchy(result))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -16769,6 +17081,24 @@ impl TryFrom<&[u8]> for PropertyEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl PropertyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (property, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (what, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(11..).ok_or(ParseError::ParseError)?;
+        let what = what.try_into()?;
+        let _ = remaining;
+        let result = PropertyEvent { response_type, extension, sequence, length, event_type, deviceid, time, property, what };
+        Ok(super::Event::XinputProperty(result))
+    }
+}
 
 /// Opcode for the RawKeyPress event
 pub const RAW_KEY_PRESS_EVENT: u16 = 13;
@@ -16832,6 +17162,28 @@ impl RawKeyPressEvent {
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
+    }
+}
+impl RawKeyPressEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let _ = remaining;
+        let result = RawKeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
+        Ok(super::Event::XinputRawKeyPress(result))
     }
 }
 
@@ -16901,6 +17253,28 @@ impl RawButtonPressEvent {
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
+    }
+}
+impl RawButtonPressEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let _ = remaining;
+        let result = RawButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
+        Ok(super::Event::XinputRawButtonPress(result))
     }
 }
 
@@ -17039,6 +17413,38 @@ impl TouchBeginEvent {
             .try_into().unwrap()
     }
 }
+impl TouchBeginEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event, remaining) = xproto::Window::try_parse(remaining)?;
+        let (child, remaining) = xproto::Window::try_parse(remaining)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (event_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (buttons_len, remaining) = u16::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (mods, remaining) = ModifierInfo::try_parse(remaining)?;
+        let (group, remaining) = GroupInfo::try_parse(remaining)?;
+        let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let _ = remaining;
+        let result = TouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
+        Ok(super::Event::XinputTouchBegin(result))
+    }
+}
 
 /// Opcode for the TouchUpdate event
 pub const TOUCH_UPDATE_EVENT: u16 = 19;
@@ -17157,6 +17563,29 @@ impl TryFrom<&[u8]> for TouchOwnershipEvent {
         Ok(Self::try_parse(value)?.0)
     }
 }
+impl TouchOwnershipEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (touchid, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event, remaining) = xproto::Window::try_parse(remaining)?;
+        let (child, remaining) = xproto::Window::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(8..).ok_or(ParseError::ParseError)?;
+        let flags = flags.try_into()?;
+        let _ = remaining;
+        let result = TouchOwnershipEvent { response_type, extension, sequence, length, event_type, deviceid, time, touchid, root, event, child, sourceid, flags };
+        Ok(super::Event::XinputTouchOwnership(result))
+    }
+}
 
 /// Opcode for the RawTouchBegin event
 pub const RAW_TOUCH_BEGIN_EVENT: u16 = 22;
@@ -17220,6 +17649,28 @@ impl RawTouchBeginEvent {
     pub fn valuators_len(&self) -> u16 {
         self.valuator_mask.len()
             .try_into().unwrap()
+    }
+}
+impl RawTouchBeginEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (detail, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (valuators_len, remaining) = u16::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::ParseError))?.try_into().or(Err(ParseError::ParseError))?)?;
+        let _ = remaining;
+        let result = RawTouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
+        Ok(super::Event::XinputRawTouchBegin(result))
     }
 }
 
@@ -17350,6 +17801,32 @@ impl TryFrom<&[u8]> for BarrierHitEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl BarrierHitEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (eventid, remaining) = u32::try_parse(remaining)?;
+        let (root, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event, remaining) = xproto::Window::try_parse(remaining)?;
+        let (barrier, remaining) = xfixes::Barrier::try_parse(remaining)?;
+        let (dtime, remaining) = u32::try_parse(remaining)?;
+        let (flags, remaining) = u32::try_parse(remaining)?;
+        let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (root_x, remaining) = Fp1616::try_parse(remaining)?;
+        let (root_y, remaining) = Fp1616::try_parse(remaining)?;
+        let (dx, remaining) = Fp3232::try_parse(remaining)?;
+        let (dy, remaining) = Fp3232::try_parse(remaining)?;
+        let _ = remaining;
+        let result = BarrierHitEvent { response_type, extension, sequence, length, event_type, deviceid, time, eventid, root, event, barrier, dtime, flags, sourceid, root_x, root_y, dx, dy };
+        Ok(super::Event::XinputBarrierHit(result))
     }
 }
 

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -12226,6 +12226,27 @@ impl From<NewKeyboardNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl NewKeyboardNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (old_device_id, remaining) = u8::try_parse(remaining)?;
+        let (min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (old_min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (old_max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (request_major, remaining) = u8::try_parse(remaining)?;
+        let (request_minor, remaining) = u8::try_parse(remaining)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(14..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = NewKeyboardNotifyEvent { response_type, xkb_type, sequence, time, device_id, old_device_id, min_key_code, max_key_code, old_min_key_code, old_max_key_code, request_major, request_minor, changed };
+        Ok(super::Event::XkbNewKeyboardNotify(result))
+    }
+}
 
 /// Opcode for the MapNotify event
 pub const MAP_NOTIFY_EVENT: u8 = 1;
@@ -12362,6 +12383,38 @@ impl From<&MapNotifyEvent> for [u8; 32] {
 impl From<MapNotifyEvent> for [u8; 32] {
     fn from(input: MapNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl MapNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (ptr_btn_actions, remaining) = u8::try_parse(remaining)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let (min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (first_type, remaining) = u8::try_parse(remaining)?;
+        let (n_types, remaining) = u8::try_parse(remaining)?;
+        let (first_key_sym, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (n_key_syms, remaining) = u8::try_parse(remaining)?;
+        let (first_key_act, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (n_key_acts, remaining) = u8::try_parse(remaining)?;
+        let (first_key_behavior, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (n_key_behavior, remaining) = u8::try_parse(remaining)?;
+        let (first_key_explicit, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
+        let (first_mod_map_key, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (n_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let (first_v_mod_map_key, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
+        let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = MapNotifyEvent { response_type, xkb_type, sequence, time, device_id, ptr_btn_actions, changed, min_key_code, max_key_code, first_type, n_types, first_key_sym, n_key_syms, first_key_act, n_key_acts, first_key_behavior, n_key_behavior, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, virtual_mods };
+        Ok(super::Event::XkbMapNotify(result))
     }
 }
 
@@ -12503,6 +12556,39 @@ impl From<StateNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl StateNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
+        let (base_mods, remaining) = u8::try_parse(remaining)?;
+        let (latched_mods, remaining) = u8::try_parse(remaining)?;
+        let (locked_mods, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = u8::try_parse(remaining)?;
+        let (base_group, remaining) = i16::try_parse(remaining)?;
+        let (latched_group, remaining) = i16::try_parse(remaining)?;
+        let (locked_group, remaining) = u8::try_parse(remaining)?;
+        let (compat_state, remaining) = u8::try_parse(remaining)?;
+        let (grab_mods, remaining) = u8::try_parse(remaining)?;
+        let (compat_grab_mods, remaining) = u8::try_parse(remaining)?;
+        let (lookup_mods, remaining) = u8::try_parse(remaining)?;
+        let (compat_loockup_mods, remaining) = u8::try_parse(remaining)?;
+        let (ptr_btn_state, remaining) = u16::try_parse(remaining)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (event_type, remaining) = u8::try_parse(remaining)?;
+        let (request_major, remaining) = u8::try_parse(remaining)?;
+        let (request_minor, remaining) = u8::try_parse(remaining)?;
+        let group = group.try_into()?;
+        let locked_group = locked_group.try_into()?;
+        let _ = remaining;
+        let result = StateNotifyEvent { response_type, xkb_type, sequence, time, device_id, mods, base_mods, latched_mods, locked_mods, group, base_group, latched_group, locked_group, compat_state, grab_mods, compat_grab_mods, lookup_mods, compat_loockup_mods, ptr_btn_state, changed, keycode, event_type, request_major, request_minor };
+        Ok(super::Event::XkbStateNotify(result))
+    }
+}
 
 /// Opcode for the ControlsNotify event
 pub const CONTROLS_NOTIFY_EVENT: u8 = 3;
@@ -12609,6 +12695,28 @@ impl From<ControlsNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ControlsNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (num_groups, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let (changed_controls, remaining) = u32::try_parse(remaining)?;
+        let (enabled_controls, remaining) = u32::try_parse(remaining)?;
+        let (enabled_control_changes, remaining) = u32::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (event_type, remaining) = u8::try_parse(remaining)?;
+        let (request_major, remaining) = u8::try_parse(remaining)?;
+        let (request_minor, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = ControlsNotifyEvent { response_type, xkb_type, sequence, time, device_id, num_groups, changed_controls, enabled_controls, enabled_control_changes, keycode, event_type, request_major, request_minor };
+        Ok(super::Event::XkbControlsNotify(result))
+    }
+}
 
 /// Opcode for the IndicatorStateNotify event
 pub const INDICATOR_STATE_NOTIFY_EVENT: u8 = 4;
@@ -12697,6 +12805,22 @@ impl From<IndicatorStateNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl IndicatorStateNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (state, remaining) = u32::try_parse(remaining)?;
+        let (state_changed, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = IndicatorStateNotifyEvent { response_type, xkb_type, sequence, time, device_id, state, state_changed };
+        Ok(super::Event::XkbIndicatorStateNotify(result))
+    }
+}
 
 /// Opcode for the IndicatorMapNotify event
 pub const INDICATOR_MAP_NOTIFY_EVENT: u8 = 5;
@@ -12783,6 +12907,22 @@ impl From<&IndicatorMapNotifyEvent> for [u8; 32] {
 impl From<IndicatorMapNotifyEvent> for [u8; 32] {
     fn from(input: IndicatorMapNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl IndicatorMapNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let (state, remaining) = u32::try_parse(remaining)?;
+        let (map_changed, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(12..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = IndicatorMapNotifyEvent { response_type, xkb_type, sequence, time, device_id, state, map_changed };
+        Ok(super::Event::XkbIndicatorMapNotify(result))
     }
 }
 
@@ -12904,6 +13044,33 @@ impl From<NamesNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl NamesNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (changed, remaining) = u16::try_parse(remaining)?;
+        let (first_type, remaining) = u8::try_parse(remaining)?;
+        let (n_types, remaining) = u8::try_parse(remaining)?;
+        let (first_level_name, remaining) = u8::try_parse(remaining)?;
+        let (n_level_names, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (n_radio_groups, remaining) = u8::try_parse(remaining)?;
+        let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
+        let (changed_group_names, remaining) = u8::try_parse(remaining)?;
+        let (changed_virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let (first_key, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (n_keys, remaining) = u8::try_parse(remaining)?;
+        let (changed_indicators, remaining) = u32::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = NamesNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed, first_type, n_types, first_level_name, n_level_names, n_radio_groups, n_key_aliases, changed_group_names, changed_virtual_mods, first_key, n_keys, changed_indicators };
+        Ok(super::Event::XkbNamesNotify(result))
+    }
+}
 
 /// Opcode for the CompatMapNotify event
 pub const COMPAT_MAP_NOTIFY_EVENT: u8 = 7;
@@ -12995,6 +13162,23 @@ impl From<&CompatMapNotifyEvent> for [u8; 32] {
 impl From<CompatMapNotifyEvent> for [u8; 32] {
     fn from(input: CompatMapNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl CompatMapNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (changed_groups, remaining) = u8::try_parse(remaining)?;
+        let (first_si, remaining) = u16::try_parse(remaining)?;
+        let (n_si, remaining) = u16::try_parse(remaining)?;
+        let (n_total_si, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = CompatMapNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed_groups, first_si, n_si, n_total_si };
+        Ok(super::Event::XkbCompatMapNotify(result))
     }
 }
 
@@ -13103,6 +13287,28 @@ impl From<BellNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl BellNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (bell_class, remaining) = u8::try_parse(remaining)?;
+        let (bell_id, remaining) = u8::try_parse(remaining)?;
+        let (percent, remaining) = u8::try_parse(remaining)?;
+        let (pitch, remaining) = u16::try_parse(remaining)?;
+        let (duration, remaining) = u16::try_parse(remaining)?;
+        let (name, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (window, remaining) = xproto::Window::try_parse(remaining)?;
+        let (event_only, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(7..).ok_or(ParseError::ParseError)?;
+        let bell_class = bell_class.try_into()?;
+        let _ = remaining;
+        let result = BellNotifyEvent { response_type, xkb_type, sequence, time, device_id, bell_class, bell_id, percent, pitch, duration, name, window, event_only };
+        Ok(super::Event::XkbBellNotify(result))
+    }
+}
 
 /// Opcode for the ActionMessage event
 pub const ACTION_MESSAGE_EVENT: u8 = 9;
@@ -13203,6 +13409,27 @@ impl From<ActionMessageEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ActionMessageEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (press, remaining) = bool::try_parse(remaining)?;
+        let (key_event_follows, remaining) = bool::try_parse(remaining)?;
+        let (mods, remaining) = u8::try_parse(remaining)?;
+        let (group, remaining) = u8::try_parse(remaining)?;
+        let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, 8)?;
+        let message = <[u8; 8]>::try_from(message).unwrap();
+        let remaining = remaining.get(10..).ok_or(ParseError::ParseError)?;
+        let group = group.try_into()?;
+        let _ = remaining;
+        let result = ActionMessageEvent { response_type, xkb_type, sequence, time, device_id, keycode, press, key_event_follows, mods, group, message };
+        Ok(super::Event::XkbActionMessage(result))
+    }
+}
 
 /// Opcode for the AccessXNotify event
 pub const ACCESS_X_NOTIFY_EVENT: u8 = 10;
@@ -13294,6 +13521,23 @@ impl From<&AccessXNotifyEvent> for [u8; 32] {
 impl From<AccessXNotifyEvent> for [u8; 32] {
     fn from(input: AccessXNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl AccessXNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
+        let (detailt, remaining) = u16::try_parse(remaining)?;
+        let (slow_keys_delay, remaining) = u16::try_parse(remaining)?;
+        let (debounce_delay, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(16..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = AccessXNotifyEvent { response_type, xkb_type, sequence, time, device_id, keycode, detailt, slow_keys_delay, debounce_delay };
+        Ok(super::Event::XkbAccessXNotify(result))
     }
 }
 
@@ -13404,6 +13648,30 @@ impl From<&ExtensionDeviceNotifyEvent> for [u8; 32] {
 impl From<ExtensionDeviceNotifyEvent> for [u8; 32] {
     fn from(input: ExtensionDeviceNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl ExtensionDeviceNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (xkb_type, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (device_id, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (reason, remaining) = u16::try_parse(remaining)?;
+        let (led_class, remaining) = u16::try_parse(remaining)?;
+        let (led_id, remaining) = u16::try_parse(remaining)?;
+        let (leds_defined, remaining) = u32::try_parse(remaining)?;
+        let (led_state, remaining) = u32::try_parse(remaining)?;
+        let (first_button, remaining) = u8::try_parse(remaining)?;
+        let (n_buttons, remaining) = u8::try_parse(remaining)?;
+        let (supported, remaining) = u16::try_parse(remaining)?;
+        let (unsupported, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let led_class = led_class.try_into()?;
+        let _ = remaining;
+        let result = ExtensionDeviceNotifyEvent { response_type, xkb_type, sequence, time, device_id, reason, led_class, led_id, leds_defined, led_state, first_button, n_buttons, supported, unsupported };
+        Ok(super::Event::XkbExtensionDeviceNotify(result))
     }
 }
 

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -2596,6 +2596,18 @@ impl From<NotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl NotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (context, remaining) = Pcontext::try_parse(remaining)?;
+        let (cancel, remaining) = bool::try_parse(remaining)?;
+        let _ = remaining;
+        let result = NotifyEvent { response_type, detail, sequence, context, cancel };
+        Ok(super::Event::XprintNotify(result))
+    }
+}
 
 /// Opcode for the AttributNotify event
 pub const ATTRIBUT_NOTIFY_EVENT: u8 = 1;
@@ -2672,6 +2684,17 @@ impl From<&AttributNotifyEvent> for [u8; 32] {
 impl From<AttributNotifyEvent> for [u8; 32] {
     fn from(input: AttributNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl AttributNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (context, remaining) = Pcontext::try_parse(remaining)?;
+        let _ = remaining;
+        let result = AttributNotifyEvent { response_type, detail, sequence, context };
+        Ok(super::Event::XprintAttributNotify(result))
     }
 }
 

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -1526,6 +1526,27 @@ impl From<KeyPressEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl KeyPressEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = Keycode::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = KeyPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
+        Ok(super::Event::KeyPress(result))
+    }
+}
 
 /// Opcode for the KeyRelease event
 pub const KEY_RELEASE_EVENT: u8 = 3;
@@ -1716,6 +1737,27 @@ impl From<&ButtonPressEvent> for [u8; 32] {
 impl From<ButtonPressEvent> for [u8; 32] {
     fn from(input: ButtonPressEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl ButtonPressEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = Button::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = ButtonPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
+        Ok(super::Event::ButtonPress(result))
     }
 }
 
@@ -1920,6 +1962,28 @@ impl From<&MotionNotifyEvent> for [u8; 32] {
 impl From<MotionNotifyEvent> for [u8; 32] {
     fn from(input: MotionNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl MotionNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (same_screen, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let detail = detail.try_into()?;
+        let _ = remaining;
+        let result = MotionNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
+        Ok(super::Event::MotionNotify(result))
     }
 }
 
@@ -2194,6 +2258,29 @@ impl From<EnterNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl EnterNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (root, remaining) = Window::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (child, remaining) = Window::try_parse(remaining)?;
+        let (root_x, remaining) = i16::try_parse(remaining)?;
+        let (root_y, remaining) = i16::try_parse(remaining)?;
+        let (event_x, remaining) = i16::try_parse(remaining)?;
+        let (event_y, remaining) = i16::try_parse(remaining)?;
+        let (state, remaining) = u16::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let (same_screen_focus, remaining) = u8::try_parse(remaining)?;
+        let detail = detail.try_into()?;
+        let mode = mode.try_into()?;
+        let _ = remaining;
+        let result = EnterNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, mode, same_screen_focus };
+        Ok(super::Event::EnterNotify(result))
+    }
+}
 
 /// Opcode for the LeaveNotify event
 pub const LEAVE_NOTIFY_EVENT: u8 = 8;
@@ -2290,6 +2377,21 @@ impl From<FocusInEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl FocusInEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (detail, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (mode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let detail = detail.try_into()?;
+        let mode = mode.try_into()?;
+        let _ = remaining;
+        let result = FocusInEvent { response_type, detail, sequence, event, mode };
+        Ok(super::Event::FocusIn(result))
+    }
+}
 
 /// Opcode for the FocusOut event
 pub const FOCUS_OUT_EVENT: u8 = 10;
@@ -2363,6 +2465,16 @@ impl From<&KeymapNotifyEvent> for [u8; 32] {
 impl From<KeymapNotifyEvent> for [u8; 32] {
     fn from(input: KeymapNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl KeymapNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 31)?;
+        let keys = <[u8; 31]>::try_from(keys).unwrap();
+        let _ = remaining;
+        let result = KeymapNotifyEvent { response_type, keys };
+        Ok(super::Event::KeymapNotify(result))
     }
 }
 
@@ -2472,6 +2584,23 @@ impl From<ExposeEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ExposeEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (x, remaining) = u16::try_parse(remaining)?;
+        let (y, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = ExposeEvent { response_type, sequence, window, x, y, width, height, count };
+        Ok(super::Event::Expose(result))
+    }
+}
 
 /// Opcode for the GraphicsExposure event
 pub const GRAPHICS_EXPOSURE_EVENT: u8 = 13;
@@ -2570,6 +2699,25 @@ impl From<GraphicsExposureEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl GraphicsExposureEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (x, remaining) = u16::try_parse(remaining)?;
+        let (y, remaining) = u16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (count, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = GraphicsExposureEvent { response_type, sequence, drawable, x, y, width, height, minor_opcode, count, major_opcode };
+        Ok(super::Event::GraphicsExposure(result))
+    }
+}
 
 /// Opcode for the NoExposure event
 pub const NO_EXPOSURE_EVENT: u8 = 14;
@@ -2651,6 +2799,20 @@ impl From<&NoExposureEvent> for [u8; 32] {
 impl From<NoExposureEvent> for [u8; 32] {
     fn from(input: NoExposureEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl NoExposureEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (drawable, remaining) = Drawable::try_parse(remaining)?;
+        let (minor_opcode, remaining) = u16::try_parse(remaining)?;
+        let (major_opcode, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = NoExposureEvent { response_type, sequence, drawable, minor_opcode, major_opcode };
+        Ok(super::Event::NoExposure(result))
     }
 }
 
@@ -2799,6 +2961,20 @@ impl From<VisibilityNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl VisibilityNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let state = state.try_into()?;
+        let _ = remaining;
+        let result = VisibilityNotifyEvent { response_type, sequence, window, state };
+        Ok(super::Event::VisibilityNotify(result))
+    }
+}
 
 /// Opcode for the CreateNotify event
 pub const CREATE_NOTIFY_EVENT: u8 = 16;
@@ -2897,6 +3073,25 @@ impl From<CreateNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl CreateNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (border_width, remaining) = u16::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = CreateNotifyEvent { response_type, sequence, parent, window, x, y, width, height, border_width, override_redirect };
+        Ok(super::Event::CreateNotify(result))
+    }
+}
 
 /// Opcode for the DestroyNotify event
 pub const DESTROY_NOTIFY_EVENT: u8 = 17;
@@ -2985,6 +3180,18 @@ impl From<&DestroyNotifyEvent> for [u8; 32] {
 impl From<DestroyNotifyEvent> for [u8; 32] {
     fn from(input: DestroyNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl DestroyNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let _ = remaining;
+        let result = DestroyNotifyEvent { response_type, sequence, event, window };
+        Ok(super::Event::DestroyNotify(result))
     }
 }
 
@@ -3083,6 +3290,20 @@ impl From<UnmapNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl UnmapNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (from_configure, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = UnmapNotifyEvent { response_type, sequence, event, window, from_configure };
+        Ok(super::Event::UnmapNotify(result))
+    }
+}
 
 /// Opcode for the MapNotify event
 pub const MAP_NOTIFY_EVENT: u8 = 19;
@@ -3178,6 +3399,20 @@ impl From<MapNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl MapNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = MapNotifyEvent { response_type, sequence, event, window, override_redirect };
+        Ok(super::Event::MapNotify(result))
+    }
+}
 
 /// Opcode for the MapRequest event
 pub const MAP_REQUEST_EVENT: u8 = 20;
@@ -3265,6 +3500,18 @@ impl From<&MapRequestEvent> for [u8; 32] {
 impl From<MapRequestEvent> for [u8; 32] {
     fn from(input: MapRequestEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl MapRequestEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let _ = remaining;
+        let result = MapRequestEvent { response_type, sequence, parent, window };
+        Ok(super::Event::MapRequest(result))
     }
 }
 
@@ -3357,6 +3604,23 @@ impl From<&ReparentNotifyEvent> for [u8; 32] {
 impl From<ReparentNotifyEvent> for [u8; 32] {
     fn from(input: ReparentNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl ReparentNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = ReparentNotifyEvent { response_type, sequence, event, window, parent, x, y, override_redirect };
+        Ok(super::Event::ReparentNotify(result))
     }
 }
 
@@ -3482,6 +3746,26 @@ impl From<ConfigureNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ConfigureNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (above_sibling, remaining) = Window::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (border_width, remaining) = u16::try_parse(remaining)?;
+        let (override_redirect, remaining) = bool::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = ConfigureNotifyEvent { response_type, sequence, event, window, above_sibling, x, y, width, height, border_width, override_redirect };
+        Ok(super::Event::ConfigureNotify(result))
+    }
+}
 
 /// Opcode for the ConfigureRequest event
 pub const CONFIGURE_REQUEST_EVENT: u8 = 23;
@@ -3585,6 +3869,26 @@ impl From<ConfigureRequestEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ConfigureRequestEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (stack_mode, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (parent, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (sibling, remaining) = Window::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let (border_width, remaining) = u16::try_parse(remaining)?;
+        let (value_mask, remaining) = u16::try_parse(remaining)?;
+        let stack_mode = stack_mode.try_into()?;
+        let _ = remaining;
+        let result = ConfigureRequestEvent { response_type, stack_mode, sequence, parent, window, sibling, x, y, width, height, border_width, value_mask };
+        Ok(super::Event::ConfigureRequest(result))
+    }
+}
 
 /// Opcode for the GravityNotify event
 pub const GRAVITY_NOTIFY_EVENT: u8 = 24;
@@ -3670,6 +3974,20 @@ impl From<GravityNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl GravityNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (x, remaining) = i16::try_parse(remaining)?;
+        let (y, remaining) = i16::try_parse(remaining)?;
+        let _ = remaining;
+        let result = GravityNotifyEvent { response_type, sequence, event, window, x, y };
+        Ok(super::Event::GravityNotify(result))
+    }
+}
 
 /// Opcode for the ResizeRequest event
 pub const RESIZE_REQUEST_EVENT: u8 = 25;
@@ -3750,6 +4068,19 @@ impl From<&ResizeRequestEvent> for [u8; 32] {
 impl From<ResizeRequestEvent> for [u8; 32] {
     fn from(input: ResizeRequestEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl ResizeRequestEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (width, remaining) = u16::try_parse(remaining)?;
+        let (height, remaining) = u16::try_parse(remaining)?;
+        let _ = remaining;
+        let result = ResizeRequestEvent { response_type, sequence, window, width, height };
+        Ok(super::Event::ResizeRequest(result))
     }
 }
 
@@ -3921,6 +4252,22 @@ impl From<&CirculateNotifyEvent> for [u8; 32] {
 impl From<CirculateNotifyEvent> for [u8; 32] {
     fn from(input: CirculateNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl CirculateNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (event, remaining) = Window::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let remaining = remaining.get(4..).ok_or(ParseError::ParseError)?;
+        let (place, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let place = place.try_into()?;
+        let _ = remaining;
+        let result = CirculateNotifyEvent { response_type, sequence, event, window, place };
+        Ok(super::Event::CirculateNotify(result))
     }
 }
 
@@ -4096,6 +4443,22 @@ impl From<PropertyNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl PropertyNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (atom, remaining) = Atom::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(3..).ok_or(ParseError::ParseError)?;
+        let state = state.try_into()?;
+        let _ = remaining;
+        let result = PropertyNotifyEvent { response_type, sequence, window, atom, time, state };
+        Ok(super::Event::PropertyNotify(result))
+    }
+}
 
 /// Opcode for the SelectionClear event
 pub const SELECTION_CLEAR_EVENT: u8 = 29;
@@ -4176,6 +4539,19 @@ impl From<&SelectionClearEvent> for [u8; 32] {
 impl From<SelectionClearEvent> for [u8; 32] {
     fn from(input: SelectionClearEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl SelectionClearEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (owner, remaining) = Window::try_parse(remaining)?;
+        let (selection, remaining) = Atom::try_parse(remaining)?;
+        let _ = remaining;
+        let result = SelectionClearEvent { response_type, sequence, time, owner, selection };
+        Ok(super::Event::SelectionClear(result))
     }
 }
 
@@ -4504,6 +4880,22 @@ impl From<SelectionRequestEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl SelectionRequestEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (owner, remaining) = Window::try_parse(remaining)?;
+        let (requestor, remaining) = Window::try_parse(remaining)?;
+        let (selection, remaining) = Atom::try_parse(remaining)?;
+        let (target, remaining) = Atom::try_parse(remaining)?;
+        let (property, remaining) = Atom::try_parse(remaining)?;
+        let _ = remaining;
+        let result = SelectionRequestEvent { response_type, sequence, time, owner, requestor, selection, target, property };
+        Ok(super::Event::SelectionRequest(result))
+    }
+}
 
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 31;
@@ -4590,6 +4982,21 @@ impl From<&SelectionNotifyEvent> for [u8; 32] {
 impl From<SelectionNotifyEvent> for [u8; 32] {
     fn from(input: SelectionNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl SelectionNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = Timestamp::try_parse(remaining)?;
+        let (requestor, remaining) = Window::try_parse(remaining)?;
+        let (selection, remaining) = Atom::try_parse(remaining)?;
+        let (target, remaining) = Atom::try_parse(remaining)?;
+        let (property, remaining) = Atom::try_parse(remaining)?;
+        let _ = remaining;
+        let result = SelectionNotifyEvent { response_type, sequence, time, requestor, selection, target, property };
+        Ok(super::Event::SelectionNotify(result))
     }
 }
 
@@ -4823,6 +5230,22 @@ impl From<&ColormapNotifyEvent> for [u8; 32] {
 impl From<ColormapNotifyEvent> for [u8; 32] {
     fn from(input: ColormapNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl ColormapNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (colormap, remaining) = Colormap::try_parse(remaining)?;
+        let (new, remaining) = bool::try_parse(remaining)?;
+        let (state, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(2..).ok_or(ParseError::ParseError)?;
+        let state = state.try_into()?;
+        let _ = remaining;
+        let result = ColormapNotifyEvent { response_type, sequence, window, colormap, new, state };
+        Ok(super::Event::ColormapNotify(result))
     }
 }
 
@@ -5080,6 +5503,19 @@ impl From<ClientMessageEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl ClientMessageEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (format, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (window, remaining) = Window::try_parse(remaining)?;
+        let (type_, remaining) = Atom::try_parse(remaining)?;
+        let (data, remaining) = ClientMessageData::try_parse(remaining)?;
+        let _ = remaining;
+        let result = ClientMessageEvent { response_type, format, sequence, window, type_, data };
+        Ok(super::Event::ClientMessage(result))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -5236,6 +5672,21 @@ impl From<MappingNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl MappingNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (request, remaining) = u8::try_parse(remaining)?;
+        let (first_keycode, remaining) = Keycode::try_parse(remaining)?;
+        let (count, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let request = request.try_into()?;
+        let _ = remaining;
+        let result = MappingNotifyEvent { response_type, sequence, request, first_keycode, count };
+        Ok(super::Event::MappingNotify(result))
+    }
+}
 
 /// Opcode for the GeGeneric event
 pub const GE_GENERIC_EVENT: u8 = 35;
@@ -5274,6 +5725,19 @@ impl TryFrom<&[u8]> for GeGenericEvent {
     type Error = ParseError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self::try_parse(value)?.0)
+    }
+}
+impl GeGenericEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (extension, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (length, remaining) = u32::try_parse(remaining)?;
+        let (event_type, remaining) = u16::try_parse(remaining)?;
+        let remaining = remaining.get(22..).ok_or(ParseError::ParseError)?;
+        let _ = remaining;
+        let result = GeGenericEvent { response_type, extension, sequence, length, event_type };
+        Ok(super::Event::GeGeneric(result))
     }
 }
 

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -1487,6 +1487,20 @@ impl From<VideoNotifyEvent> for [u8; 32] {
         Self::from(&input)
     }
 }
+impl VideoNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let (reason, remaining) = u8::try_parse(remaining)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
+        let (port, remaining) = Port::try_parse(remaining)?;
+        let reason = reason.try_into()?;
+        let _ = remaining;
+        let result = VideoNotifyEvent { response_type, reason, sequence, time, drawable, port };
+        Ok(super::Event::XvVideoNotify(result))
+    }
+}
 
 /// Opcode for the PortNotify event
 pub const PORT_NOTIFY_EVENT: u8 = 1;
@@ -1570,6 +1584,20 @@ impl From<&PortNotifyEvent> for [u8; 32] {
 impl From<PortNotifyEvent> for [u8; 32] {
     fn from(input: PortNotifyEvent) -> Self {
         Self::from(&input)
+    }
+}
+impl PortNotifyEvent {
+    pub(crate) fn ugly_hack(remaining: &[u8]) -> Result<super::Event, ParseError> {
+        let (response_type, remaining) = u8::try_parse(remaining)?;
+        let remaining = remaining.get(1..).ok_or(ParseError::ParseError)?;
+        let (sequence, remaining) = u16::try_parse(remaining)?;
+        let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
+        let (port, remaining) = Port::try_parse(remaining)?;
+        let (attribute, remaining) = xproto::Atom::try_parse(remaining)?;
+        let (value, remaining) = i32::try_parse(remaining)?;
+        let _ = remaining;
+        let result = PortNotifyEvent { response_type, sequence, time, port, attribute, value };
+        Ok(super::Event::XvPortNotify(result))
     }
 }
 


### PR DESCRIPTION
On master, each events has an impl for TryFrom<&[u8]>. protocol::Event
uses this impl to parse the event and then wrap it in the Event enum.
This means that the result from the TryFrom implementation has to be
copied into the Event enum and the generated code actually contains such
a copy. Actually, it contains many such copy sequences, one per event.

This commit changes the structure a bit. Each event gets a function
ugly_hack(&[u8]) -> Result<Event, ParseError>. Thus, protocol::Event
only has to figure out which event this is and then call that event's
ugly_hack(). This function then immediately constructs an instance of
Event, thus avoiding the copy-bytes-around in the caller.

This commit changes the size of the stripped xclock_utc example in a
release build from 503 KiB to 495 KiB. This is a reduction in binary
size by about 2.5 %.

The assembler code for the full library goes from 159662 to 158847 lines
(0.5% less), but the object file (.o) keeps its size / does not change.

You might notice from the function name "ugly_hack" that I am not really
happy with this implementation. Instead, I wanted to check if the
general approach has merits. Apparently it does.

This is related to #488.