### PR TITLE
Inline cow_strip_length in the callers

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -1110,10 +1110,8 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 IovecConversion::Into => {
                                     request_slices.push(format!("{}.into()", next_slice))
                                 }
-                                IovecConversion::CowStripLength => request_slices.push(format!(
-                                    "crate::x11_utils::cow_strip_length(&{})",
-                                    next_slice
-                                )),
+                                IovecConversion::CowStripLength => request_slices
+                                    .push(format!("Cow::Owned({}.to_vec())", next_slice)),
                             }
                         }
                     }

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -7841,7 +7841,7 @@ impl<'input> SetControlsRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), crate::x11_utils::cow_strip_length(&self.per_key_repeat)], vec![]))
+        Ok((vec![request0.into(), Cow::Owned(self.per_key_repeat.to_vec())], vec![]))
     }
     /// Parse this request given its header, its body, and any fds that go along with it
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -10941,7 +10941,7 @@ impl<'input> SendEventRequest<'input> {
         assert_eq!(length_so_far % 4, 0);
         let length = u16::try_from(length_so_far / 4).unwrap_or(0);
         request0[2..4].copy_from_slice(&length.to_ne_bytes());
-        Ok((vec![request0.into(), crate::x11_utils::cow_strip_length(&self.event)], vec![]))
+        Ok((vec![request0.into(), Cow::Owned(self.event.to_vec())], vec![]))
     }
     /// Parse this request given its header, its body, and any fds that go along with it
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::convert::TryInto;
 
 use crate::errors::ParseError;
@@ -525,9 +524,4 @@ macro_rules! __atom_manager_atom_value {
     ($field_name:ident: $atom_value:expr) => {
         $atom_value
     };
-}
-
-#[allow(clippy::ptr_arg)]
-pub(crate) fn cow_strip_length(cow: &Cow<'_, [u8; 32]>) -> Cow<'static, [u8]> {
-    Cow::Owned(cow.to_vec())
 }


### PR DESCRIPTION
There are just two places where this is used and just inlining the
copying code here takes less characters. No idea what this does for the
code size, but with just two uses, I'd expect that this does not make
much of a difference.

Signed-off-by: Uli Schlachter <psychon@znc.in>