### PR TITLE
Update the mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,8 +3,12 @@ pull_request_rules:
     conditions:
       - label!=no-mergify
       - "#approved-reviews-by>=1"
-      - status-success~=^CI / .* (pull_request)$
       - status-success=continuous-integration/appveyor/pr
+      - status-success=big-endian-test
+      - status-success=build (1.40.0)
+      - status-success=build (stable)
+      - status-success=clippy-rustfmt (stable)
+      - status-success=code_gen
     actions:
       merge:
         method: merge


### PR DESCRIPTION
This updates the mergify configuration to spell out which statuses are required before we can merge things. I left out anything with "beta" or "nightly" in its name. No idea if (1) this actually works as written and (2) this is what we want. Feel free to tell me. :-)

Also, I am (ab)using this PR to test the new GH actions. I added some commits which should cause lots of failures to test that e.g. the big endian tests are run correctly. These commits are of course not meant to be merged. I will edit this text to add a link to the commits and the resulting failures (if everything works out as intended).

Edit:

https://github.com/psychon/x11rb/pull/534/commits/34e4a5fc9baf926fd710866ce7826fb461595701 caused big-endian-test to fail with
```
test parse_setup ... FAILED

failures:

---- parse_setup stdout ----
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `80`,
 right: `1342177280`', tests/parsing_tests.rs:127:5
```
https://github.com/psychon/x11rb/pull/534/commits/a6320d76a9b8c5d490a0dcc881bde0e4ec99c3b3 caused code gen to fail as expected
https://github.com/psychon/x11rb/pull/534/commits/287c59da23fa218acbe6bf00a2b9dfb3336a943e and https://github.com/psychon/x11rb/pull/534/commits/9a9790f2aec03af7f01156332ab53f36fa06d740 both caused rustfmt to complain
https://github.com/psychon/x11rb/pull/534/commits/9a9790f2aec03af7f01156332ab53f36fa06d740 caused the 1.40.0 build to fail with
```
rror[E0599]: no method named `map_or` found for type `std::result::Result<u32, ()>` in the current scope
   --> cairo-example/src/main.rs:213:48
    |
213 |     let this_should_fail_on_rust_1_40 = result.map_or(0, |n| 2*n);
    |                                                ^^^^^^ help: there is a method with a similar name: `map_err`
```
That should be enough to be moderately sure that everything works. Clippy wasn't tested, but so what?

I'll remove the extra commits from this PR.