### PR TITLE
XIGetPropertyReply sent in response to a XIGetPropertyRequest with delete = true fails to parse.

### DIFF
--- a/tests/parsing_tests.rs
+++ b/tests/parsing_tests.rs
@@ -133,3 +133,10 @@ fn parse_setup() -> Result<(), ParseError> {
 
     Ok(())
 }
+
+#[test]
+fn parse_xi_get_property_reply() {
+    use x11rb::protocol::xinput::XIGetPropertyReply;
+    let bytes: &[u8] = &[0x1, 0x3b, 0x6b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    XIGetPropertyReply::try_parse(bytes).unwrap();
+}


### PR DESCRIPTION
When snooping on X traffic I came across this. It looks like if there are no items in the reply the X server does not bother filling in fields like `format`, but 0 is not a valid value for those fields so this fails to parse.

Maybe this needs to become an altenum in xcb.