### PR TITLE
Add a 'cursor' feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,4 +100,4 @@ script:
   - cargo build --verbose --all-targets --features all-extensions
 
   # Run the examples as 'integration tests'. This time using RustConnection.
-  - run_examples --features "all-extensions libc"
+  - run_examples --features "all-extensions libc cursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ features = ["winsock2"]
 # #![deny(unsafe_code)]. This has the effect of disabling the XCB FFI bindings.
 allow-unsafe-code = ["libc"]
 
+# Enable utility functions for loading mouse cursors.
+cursor = ["render"]
+
 # Enable this feature to enable all the X11 extensions
 all-extensions = [
     "composite",
@@ -97,7 +100,7 @@ xv = ["shm"]
 xvmc = ["xv"]
 
 [package.metadata.docs.rs]
-features = [ "all-extensions" ]
+features = [ "all-extensions", "cursor" ]
 
 [[example]]
 name = "generic_events"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,5 +114,9 @@ required-features = ["libc", "shm"]
 name = "xeyes"
 required-features = ["shape"]
 
+[[example]]
+name = "simple_window"
+required-features = ["cursor"]
+
 [workspace]
 members = ["generator", "xcbgen-rs", "cairo-example"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Additionally, the `allow-unsafe-code` feature enables `XCBConnection`. This uses
 `libxcb` internally and allows sharing the underlying `xcb_connection_t` pointer
 with other code.
 
+The `cursor` feature enables X11 cursor support via the `cursor` module. This
+module helps with loading cursors from the current cursor theme.
+
 
 ## Current state
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,15 @@ test_script:
   # Build once with the 'allow-unsafe-code' feature to
   # check that this works fine. Use 'check' instead of 'build' because
   # a full build requires the libxcb library
-  - cargo check --verbose --all-targets --features all-extensions
+  - cargo check --verbose --all-targets --features all-extensions,cursor
 
   # Also build once without any feature
   - cargo check --verbose --all-targets
 
   # We do not have libxcb and thus cannot build XCBConnection
-  - cargo build --verbose --all-targets --features all-extensions
-  - cargo test --verbose --features all-extensions
-  - cargo doc --verbose --features all-extensions
+  - cargo build --verbose --all-targets --features all-extensions,cursor
+  - cargo test --verbose --features all-extensions,cursor
+  - cargo doc --verbose --features all-extensions,cursor
 
   # Start an X11 server in the background
   - ps: $Server = Start-Process -PassThru -FilePath C:\cygwin\bin\Xvfb.exe -ArgumentList "-listen tcp :0"
@@ -36,7 +36,7 @@ test_script:
   # time soon. Requirements include "must fail if the command fails".
   - ps: >-
       Get-ChildItem examples | Where {$_.extension -eq ".rs"} | Where {$_.BaseName -ne "tutorial"} | Where {$_.BaseName -ne "shared_memory"} | Foreach-Object {
-        $cmd = "cargo run --verbose --features all-extensions --example $($_.BaseName) 2>&1"
+        $cmd = "cargo run --verbose --features all-extensions,cursor --example $($_.BaseName) 2>&1"
         Write-Host -ForegroundColor Yellow $cmd
         $backupErrorActionPreference = $script:ErrorActionPreference
         $script:ErrorActionPreference = "Continue"

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -148,15 +148,16 @@ impl Handle {
             0,
             1 << 20,
         )?;
-        let mut render_info = None;
-        if conn
+        let render_info = if conn
             .extension_information(render::X11_EXTENSION_NAME)?
             .is_some()
         {
             let render_version = render::query_version(conn, 0, 8)?;
             let render_pict_format = render::query_pict_formats(conn)?;
-            render_info = Some((render_version, render_pict_format));
-        }
+            Some((render_version, render_pict_format))
+        } else {
+            None
+        };
         Ok(Cookie {
             conn,
             screen,
@@ -292,9 +293,8 @@ fn load_cursor<C: Connection>(
 
     // Load the cursor from the file
     use std::io::BufReader;
-    let images =
-        parse_cursor::parse_cursor(&mut BufReader::new(cursor_file), handle.cursor_size)
-            .or(Err(crate::errors::ParseError::ParseError))?;
+    let images = parse_cursor::parse_cursor(&mut BufReader::new(cursor_file), handle.cursor_size)
+        .or(Err(crate::errors::ParseError::ParseError))?;
     let mut images = &images[..];
 
     // No animated cursor support? Only use the first image

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub mod xcb_ffi;
 pub mod x11_utils;
 pub mod connection;
 pub mod cookie;
+#[cfg(feature = "cursor")]
 pub mod cursor;
 pub mod errors;
 pub mod extension_manager;


### PR DESCRIPTION
It occurred to me that there is a lot of code in src/cursor/. It is
larger than about half of the files in src/protocol/ (although quite a
bit of that size is tests). Still, cursor support is something that most
people will likely not need. Thus, it makes sense to add a feature for
it.

This commit adds a 'cursor' feature and makes it require 'render'. That
way, the cursor code is simplified a bit, because it can always assume
that render is available. Plus, no one would want 'cursor' without
'render' anyway.

Signed-off-by: Uli Schlachter <psychon@znc.in>