### PR TITLE
Also run image, cursor etc tests on Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,7 +95,7 @@ jobs:
         override: true
 
     - name: Set ALL_FEATURES
-      run: echo "ALL_FEATURES=$ALL_FEATURES allow-unsafe-code dl-libxcb" >> $GITHUB_ENV
+      run: echo "ALL_FEATURES=$MOST_FEATURES allow-unsafe-code dl-libxcb" >> $GITHUB_ENV
 
     # build
     - name: cargo build with all features


### PR DESCRIPTION
This commit changes a line that sets $ALL_FEATURES. Before this line,
$ALL_FEATURES is empty, but $MOST_FEATURES contains "all-extensions
cursor image". These are the values that we want here.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

I just looked at some commits that added tests for `x11rb::image` and out of a hunch I checked the output of GH Actions for whether these tests are run. This is where I ended up...