### PR TITLE
Add dl-libxcb feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,14 @@ addons:
       - xvfb
 
 before_script:
+  - |
+    if [ "$TRAVIS_RUST_VERSION" = "1.37.0" ]; then
+        # libloading needs 1.40
+        export ALL_FEATURES="all-extensions allow-unsafe-code cursor image "
+    else
+        export ALL_FEATURES="all-extensions allow-unsafe-code dl-libxcb cursor image"        
+    fi
+
   # Run the examples as 'integration tests'. For this, there is a special
   # timeout mode where the examples close automatically after some time.
   - |
@@ -88,16 +96,16 @@ script:
   # to check that this works fine.
   - cargo check --verbose --all-targets --features "$EXTRA_FEATURES"
 
-  - cargo build --verbose --all-targets --all-features
-  - cargo test --verbose --all-features
-  - cargo doc --verbose --all-features
+  - cargo build --verbose --all-targets --features "$ALL_FEATURES $EXTRA_FEATURES"
+  - cargo test --verbose --features "$ALL_FEATURES $EXTRA_FEATURES"
+  - cargo doc --verbose --features "$ALL_FEATURES $EXTRA_FEATURES"
 
   # Run the examples as 'integration tests'.
   # Enable the 'all-extensions' feature or Cargo will complain.
   # Enable the 'allow-unsafe-code' feature so XCBConnection is used.
-  - run_examples --all-features
+  - run_examples --features "$ALL_FEATURES $EXTRA_FEATURES"
 
-  - cargo build --verbose --all-targets --features "all-extensions,$EXTRA_FEATURES"
+  - cargo build --verbose --all-targets --features "all-extensions $EXTRA_FEATURES"
 
   # Run the examples as 'integration tests'. This time using RustConnection.
   - run_examples --features "all-extensions libc cursor image $EXTRA_FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ exclude = [
 
 [dependencies]
 libc = { version = "0.2", optional = true }
+libloading = { version = "0.6.3", optional = true }
+once_cell = { version = "1.4.1", optional = true }
 gethostname = "0.2.1"
 
 [target.'cfg(unix)'.dependencies]
@@ -42,6 +44,8 @@ cursor = ["render"]
 
 # Enable utility functions in `x11rb::image` for working with image data.
 image = []
+
+dl-libxcb = ["allow-unsafe-code", "libloading", "once_cell"]
 
 # Some enums are marked as #[non_exhaustive]. This breaks compatibility with
 # Rust 1.37, because non-exhaustive was only stabilised in Rust 1.40. This

--- a/generator/src/generator/error_events.rs
+++ b/generator/src/generator/error_events.rs
@@ -63,6 +63,7 @@ fn generate_errors(out: &mut Output, module: &xcbgen::defs::Module) {
     outln!(out, "");
     outln!(out, "impl ErrorKind {{");
     out.indented(|out| {
+        outln!(out, "#[allow(clippy::match_single_binding)]");
         outln!(out, "pub fn from_wire_error_code(");
         outln!(out.indent(), "error_code: u8,");
         outln!(out.indent(), "ext_info_provider: &dyn ExtInfoProvider,");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,13 +7,9 @@ use crate::x11_utils::X11Error;
 #[cfg(feature = "dl-libxcb")]
 #[derive(Debug, Clone)]
 pub enum LibxcbLoadError {
-    /// Could not open the library. `load_libxcb` might try to load
-    /// different library file names, so the vector contains the reason
-    /// that caused each one to fail.
-    ///
-    /// The `OsString` is the library file name and the string is the
-    /// reason.
-    OpenLibError(Vec<(std::ffi::OsString, String)>),
+    /// Could not open the library. The `OsString` is the library
+    /// file name and the string is the reason.
+    OpenLibError(std::ffi::OsString, String),
     /// Could not get a symbol from the library. The byte vector is the
     /// symbol name and the string is the reason.
     GetSymbolError(Vec<u8>, String),
@@ -23,15 +19,8 @@ pub enum LibxcbLoadError {
 impl std::fmt::Display for LibxcbLoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LibxcbLoadError::OpenLibError(libs_errors) => {
-                f.write_str("failed to open libraries: ")?;
-                for (i, (lib_name, e)) in libs_errors.iter().enumerate() {
-                    if i != 0 {
-                        f.write_str(", ")?;
-                    }
-                    write!(f, "{:?} ({})", lib_name, e)?;
-                }
-                Ok(())
+            LibxcbLoadError::OpenLibError(lib_name, e) => {
+                write!(f, "failed to open library {:?}: {}", lib_name, e)
             }
             LibxcbLoadError::GetSymbolError(symbol, e) => write!(
                 f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,10 @@
 //! Additionally, the following flags exist:
 //! * `allow-unsafe-code`: Enable features that require `unsafe`. Without this flag,
 //!   `x11rb::xcb_ffi::XCBConnection` and some support code for it are unavailable.
-//!
+//! * `dl-libxcb`: Enabling this feature will prevent from libxcb being linked to the
+//!   resulting executable. Instead libxcb will be dynamically loaded at runtime.
+//!   This feature adds the `x11rb::xcb_ffi::load_libxcb` function, that allows load
+//!   libxcb and check for success or failure.
 //!
 //! # Integrating x11rb with an Event Loop
 //!

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -7097,6 +7097,7 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
+    #[allow(clippy::match_single_binding)]
     pub fn from_wire_error_code(
         error_code: u8,
         ext_info_provider: &dyn ExtInfoProvider,

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -30,6 +30,9 @@ use crate::x11_utils::ExtensionInformation;
 mod pending_errors;
 mod raw_ffi;
 
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+pub use raw_ffi::load_libxcb;
+
 type Buffer = <XCBConnection as RequestConnection>::Buf;
 /// The raw bytes of an event received by [`XCBConnection`] and its sequence number.
 pub type RawEventAndSeqNumber = crate::connection::RawEventAndSeqNumber<Buffer>;

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -31,7 +31,7 @@ mod pending_errors;
 mod raw_ffi;
 
 #[cfg(all(not(test), feature = "dl-libxcb"))]
-pub use raw_ffi::load_libxcb;
+pub use raw_ffi::libxcb_library::load_libxcb;
 
 type Buffer = <XCBConnection as RequestConnection>::Buf;
 /// The raw bytes of an event received by [`XCBConnection`] and its sequence number.

--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -144,18 +144,12 @@ impl LibxcbLibrary {
     fn open_lib() -> Result<libloading::Library, LibxcbLoadError> {
         // TODO: Names for non-unix platforms
         #[cfg(unix)]
-        const LIB_NAMES: &[&str] = &["libxcb.so.1", "libxcb.so"];
+        const LIB_NAME: &str = "libxcb.so.1";
         #[cfg(not(unix))]
         compile_error!("dl-libxcb feature is not supported on non-unix");
 
-        let mut errors = Vec::new();
-        for lib_name in LIB_NAMES.iter() {
-            match libloading::Library::new(lib_name) {
-                Ok(library) => return Ok(library),
-                Err(e) => errors.push((lib_name.into(), e.to_string())),
-            }
-        }
-        Err(LibxcbLoadError::OpenLibError(errors))
+        libloading::Library::new(LIB_NAME)
+            .map_err(|e| LibxcbLoadError::OpenLibError(LIB_NAME.into(), e.to_string()))
     }
 
     /// # Safety

--- a/src/xcb_ffi/raw_ffi.rs
+++ b/src/xcb_ffi/raw_ffi.rs
@@ -6,6 +6,9 @@ use libc::c_void;
 pub(crate) use libc::iovec;
 use libc::{c_char, c_int, c_uint};
 
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+use crate::errors::LibxcbLoadError;
+
 // As defined in xcb_windefs.h
 #[cfg(not(unix))]
 #[derive(Copy, Clone, Debug)]
@@ -129,57 +132,182 @@ pub(crate) mod send_request_flags {
     pub(crate) const REPLY_FDS: c_int = 8;
 }
 
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+struct LibxcbLibrary {
+    // Needed to keep the library loaded
+    _library: libloading::Library,
+    funcs: LibxcbFuncs,
+}
+
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+impl LibxcbLibrary {
+    fn open_lib() -> Result<libloading::Library, LibxcbLoadError> {
+        // TODO: Names for non-unix platforms
+        #[cfg(unix)]
+        const LIB_NAMES: &[&str] = &["libxcb.so.1", "libxcb.so"];
+        #[cfg(not(unix))]
+        compile_error!("dl-libxcb feature is not supported on non-unix");
+
+        let mut errors = Vec::new();
+        for lib_name in LIB_NAMES.iter() {
+            match libloading::Library::new(lib_name) {
+                Ok(library) => return Ok(library),
+                Err(e) => errors.push((lib_name.into(), e.to_string())),
+            }
+        }
+        Err(LibxcbLoadError::OpenLibError(errors))
+    }
+
+    /// # Safety
+    ///
+    /// The functions pointers in `funcs` do not have lifetime,
+    /// but they must not outlive the returned result.
+    #[cold]
+    #[inline(never)]
+    unsafe fn load() -> Result<Self, LibxcbLoadError> {
+        let library = Self::open_lib()?;
+        let funcs = LibxcbFuncs::new(&library)
+            .map_err(|(symbol, e)| LibxcbLoadError::GetSymbolError(symbol.into(), e.to_string()))?;
+        Ok(Self {
+            _library: library,
+            funcs,
+        })
+    }
+}
+
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+use once_cell::sync::Lazy;
+
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+static LIBXCB_LIBRARY: Lazy<Result<LibxcbLibrary, LibxcbLoadError>> =
+    Lazy::new(|| unsafe { LibxcbLibrary::load() });
+
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+fn get_libxcb() -> &'static LibxcbLibrary {
+    #[cold]
+    #[inline(never)]
+    fn failed(e: &LibxcbLoadError) -> ! {
+        panic!("failed to load libxcb: {}", e);
+    }
+    match *LIBXCB_LIBRARY {
+        Ok(ref library) => library,
+        Err(ref e) => failed(e),
+    }
+}
+
+/// Tries to dynamically load libxcb, returning an error on failure.
+///
+/// It is not required to call this function, as libxcb will be lazily loaded.
+/// However, if a lazy load fails, a panic will be raised, missing the chance
+/// to (nicely) handle the error.
+///
+/// It is safe to call this function more than once from the same or different
+/// threads. Only the first call will try to load libxcb, subsequent calls will
+/// always return the same result.
+#[cfg(all(not(test), feature = "dl-libxcb"))]
+pub fn load_libxcb() -> Result<(), LibxcbLoadError> {
+    match Lazy::force(&LIBXCB_LIBRARY) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.clone()),
+    }
+}
+
 #[cfg(not(test))]
-#[link(name = "xcb")]
-extern "C" {
+macro_rules! make_ffi_fn_defs {
+    {
+        $(
+            $(#[$fn_attr:meta])*
+            fn $fn_name:ident($($fn_arg_name:ident: $fn_arg_type:ty),*) $(-> $fn_ret_ty:ty)?;
+        )*
+    } => {
+        #[cfg(not(feature = "dl-libxcb"))]
+        #[link(name = "xcb")]
+        extern "C" {
+            $(
+                $(#[$fn_attr])*
+                pub(crate) fn $fn_name($($fn_arg_name: $fn_arg_type),*) $(-> $fn_ret_ty)?;
+            )*
+        }
+
+        #[cfg(feature = "dl-libxcb")]
+        struct LibxcbFuncs {
+            $(
+                $(#[$fn_attr])*
+                $fn_name: fn($($fn_arg_name: $fn_arg_type),*) $(-> $fn_ret_ty)?,
+            )*
+        }
+
+        impl LibxcbFuncs {
+            unsafe fn new(library: &libloading::Library) -> Result<Self, (&'static [u8], libloading::Error)> {
+                Ok(Self {
+                    $($fn_name: {
+                        let symbol_name = concat!(stringify!($fn_name), "\0").as_bytes();
+                        *library.get(symbol_name).map_err(|e| (symbol_name, e))?
+                    },)*
+                })
+            }
+        }
+
+        $(
+            #[cfg(feature = "dl-libxcb")]
+            $(#[$fn_attr])*
+            pub(crate) unsafe fn $fn_name($($fn_arg_name: $fn_arg_type),*) $(-> $fn_ret_ty)? {
+                (get_libxcb().funcs.$fn_name)($($fn_arg_name),*)
+            }
+        )*
+    };
+}
+
+#[cfg(not(test))]
+make_ffi_fn_defs! {
     // From xcb.h
-    pub(crate) fn xcb_flush(c: *mut xcb_connection_t) -> c_int;
-    pub(crate) fn xcb_get_maximum_request_length(c: *mut xcb_connection_t) -> u32;
-    pub(crate) fn xcb_prefetch_maximum_request_length(c: *mut xcb_connection_t);
-    pub(crate) fn xcb_wait_for_event(c: *mut xcb_connection_t) -> *mut xcb_generic_event_t;
-    pub(crate) fn xcb_poll_for_event(c: *mut xcb_connection_t) -> *mut xcb_generic_event_t;
-    pub(crate) fn xcb_request_check(
+    fn xcb_flush(c: *mut xcb_connection_t) -> c_int;
+    fn xcb_get_maximum_request_length(c: *mut xcb_connection_t) -> u32;
+    fn xcb_prefetch_maximum_request_length(c: *mut xcb_connection_t);
+    fn xcb_wait_for_event(c: *mut xcb_connection_t) -> *mut xcb_generic_event_t;
+    fn xcb_poll_for_event(c: *mut xcb_connection_t) -> *mut xcb_generic_event_t;
+    fn xcb_request_check(
         c: *mut xcb_connection_t,
-        void_cookie: xcb_void_cookie_t,
+        void_cookie: xcb_void_cookie_t
     ) -> *mut xcb_generic_error_t;
-    pub(crate) fn xcb_discard_reply64(c: *mut xcb_connection_t, sequence: u64);
-    pub(crate) fn xcb_get_setup(c: *mut xcb_connection_t) -> *const xcb_setup_t;
+    fn xcb_discard_reply64(c: *mut xcb_connection_t, sequence: u64);
+    fn xcb_get_setup(c: *mut xcb_connection_t) -> *const xcb_setup_t;
     #[cfg(unix)]
-    pub(crate) fn xcb_get_file_descriptor(c: *mut xcb_connection_t) -> c_int;
-    pub(crate) fn xcb_connection_has_error(c: *mut xcb_connection_t) -> c_int;
-    pub(crate) fn xcb_disconnect(c: *mut xcb_connection_t);
-    pub(crate) fn xcb_connect(
+    fn xcb_get_file_descriptor(c: *mut xcb_connection_t) -> c_int;
+    fn xcb_connection_has_error(c: *mut xcb_connection_t) -> c_int;
+    fn xcb_disconnect(c: *mut xcb_connection_t);
+    fn xcb_connect(
         displayname: *const c_char,
-        screenp: *mut c_int,
+        screenp: *mut c_int
     ) -> *mut xcb_connection_t;
-    pub(crate) fn xcb_generate_id(c: *mut xcb_connection_t) -> u32;
+    fn xcb_generate_id(c: *mut xcb_connection_t) -> u32;
 
     // From xcbext.h
-    pub(crate) fn xcb_send_request64(
+    fn xcb_send_request64(
         c: *mut xcb_connection_t,
         flags: c_int,
         vector: *mut iovec,
-        request: *const xcb_protocol_request_t,
+        request: *const xcb_protocol_request_t
     ) -> u64;
     #[cfg(unix)]
-    pub(crate) fn xcb_send_request_with_fds64(
+    fn xcb_send_request_with_fds64(
         c: *mut xcb_connection_t,
         flags: c_int,
         vector: *mut iovec,
         request: *const xcb_protocol_request_t,
         num_fds: c_uint,
-        fds: *mut c_int,
+        fds: *mut c_int
     ) -> u64;
-    pub(crate) fn xcb_wait_for_reply64(
+    fn xcb_wait_for_reply64(
         c: *mut xcb_connection_t,
         request: u64,
-        e: *mut *mut xcb_generic_error_t,
+        e: *mut *mut xcb_generic_error_t
     ) -> *mut c_void;
-    pub(crate) fn xcb_poll_for_reply64(
+    fn xcb_poll_for_reply64(
         c: *mut xcb_connection_t,
         request: u64,
         reply: *mut *mut c_void,
-        error: *mut *mut xcb_generic_error_t,
+        error: *mut *mut xcb_generic_error_t
     ) -> c_int;
 }
 


### PR DESCRIPTION
Enabling this feature will prevent from libxcb being linked to the resulting executable. Instead libxcb will be dynamically loaded at runtime.

This allows to compile an application with different graphic backends that may run with another backend if libxcb is not installed on the system.

Fixes https://github.com/psychon/x11rb/issues/522.
