### PR TITLE
Add an xtrace example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,4 +127,4 @@ name = "display_ppm"
 required-features = ["image"]
 
 [workspace]
-members = ["generator", "xcbgen-rs", "cairo-example"]
+members = ["generator", "xcbgen-rs", "cairo-example", "xtrace-example"]

--- a/xtrace-example/Cargo.toml
+++ b/xtrace-example/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "xtrace-example"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+smol = "0.1"
+
+[dependencies.x11rb]
+path = "../"
+features = ["all-extensions"]
+
+[dependencies.futures-util]
+version = "0.3"
+default-features = false
+features = ["async-await", "async-await-macro"]
+
+[dependencies.futures-io]
+version = "0.3"
+default-features = false

--- a/xtrace-example/Cargo.toml
+++ b/xtrace-example/Cargo.toml
@@ -16,7 +16,7 @@ features = ["all-extensions"]
 [dependencies.futures-util]
 version = "0.3"
 default-features = false
-features = ["async-await", "async-await-macro"]
+features = ["async-await", "async-await-macro", "io", "std"]
 
 [dependencies.futures-io]
 version = "0.3"

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -1,0 +1,20 @@
+use std::io::Result as IOResult;
+use futures_io::{AsyncRead, AsyncWrite};
+
+#[derive(Debug, Default)]
+pub struct Connection {
+}
+
+impl Connection {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub async fn forward_client(&self, client: impl AsyncRead, server: impl AsyncWrite) -> IOResult<()> {
+        Ok(())
+    }
+
+    pub async fn forward_server(&self, server: impl AsyncRead, client: impl AsyncWrite) -> IOResult<()> {
+        Ok(())
+    }
+}

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -1,6 +1,8 @@
 use std::io::Result as IOResult;
 use futures_io::{AsyncRead, AsyncWrite};
 
+use crate::forwarder::forward_with_callback;
+
 #[derive(Debug, Default)]
 pub struct Connection {
 }
@@ -10,11 +12,35 @@ impl Connection {
         Default::default()
     }
 
-    pub async fn forward_client(&self, client: impl AsyncRead, server: impl AsyncWrite) -> IOResult<()> {
-        Ok(())
+    pub async fn forward_client(
+        &self,
+        client: impl AsyncRead + Unpin,
+        server: impl AsyncWrite + Unpin,
+    ) -> IOResult<()> {
+        forward_with_callback(client, server, |packet| self.parse_client_packet(packet)).await
     }
 
-    pub async fn forward_server(&self, server: impl AsyncRead, client: impl AsyncWrite) -> IOResult<()> {
-        Ok(())
+    pub async fn forward_server(
+        &self,
+        server: impl AsyncRead + Unpin,
+        client: impl AsyncWrite + Unpin,
+    ) -> IOResult<()> {
+        forward_with_callback(server, client, |packet| self.parse_server_packet(packet)).await
+    }
+
+    fn parse_client_packet(&self, packet: &[u8]) -> Option<usize> {
+        if packet.is_empty() {
+            Some(1)
+        } else {
+            None
+        }
+    }
+
+    fn parse_server_packet(&self, packet: &[u8]) -> Option<usize> {
+        if packet.is_empty() {
+            Some(1)
+        } else {
+            None
+        }
     }
 }

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -9,6 +9,7 @@ use x11rb::protocol::xproto::GE_GENERIC_EVENT;
 use crate::forwarder::forward_with_callback;
 use crate::connection_inner::ConnectionInner;
 
+/// A forwarded connection between an X11 client and X11 server.
 #[derive(Debug, Default)]
 pub struct Connection {
     read_client_setup: AtomicBool,
@@ -17,11 +18,6 @@ pub struct Connection {
 }
 
 impl Connection {
-    /// Create a new instance of this struct.
-    pub fn new() -> Self {
-        Default::default()
-    }
-
     /// Handle forwarding the client's data to the server.
     pub async fn forward_client(
         &self,

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -1,17 +1,28 @@
+use std::convert::{TryInto, TryFrom};
 use std::io::Result as IOResult;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use futures_io::{AsyncRead, AsyncWrite};
 
+use x11rb::protocol::xproto::GE_GENERIC_EVENT;
+
 use crate::forwarder::forward_with_callback;
+use crate::connection_inner::ConnectionInner;
 
 #[derive(Debug, Default)]
 pub struct Connection {
+    read_client_setup: AtomicBool,
+    read_server_setup: AtomicBool,
+    connection_inner: Mutex<ConnectionInner>,
 }
 
 impl Connection {
+    /// Create a new instance of this struct.
     pub fn new() -> Self {
         Default::default()
     }
 
+    /// Handle forwarding the client's data to the server.
     pub async fn forward_client(
         &self,
         client: impl AsyncRead + Unpin,
@@ -20,6 +31,7 @@ impl Connection {
         forward_with_callback(client, server, |packet| self.parse_client_packet(packet)).await
     }
 
+    /// Handle forwarding the server's data to the client.
     pub async fn forward_server(
         &self,
         server: impl AsyncRead + Unpin,
@@ -28,19 +40,110 @@ impl Connection {
         forward_with_callback(server, client, |packet| self.parse_server_packet(packet)).await
     }
 
+    /// Handle a packet from the client.
+    ///
+    /// Returns `None` if a complete packet was read. Otherwise returns the number of additional
+    /// bytes that are needed.
     fn parse_client_packet(&self, packet: &[u8]) -> Option<usize> {
-        if packet.is_empty() {
-            Some(1)
+        if self.read_client_setup.load(Ordering::Relaxed) {
+            let length_field = match packet.get(2..4) {
+                None => return Some(packet.len() - 4),
+                Some(length_field) => u16::from_ne_bytes(length_field.try_into().unwrap()),
+            };
+            let length_field = if length_field != 0 {
+                usize::from(length_field) * 4
+            } else {
+                // Big requests
+                let length_field = match packet.get(4..8) {
+                    None => return Some(packet.len() - 8),
+                    Some(length_field) => u32::from_ne_bytes(length_field.try_into().unwrap()),
+                };
+                usize::try_from(length_field).unwrap() * 4
+            };
+            if packet.len() < length_field {
+                // Need more data
+                Some(length_field - packet.len())
+            } else {
+                self.connection_inner.lock().unwrap().client_request(packet);
+                None
+            }
         } else {
+            let minimum_length = 12;
+            if packet.len() < minimum_length {
+                return Some(minimum_length - packet.len());
+            }
+            println!("TODO: Check that the byte order is correct: {:?}", packet[0]);
+            // There is no simple length field to use, so we let the inner handle this.
+            self.connection_inner.lock().unwrap().client_setup(packet);
+            todo!("Figure out request length");
+            if false {
+                // Got complete setup request
+                self.read_client_setup.store(true, Ordering::Relaxed);
+            }
             None
         }
     }
 
+    /// Handle a packet from the server.
+    ///
+    /// Returns `None` if a complete packet was read. Otherwise returns the number of additional
+    /// bytes that are needed.
     fn parse_server_packet(&self, packet: &[u8]) -> Option<usize> {
-        if packet.is_empty() {
-            Some(1)
+        if self.read_server_setup.load(Ordering::Relaxed) {
+            const ERROR: u8 = 0;
+            const REPLY: u8 = 1;
+
+            // Try to figure out the length of the packet
+            let has_length_field = match packet.get(0) {
+                Some(&REPLY) => true,
+                Some(x) if x & 0x7f == GE_GENERIC_EVENT => true,
+                _ => false,
+            };
+            let additional_length = if has_length_field {
+                if let Some(length_field) = packet.get(4..8) {
+                    let length_field = u32::from_ne_bytes(length_field.try_into().unwrap());
+                    let length_field = usize::try_from(length_field).unwrap();
+                    assert!(length_field <= usize::max_value() / 4);
+                    4 * length_field
+                } else {
+                    0
+                }
+            } else {
+                0
+            };
+            // All packets are at least 32 bytes
+            let packet_length = 32 + additional_length;
+            if packet.len() < packet_length {
+                // Need more data
+                Some(packet_length - packet.len())
+            } else {
+                // Got a full packet
+                let mut inner = self.connection_inner.lock().unwrap();
+                match packet[0] {
+                    ERROR => inner.server_error(packet),
+                    REPLY => inner.server_reply(packet),
+                    _ => inner.server_event(packet),
+                }
+                None
+            }
         } else {
-            None
+            // Get the length field of the server setup
+            let length_field = match packet.get(7..8) {
+                // Need more data
+                None => return Some(8 - packet.len()),
+                Some(field) => u16::from_ne_bytes(field.try_into().unwrap()),
+            };
+            let length_field = usize::from(length_field);
+            let length = 40 + length_field * 4;
+            if packet.len() < length {
+                // Need more data
+                Some(length - packet.len())
+            } else {
+                // Got the complete setup
+                self.connection_inner.lock().unwrap().server_setup(packet);
+                self.read_server_setup.store(true, Ordering::Relaxed);
+                None
+            }
         }
     }
 }

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -1,13 +1,13 @@
-use std::convert::{TryInto, TryFrom};
-use std::io::Result as IOResult;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
 use futures_io::{AsyncRead, AsyncWrite};
+use std::convert::{TryFrom, TryInto};
+use std::io::Result as IOResult;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 use x11rb::protocol::xproto::GE_GENERIC_EVENT;
 
-use crate::forwarder::forward_with_callback;
 use crate::connection_inner::ConnectionInner;
+use crate::forwarder::forward_with_callback;
 
 /// A forwarded connection between an X11 client and X11 server.
 #[derive(Debug, Default)]

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -84,7 +84,6 @@ impl Connection {
             if packet.len() < packet_length {
                 Some(packet_length - packet.len())
             } else {
-                println!("TODO: Check that the byte order is correct: {:?}", packet[0]);
                 self.connection_inner.lock().unwrap().client_setup(packet);
                 // Got complete setup request
                 self.read_client_setup.store(true, Ordering::Relaxed);

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -1,5 +1,5 @@
 use x11rb::errors::ParseError;
-use x11rb::protocol::{Request, xproto};
+use x11rb::protocol::{Error, Request, xproto};
 use x11rb::x11_utils::{BigRequests, ExtInfoProvider, ExtensionInformation, TryParse, parse_request_header};
 
 fn print_obj_remaining(obj: &impl std::fmt::Debug, data: &[u8], remaining: &[u8]) {
@@ -54,6 +54,7 @@ impl ConnectionInner {
 
     /// Handle the server's Setup (or SetupFailed, SetupAuthenticate)
     pub fn server_setup(&mut self, packet: &[u8]) {
+        print!("server: ");
         match packet[0] {
             0 => print_parse::<xproto::SetupFailed>(packet),
             1 => {
@@ -83,7 +84,7 @@ impl ConnectionInner {
             let request = Request::parse(header, remaining, &mut Vec::new(), &inner.ext_info)?;
             // TODO: Can we get some "remaining" data somehow?
             //print_obj_remaining(&request, packet, remaining);
-            println!("{:?}", request);
+            println!("client: {:?}", request);
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
@@ -93,7 +94,14 @@ impl ConnectionInner {
 
     /// Handle an X11 error sent by the server
     pub fn server_error(&mut self, packet: &[u8]) {
-        let _ = packet;
+        fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
+            let err = Error::parse(packet, &inner.ext_info)?;
+            println!("server: {:?}", err);
+            Ok(())
+        }
+        if let Err(e) = do_parse(self, packet) {
+            eprintln!("Error while parsing an X11 error: {:?}", e);
+        }
     }
 
     /// Handle an X11 event sent by the server

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -1,5 +1,5 @@
 use x11rb::errors::ParseError;
-use x11rb::protocol::{Error, Request, xproto};
+use x11rb::protocol::{Error, Event, Request, xproto};
 use x11rb::x11_utils::{BigRequests, ExtInfoProvider, ExtensionInformation, TryParse, parse_request_header};
 
 fn print_obj_remaining(obj: &impl std::fmt::Debug, data: &[u8], remaining: &[u8]) {
@@ -106,7 +106,14 @@ impl ConnectionInner {
 
     /// Handle an X11 event sent by the server
     pub fn server_event(&mut self, packet: &[u8]) {
-        let _ = packet;
+        fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
+            let err = Event::parse(packet, &inner.ext_info)?;
+            println!("server: {:?}", err);
+            Ok(())
+        }
+        if let Err(e) = do_parse(self, packet) {
+            eprintln!("Error while parsing an X11 event: {:?}", e);
+        }
     }
 
     /// Handle a reply sent by the server

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -190,6 +190,12 @@ impl ConnectionInner {
                         inner.ext_info.add_extension(extension, info);
                     }
                 }
+            } else if let Reply::ListFontsWithInfo(reply) = reply {
+                // There is one request that can generate multiple replies: ListFontsWithInfo. Mark it
+                // as pending again if it is not the last reply. This makes 'xlsfonts -l' work.
+                if !reply.name.is_empty() {
+                    inner.pending_replies.push_front(request);
+                }
             }
 
             Ok(())

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -132,7 +132,7 @@ impl ConnectionInner {
 
             // Remove a pending request if it failed
             if inner.pending_replies.front().map(|r| r.seqno) == Some(err.wire_sequence_number()) {
-                inner.pending_replies.pop_front();
+                let _ = inner.pending_replies.pop_front();
             }
 
             Ok(())

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -1,6 +1,9 @@
 use x11rb::errors::ParseError;
-use x11rb::protocol::{Error, Event, Request, xproto};
-use x11rb::x11_utils::{BigRequests, ExtInfoProvider, ExtensionInformation, TryParse, parse_request_header};
+use x11rb::protocol::{Error, Event, Reply, Request, xproto};
+use x11rb::x11_utils::{BigRequests, ExtInfoProvider, ExtensionInformation, TryParse, ReplyParsingFunction, parse_request_header};
+
+use std::collections::VecDeque;
+use std::convert::TryInto;
 
 fn print_obj_remaining(obj: &impl std::fmt::Debug, data: &[u8], remaining: &[u8]) {
     println!("{:?}", obj);
@@ -31,6 +34,8 @@ fn print_parse<T: TryParse + std::fmt::Debug>(data: &[u8]) {
 #[derive(Debug, Default)]
 pub struct ConnectionInner {
     ext_info: ExtInfo,
+    next_client_request: u16,
+    pending_replies: VecDeque<PendingReply>,
 }
 
 impl ConnectionInner {
@@ -50,6 +55,8 @@ impl ConnectionInner {
             );
         }
         print_parse::<xproto::SetupRequest>(packet);
+        assert_eq!(self.next_client_request, 0);
+        self.next_client_request = 1;
     }
 
     /// Handle the server's Setup (or SetupFailed, SetupAuthenticate)
@@ -80,11 +87,36 @@ impl ConnectionInner {
     /// Handle a request sent by the client
     pub fn client_request(&mut self, packet: &[u8]) {
         fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
+            let seqno = inner.next_client_request;
+            inner.next_client_request = seqno.wrapping_add(1);
+
             let (header, remaining) = parse_request_header(packet, BigRequests::Enabled)?;
             let request = Request::parse(header, remaining, &mut Vec::new(), &inner.ext_info)?;
             // TODO: Can we get some "remaining" data somehow?
             //print_obj_remaining(&request, packet, remaining);
-            println!("client: {:?}", request);
+            println!("client ({}): {:?}", seqno, request);
+
+            // Is this a QueryExtension?
+            let queried_extension = if let Request::QueryExtension(ref request) = request {
+                match String::from_utf8(request.name.to_vec()) {
+                    Ok(name) => {
+                        println!("Extension name: {}", name);
+                        Some(name)
+                    },
+                    Err(e) => {
+                        println!("Extension name is not utf8: {:?}", e);
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            // Does the request have a reply? If so, remember it.
+            if let Some(parser) = request.reply_parser() {
+                inner.pending_replies.push_back(PendingReply::new(seqno, parser, queried_extension));
+            }
+
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
@@ -96,7 +128,13 @@ impl ConnectionInner {
     pub fn server_error(&mut self, packet: &[u8]) {
         fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
             let err = Error::parse(packet, &inner.ext_info)?;
-            println!("server: {:?}", err);
+            println!("server ({}): {:?}", err.wire_sequence_number(), err);
+
+            // Remove a pending request if it failed
+            if inner.pending_replies.front().map(|r| r.seqno) == Some(err.wire_sequence_number()) {
+                inner.pending_replies.pop_front();
+            }
+
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
@@ -107,8 +145,8 @@ impl ConnectionInner {
     /// Handle an X11 event sent by the server
     pub fn server_event(&mut self, packet: &[u8]) {
         fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
-            let err = Event::parse(packet, &inner.ext_info)?;
-            println!("server: {:?}", err);
+            let event = Event::parse(packet, &inner.ext_info)?;
+            println!("server ({}): {:?}", event.wire_sequence_number().unwrap_or(0), event);
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
@@ -118,16 +156,75 @@ impl ConnectionInner {
 
     /// Handle a reply sent by the server
     pub fn server_reply(&mut self, packet: &[u8]) {
-        let _ = packet;
+        fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
+            let request = match inner.pending_replies.pop_front() {
+                None => {
+                    println!("server: Got unexpected reply {:?}", packet);
+                    return Ok(())
+                },
+                Some(request) => request,
+            };
+
+            let seqno = u16::from_ne_bytes(packet[2..4].try_into().unwrap());
+            if request.seqno != seqno {
+                println!("Expected reply with seqno={}, but got seqno={}", request.seqno, seqno);
+            }
+
+            let (reply, remaining) = (request.parser)(packet, &mut Vec::new())?;
+            print!("server ({}): ", seqno);
+            print_obj_remaining(&reply, packet, remaining);
+
+            if let Some(extension) = request.queried_extension {
+                if let Reply::QueryExtension(reply) = reply {
+                    if reply.present {
+                        let info = ExtensionInformation {
+                            major_opcode: reply.major_opcode,
+                            first_event: reply.first_event,
+                            first_error: reply.first_error,
+                        };
+                        inner.ext_info.add_extension(extension, info);
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        if let Err(e) = do_parse(self, packet) {
+            eprintln!("Error while parsing an X11 event: {:?}", e);
+        }
     }
 }
 
-#[derive(Clone, Default, Debug)]
+struct PendingReply {
+    seqno: u16,
+    parser: ReplyParsingFunction,
+    queried_extension: Option<String>,
+}
+
+impl std::fmt::Debug for PendingReply {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingReply")
+            .field("seqno", &self.seqno)
+            .field("parser", &"<???>")
+            .field("queried_extension", &self.queried_extension)
+            .finish()
+    }
+}
+
+impl PendingReply {
+    fn new(seqno: u16, parser: ReplyParsingFunction, queried_extension: Option<String>) -> Self {
+        Self { seqno, parser, queried_extension }
+    }
+}
+
+/// Information about known extensions
+#[derive(Debug, Default)]
 struct ExtInfo {
     exts: Vec<(String, ExtensionInformation)>,
 }
 
 impl ExtInfo {
+    /// Add a new extension to the state
     fn add_extension(&mut self, name: String, info: ExtensionInformation) {
         self.exts.push((name, info))
     }

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Default)]
+pub struct ConnectionInner {
+}
+
+impl ConnectionInner {
+    /// Handle the client's SetupRequest
+    pub fn client_setup(&mut self, packet: &[u8]) {
+        let _ = packet;
+    }
+
+    /// Handle a request sent by the client
+    pub fn client_request(&mut self, packet: &[u8]) {
+        let _ = packet;
+    }
+
+    /// Handle the server's Setup (or SetupFailed, SetupAuthenticate)
+    pub fn server_setup(&mut self, packet: &[u8]) {
+        let _ = packet;
+    }
+
+    /// Handle an X11 error sent by the server
+    pub fn server_error(&mut self, packet: &[u8]) {
+        let _ = packet;
+    }
+
+    /// Handle an X11 event sent by the server
+    pub fn server_event(&mut self, packet: &[u8]) {
+        let _ = packet;
+    }
+
+    /// Handle a reply sent by the server
+    pub fn server_reply(&mut self, packet: &[u8]) {
+        let _ = packet;
+    }
+}

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -1,3 +1,29 @@
+use x11rb::errors::ParseError;
+use x11rb::protocol::xproto;
+use x11rb::x11_utils::TryParse;
+
+fn print_parse_return<T: TryParse + std::fmt::Debug>(data: &[u8]) -> Result<T, ParseError> {
+    match T::try_parse(data) {
+        Err(e) => {
+            println!("Error while parsing: {:?}", e);
+            Err(e)
+        }
+        Ok((obj, remaining)) => {
+            println!("{:?}", obj);
+            if !remaining.is_empty() {
+                println!("Left-over data while parsing:");
+                println!("Input:    {:x?}", data);
+                println!("Remaining {:x?}", remaining);
+            }
+            Ok(obj)
+        }
+    }
+}
+
+fn print_parse<T: TryParse + std::fmt::Debug>(data: &[u8]) {
+    let _ = print_parse_return::<T>(data);
+}
+
 #[derive(Debug, Default)]
 pub struct ConnectionInner {
 }
@@ -5,16 +31,48 @@ pub struct ConnectionInner {
 impl ConnectionInner {
     /// Handle the client's SetupRequest
     pub fn client_setup(&mut self, packet: &[u8]) {
-        let _ = packet;
-    }
-
-    /// Handle a request sent by the client
-    pub fn client_request(&mut self, packet: &[u8]) {
-        let _ = packet;
+        // Check the byte order before parsing, because we cannot parse length fields with the
+        // wrong byte order
+        #[cfg(target_endian = "little")]
+        let byte_order = 0x6c;
+        #[cfg(target_endian = "big")]
+        let byte_order = 0x42;
+        if byte_order != packet[0] {
+            eprintln!(
+                "Client is unexpected byte order {:x} != {:x}, only native byte order is supported!",
+                byte_order,
+                packet[0],
+            );
+        }
+        print_parse::<xproto::SetupRequest>(packet);
     }
 
     /// Handle the server's Setup (or SetupFailed, SetupAuthenticate)
     pub fn server_setup(&mut self, packet: &[u8]) {
+        match packet[0] {
+            0 => print_parse::<xproto::SetupFailed>(packet),
+            1 => {
+                if let Ok(setup) = print_parse_return::<xproto::Setup>(packet) {
+                    let expected = (11, 0);
+                    let actual = (setup.protocol_major_version, setup.protocol_minor_version);
+                    if expected != actual {
+                        println!(
+                            "Unexpected protocol version: {}.{} != {}.{}",
+                             expected.0,
+                             expected.1,
+                             actual.0,
+                             actual.1,
+                         );
+                    }
+                }
+            }
+            2 => print_parse::<xproto::SetupAuthenticate>(packet),
+            _ => eprintln!("Unknown server setup response: {:?}", packet),
+        }
+    }
+
+    /// Handle a request sent by the client
+    pub fn client_request(&mut self, packet: &[u8]) {
         let _ = packet;
     }
 

--- a/xtrace-example/src/forwarder.rs
+++ b/xtrace-example/src/forwarder.rs
@@ -1,0 +1,37 @@
+use std::io::Result as IOResult;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{AsyncReadExt, AsyncWriteExt};
+
+/// Forward data between a reader and a writer, calling a callback on the data.
+///
+/// This function copies all data from `read` to `write`. At each step, a callback is invoked with
+/// the data of the current packet. If `None` is returned, then the packet is complete and can be
+/// forwarded to the other end. If `Some(length)` is returned, then the packet is incomplete and at
+/// least `length` more bytes are needed.
+pub async fn forward_with_callback<F>(
+    mut read: impl AsyncRead + Unpin,
+    mut write: impl AsyncWrite + Unpin,
+    callback: F
+) -> IOResult<()>
+where
+    F: Fn(&[u8]) -> Option<usize>
+{
+    let mut buffer = Vec::new();
+    loop {
+        // Ask the callback for an estimation of the size of the packet
+        match callback(&buffer) {
+            None => {
+                // We have a full packet, forward it
+                write.write_all(&buffer).await?;
+                buffer.clear();
+            }
+            Some(extra_length) => {
+                // Need to read more
+                assert!(extra_length > 0);
+                let old_len = buffer.len();
+                buffer.resize_with(old_len + extra_length, Default::default);
+                read.read_exact(&mut buffer[old_len..]).await?;
+            }
+        }
+    }
+}

--- a/xtrace-example/src/forwarder.rs
+++ b/xtrace-example/src/forwarder.rs
@@ -1,6 +1,6 @@
-use std::io::Result as IOResult;
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::{AsyncReadExt, AsyncWriteExt};
+use std::io::Result as IOResult;
 
 /// Forward data between a reader and a writer, calling a callback on the data.
 ///
@@ -11,10 +11,10 @@ use futures_util::{AsyncReadExt, AsyncWriteExt};
 pub async fn forward_with_callback<F>(
     mut read: impl AsyncRead + Unpin,
     mut write: impl AsyncWrite + Unpin,
-    callback: F
+    callback: F,
 ) -> IOResult<()>
 where
-    F: Fn(&[u8]) -> Option<usize>
+    F: Fn(&[u8]) -> Option<usize>,
 {
     let mut buffer = Vec::new();
     loop {

--- a/xtrace-example/src/main.rs
+++ b/xtrace-example/src/main.rs
@@ -1,0 +1,61 @@
+use std::io::Result as IOResult;
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::net::UnixStream;
+use smol::{Async, Task};
+
+mod connection;
+
+async fn handle_client_impl(client: Async<TcpStream>) -> IOResult<()> {
+    let server = UnixStream::connect("/tmp/.X11-unix/X0")?;
+
+    // We will spawn two tasks:
+    // - Read from client, forward to server
+    // - Read from server, forward to client
+    //
+    // Each task needs its own copy of the socket.
+    let server2 = server.try_clone()?;
+
+    // There is no Async::try_clone(), so we have to destroy the Async first
+    let client = client.into_inner()?;
+    let client2 = client.try_clone()?;
+
+    let server = Async::new(server)?;
+    let server2 = Async::new(server2)?;
+    let client = Async::new(client)?;
+    let client2 = Async::new(client2)?;
+
+    let connection = connection::Connection::new();
+
+    let future1 = connection.forward_client(client, server);
+    let future2 = connection.forward_server(server2, client2);
+
+    futures_util::try_join!(future1, future2)?;
+
+    Ok(())
+}
+
+async fn handle_client(client: Async<TcpStream>) {
+    handle_client_impl(client).await.expect("Error in client handling")
+}
+
+fn spawn_command_line(display: &str) {
+    std::env::set_var("DISPLAY", display);
+    let mut args = std::env::args_os().skip(1);
+    if let Some(command) = args.next() {
+        std::process::Command::new(command)
+            .args(args)
+            .spawn()
+            .unwrap();
+    }
+}
+
+fn main() -> IOResult<()> {
+    smol::run(async {
+        let listener = Async::<TcpListener>::bind("127.0.0.1:6004")?;
+        spawn_command_line(":4");
+        loop {
+            let (socket, _addr) = listener.accept().await?;
+            Task::spawn(handle_client(socket)).detach();
+        }
+    })
+}

--- a/xtrace-example/src/main.rs
+++ b/xtrace-example/src/main.rs
@@ -131,7 +131,7 @@ fn main() -> IOResult<()> {
         spawn_command_line(":4");
         loop {
             let (socket, _addr) = listener.accept().await?;
-            Task::spawn(handle_client(socket)).detach();
+            Task::local(handle_client(socket)).detach();
         }
     })
 }

--- a/xtrace-example/src/main.rs
+++ b/xtrace-example/src/main.rs
@@ -4,6 +4,7 @@ use std::os::unix::net::UnixStream;
 use smol::{Async, Task};
 
 pub(crate) mod connection;
+pub(crate) mod connection_inner;
 pub(crate) mod forwarder;
 
 async fn handle_client_impl(client: Async<TcpStream>) -> IOResult<()> {

--- a/xtrace-example/src/main.rs
+++ b/xtrace-example/src/main.rs
@@ -42,17 +42,17 @@
     trivial_casts,
     trivial_numeric_casts,
     unused_import_braces,
-    unused_results,
+    unused_results
 )]
 #![deny(
     // #[derive] generates an #[allow] for this
     unused_qualifications,
 )]
 
+use smol::{Async, Task};
 use std::io::Result as IOResult;
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::net::UnixStream;
-use smol::{Async, Task};
 
 pub(crate) mod connection;
 pub(crate) mod connection_inner;
@@ -110,16 +110,17 @@ fn spawn_command_line(display: &str) {
     std::env::set_var("DISPLAY", display);
     let mut args = std::env::args_os().skip(1);
     if let Some(command) = args.next() {
-        let command = std::process::Command::new(command)
-            .args(args)
-            .spawn();
+        let command = std::process::Command::new(command).args(args).spawn();
         match command {
             Ok(child) => println!("Started child process with ID {}", child.id()),
             Err(e) => eprintln!("Error while starting child process: {}", e),
         }
     } else {
         println!("You can now start programs with DISPLAY=\"{}\"", display);
-        println!("Hint: Alternatively, you could run {} [your-command]", std::env::args().next().unwrap());
+        println!(
+            "Hint: Alternatively, you could run {} [your-command]",
+            std::env::args().next().unwrap(),
+        );
     }
 }
 

--- a/xtrace-example/src/main.rs
+++ b/xtrace-example/src/main.rs
@@ -1,3 +1,54 @@
+//! xtrace implemented with x11rb.
+//!
+//! This example shows a capability of x11rb that is most likely not useful to many projects: You
+//! can write a transparent "proxy" that intercepts X11 traffic.
+//!
+//! Specifically, this program accepts X11 clients on `DISPLAY=":4"` via TCP and connects them to
+//! `DISPLAY=":0"` via a Unix stream. All traffic between the client and the server is forwarded
+//! and additionally decoded.
+//!
+//! Plus, just because I wanted to do a simple experiment: All of this is written in `async`hronous
+//! code using `smol` as the runtime.
+//!
+//!
+//! # Structure of the code
+//!
+//! The main file sets up the listener and spawns a task for each connection. That task, called
+//! `handle_client` handles everything concerning this one client.
+//!
+//! In the `forwarder` module, there is a generic utility function `forward_with_callback` that
+//! forwards everything that is read from an `AsyncRead` to an `AsyncWrite`. A callback is called
+//! on the data that is forwarded. The callback is used to decode and print the traffic.
+//!
+//! The `connection` module then chunks the traffic into X11 packets, i.e. it determines the length
+//! of each packet that comes across. This requires some decoding of length fields, but no output
+//! is generated. The code here also determines the types of packets (connection setup, requests,
+//! replies, errors, and events).
+//!
+//! Finally, the code in the `connection_inner` actually decodes the packets. For each X11
+//! connection, some state is kept:
+//! - The number of requests the client already sent (sequence numbers). These numbers are needed
+//!   to map replies to their corresponding requests.
+//! - The X11 extensions that are known to be supported. This cache is filled from `QueryExtension`
+//!   requests and replies that "fly by".
+//! - A list of pending requests for which a reply is still expected.
+//!
+//! The code in `connection_inner` then handles decoding X11 packets, updating the state of the
+//! connection, and generating output via `println!`.
+
+#![forbid(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_import_braces,
+    unused_results,
+)]
+#![deny(
+    // #[derive] generates an #[allow] for this
+    unused_qualifications,
+)]
+
 use std::io::Result as IOResult;
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::net::UnixStream;
@@ -7,14 +58,18 @@ pub(crate) mod connection;
 pub(crate) mod connection_inner;
 pub(crate) mod forwarder;
 
+/// Handle an incoming client connection.
+///
+/// This function sets up a connection to the server
 async fn handle_client_impl(client: Async<TcpStream>) -> IOResult<()> {
     let server = UnixStream::connect("/tmp/.X11-unix/X0")?;
 
-    // We will spawn two tasks:
+    // We will have two futures:
     // - Read from client, forward to server
     // - Read from server, forward to client
     //
-    // Each task needs its own copy of the socket.
+    // Each futures needs its own copy of the socket. Feel free to suggest a better approach to do
+    // this.
     let server2 = server.try_clone()?;
 
     // There is no Async::try_clone(), so we have to destroy the Async first
@@ -26,16 +81,20 @@ async fn handle_client_impl(client: Async<TcpStream>) -> IOResult<()> {
     let client = Async::new(client)?;
     let client2 = Async::new(client2)?;
 
-    let connection = connection::Connection::new();
-
+    let connection = connection::Connection::default();
     let future1 = connection.forward_client(client, server);
     let future2 = connection.forward_server(server2, client2);
 
+    // try_join polls both futures and returns an error once one of them returns an error.
+    // (It also returns a result once both futures are done, but that should not matter here).
     futures_util::try_join!(future1, future2)?;
 
     Ok(())
 }
 
+/// Handle an incoming client connection.
+///
+/// This function simply calls `handle_client_impl` and handles the return value.
 async fn handle_client(client: Async<TcpStream>) {
     use std::io::ErrorKind;
 
@@ -46,19 +105,27 @@ async fn handle_client(client: Async<TcpStream>) {
     }
 }
 
+/// Spawn the command line as a program / command.
 fn spawn_command_line(display: &str) {
     std::env::set_var("DISPLAY", display);
     let mut args = std::env::args_os().skip(1);
     if let Some(command) = args.next() {
-        std::process::Command::new(command)
+        let command = std::process::Command::new(command)
             .args(args)
-            .spawn()
-            .unwrap();
+            .spawn();
+        match command {
+            Ok(child) => println!("Started child process with ID {}", child.id()),
+            Err(e) => eprintln!("Error while starting child process: {}", e),
+        }
+    } else {
+        println!("You can now start programs with DISPLAY=\"{}\"", display);
+        println!("Hint: Alternatively, you could run {} [your-command]", std::env::args().next().unwrap());
     }
 }
 
 fn main() -> IOResult<()> {
     smol::run(async {
+        // Port 6004 is DISPLAY=:4 (as TCP)
         let listener = Async::<TcpListener>::bind("127.0.0.1:6004")?;
         spawn_command_line(":4");
         loop {


### PR DESCRIPTION
This implements #442: It adds an xtrace/xtruss-like example program.

Instead of being thread-based and spaghetti-coded, this one now uses `async` (just because I wanted to do something with `async` (well, and this means I do not have to mess with threads)). Plus, we now have some own code that uses the request parsing that @khuey added, which might not be the worst thing. (Designing an API without trying to use it can allow weird stuff to slip through.)

The sad news is that I am now out of toy projects to do "just because". Next, I'll have to actually fix some issues on x11rb...