### PR TITLE
Mark enums as non-exhaustive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     # std::io::IoSlice was stabilised in 1.36.0, but 1.36.0 fails with a weird
     # error enabled by deny(single_use_lifetimes).
     - rust: 1.37.0
-      env: CLIPPY_RUSTFMT=no
+      env: CLIPPY_RUSTFMT=no EXTRA_FEATURES=I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive
     - rust: stable
       env: CLIPPY_RUSTFMT=yes
     - rust: beta
@@ -86,7 +86,7 @@ script:
 
   # Build once with just the default features, i.e. without all the extensions
   # to check that this works fine.
-  - cargo check --verbose --all-targets
+  - cargo check --verbose --all-targets --features "$EXTRA_FEATURES"
 
   - cargo build --verbose --all-targets --all-features
   - cargo test --verbose --all-features
@@ -97,7 +97,7 @@ script:
   # Enable the 'allow-unsafe-code' feature so XCBConnection is used.
   - run_examples --all-features
 
-  - cargo build --verbose --all-targets --features all-extensions
+  - cargo build --verbose --all-targets --features "all-extensions,$EXTRA_FEATURES"
 
   # Run the examples as 'integration tests'. This time using RustConnection.
-  - run_examples --features "all-extensions libc cursor image"
+  - run_examples --features "all-extensions libc cursor image $EXTRA_FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,12 @@ cursor = ["render"]
 # Enable utility functions in `x11rb::image` for working with image data.
 image = []
 
+# Some enums are marked as #[non_exhaustive]. This breaks compatibility with
+# Rust 1.37, because non-exhaustive was only stabilised in Rust 1.40. This
+# feature disables the use of #[non_exhaustive] for compatibility with Rust
+# 1.37. However, you still must treat the affected enums as #[non_exhaustive]!
+I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive = []
+
 # Enable this feature to enable all the X11 extensions
 all-extensions = [
     "composite",

--- a/generator/src/generator/error_events.rs
+++ b/generator/src/generator/error_events.rs
@@ -1,5 +1,6 @@
 use super::get_ns_name_prefix;
 use super::output::Output;
+use super::namespace::NON_EXHAUSTIVE;
 
 pub(super) fn generate(out: &mut Output, module: &xcbgen::defs::Module) {
     generate_errors(out, module);
@@ -42,6 +43,7 @@ fn generate_errors(out: &mut Output, module: &xcbgen::defs::Module) {
 
     outln!(out, "/// Enumeration of all possible X11 error kinds.");
     outln!(out, "#[derive(Debug, Clone, Copy, PartialEq, Eq)]");
+    outln!(out, "{}", NON_EXHAUSTIVE);
     outln!(out, "pub enum ErrorKind {{");
     out.indented(|out| {
         outln!(out, "Unknown(u8),");
@@ -141,6 +143,7 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
 
     outln!(out, "/// Enumeration of all possible X11 events.");
     outln!(out, "#[derive(Debug, Clone)]");
+    outln!(out, "{}", NON_EXHAUSTIVE);
     outln!(out, "pub enum Event {{");
     out.indented(|out| {
         outln!(out, "Unknown(Vec<u8>),");

--- a/generator/src/generator/error_events.rs
+++ b/generator/src/generator/error_events.rs
@@ -1,6 +1,6 @@
 use super::get_ns_name_prefix;
-use super::output::Output;
 use super::namespace::NON_EXHAUSTIVE;
+use super::output::Output;
 
 pub(super) fn generate(out: &mut Output, module: &xcbgen::defs::Module) {
     generate_errors(out, module);

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -12,7 +12,7 @@ use xcbgen::defs as xcbdefs;
 use super::output::Output;
 use super::{get_ns_name_prefix, special_cases};
 
-pub(crate) static NON_EXHAUSTIVE: &str = "#[cfg_attr(not(feature = \"I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive\"), non_exhaustive)]";
+pub(crate) static NON_EXHAUSTIVE: &str = "#[cfg_attr(\n    not(feature = \"I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive\"),\n    non_exhaustive\n)]";
 
 #[derive(Debug, Default)]
 pub(super) struct PerModuleEnumCases {

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -12,6 +12,8 @@ use xcbgen::defs as xcbdefs;
 use super::output::Output;
 use super::{get_ns_name_prefix, special_cases};
 
+pub(crate) static NON_EXHAUSTIVE: &str = "#[cfg_attr(not(feature = \"I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive\"), non_exhaustive)]";
+
 #[derive(Debug, Default)]
 pub(super) struct PerModuleEnumCases {
     /// Lines that belong in the Request enum definition.
@@ -52,6 +54,7 @@ pub(super) fn generate_request_reply_enum(
     outln!(out, "#[derive(Debug)]");
     // clippy::large_enum_variant for XkbSetNamesRequest.
     outln!(out, "#[allow(clippy::large_enum_variant)]");
+    outln!(out, "{}", NON_EXHAUSTIVE);
     outln!(out, "pub enum Request<'input> {{");
     out.indented(|out| {
         outln!(out, "Unknown(RequestHeader, Cow<'input, [u8]>),");
@@ -223,6 +226,7 @@ pub(super) fn generate_request_reply_enum(
     outln!(out, "#[derive(Debug)]");
     // clippy::large_enum_variant for XkbGetKbdByNameReply.
     outln!(out, "#[allow(clippy::large_enum_variant)]");
+    outln!(out, "{}", NON_EXHAUSTIVE);
     outln!(out, "pub enum Reply {{");
     out.indented(|out| {
         outln!(out, "Void,");
@@ -2161,6 +2165,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             // all the values fit. This prevents the 'enum_clike_unportable_variant' clippy warning.
             outln!(out, "#[repr({})]", to_type);
         }
+        outln!(out, "{}", NON_EXHAUSTIVE);
         outln!(out, "pub enum {} {{", rust_name);
         for enum_item in enum_def.items.iter() {
             let rust_item_name = ename_to_rust(&enum_item.name);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use crate::x11_utils::X11Error;
 
 /// An error occurred while parsing some data
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ParseError {
     /// Not enough data was provided.
     InsufficientData,
@@ -58,6 +59,7 @@ impl std::fmt::Display for ParseError {
 
 /// An error that occurred while connecting to an X11 server
 #[derive(Debug)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ConnectError {
     /// An unknown error occurred.
     ///
@@ -143,6 +145,7 @@ impl From<std::io::Error> for ConnectError {
 
 /// An error that occurred on an already established X11 connection
 #[derive(Debug)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ConnectionError {
     /// An unknown error occurred.
     ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,10 @@ use crate::x11_utils::X11Error;
 
 /// An error occurred while parsing some data
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ParseError {
     /// Not enough data was provided.
     InsufficientData,
@@ -59,7 +62,10 @@ impl std::fmt::Display for ParseError {
 
 /// An error that occurred while connecting to an X11 server
 #[derive(Debug)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ConnectError {
     /// An unknown error occurred.
     ///
@@ -145,7 +151,10 @@ impl From<std::io::Error> for ConnectError {
 
 /// An error that occurred on an already established X11 connection
 #[derive(Debug)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ConnectionError {
     /// An unknown error occurred.
     ///

--- a/src/image.rs
+++ b/src/image.rs
@@ -346,6 +346,7 @@ number_enum! {
     ///
     /// Each line of an image is padded to a multiple of some value. This value is the scanline
     /// padding, which this enum represents.
+    #[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
     pub enum ScanlinePad {
         /// Padding to multiples of 8 bits, i.e. no padding.
         Pad8 = 8,
@@ -434,6 +435,7 @@ number_enum! {
     /// This value is only about the size of one pixel in memory. Other names for it include
     /// `bits_per_pixel` or `bpp`. It may be larger than the number of meaningful bits for a pixel
     /// value, which is its `depth`.
+    #[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
     pub enum BitsPerPixel {
         /// Each pixel takes one bit of memory.
         B1 = 1,

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -38,6 +38,7 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 4);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Redirect {
     Automatic = 0,
     Manual = 1,

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -38,7 +38,10 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 4);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Redirect {
     Automatic = 0,
     Manual = 1,

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -40,7 +40,10 @@ pub type Damage = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ReportLevel {
     RawRectangles = 0,
     DeltaRectangles = 1,

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -40,6 +40,7 @@ pub type Damage = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ReportLevel {
     RawRectangles = 0,
     DeltaRectangles = 1,

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -502,7 +502,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DPMSMode {
     On = 0,
     Standby = 1,

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -502,6 +502,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DPMSMode {
     On = 0,
     Standby = 1,

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -37,7 +37,10 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 4);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Attachment {
     BufferFrontLeft = 0,
     BufferBackLeft = 1,
@@ -128,7 +131,10 @@ impl TryFrom<u32> for Attachment {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DriverType {
     DRI = 0,
     VDPAU = 1,
@@ -199,7 +205,10 @@ impl TryFrom<u32> for DriverType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum EventType {
     ExchangeComplete = 1,
     BlitComplete = 2,

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 4);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Attachment {
     BufferFrontLeft = 0,
     BufferBackLeft = 1,
@@ -127,6 +128,7 @@ impl TryFrom<u32> for Attachment {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DriverType {
     DRI = 0,
     VDPAU = 1,
@@ -197,6 +199,7 @@ impl TryFrom<u32> for DriverType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum EventType {
     ExchangeComplete = 1,
     BlitComplete = 2,

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -297,7 +297,10 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PBCET {
     Damaged = 32791,
     Saved = 32792,
@@ -344,7 +347,10 @@ impl TryFrom<u32> for PBCET {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PBCDT {
     Window = 32793,
     Pbuffer = 32794,
@@ -1282,7 +1288,10 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GC {
     GL_CURRENT_BIT = 1 << 0,
     GL_POINT_BIT = 1 << 1,
@@ -4567,7 +4576,10 @@ impl RenderModeReply {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum RM {
     GL_RENDER = 7168,
     GL_FEEDBACK = 7169,

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -297,6 +297,7 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PBCET {
     Damaged = 32791,
     Saved = 32792,
@@ -343,6 +344,7 @@ impl TryFrom<u32> for PBCET {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PBCDT {
     Window = 32793,
     Pbuffer = 32794,
@@ -1280,6 +1282,7 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GC {
     GL_CURRENT_BIT = 1 << 0,
     GL_POINT_BIT = 1 << 1,
@@ -4564,6 +4567,7 @@ impl RenderModeReply {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum RM {
     GL_RENDER = 7168,
     GL_FEEDBACK = 7169,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -75,7 +75,10 @@ pub mod xvmc;
 /// Enumeration of all possible X11 requests.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Request<'input> {
     Unknown(RequestHeader, Cow<'input, [u8]>),
     CreateWindow(xproto::CreateWindowRequest<'input>),
@@ -4489,7 +4492,10 @@ impl<'input> Request<'input> {
 /// Enumeration of all possible X11 replies.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Reply {
     Void,
     GetWindowAttributes(xproto::GetWindowAttributesReply),
@@ -6971,7 +6977,10 @@ impl From<xvmc::ListSubpictureTypesReply> for Reply {
 
 /// Enumeration of all possible X11 error kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ErrorKind {
     Unknown(u8),
     Access,
@@ -7250,7 +7259,10 @@ impl ErrorKind {
 
 /// Enumeration of all possible X11 events.
 #[derive(Debug, Clone)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Event {
     Unknown(Vec<u8>),
     Error(X11Error),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -75,6 +75,7 @@ pub mod xvmc;
 /// Enumeration of all possible X11 requests.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Request<'input> {
     Unknown(RequestHeader, Cow<'input, [u8]>),
     CreateWindow(xproto::CreateWindowRequest<'input>),
@@ -4488,6 +4489,7 @@ impl<'input> Request<'input> {
 /// Enumeration of all possible X11 replies.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Reply {
     Void,
     GetWindowAttributes(xproto::GetWindowAttributesReply),
@@ -6969,6 +6971,7 @@ impl From<xvmc::ListSubpictureTypesReply> for Reply {
 
 /// Enumeration of all possible X11 error kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ErrorKind {
     Unknown(u8),
     Access,
@@ -7247,6 +7250,7 @@ impl ErrorKind {
 
 /// Enumeration of all possible X11 events.
 #[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Event {
     Unknown(Vec<u8>),
     Error(X11Error),

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -40,7 +40,10 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum EventEnum {
     ConfigureNotify = 0,
     CompleteNotify = 1,
@@ -109,7 +112,10 @@ impl TryFrom<u32> for EventEnum {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum EventMask {
     NoEvent = 0,
     ConfigureNotify = 1 << 0,
@@ -183,7 +189,10 @@ bitmask_binop!(EventMask, u8);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Option {
     None = 0,
     Async = 1 << 0,
@@ -257,7 +266,10 @@ bitmask_binop!(Option, u8);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Capability {
     None = 0,
     Async = 1 << 0,
@@ -327,7 +339,10 @@ bitmask_binop!(Capability, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CompleteKind {
     Pixmap = 0,
     NotifyMSC = 1,
@@ -398,7 +413,10 @@ impl TryFrom<u32> for CompleteKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CompleteMode {
     Copy = 0,
     Flip = 1,

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -40,6 +40,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum EventEnum {
     ConfigureNotify = 0,
     CompleteNotify = 1,
@@ -108,6 +109,7 @@ impl TryFrom<u32> for EventEnum {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum EventMask {
     NoEvent = 0,
     ConfigureNotify = 1 << 0,
@@ -181,6 +183,7 @@ bitmask_binop!(EventMask, u8);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Option {
     None = 0,
     Async = 1 << 0,
@@ -254,6 +257,7 @@ bitmask_binop!(Option, u8);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Capability {
     None = 0,
     Async = 1 << 0,
@@ -323,6 +327,7 @@ bitmask_binop!(Capability, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CompleteKind {
     Pixmap = 0,
     NotifyMSC = 1,
@@ -393,6 +398,7 @@ impl TryFrom<u32> for CompleteKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CompleteMode {
     Copy = 0,
     Flip = 1,

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -60,6 +60,7 @@ pub const BAD_PROVIDER_ERROR: u8 = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Rotation {
     Rotate0 = 1 << 0,
     Rotate90 = 1 << 1,
@@ -340,6 +341,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SetConfig {
     Success = 0,
     InvalidConfigTime = 1,
@@ -558,6 +560,7 @@ impl TryFrom<&[u8]> for SetScreenConfigReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum NotifyMask {
     ScreenChange = 1 << 0,
     CrtcChange = 1 << 1,
@@ -1046,6 +1049,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ModeFlag {
     HsyncPositive = 1 << 0,
     HsyncNegative = 1 << 1,
@@ -1405,6 +1409,7 @@ impl GetScreenResourcesReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Connection {
     Connected = 0,
     Disconnected = 1,
@@ -3552,6 +3557,7 @@ impl GetScreenResourcesCurrentReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Transform {
     Unit = 1 << 0,
     ScaleUp = 1 << 1,
@@ -4547,6 +4553,7 @@ impl GetProvidersReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ProviderCapability {
     SourceOutput = 1 << 0,
     SinkOutput = 1 << 1,
@@ -5775,6 +5782,7 @@ impl From<ScreenChangeNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Notify {
     CrtcChange = 0,
     OutputChange = 1,

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -60,7 +60,10 @@ pub const BAD_PROVIDER_ERROR: u8 = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Rotation {
     Rotate0 = 1 << 0,
     Rotate90 = 1 << 1,
@@ -341,7 +344,10 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SetConfig {
     Success = 0,
     InvalidConfigTime = 1,
@@ -560,7 +566,10 @@ impl TryFrom<&[u8]> for SetScreenConfigReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum NotifyMask {
     ScreenChange = 1 << 0,
     CrtcChange = 1 << 1,
@@ -1049,7 +1058,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ModeFlag {
     HsyncPositive = 1 << 0,
     HsyncNegative = 1 << 1,
@@ -1409,7 +1421,10 @@ impl GetScreenResourcesReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Connection {
     Connected = 0,
     Disconnected = 1,
@@ -3557,7 +3572,10 @@ impl GetScreenResourcesCurrentReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Transform {
     Unit = 1 << 0,
     ScaleUp = 1 << 1,
@@ -4553,7 +4571,10 @@ impl GetProvidersReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ProviderCapability {
     SourceOutput = 1 << 0,
     SinkOutput = 1 << 1,
@@ -5782,7 +5803,10 @@ impl From<ScreenChangeNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Notify {
     CrtcChange = 0,
     OutputChange = 1,

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -240,6 +240,7 @@ pub type ElementHeader = u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum HType {
     FromServerTime = 1 << 0,
     FromClientTime = 1 << 1,
@@ -308,6 +309,7 @@ pub type ClientSpec = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CS {
     CurrentClients = 1,
     FutureClients = 2,

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -240,7 +240,10 @@ pub type ElementHeader = u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum HType {
     FromServerTime = 1 << 0,
     FromClientTime = 1 << 1,
@@ -309,7 +312,10 @@ pub type ClientSpec = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CS {
     CurrentClients = 1,
     FutureClients = 2,

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 11);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PictType {
     Indexed = 0,
     Direct = 1,
@@ -107,6 +108,7 @@ impl TryFrom<u32> for PictType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PictureEnum {
     None = 0,
 }
@@ -166,6 +168,7 @@ impl TryFrom<u32> for PictureEnum {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PictOp {
     Clear = 0,
     Src = 1,
@@ -381,6 +384,7 @@ impl TryFrom<u32> for PictOp {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PolyEdge {
     Sharp = 0,
     Smooth = 1,
@@ -451,6 +455,7 @@ impl TryFrom<u32> for PolyEdge {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PolyMode {
     Precise = 0,
     Imprecise = 1,
@@ -521,6 +526,7 @@ impl TryFrom<u32> for PolyMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CP {
     Repeat = 1 << 0,
     AlphaMap = 1 << 1,
@@ -601,6 +607,7 @@ bitmask_binop!(CP, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SubPixel {
     Unknown = 0,
     HorizontalRGB = 1,
@@ -675,6 +682,7 @@ impl TryFrom<u32> for SubPixel {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Repeat {
     None = 0,
     Normal = 1,

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -37,7 +37,10 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 11);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PictType {
     Indexed = 0,
     Direct = 1,
@@ -108,7 +111,10 @@ impl TryFrom<u32> for PictType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PictureEnum {
     None = 0,
 }
@@ -168,7 +174,10 @@ impl TryFrom<u32> for PictureEnum {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PictOp {
     Clear = 0,
     Src = 1,
@@ -384,7 +393,10 @@ impl TryFrom<u32> for PictOp {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PolyEdge {
     Sharp = 0,
     Smooth = 1,
@@ -455,7 +467,10 @@ impl TryFrom<u32> for PolyEdge {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PolyMode {
     Precise = 0,
     Imprecise = 1,
@@ -526,7 +541,10 @@ impl TryFrom<u32> for PolyMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CP {
     Repeat = 1 << 0,
     AlphaMap = 1 << 1,
@@ -607,7 +625,10 @@ bitmask_binop!(CP, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SubPixel {
     Unknown = 0,
     HorizontalRGB = 1,
@@ -682,7 +703,10 @@ impl TryFrom<u32> for SubPixel {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Repeat {
     None = 0,
     Normal = 1,

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -121,6 +121,7 @@ impl Serialize for Type {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ClientIdMask {
     ClientXID = 1 << 0,
     LocalClientPID = 1 << 1,

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -121,7 +121,10 @@ impl Serialize for Type {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ClientIdMask {
     ClientXID = 1 << 0,
     LocalClientPID = 1 << 1,

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Kind {
     Blanked = 0,
     Internal = 1,
@@ -102,6 +103,7 @@ impl TryFrom<u32> for Kind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Event {
     NotifyMask = 1 << 0,
     CycleMask = 1 << 1,
@@ -165,6 +167,7 @@ bitmask_binop!(Event, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum State {
     Off = 0,
     On = 1,

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -37,7 +37,10 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Kind {
     Blanked = 0,
     Internal = 1,
@@ -103,7 +106,10 @@ impl TryFrom<u32> for Kind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Event {
     NotifyMask = 1 << 0,
     CycleMask = 1 << 1,
@@ -167,7 +173,10 @@ bitmask_binop!(Event, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum State {
     Off = 0,
     On = 1,

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -41,7 +41,10 @@ pub type Kind = u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SO {
     Set = 0,
     Union = 1,
@@ -113,7 +116,10 @@ impl TryFrom<u32> for SO {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SK {
     Bounding = 0,
     Clip = 1,

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -41,6 +41,7 @@ pub type Kind = u8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SO {
     Set = 0,
     Union = 1,
@@ -112,6 +113,7 @@ impl TryFrom<u32> for SO {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SK {
     Bounding = 0,
     Clip = 1,

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -39,6 +39,7 @@ pub type Alarm = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ALARMSTATE {
     Active = 0,
     Inactive = 1,
@@ -108,6 +109,7 @@ pub type Fence = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum TESTTYPE {
     PositiveTransition = 0,
     NegativeTransition = 1,
@@ -176,6 +178,7 @@ impl TryFrom<u32> for TESTTYPE {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum VALUETYPE {
     Absolute = 0,
     Relative = 1,
@@ -246,6 +249,7 @@ impl TryFrom<u32> for VALUETYPE {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CA {
     Counter = 1 << 0,
     ValueType = 1 << 1,

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -39,7 +39,10 @@ pub type Alarm = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ALARMSTATE {
     Active = 0,
     Inactive = 1,
@@ -109,7 +112,10 @@ pub type Fence = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum TESTTYPE {
     PositiveTransition = 0,
     NegativeTransition = 1,
@@ -178,7 +184,10 @@ impl TryFrom<u32> for TESTTYPE {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum VALUETYPE {
     Absolute = 0,
     Relative = 1,
@@ -249,7 +258,10 @@ impl TryFrom<u32> for VALUETYPE {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CA {
     Counter = 1 << 0,
     ValueType = 1 << 1,

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -330,7 +330,10 @@ impl TryFrom<&[u8]> for EndReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Datatype {
     Unmodified = 0,
     Modified = 1,

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -330,6 +330,7 @@ impl TryFrom<&[u8]> for EndReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Datatype {
     Unmodified = 0,
     Modified = 1,

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -40,7 +40,10 @@ pub type Dotclock = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ModeFlag {
     PositiveHSync = 1 << 0,
     NegativeHSync = 1 << 1,
@@ -121,7 +124,10 @@ bitmask_binop!(ModeFlag, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ClockFlag {
     Programable = 1 << 0,
 }
@@ -182,7 +188,10 @@ bitmask_binop!(ClockFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Permission {
     Read = 1 << 0,
     Write = 1 << 1,

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -40,6 +40,7 @@ pub type Dotclock = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ModeFlag {
     PositiveHSync = 1 << 0,
     NegativeHSync = 1 << 1,
@@ -120,6 +121,7 @@ bitmask_binop!(ModeFlag, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ClockFlag {
     Programable = 1 << 0,
 }
@@ -180,6 +182,7 @@ bitmask_binop!(ClockFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Permission {
     Read = 1 << 0,
     Write = 1 << 1,

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -147,7 +147,10 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SaveSetMode {
     Insert = 0,
     Delete = 1,
@@ -218,7 +221,10 @@ impl TryFrom<u32> for SaveSetMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SaveSetTarget {
     Nearest = 0,
     Root = 1,
@@ -289,7 +295,10 @@ impl TryFrom<u32> for SaveSetTarget {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SaveSetMapping {
     Map = 0,
     Unmap = 1,
@@ -448,7 +457,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SelectionEvent {
     SetSelectionOwner = 0,
     SelectionWindowDestroy = 1,
@@ -514,7 +526,10 @@ impl TryFrom<u32> for SelectionEvent {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SelectionEventMask {
     SetSelectionOwner = 1 << 0,
     SelectionWindowDestroy = 1 << 1,
@@ -757,7 +772,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CursorNotify {
     DisplayCursor = 0,
 }
@@ -817,7 +835,10 @@ impl TryFrom<u32> for CursorNotify {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CursorNotifyMask {
     DisplayCursor = 1 << 0,
 }
@@ -1147,7 +1168,10 @@ pub const BAD_REGION_ERROR: u8 = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum RegionEnum {
     None = 0,
 }
@@ -3430,7 +3454,10 @@ pub type Barrier = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BarrierDirections {
     PositiveX = 1 << 0,
     PositiveY = 1 << 1,

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -147,6 +147,7 @@ impl TryFrom<&[u8]> for QueryVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SaveSetMode {
     Insert = 0,
     Delete = 1,
@@ -217,6 +218,7 @@ impl TryFrom<u32> for SaveSetMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SaveSetTarget {
     Nearest = 0,
     Root = 1,
@@ -287,6 +289,7 @@ impl TryFrom<u32> for SaveSetTarget {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SaveSetMapping {
     Map = 0,
     Unmap = 1,
@@ -445,6 +448,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SelectionEvent {
     SetSelectionOwner = 0,
     SelectionWindowDestroy = 1,
@@ -510,6 +514,7 @@ impl TryFrom<u32> for SelectionEvent {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SelectionEventMask {
     SetSelectionOwner = 1 << 0,
     SelectionWindowDestroy = 1 << 1,
@@ -752,6 +757,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CursorNotify {
     DisplayCursor = 0,
 }
@@ -811,6 +817,7 @@ impl TryFrom<u32> for CursorNotify {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CursorNotifyMask {
     DisplayCursor = 1 << 0,
 }
@@ -1140,6 +1147,7 @@ pub const BAD_REGION_ERROR: u8 = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum RegionEnum {
     None = 0,
 }
@@ -3422,6 +3430,7 @@ pub type Barrier = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BarrierDirections {
     PositiveX = 1 << 0,
     PositiveY = 1 << 1,

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -202,6 +202,7 @@ impl TryFrom<&[u8]> for GetExtensionVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DeviceUse {
     IsXPointer = 0,
     IsXKeyboard = 1,
@@ -273,6 +274,7 @@ impl TryFrom<u32> for DeviceUse {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum InputClass {
     Key = 0,
     Button = 1,
@@ -350,6 +352,7 @@ impl TryFrom<u32> for InputClass {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ValuatorMode {
     Relative = 0,
     Absolute = 1,
@@ -1642,6 +1645,7 @@ impl GetSelectedExtensionEventsReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PropagateMode {
     AddToList = 0,
     DeleteFromList = 1,
@@ -2547,6 +2551,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ModifierDevice {
     UseXKeyboard = 255,
 }
@@ -3097,6 +3102,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DeviceInputMode {
     AsyncThisDevice = 0,
     SyncThisDevice = 1,
@@ -3452,6 +3458,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum FeedbackClass {
     Keyboard = 0,
     Pointer = 1,
@@ -5434,6 +5441,7 @@ impl Serialize for FeedbackCtl {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ChangeFeedbackControlMask {
     KeyClickPercent,
     Percent,
@@ -6446,6 +6454,7 @@ impl Serialize for ButtonState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ValuatorStateModeMask {
     DeviceModeAbsolute = 1 << 0,
     OutOfProximity = 1 << 1,
@@ -7191,6 +7200,7 @@ impl TryFrom<&[u8]> for SetDeviceValuatorsReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DeviceControl {
     Resolution = 1,
     Abscalib = 2,
@@ -9110,6 +9120,7 @@ impl ListDevicePropertiesReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PropertyFormat {
     M8Bits = 8,
     M16Bits = 16,
@@ -9696,6 +9707,7 @@ impl TryFrom<&[u8]> for GetDevicePropertyReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Device {
     All = 0,
     AllMaster = 1,
@@ -10235,6 +10247,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum HierarchyChangeType {
     AddMaster = 1,
     RemoveMaster = 2,
@@ -10303,6 +10316,7 @@ impl TryFrom<u32> for HierarchyChangeType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ChangeMode {
     Attach = 1,
     Float = 2,
@@ -11170,6 +11184,7 @@ impl TryFrom<&[u8]> for XIGetClientPointerReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum XIEventMask {
     DeviceChanged = 1 << 1,
     KeyPress = 1 << 2,
@@ -11516,6 +11531,7 @@ impl TryFrom<&[u8]> for XIQueryVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DeviceClassType {
     Key = 0,
     Button = 1,
@@ -11587,6 +11603,7 @@ impl TryFrom<u32> for DeviceClassType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DeviceType {
     MasterPointer = 1,
     MasterKeyboard = 2,
@@ -11658,6 +11675,7 @@ impl TryFrom<u32> for DeviceType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ScrollFlags {
     NoEmulation = 1 << 0,
     Preferred = 1 << 1,
@@ -11721,6 +11739,7 @@ bitmask_binop!(ScrollFlags, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ScrollType {
     Vertical = 1,
     Horizontal = 2,
@@ -11783,6 +11802,7 @@ impl TryFrom<u32> for ScrollType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum TouchMode {
     Direct = 1,
     Dependent = 2,
@@ -13048,6 +13068,7 @@ impl TryFrom<&[u8]> for XIGetFocusReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GrabOwner {
     NoOwner = 0,
     Owner = 1,
@@ -13373,6 +13394,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum EventMode {
     AsyncDevice = 0,
     SyncDevice = 1,
@@ -13556,6 +13578,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GrabMode22 {
     Sync = 0,
     Async = 1,
@@ -13621,6 +13644,7 @@ impl TryFrom<u32> for GrabMode22 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GrabType {
     Button = 0,
     Keycode = 1,
@@ -13692,6 +13716,7 @@ impl TryFrom<u32> for GrabType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ModifierMask {
     Any = 1 << 31,
 }
@@ -15089,6 +15114,7 @@ impl From<DeviceValuatorEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum MoreEventsMask {
     MoreEvents = 1 << 7,
 }
@@ -15373,6 +15399,7 @@ pub type ProximityOutEvent = DeviceKeyPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ClassesReportedMask {
     OutOfProximity = 1 << 7,
     DeviceModeAbsolute = 1 << 6,
@@ -15641,6 +15668,7 @@ impl From<DeviceMappingNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ChangeDevice {
     NewPointer = 0,
     NewKeyboard = 1,
@@ -15947,6 +15975,7 @@ impl From<DeviceButtonStateNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DeviceChange {
     Added = 0,
     Removed = 1,
@@ -16192,6 +16221,7 @@ impl From<DevicePropertyNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ChangeReason {
     SlaveSwitch = 1,
     DeviceChange = 2,
@@ -16314,6 +16344,7 @@ impl DeviceChangedEvent {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum KeyEventFlags {
     KeyRepeat = 1 << 16,
 }
@@ -16443,6 +16474,7 @@ pub type KeyReleaseEvent = KeyPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PointerEventFlags {
     PointerEmulated = 1 << 16,
 }
@@ -16576,6 +16608,7 @@ pub type MotionEvent = ButtonPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum NotifyMode {
     Normal = 0,
     Grab = 1,
@@ -16650,6 +16683,7 @@ impl TryFrom<u32> for NotifyMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum NotifyDetail {
     Ancestor = 0,
     Virtual = 1,
@@ -16826,6 +16860,7 @@ pub type FocusOutEvent = EnterEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum HierarchyMask {
     MasterAdded = 1 << 0,
     MasterRemoved = 1 << 1,
@@ -17025,6 +17060,7 @@ impl HierarchyEvent {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PropertyFlag {
     Deleted = 0,
     Created = 1,
@@ -17274,6 +17310,7 @@ pub type RawMotionEvent = RawButtonPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum TouchEventFlags {
     TouchPendingEnd = 1 << 16,
     TouchEmulatingPointer = 1 << 17,
@@ -17410,6 +17447,7 @@ pub type TouchEndEvent = TouchBeginEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum TouchOwnershipFlags {
     None = 0,
 }
@@ -17593,6 +17631,7 @@ pub type RawTouchEndEvent = RawTouchBeginEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BarrierFlags {
     PointerReleased = 1 << 0,
     DeviceIsGrabbed = 1 << 1,

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -202,7 +202,10 @@ impl TryFrom<&[u8]> for GetExtensionVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DeviceUse {
     IsXPointer = 0,
     IsXKeyboard = 1,
@@ -274,7 +277,10 @@ impl TryFrom<u32> for DeviceUse {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum InputClass {
     Key = 0,
     Button = 1,
@@ -352,7 +358,10 @@ impl TryFrom<u32> for InputClass {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ValuatorMode {
     Relative = 0,
     Absolute = 1,
@@ -1645,7 +1654,10 @@ impl GetSelectedExtensionEventsReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PropagateMode {
     AddToList = 0,
     DeleteFromList = 1,
@@ -2551,7 +2563,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ModifierDevice {
     UseXKeyboard = 255,
 }
@@ -3102,7 +3117,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DeviceInputMode {
     AsyncThisDevice = 0,
     SyncThisDevice = 1,
@@ -3458,7 +3476,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum FeedbackClass {
     Keyboard = 0,
     Pointer = 1,
@@ -5441,7 +5462,10 @@ impl Serialize for FeedbackCtl {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ChangeFeedbackControlMask {
     KeyClickPercent,
     Percent,
@@ -6454,7 +6478,10 @@ impl Serialize for ButtonState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ValuatorStateModeMask {
     DeviceModeAbsolute = 1 << 0,
     OutOfProximity = 1 << 1,
@@ -7200,7 +7227,10 @@ impl TryFrom<&[u8]> for SetDeviceValuatorsReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DeviceControl {
     Resolution = 1,
     Abscalib = 2,
@@ -9120,7 +9150,10 @@ impl ListDevicePropertiesReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PropertyFormat {
     M8Bits = 8,
     M16Bits = 16,
@@ -9707,7 +9740,10 @@ impl TryFrom<&[u8]> for GetDevicePropertyReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Device {
     All = 0,
     AllMaster = 1,
@@ -10247,7 +10283,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum HierarchyChangeType {
     AddMaster = 1,
     RemoveMaster = 2,
@@ -10316,7 +10355,10 @@ impl TryFrom<u32> for HierarchyChangeType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ChangeMode {
     Attach = 1,
     Float = 2,
@@ -11184,7 +11226,10 @@ impl TryFrom<&[u8]> for XIGetClientPointerReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum XIEventMask {
     DeviceChanged = 1 << 1,
     KeyPress = 1 << 2,
@@ -11531,7 +11576,10 @@ impl TryFrom<&[u8]> for XIQueryVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DeviceClassType {
     Key = 0,
     Button = 1,
@@ -11603,7 +11651,10 @@ impl TryFrom<u32> for DeviceClassType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DeviceType {
     MasterPointer = 1,
     MasterKeyboard = 2,
@@ -11675,7 +11726,10 @@ impl TryFrom<u32> for DeviceType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ScrollFlags {
     NoEmulation = 1 << 0,
     Preferred = 1 << 1,
@@ -11739,7 +11793,10 @@ bitmask_binop!(ScrollFlags, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ScrollType {
     Vertical = 1,
     Horizontal = 2,
@@ -11802,7 +11859,10 @@ impl TryFrom<u32> for ScrollType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum TouchMode {
     Direct = 1,
     Dependent = 2,
@@ -13068,7 +13128,10 @@ impl TryFrom<&[u8]> for XIGetFocusReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GrabOwner {
     NoOwner = 0,
     Owner = 1,
@@ -13394,7 +13457,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum EventMode {
     AsyncDevice = 0,
     SyncDevice = 1,
@@ -13578,7 +13644,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GrabMode22 {
     Sync = 0,
     Async = 1,
@@ -13644,7 +13713,10 @@ impl TryFrom<u32> for GrabMode22 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GrabType {
     Button = 0,
     Keycode = 1,
@@ -13716,7 +13788,10 @@ impl TryFrom<u32> for GrabType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ModifierMask {
     Any = 1 << 31,
 }
@@ -15114,7 +15189,10 @@ impl From<DeviceValuatorEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum MoreEventsMask {
     MoreEvents = 1 << 7,
 }
@@ -15399,7 +15477,10 @@ pub type ProximityOutEvent = DeviceKeyPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ClassesReportedMask {
     OutOfProximity = 1 << 7,
     DeviceModeAbsolute = 1 << 6,
@@ -15668,7 +15749,10 @@ impl From<DeviceMappingNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ChangeDevice {
     NewPointer = 0,
     NewKeyboard = 1,
@@ -15975,7 +16059,10 @@ impl From<DeviceButtonStateNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DeviceChange {
     Added = 0,
     Removed = 1,
@@ -16221,7 +16308,10 @@ impl From<DevicePropertyNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ChangeReason {
     SlaveSwitch = 1,
     DeviceChange = 2,
@@ -16344,7 +16434,10 @@ impl DeviceChangedEvent {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum KeyEventFlags {
     KeyRepeat = 1 << 16,
 }
@@ -16474,7 +16567,10 @@ pub type KeyReleaseEvent = KeyPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PointerEventFlags {
     PointerEmulated = 1 << 16,
 }
@@ -16608,7 +16704,10 @@ pub type MotionEvent = ButtonPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum NotifyMode {
     Normal = 0,
     Grab = 1,
@@ -16683,7 +16782,10 @@ impl TryFrom<u32> for NotifyMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum NotifyDetail {
     Ancestor = 0,
     Virtual = 1,
@@ -16860,7 +16962,10 @@ pub type FocusOutEvent = EnterEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum HierarchyMask {
     MasterAdded = 1 << 0,
     MasterRemoved = 1 << 1,
@@ -17060,7 +17165,10 @@ impl HierarchyEvent {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PropertyFlag {
     Deleted = 0,
     Created = 1,
@@ -17310,7 +17418,10 @@ pub type RawMotionEvent = RawButtonPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum TouchEventFlags {
     TouchPendingEnd = 1 << 16,
     TouchEmulatingPointer = 1 << 17,
@@ -17447,7 +17558,10 @@ pub type TouchEndEvent = TouchBeginEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum TouchOwnershipFlags {
     None = 0,
 }
@@ -17631,7 +17745,10 @@ pub type RawTouchEndEvent = RawTouchBeginEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BarrierFlags {
     PointerReleased = 1 << 0,
     DeviceIsGrabbed = 1 << 1,

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Const {
     MaxLegalKeyCode = 255,
     PerKeyBitArraySize = 32,
@@ -102,6 +103,7 @@ impl TryFrom<u32> for Const {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum EventType {
     NewKeyboardNotify = 1 << 0,
     MapNotify = 1 << 1,
@@ -179,6 +181,7 @@ bitmask_binop!(EventType, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum NKNDetail {
     Keycodes = 1 << 0,
     Geometry = 1 << 1,
@@ -245,6 +248,7 @@ bitmask_binop!(NKNDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum AXNDetail {
     SKPress = 1 << 0,
     SKAccept = 1 << 1,
@@ -323,6 +327,7 @@ bitmask_binop!(AXNDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum MapPart {
     KeyTypes = 1 << 0,
     KeySyms = 1 << 1,
@@ -404,6 +409,7 @@ bitmask_binop!(MapPart, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SetMapFlags {
     ResizeTypes = 1 << 0,
     RecomputeActions = 1 << 1,
@@ -467,6 +473,7 @@ bitmask_binop!(SetMapFlags, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum StatePart {
     ModifierState = 1 << 0,
     ModifierBase = 1 << 1,
@@ -550,6 +557,7 @@ bitmask_binop!(StatePart, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BoolCtrl {
     RepeatKeys = 1 << 0,
     SlowKeys = 1 << 1,
@@ -630,6 +638,7 @@ bitmask_binop!(BoolCtrl, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Control {
     GroupsWrap = 1 << 27,
     InternalMods = 1 << 28,
@@ -670,6 +679,7 @@ bitmask_binop!(Control, u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum AXOption {
     SKPressFB = 1 << 0,
     SKAcceptFB = 1 << 1,
@@ -749,6 +759,7 @@ pub type DeviceSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum LedClassResult {
     KbdFeedbackClass = 0,
     LedFeedbackClass = 4,
@@ -811,6 +822,7 @@ impl TryFrom<u32> for LedClassResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum LedClass {
     KbdFeedbackClass = 0,
     LedFeedbackClass = 4,
@@ -865,6 +877,7 @@ pub type LedClassSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BellClassResult {
     KbdFeedbackClass = 0,
     BellFeedbackClass = 5,
@@ -927,6 +940,7 @@ impl TryFrom<u32> for BellClassResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BellClass {
     KbdFeedbackClass = 0,
     BellFeedbackClass = 5,
@@ -978,6 +992,7 @@ pub type BellClassSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ID {
     UseCoreKbd = 256,
     UseCorePtr = 512,
@@ -1041,6 +1056,7 @@ pub type IDSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Group {
     M1 = 0,
     M2 = 1,
@@ -1109,6 +1125,7 @@ impl TryFrom<u32> for Group {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Groups {
     Any = 254,
     All = 255,
@@ -1171,6 +1188,7 @@ impl TryFrom<u32> for Groups {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SetOfGroup {
     Group1 = 1 << 0,
     Group2 = 1 << 1,
@@ -1240,6 +1258,7 @@ bitmask_binop!(SetOfGroup, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SetOfGroups {
     Any = 1 << 7,
 }
@@ -1300,6 +1319,7 @@ bitmask_binop!(SetOfGroups, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GroupsWrap {
     WrapIntoRange = 0,
     ClampIntoRange = 1 << 6,
@@ -1366,6 +1386,7 @@ bitmask_binop!(GroupsWrap, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum VModsHigh {
     M15 = 1 << 7,
     M14 = 1 << 6,
@@ -1447,6 +1468,7 @@ bitmask_binop!(VModsHigh, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum VModsLow {
     M7 = 1 << 7,
     M6 = 1 << 6,
@@ -1528,6 +1550,7 @@ bitmask_binop!(VModsLow, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum VMod {
     M15 = 1 << 15,
     M14 = 1 << 14,
@@ -1617,6 +1640,7 @@ bitmask_binop!(VMod, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Explicit {
     VModMap = 1 << 7,
     Behavior = 1 << 6,
@@ -1698,6 +1722,7 @@ bitmask_binop!(Explicit, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SymInterpretMatch {
     NoneOf = 0,
     AnyOfOrNone = 1,
@@ -1769,6 +1794,7 @@ impl TryFrom<u32> for SymInterpretMatch {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SymInterpMatch {
     LevelOneOnly = 1 << 7,
     OpMask = 127,
@@ -1831,6 +1857,7 @@ impl TryFrom<u32> for SymInterpMatch {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum IMFlag {
     NoExplicit = 1 << 7,
     NoAutomatic = 1 << 6,
@@ -1897,6 +1924,7 @@ bitmask_binop!(IMFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum IMModsWhich {
     UseCompat = 1 << 4,
     UseEffective = 1 << 3,
@@ -1969,6 +1997,7 @@ bitmask_binop!(IMModsWhich, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum IMGroupsWhich {
     UseCompat = 1 << 4,
     UseEffective = 1 << 3,
@@ -2115,6 +2144,7 @@ impl Serialize for IndicatorMap {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CMDetail {
     SymInterp = 1 << 0,
     GroupCompat = 1 << 1,
@@ -2178,6 +2208,7 @@ bitmask_binop!(CMDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum NameDetail {
     Keycodes = 1 << 0,
     Geometry = 1 << 1,
@@ -2261,6 +2292,7 @@ bitmask_binop!(NameDetail, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GBNDetail {
     Types = 1 << 0,
     CompatMap = 1 << 1,
@@ -2342,6 +2374,7 @@ bitmask_binop!(GBNDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum XIFeature {
     Keyboards = 1 << 0,
     ButtonActions = 1 << 1,
@@ -2414,6 +2447,7 @@ bitmask_binop!(XIFeature, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PerClientFlag {
     DetectableAutoRepeat = 1 << 0,
     GrabsUseXKBState = 1 << 1,
@@ -3136,6 +3170,7 @@ impl From<u8> for Behavior {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BehaviorType {
     Default = 0,
     Lock = 1,
@@ -3853,6 +3888,7 @@ impl Row {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum DoodadType {
     Outline = 1,
     Solid = 2,
@@ -4036,6 +4072,7 @@ impl Serialize for DeviceLedInfo {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Error {
     BadDevice = 255,
     BadClass = 254,
@@ -4103,6 +4140,7 @@ impl TryFrom<u32> for Error {
 pub const KEYBOARD_ERROR: u8 = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SA {
     ClearLocks,
     LatchToLock,
@@ -4148,6 +4186,7 @@ bitmask_binop!(SA, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SAType {
     NoAction = 0,
     SetMods = 1,
@@ -4426,6 +4465,7 @@ pub type SALockGroup = SASetGroup;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SAMovePtrFlag {
     NoAcceleration = 1 << 0,
     MoveAbsoluteX = 1 << 1,
@@ -4657,6 +4697,7 @@ impl Serialize for SALockPtrBtn {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SASetPtrDfltFlag {
     DfltBtnAbsolute = 1 << 2,
     AffectDfltButton = 1 << 0,
@@ -4772,6 +4813,7 @@ impl Serialize for SASetPtrDflt {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SAIsoLockFlag {
     NoLock,
     NoUnlock,
@@ -4819,6 +4861,7 @@ bitmask_binop!(SAIsoLockFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SAIsoLockNoAffect {
     Ctrls = 1 << 3,
     Ptr = 1 << 4,
@@ -4996,6 +5039,7 @@ impl Serialize for SATerminate {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SwitchScreenFlag {
     Application = 1 << 0,
     Absolute = 1 << 2,
@@ -5108,6 +5152,7 @@ impl Serialize for SASwitchScreen {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BoolCtrlsHigh {
     AccessXFeedback = 1 << 0,
     AudibleBell = 1 << 1,
@@ -5180,6 +5225,7 @@ bitmask_binop!(BoolCtrlsHigh, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BoolCtrlsLow {
     RepeatKeys = 1 << 0,
     SlowKeys = 1 << 1,
@@ -5314,6 +5360,7 @@ pub type SALockControls = SASetControls;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ActionMessageFlag {
     OnPress = 1 << 0,
     OnRelease = 1 << 1,
@@ -5551,6 +5598,7 @@ impl Serialize for SADeviceBtn {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum LockDeviceFlags {
     NoLock = 1 << 0,
     NoUnlock = 1 << 1,
@@ -5669,6 +5717,7 @@ impl Serialize for SALockDeviceBtn {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SAValWhat {
     IgnoreVal = 0,
     SetValMin = 1,

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -37,7 +37,10 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Const {
     MaxLegalKeyCode = 255,
     PerKeyBitArraySize = 32,
@@ -103,7 +106,10 @@ impl TryFrom<u32> for Const {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum EventType {
     NewKeyboardNotify = 1 << 0,
     MapNotify = 1 << 1,
@@ -181,7 +187,10 @@ bitmask_binop!(EventType, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum NKNDetail {
     Keycodes = 1 << 0,
     Geometry = 1 << 1,
@@ -248,7 +257,10 @@ bitmask_binop!(NKNDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum AXNDetail {
     SKPress = 1 << 0,
     SKAccept = 1 << 1,
@@ -327,7 +339,10 @@ bitmask_binop!(AXNDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum MapPart {
     KeyTypes = 1 << 0,
     KeySyms = 1 << 1,
@@ -409,7 +424,10 @@ bitmask_binop!(MapPart, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SetMapFlags {
     ResizeTypes = 1 << 0,
     RecomputeActions = 1 << 1,
@@ -473,7 +491,10 @@ bitmask_binop!(SetMapFlags, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum StatePart {
     ModifierState = 1 << 0,
     ModifierBase = 1 << 1,
@@ -557,7 +578,10 @@ bitmask_binop!(StatePart, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BoolCtrl {
     RepeatKeys = 1 << 0,
     SlowKeys = 1 << 1,
@@ -638,7 +662,10 @@ bitmask_binop!(BoolCtrl, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Control {
     GroupsWrap = 1 << 27,
     InternalMods = 1 << 28,
@@ -679,7 +706,10 @@ bitmask_binop!(Control, u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum AXOption {
     SKPressFB = 1 << 0,
     SKAcceptFB = 1 << 1,
@@ -759,7 +789,10 @@ pub type DeviceSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum LedClassResult {
     KbdFeedbackClass = 0,
     LedFeedbackClass = 4,
@@ -822,7 +855,10 @@ impl TryFrom<u32> for LedClassResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum LedClass {
     KbdFeedbackClass = 0,
     LedFeedbackClass = 4,
@@ -877,7 +913,10 @@ pub type LedClassSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BellClassResult {
     KbdFeedbackClass = 0,
     BellFeedbackClass = 5,
@@ -940,7 +979,10 @@ impl TryFrom<u32> for BellClassResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BellClass {
     KbdFeedbackClass = 0,
     BellFeedbackClass = 5,
@@ -992,7 +1034,10 @@ pub type BellClassSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ID {
     UseCoreKbd = 256,
     UseCorePtr = 512,
@@ -1056,7 +1101,10 @@ pub type IDSpec = u16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Group {
     M1 = 0,
     M2 = 1,
@@ -1125,7 +1173,10 @@ impl TryFrom<u32> for Group {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Groups {
     Any = 254,
     All = 255,
@@ -1188,7 +1239,10 @@ impl TryFrom<u32> for Groups {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SetOfGroup {
     Group1 = 1 << 0,
     Group2 = 1 << 1,
@@ -1258,7 +1312,10 @@ bitmask_binop!(SetOfGroup, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SetOfGroups {
     Any = 1 << 7,
 }
@@ -1319,7 +1376,10 @@ bitmask_binop!(SetOfGroups, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GroupsWrap {
     WrapIntoRange = 0,
     ClampIntoRange = 1 << 6,
@@ -1386,7 +1446,10 @@ bitmask_binop!(GroupsWrap, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum VModsHigh {
     M15 = 1 << 7,
     M14 = 1 << 6,
@@ -1468,7 +1531,10 @@ bitmask_binop!(VModsHigh, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum VModsLow {
     M7 = 1 << 7,
     M6 = 1 << 6,
@@ -1550,7 +1616,10 @@ bitmask_binop!(VModsLow, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum VMod {
     M15 = 1 << 15,
     M14 = 1 << 14,
@@ -1640,7 +1709,10 @@ bitmask_binop!(VMod, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Explicit {
     VModMap = 1 << 7,
     Behavior = 1 << 6,
@@ -1722,7 +1794,10 @@ bitmask_binop!(Explicit, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SymInterpretMatch {
     NoneOf = 0,
     AnyOfOrNone = 1,
@@ -1794,7 +1869,10 @@ impl TryFrom<u32> for SymInterpretMatch {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SymInterpMatch {
     LevelOneOnly = 1 << 7,
     OpMask = 127,
@@ -1857,7 +1935,10 @@ impl TryFrom<u32> for SymInterpMatch {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum IMFlag {
     NoExplicit = 1 << 7,
     NoAutomatic = 1 << 6,
@@ -1924,7 +2005,10 @@ bitmask_binop!(IMFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum IMModsWhich {
     UseCompat = 1 << 4,
     UseEffective = 1 << 3,
@@ -1997,7 +2081,10 @@ bitmask_binop!(IMModsWhich, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum IMGroupsWhich {
     UseCompat = 1 << 4,
     UseEffective = 1 << 3,
@@ -2144,7 +2231,10 @@ impl Serialize for IndicatorMap {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CMDetail {
     SymInterp = 1 << 0,
     GroupCompat = 1 << 1,
@@ -2208,7 +2298,10 @@ bitmask_binop!(CMDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum NameDetail {
     Keycodes = 1 << 0,
     Geometry = 1 << 1,
@@ -2292,7 +2385,10 @@ bitmask_binop!(NameDetail, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GBNDetail {
     Types = 1 << 0,
     CompatMap = 1 << 1,
@@ -2374,7 +2470,10 @@ bitmask_binop!(GBNDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum XIFeature {
     Keyboards = 1 << 0,
     ButtonActions = 1 << 1,
@@ -2447,7 +2546,10 @@ bitmask_binop!(XIFeature, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PerClientFlag {
     DetectableAutoRepeat = 1 << 0,
     GrabsUseXKBState = 1 << 1,
@@ -3170,7 +3272,10 @@ impl From<u8> for Behavior {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BehaviorType {
     Default = 0,
     Lock = 1,
@@ -3888,7 +3993,10 @@ impl Row {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum DoodadType {
     Outline = 1,
     Solid = 2,
@@ -4072,7 +4180,10 @@ impl Serialize for DeviceLedInfo {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Error {
     BadDevice = 255,
     BadClass = 254,
@@ -4140,7 +4251,10 @@ impl TryFrom<u32> for Error {
 pub const KEYBOARD_ERROR: u8 = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SA {
     ClearLocks,
     LatchToLock,
@@ -4186,7 +4300,10 @@ bitmask_binop!(SA, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SAType {
     NoAction = 0,
     SetMods = 1,
@@ -4465,7 +4582,10 @@ pub type SALockGroup = SASetGroup;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SAMovePtrFlag {
     NoAcceleration = 1 << 0,
     MoveAbsoluteX = 1 << 1,
@@ -4697,7 +4817,10 @@ impl Serialize for SALockPtrBtn {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SASetPtrDfltFlag {
     DfltBtnAbsolute = 1 << 2,
     AffectDfltButton = 1 << 0,
@@ -4813,7 +4936,10 @@ impl Serialize for SASetPtrDflt {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SAIsoLockFlag {
     NoLock,
     NoUnlock,
@@ -4861,7 +4987,10 @@ bitmask_binop!(SAIsoLockFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SAIsoLockNoAffect {
     Ctrls = 1 << 3,
     Ptr = 1 << 4,
@@ -5039,7 +5168,10 @@ impl Serialize for SATerminate {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SwitchScreenFlag {
     Application = 1 << 0,
     Absolute = 1 << 2,
@@ -5152,7 +5284,10 @@ impl Serialize for SASwitchScreen {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BoolCtrlsHigh {
     AccessXFeedback = 1 << 0,
     AudibleBell = 1 << 1,
@@ -5225,7 +5360,10 @@ bitmask_binop!(BoolCtrlsHigh, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BoolCtrlsLow {
     RepeatKeys = 1 << 0,
     SlowKeys = 1 << 1,
@@ -5360,7 +5498,10 @@ pub type SALockControls = SASetControls;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ActionMessageFlag {
     OnPress = 1 << 0,
     OnRelease = 1 << 1,
@@ -5598,7 +5739,10 @@ impl Serialize for SADeviceBtn {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum LockDeviceFlags {
     NoLock = 1 << 0,
     NoUnlock = 1 << 1,
@@ -5717,7 +5861,10 @@ impl Serialize for SALockDeviceBtn {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SAValWhat {
     IgnoreVal = 0,
     SetValMin = 1,

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -120,7 +120,10 @@ pub type Pcontext = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GetDoc {
     Finished = 0,
     SecondConsumer = 1,
@@ -191,7 +194,10 @@ impl TryFrom<u32> for GetDoc {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum EvMask {
     NoEventMask = 0,
     PrintMask = 1 << 0,
@@ -258,7 +264,10 @@ bitmask_binop!(EvMask, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Detail {
     StartJobNotify = 1,
     EndJobNotify = 2,
@@ -333,7 +342,10 @@ impl TryFrom<u32> for Detail {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Attr {
     JobAttr = 1,
     DocAttr = 2,

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -120,6 +120,7 @@ pub type Pcontext = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GetDoc {
     Finished = 0,
     SecondConsumer = 1,
@@ -190,6 +191,7 @@ impl TryFrom<u32> for GetDoc {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum EvMask {
     NoEventMask = 0,
     PrintMask = 1 << 0,
@@ -256,6 +258,7 @@ bitmask_binop!(EvMask, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Detail {
     StartJobNotify = 1,
     EndJobNotify = 2,
@@ -330,6 +333,7 @@ impl TryFrom<u32> for Detail {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Attr {
     JobAttr = 1,
     DocAttr = 2,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -297,6 +297,7 @@ impl Serialize for Format {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum VisualClass {
     StaticGray = 0,
     GrayScale = 1,
@@ -507,6 +508,7 @@ impl Depth {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum EventMask {
     NoEvent = 0,
     KeyPress = 1 << 0,
@@ -610,6 +612,7 @@ bitmask_binop!(EventMask, u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BackingStore {
     NotUseful = 0,
     WhenMapped = 1,
@@ -979,6 +982,7 @@ impl SetupAuthenticate {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ImageOrder {
     LSBFirst = 0,
     MSBFirst = 1,
@@ -1193,6 +1197,7 @@ impl Setup {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ModMask {
     Shift = 1 << 0,
     Lock = 1 << 1,
@@ -1261,6 +1266,7 @@ bitmask_binop!(ModMask, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum KeyButMask {
     Shift = 1 << 0,
     Lock = 1 << 1,
@@ -1341,6 +1347,7 @@ bitmask_binop!(KeyButMask, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum WindowEnum {
     None = 0,
 }
@@ -1533,6 +1540,7 @@ pub type KeyReleaseEvent = KeyPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ButtonMask {
     M1 = 1 << 8,
     M2 = 1 << 9,
@@ -1725,6 +1733,7 @@ pub type ButtonReleaseEvent = ButtonPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Motion {
     Normal = 0,
     Hint = 1,
@@ -1925,6 +1934,7 @@ impl From<MotionNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum NotifyDetail {
     Ancestor = 0,
     Virtual = 1,
@@ -2005,6 +2015,7 @@ impl TryFrom<u32> for NotifyDetail {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum NotifyMode {
     Normal = 0,
     Grab = 1,
@@ -2656,6 +2667,7 @@ impl From<NoExposureEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Visibility {
     Unobscured = 0,
     PartiallyObscured = 1,
@@ -3759,6 +3771,7 @@ impl From<ResizeRequestEvent> for [u8; 32] {
 /// * `OnBottom` - The window is now below all siblings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Place {
     OnTop = 0,
     OnBottom = 1,
@@ -3930,6 +3943,7 @@ pub type CirculateRequestEvent = CirculateNotifyEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Property {
     NewValue = 0,
     Delete = 1,
@@ -4181,6 +4195,7 @@ impl From<SelectionClearEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Time {
     CurrentTime = 0,
 }
@@ -4240,6 +4255,7 @@ impl TryFrom<u32> for Time {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum AtomEnum {
     None,
     Any,
@@ -4599,6 +4615,7 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 /// * `Installed` - The colormap was installed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ColormapState {
     Uninstalled = 0,
     Installed = 1,
@@ -4669,6 +4686,7 @@ impl TryFrom<u32> for ColormapState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ColormapEnum {
     None = 0,
 }
@@ -5083,6 +5101,7 @@ impl From<ClientMessageEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Mapping {
     Modifier = 0,
     Keyboard = 1,
@@ -5330,6 +5349,7 @@ pub const IMPLEMENTATION_ERROR: u8 = 17;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum WindowClass {
     CopyFromParent = 0,
     InputOutput = 1,
@@ -5465,6 +5485,7 @@ impl TryFrom<u32> for WindowClass {
 /// parent's cursor will cause an immediate change in the displayed cursor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CW {
     BackPixmap = 1 << 0,
     BackPixel = 1 << 1,
@@ -5551,6 +5572,7 @@ bitmask_binop!(CW, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum BackPixmap {
     None = 0,
     ParentRelative = 1,
@@ -5620,6 +5642,7 @@ impl TryFrom<u32> for BackPixmap {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Gravity {
     BitForget,
     WinUnmap,
@@ -6779,6 +6802,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum MapState {
     Unmapped = 0,
     Unviewable = 1,
@@ -7193,6 +7217,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SetMode {
     Insert = 0,
     Delete = 1,
@@ -7914,6 +7939,7 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ConfigWindow {
     X = 1 << 0,
     Y = 1 << 1,
@@ -7992,6 +8018,7 @@ bitmask_binop!(ConfigWindow, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum StackMode {
     Above = 0,
     Below = 1,
@@ -8430,6 +8457,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Circulate {
     RaiseLowest = 0,
     LowerHighest = 1,
@@ -9329,6 +9357,7 @@ impl GetAtomNameReply {
 /// defined with the correct type and format with zero-length data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PropMode {
     Replace = 0,
     Prepend = 1,
@@ -9705,6 +9734,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GetPropertyType {
     Any = 0,
 }
@@ -10722,6 +10752,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SendEventDest {
     PointerWindow = 0,
     ItemFocus = 1,
@@ -11045,6 +11076,7 @@ where
 /// * `Async` - Keyboard event processing continues normally.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GrabMode {
     Sync = 0,
     Async = 1,
@@ -11115,6 +11147,7 @@ impl TryFrom<u32> for GrabMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GrabStatus {
     Success = 0,
     AlreadyGrabbed = 1,
@@ -11186,6 +11219,7 @@ impl TryFrom<u32> for GrabStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CursorEnum {
     None = 0,
 }
@@ -11668,6 +11702,7 @@ where
 /// * `5` - Scroll wheel. TODO: direction?
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ButtonIndex {
     Any = 0,
     M1 = 1,
@@ -12509,6 +12544,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Grab {
     Any = 0,
 }
@@ -12988,6 +13024,7 @@ where
 /// has no effect unless both pointer and keyboard are frozen by the client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Allow {
     AsyncPointer = 0,
     SyncPointer = 1,
@@ -13951,6 +13988,7 @@ where
 /// * `FollowKeyboard` - NOT YET DOCUMENTED. Only relevant for the xinput extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum InputFocus {
     None = 0,
     PointerRoot = 1,
@@ -14547,6 +14585,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum FontDraw {
     LeftToRight = 0,
     RightToLeft = 1,
@@ -16055,6 +16094,7 @@ where
 /// * `ArcMode` - TODO
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GC {
     Function = 1 << 0,
     PlaneMask = 1 << 1,
@@ -16149,6 +16189,7 @@ bitmask_binop!(GC, u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GX {
     Clear = 0,
     And = 1,
@@ -16253,6 +16294,7 @@ impl TryFrom<u32> for GX {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum LineStyle {
     Solid = 0,
     OnOffDash = 1,
@@ -16318,6 +16360,7 @@ impl TryFrom<u32> for LineStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CapStyle {
     NotLast = 0,
     Butt = 1,
@@ -16386,6 +16429,7 @@ impl TryFrom<u32> for CapStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum JoinStyle {
     Miter = 0,
     Round = 1,
@@ -16451,6 +16495,7 @@ impl TryFrom<u32> for JoinStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum FillStyle {
     Solid = 0,
     Tiled = 1,
@@ -16519,6 +16564,7 @@ impl TryFrom<u32> for FillStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum FillRule {
     EvenOdd = 0,
     Winding = 1,
@@ -16589,6 +16635,7 @@ impl TryFrom<u32> for FillRule {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum SubwindowMode {
     ClipByChildren = 0,
     IncludeInferiors = 1,
@@ -16659,6 +16706,7 @@ impl TryFrom<u32> for SubwindowMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ArcMode {
     Chord = 0,
     PieSlice = 1,
@@ -18242,6 +18290,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ClipOrdering {
     Unsorted = 0,
     YSorted = 1,
@@ -18918,6 +18967,7 @@ where
 /// * `Previous` - Treats all coordinates after the first as relative to the previous coordinate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CoordMode {
     Origin = 0,
     Previous = 1,
@@ -19675,6 +19725,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PolyShape {
     Complex = 0,
     Nonconvex = 1,
@@ -20106,6 +20157,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ImageFormat {
     XYBitmap = 0,
     XYPixmap = 1,
@@ -21048,6 +21100,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ColormapAlloc {
     None = 0,
     All = 1,
@@ -22299,6 +22352,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ColorFlag {
     Red = 1 << 0,
     Green = 1 << 1,
@@ -22935,6 +22989,7 @@ impl TryFrom<&[u8]> for LookupColorReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum PixmapEnum {
     None = 0,
 }
@@ -23137,6 +23192,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum FontEnum {
     None = 0,
 }
@@ -23605,6 +23661,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum QueryShapeOf {
     LargestCursor = 0,
     FastestTile = 1,
@@ -24272,6 +24329,7 @@ impl GetKeyboardMappingReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum KB {
     KeyClickPercent = 1 << 0,
     BellPercent = 1 << 1,
@@ -24353,6 +24411,7 @@ bitmask_binop!(KB, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum LedMode {
     Off = 0,
     On = 1,
@@ -24423,6 +24482,7 @@ impl TryFrom<u32> for LedMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum AutoRepeatMode {
     Off = 0,
     On = 1,
@@ -25111,6 +25171,7 @@ impl TryFrom<&[u8]> for GetPointerControlReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Blanking {
     NotPreferred = 0,
     Preferred = 1,
@@ -25176,6 +25237,7 @@ impl TryFrom<u32> for Blanking {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Exposures {
     NotAllowed = 0,
     Allowed = 1,
@@ -25425,6 +25487,7 @@ impl TryFrom<&[u8]> for GetScreenSaverReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum HostMode {
     Insert = 0,
     Delete = 1,
@@ -25495,6 +25558,7 @@ impl TryFrom<u32> for HostMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Family {
     Internet = 0,
     DECnet = 1,
@@ -25825,6 +25889,7 @@ impl ListHostsReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum AccessControl {
     Disable = 0,
     Enable = 1,
@@ -25958,6 +26023,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum CloseDown {
     DestroyAll = 0,
     RetainPermanent = 1,
@@ -26086,6 +26152,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Kill {
     AllTemporary = 0,
 }
@@ -26347,6 +26414,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ScreenSaver {
     Reset = 0,
     Active = 1,
@@ -26480,6 +26548,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum MappingStatus {
     Success = 0,
     Busy = 1,
@@ -26753,6 +26822,7 @@ impl GetPointerMappingReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum MapIndex {
     Shift = 0,
     Lock = 1,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -297,7 +297,10 @@ impl Serialize for Format {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum VisualClass {
     StaticGray = 0,
     GrayScale = 1,
@@ -508,7 +511,10 @@ impl Depth {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum EventMask {
     NoEvent = 0,
     KeyPress = 1 << 0,
@@ -612,7 +618,10 @@ bitmask_binop!(EventMask, u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BackingStore {
     NotUseful = 0,
     WhenMapped = 1,
@@ -982,7 +991,10 @@ impl SetupAuthenticate {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ImageOrder {
     LSBFirst = 0,
     MSBFirst = 1,
@@ -1197,7 +1209,10 @@ impl Setup {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ModMask {
     Shift = 1 << 0,
     Lock = 1 << 1,
@@ -1266,7 +1281,10 @@ bitmask_binop!(ModMask, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum KeyButMask {
     Shift = 1 << 0,
     Lock = 1 << 1,
@@ -1347,7 +1365,10 @@ bitmask_binop!(KeyButMask, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum WindowEnum {
     None = 0,
 }
@@ -1540,7 +1561,10 @@ pub type KeyReleaseEvent = KeyPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ButtonMask {
     M1 = 1 << 8,
     M2 = 1 << 9,
@@ -1733,7 +1757,10 @@ pub type ButtonReleaseEvent = ButtonPressEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Motion {
     Normal = 0,
     Hint = 1,
@@ -1934,7 +1961,10 @@ impl From<MotionNotifyEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum NotifyDetail {
     Ancestor = 0,
     Virtual = 1,
@@ -2015,7 +2045,10 @@ impl TryFrom<u32> for NotifyDetail {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum NotifyMode {
     Normal = 0,
     Grab = 1,
@@ -2667,7 +2700,10 @@ impl From<NoExposureEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Visibility {
     Unobscured = 0,
     PartiallyObscured = 1,
@@ -3771,7 +3807,10 @@ impl From<ResizeRequestEvent> for [u8; 32] {
 /// * `OnBottom` - The window is now below all siblings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Place {
     OnTop = 0,
     OnBottom = 1,
@@ -3943,7 +3982,10 @@ pub type CirculateRequestEvent = CirculateNotifyEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Property {
     NewValue = 0,
     Delete = 1,
@@ -4195,7 +4237,10 @@ impl From<SelectionClearEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Time {
     CurrentTime = 0,
 }
@@ -4255,7 +4300,10 @@ impl TryFrom<u32> for Time {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum AtomEnum {
     None,
     Any,
@@ -4615,7 +4663,10 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 /// * `Installed` - The colormap was installed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ColormapState {
     Uninstalled = 0,
     Installed = 1,
@@ -4686,7 +4737,10 @@ impl TryFrom<u32> for ColormapState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ColormapEnum {
     None = 0,
 }
@@ -5101,7 +5155,10 @@ impl From<ClientMessageEvent> for [u8; 32] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Mapping {
     Modifier = 0,
     Keyboard = 1,
@@ -5349,7 +5406,10 @@ pub const IMPLEMENTATION_ERROR: u8 = 17;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum WindowClass {
     CopyFromParent = 0,
     InputOutput = 1,
@@ -5485,7 +5545,10 @@ impl TryFrom<u32> for WindowClass {
 /// parent's cursor will cause an immediate change in the displayed cursor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CW {
     BackPixmap = 1 << 0,
     BackPixel = 1 << 1,
@@ -5572,7 +5635,10 @@ bitmask_binop!(CW, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum BackPixmap {
     None = 0,
     ParentRelative = 1,
@@ -5642,7 +5708,10 @@ impl TryFrom<u32> for BackPixmap {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Gravity {
     BitForget,
     WinUnmap,
@@ -6802,7 +6871,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum MapState {
     Unmapped = 0,
     Unviewable = 1,
@@ -7217,7 +7289,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SetMode {
     Insert = 0,
     Delete = 1,
@@ -7939,7 +8014,10 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ConfigWindow {
     X = 1 << 0,
     Y = 1 << 1,
@@ -8018,7 +8096,10 @@ bitmask_binop!(ConfigWindow, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum StackMode {
     Above = 0,
     Below = 1,
@@ -8457,7 +8538,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Circulate {
     RaiseLowest = 0,
     LowerHighest = 1,
@@ -9357,7 +9441,10 @@ impl GetAtomNameReply {
 /// defined with the correct type and format with zero-length data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PropMode {
     Replace = 0,
     Prepend = 1,
@@ -9734,7 +9821,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GetPropertyType {
     Any = 0,
 }
@@ -10752,7 +10842,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SendEventDest {
     PointerWindow = 0,
     ItemFocus = 1,
@@ -11076,7 +11169,10 @@ where
 /// * `Async` - Keyboard event processing continues normally.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GrabMode {
     Sync = 0,
     Async = 1,
@@ -11147,7 +11243,10 @@ impl TryFrom<u32> for GrabMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GrabStatus {
     Success = 0,
     AlreadyGrabbed = 1,
@@ -11219,7 +11318,10 @@ impl TryFrom<u32> for GrabStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CursorEnum {
     None = 0,
 }
@@ -11702,7 +11804,10 @@ where
 /// * `5` - Scroll wheel. TODO: direction?
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ButtonIndex {
     Any = 0,
     M1 = 1,
@@ -12544,7 +12649,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Grab {
     Any = 0,
 }
@@ -13024,7 +13132,10 @@ where
 /// has no effect unless both pointer and keyboard are frozen by the client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Allow {
     AsyncPointer = 0,
     SyncPointer = 1,
@@ -13988,7 +14099,10 @@ where
 /// * `FollowKeyboard` - NOT YET DOCUMENTED. Only relevant for the xinput extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum InputFocus {
     None = 0,
     PointerRoot = 1,
@@ -14585,7 +14699,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum FontDraw {
     LeftToRight = 0,
     RightToLeft = 1,
@@ -16094,7 +16211,10 @@ where
 /// * `ArcMode` - TODO
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GC {
     Function = 1 << 0,
     PlaneMask = 1 << 1,
@@ -16189,7 +16309,10 @@ bitmask_binop!(GC, u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GX {
     Clear = 0,
     And = 1,
@@ -16294,7 +16417,10 @@ impl TryFrom<u32> for GX {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum LineStyle {
     Solid = 0,
     OnOffDash = 1,
@@ -16360,7 +16486,10 @@ impl TryFrom<u32> for LineStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CapStyle {
     NotLast = 0,
     Butt = 1,
@@ -16429,7 +16558,10 @@ impl TryFrom<u32> for CapStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum JoinStyle {
     Miter = 0,
     Round = 1,
@@ -16495,7 +16627,10 @@ impl TryFrom<u32> for JoinStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum FillStyle {
     Solid = 0,
     Tiled = 1,
@@ -16564,7 +16699,10 @@ impl TryFrom<u32> for FillStyle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum FillRule {
     EvenOdd = 0,
     Winding = 1,
@@ -16635,7 +16773,10 @@ impl TryFrom<u32> for FillRule {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum SubwindowMode {
     ClipByChildren = 0,
     IncludeInferiors = 1,
@@ -16706,7 +16847,10 @@ impl TryFrom<u32> for SubwindowMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ArcMode {
     Chord = 0,
     PieSlice = 1,
@@ -18290,7 +18434,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ClipOrdering {
     Unsorted = 0,
     YSorted = 1,
@@ -18967,7 +19114,10 @@ where
 /// * `Previous` - Treats all coordinates after the first as relative to the previous coordinate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CoordMode {
     Origin = 0,
     Previous = 1,
@@ -19725,7 +19875,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PolyShape {
     Complex = 0,
     Nonconvex = 1,
@@ -20157,7 +20310,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ImageFormat {
     XYBitmap = 0,
     XYPixmap = 1,
@@ -21100,7 +21256,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ColormapAlloc {
     None = 0,
     All = 1,
@@ -22352,7 +22511,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ColorFlag {
     Red = 1 << 0,
     Green = 1 << 1,
@@ -22989,7 +23151,10 @@ impl TryFrom<&[u8]> for LookupColorReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum PixmapEnum {
     None = 0,
 }
@@ -23192,7 +23357,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum FontEnum {
     None = 0,
 }
@@ -23661,7 +23829,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum QueryShapeOf {
     LargestCursor = 0,
     FastestTile = 1,
@@ -24329,7 +24500,10 @@ impl GetKeyboardMappingReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum KB {
     KeyClickPercent = 1 << 0,
     BellPercent = 1 << 1,
@@ -24411,7 +24585,10 @@ bitmask_binop!(KB, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum LedMode {
     Off = 0,
     On = 1,
@@ -24482,7 +24659,10 @@ impl TryFrom<u32> for LedMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum AutoRepeatMode {
     Off = 0,
     On = 1,
@@ -25171,7 +25351,10 @@ impl TryFrom<&[u8]> for GetPointerControlReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Blanking {
     NotPreferred = 0,
     Preferred = 1,
@@ -25237,7 +25420,10 @@ impl TryFrom<u32> for Blanking {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Exposures {
     NotAllowed = 0,
     Allowed = 1,
@@ -25487,7 +25673,10 @@ impl TryFrom<&[u8]> for GetScreenSaverReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum HostMode {
     Insert = 0,
     Delete = 1,
@@ -25558,7 +25747,10 @@ impl TryFrom<u32> for HostMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Family {
     Internet = 0,
     DECnet = 1,
@@ -25889,7 +26081,10 @@ impl ListHostsReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum AccessControl {
     Disable = 0,
     Enable = 1,
@@ -26023,7 +26218,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum CloseDown {
     DestroyAll = 0,
     RetainPermanent = 1,
@@ -26152,7 +26350,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Kill {
     AllTemporary = 0,
 }
@@ -26414,7 +26615,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ScreenSaver {
     Reset = 0,
     Active = 1,
@@ -26548,7 +26752,10 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum MappingStatus {
     Success = 0,
     Busy = 1,
@@ -26822,7 +27029,10 @@ impl GetPointerMappingReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum MapIndex {
     Shift = 0,
     Lock = 1,

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -140,6 +140,7 @@ impl TryFrom<&[u8]> for GetVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Cursor {
     None = 0,
     Current = 1,

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -140,7 +140,10 @@ impl TryFrom<&[u8]> for GetVersionReply {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Cursor {
     None = 0,
     Current = 1,

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -42,6 +42,7 @@ pub type Encoding = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum Type {
     InputMask = 1 << 0,
     OutputMask = 1 << 1,
@@ -115,6 +116,7 @@ bitmask_binop!(Type, u8);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ImageFormatInfoType {
     RGB = 0,
     YUV = 1,
@@ -185,6 +187,7 @@ impl TryFrom<u32> for ImageFormatInfoType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ImageFormatInfoFormat {
     Packed = 0,
     Planar = 1,
@@ -255,6 +258,7 @@ impl TryFrom<u32> for ImageFormatInfoFormat {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum AttributeFlag {
     Gettable = 1 << 0,
     Settable = 1 << 1,
@@ -318,6 +322,7 @@ bitmask_binop!(AttributeFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum VideoNotifyReason {
     Started = 0,
     Stopped = 1,
@@ -389,6 +394,7 @@ impl TryFrom<u32> for VideoNotifyReason {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum ScanlineOrder {
     TopToBottom = 0,
     BottomToTop = 1,
@@ -459,6 +465,7 @@ impl TryFrom<u32> for ScanlineOrder {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
 pub enum GrabPortStatus {
     Success = 0,
     BadExtension = 1,

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -42,7 +42,10 @@ pub type Encoding = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum Type {
     InputMask = 1 << 0,
     OutputMask = 1 << 1,
@@ -116,7 +119,10 @@ bitmask_binop!(Type, u8);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ImageFormatInfoType {
     RGB = 0,
     YUV = 1,
@@ -187,7 +193,10 @@ impl TryFrom<u32> for ImageFormatInfoType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ImageFormatInfoFormat {
     Packed = 0,
     Planar = 1,
@@ -258,7 +267,10 @@ impl TryFrom<u32> for ImageFormatInfoFormat {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum AttributeFlag {
     Gettable = 1 << 0,
     Settable = 1 << 1,
@@ -322,7 +334,10 @@ bitmask_binop!(AttributeFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum VideoNotifyReason {
     Started = 0,
     Stopped = 1,
@@ -394,7 +409,10 @@ impl TryFrom<u32> for VideoNotifyReason {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum ScanlineOrder {
     TopToBottom = 0,
     BottomToTop = 1,
@@ -465,7 +483,10 @@ impl TryFrom<u32> for ScanlineOrder {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-#[cfg_attr(not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"), non_exhaustive)]
+#[cfg_attr(
+    not(feature = "I_need_rust_1_37_compatibility_but_know_that_enums_are_still_non_exhaustive"),
+    non_exhaustive
+)]
 pub enum GrabPortStatus {
     Success = 0,
     BadExtension = 1,


### PR DESCRIPTION
This fixes #306: Enums get `#[non_exhaustive]`. Rust 1.37 compatibility now requires enabling an extra feature. That's... not really all that usable for users, but people on Rust 1.37 hopefully know what they are signing up for.

Open question: Mention this somehow in the README? No idea how, but an ugly version would be (hm... perhaps also link to the lines in `Cargo.toml` explaining the feature?)
```diff
diff --git a/README.md b/README.md
index 0b4579e..db63cfa 100644
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/950g0t6i8hfc9dup/branch/master?svg=true)](https://ci.appveyor.com/project/psychon/x11rb)
 [![Crate](https://img.shields.io/crates/v/x11rb.svg)](https://crates.io/crates/x11rb)
 [![API](https://docs.rs/x11rb/badge.svg)](https://docs.rs/x11rb)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.37+-lightgray.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.37+-lightgray.svg) /
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.40+-lightgray.svg)
 [![License](https://img.shields.io/crates/l/x11rb.svg)](https://github.com/psychon/x11rb#license)
 
 Feel free to open issues for any problems or questions you might have.
```