### PR TITLE
Remove some trait impls

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2404,23 +2404,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         }
         outln!(out, "}}");
 
-        for &smaller_type in smaller_types.iter() {
-            outln!(
-                out,
-                "impl From<{}> for {}<{}> {{",
-                rust_name,
-                self.option_name,
-                smaller_type,
-            );
-            out.indented(|out| {
-                outln!(out, "#[inline]");
-                outln!(out, "fn from(input: {}) -> Self {{", rust_name);
-                outln!(out.indent(), "{}::try_from(input.0).ok()", smaller_type);
-                outln!(out, "}}");
-            });
-            outln!(out, "}}");
-        }
-
         outln!(out, "impl From<{}> for {} {{", rust_name, raw_type);
         out.indented(|out| {
             outln!(out, "#[inline]");

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2490,25 +2490,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         });
         outln!(out, "}}");
 
-        for larger_type in larger_types.iter() {
-            outln!(out, "impl TryFrom<{}> for {} {{", larger_type, rust_name);
-            out.indented(|out| {
-                outln!(out, "type Error = ParseError;");
-                outln!(
-                    out,
-                    "fn try_from(value: {}) -> Result<Self, Self::Error> {{",
-                    larger_type,
-                );
-                outln!(
-                    out.indent(),
-                    "{}::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)",
-                    raw_type,
-                );
-                outln!(out, "}}");
-            });
-            outln!(out, "}}");
-        }
-
         // An enum is ok for bitmask if all its values are <bit>
         // or have value zero (but not if all values are zero)
         let ok_for_bitmask = enum_def

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -84,18 +84,6 @@ impl From<u8> for Redirect {
         Self(value)
     }
 }
-impl TryFrom<u16> for Redirect {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Redirect {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -88,18 +88,6 @@ impl From<u8> for ReportLevel {
         Self(value)
     }
 }
-impl TryFrom<u16> for ReportLevel {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ReportLevel {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the BadDamage error
 pub const BAD_DAMAGE_ERROR: u8 = 0;

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -508,12 +508,6 @@ impl DPMSMode {
     pub const SUSPEND: Self = Self(2);
     pub const OFF: Self = Self(3);
 }
-impl From<DPMSMode> for Option<u8> {
-    #[inline]
-    fn from(input: DPMSMode) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<DPMSMode> for u16 {
     #[inline]
     fn from(input: DPMSMode) -> Self {

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -550,12 +550,6 @@ impl From<u16> for DPMSMode {
         Self(value)
     }
 }
-impl TryFrom<u32> for DPMSMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the ForceLevel request
 pub const FORCE_LEVEL_REQUEST: u8 = 6;

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -191,12 +191,6 @@ impl From<u16> for EventType {
         Self(value)
     }
 }
-impl TryFrom<u32> for EventType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DRI2Buffer {

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -50,18 +50,6 @@ impl Attachment {
     pub const BUFFER_DEPTH_STENCIL: Self = Self(9);
     pub const BUFFER_HIZ: Self = Self(10);
 }
-impl From<Attachment> for Option<u8> {
-    #[inline]
-    fn from(input: Attachment) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<Attachment> for Option<u16> {
-    #[inline]
-    fn from(input: Attachment) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<Attachment> for u32 {
     #[inline]
     fn from(input: Attachment) -> Self {
@@ -98,18 +86,6 @@ pub struct DriverType(u32);
 impl DriverType {
     pub const DRI: Self = Self(0);
     pub const VDPAU: Self = Self(1);
-}
-impl From<DriverType> for Option<u8> {
-    #[inline]
-    fn from(input: DriverType) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<DriverType> for Option<u16> {
-    #[inline]
-    fn from(input: DriverType) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<DriverType> for u32 {
     #[inline]
@@ -148,12 +124,6 @@ impl EventType {
     pub const EXCHANGE_COMPLETE: Self = Self(1);
     pub const BLIT_COMPLETE: Self = Self(2);
     pub const FLIP_COMPLETE: Self = Self(3);
-}
-impl From<EventType> for Option<u8> {
-    #[inline]
-    fn from(input: EventType) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<EventType> for u16 {
     #[inline]

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -343,12 +343,6 @@ impl From<u16> for PBCET {
         Self(value)
     }
 }
-impl TryFrom<u32> for PBCET {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PBCDT(u16);
@@ -396,12 +390,6 @@ impl From<u16> for PBCDT {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for PBCDT {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -4606,12 +4594,6 @@ impl From<u16> for RM {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for RM {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -301,12 +301,6 @@ impl PBCET {
     pub const DAMAGED: Self = Self(32791);
     pub const SAVED: Self = Self(32792);
 }
-impl From<PBCET> for Option<u8> {
-    #[inline]
-    fn from(input: PBCET) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<PBCET> for u16 {
     #[inline]
     fn from(input: PBCET) -> Self {
@@ -349,12 +343,6 @@ pub struct PBCDT(u16);
 impl PBCDT {
     pub const WINDOW: Self = Self(32793);
     pub const PBUFFER: Self = Self(32794);
-}
-impl From<PBCDT> for Option<u8> {
-    #[inline]
-    fn from(input: PBCDT) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<PBCDT> for u16 {
     #[inline]
@@ -1307,18 +1295,6 @@ impl GC {
     pub const GL_TEXTURE_BIT: Self = Self(1 << 18);
     pub const GL_SCISSOR_BIT: Self = Self(1 << 19);
     pub const GL_ALL_ATTRIB_BITS: Self = Self(16_777_215);
-}
-impl From<GC> for Option<u8> {
-    #[inline]
-    fn from(input: GC) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<GC> for Option<u16> {
-    #[inline]
-    fn from(input: GC) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<GC> for u32 {
     #[inline]
@@ -4553,12 +4529,6 @@ impl RM {
     pub const GL_RENDER: Self = Self(7168);
     pub const GL_FEEDBACK: Self = Self(7169);
     pub const GL_SELECT: Self = Self(7170);
-}
-impl From<RM> for Option<u8> {
-    #[inline]
-    fn from(input: RM) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<RM> for u16 {
     #[inline]

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -88,18 +88,6 @@ impl From<u8> for EventEnum {
         Self(value)
     }
 }
-impl TryFrom<u16> for EventEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for EventEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventMask(u8);
@@ -150,18 +138,6 @@ impl From<u8> for EventMask {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for EventMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for EventMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(EventMask, u8);
@@ -217,18 +193,6 @@ impl From<u8> for Option {
         Self(value)
     }
 }
-impl TryFrom<u16> for Option {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Option {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(Option, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -281,18 +245,6 @@ impl From<u8> for Capability {
         Self(value)
     }
 }
-impl TryFrom<u16> for Capability {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Capability {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(Capability, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -341,18 +293,6 @@ impl From<u8> for CompleteKind {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for CompleteKind {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CompleteKind {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -404,18 +344,6 @@ impl From<u8> for CompleteMode {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for CompleteMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CompleteMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -999,12 +999,6 @@ impl ModeFlag {
     pub const DOUBLE_CLOCK: Self = Self(1 << 12);
     pub const HALVE_CLOCK: Self = Self(1 << 13);
 }
-impl From<ModeFlag> for Option<u8> {
-    #[inline]
-    fn from(input: ModeFlag) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<ModeFlag> for u16 {
     #[inline]
     fn from(input: ModeFlag) -> Self {

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -110,18 +110,6 @@ impl From<u8> for Rotation {
         Self(value)
     }
 }
-impl TryFrom<u16> for Rotation {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Rotation {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(Rotation, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -379,18 +367,6 @@ impl From<u8> for SetConfig {
         Self(value)
     }
 }
-impl TryFrom<u16> for SetConfig {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SetConfig {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the SetScreenConfig request
 pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
@@ -594,18 +570,6 @@ impl From<u8> for NotifyMask {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for NotifyMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for NotifyMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(NotifyMask, u8);
@@ -1077,12 +1041,6 @@ impl From<u16> for ModeFlag {
         Self(value)
     }
 }
-impl TryFrom<u32> for ModeFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ModeFlag, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1408,18 +1366,6 @@ impl From<u8> for Connection {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Connection {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Connection {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -3555,18 +3501,6 @@ impl From<u8> for Transform {
         Self(value)
     }
 }
-impl TryFrom<u16> for Transform {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Transform {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(Transform, u8);
 
 /// Opcode for the SetCrtcTransform request
@@ -4543,18 +4477,6 @@ impl From<u8> for ProviderCapability {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ProviderCapability {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ProviderCapability {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(ProviderCapability, u8);
@@ -5769,18 +5691,6 @@ impl From<u8> for Notify {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Notify {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Notify {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -288,18 +288,6 @@ impl From<u8> for HType {
         Self(value)
     }
 }
-impl TryFrom<u16> for HType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for HType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(HType, u8);
 
 pub type ClientSpec = u32;
@@ -351,18 +339,6 @@ impl From<u8> for CS {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for CS {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CS {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -238,18 +238,6 @@ impl PolyEdge {
     pub const SHARP: Self = Self(0);
     pub const SMOOTH: Self = Self(1);
 }
-impl From<PolyEdge> for Option<u8> {
-    #[inline]
-    fn from(input: PolyEdge) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<PolyEdge> for Option<u16> {
-    #[inline]
-    fn from(input: PolyEdge) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<PolyEdge> for u32 {
     #[inline]
     fn from(input: PolyEdge) -> Self {
@@ -286,18 +274,6 @@ pub struct PolyMode(u32);
 impl PolyMode {
     pub const PRECISE: Self = Self(0);
     pub const IMPRECISE: Self = Self(1);
-}
-impl From<PolyMode> for Option<u8> {
-    #[inline]
-    fn from(input: PolyMode) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<PolyMode> for Option<u16> {
-    #[inline]
-    fn from(input: PolyMode) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<PolyMode> for u32 {
     #[inline]
@@ -347,12 +323,6 @@ impl CP {
     pub const DITHER: Self = Self(1 << 11);
     pub const COMPONENT_ALPHA: Self = Self(1 << 12);
 }
-impl From<CP> for Option<u8> {
-    #[inline]
-    fn from(input: CP) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<CP> for u16 {
     #[inline]
     fn from(input: CP) -> Self {
@@ -401,18 +371,6 @@ impl SubPixel {
     pub const VERTICAL_BGR: Self = Self(4);
     pub const NONE: Self = Self(5);
 }
-impl From<SubPixel> for Option<u8> {
-    #[inline]
-    fn from(input: SubPixel) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<SubPixel> for Option<u16> {
-    #[inline]
-    fn from(input: SubPixel) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<SubPixel> for u32 {
     #[inline]
     fn from(input: SubPixel) -> Self {
@@ -451,18 +409,6 @@ impl Repeat {
     pub const NORMAL: Self = Self(1);
     pub const PAD: Self = Self(2);
     pub const REFLECT: Self = Self(3);
-}
-impl From<Repeat> for Option<u8> {
-    #[inline]
-    fn from(input: Repeat) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<Repeat> for Option<u16> {
-    #[inline]
-    fn from(input: Repeat) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<Repeat> for u32 {
     #[inline]

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -83,18 +83,6 @@ impl From<u8> for PictType {
         Self(value)
     }
 }
-impl TryFrom<u16> for PictType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PictType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PictureEnum(u8);
@@ -141,18 +129,6 @@ impl From<u8> for PictureEnum {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for PictureEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PictureEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -253,18 +229,6 @@ impl From<u8> for PictOp {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for PictOp {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PictOp {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -423,12 +387,6 @@ impl From<u16> for CP {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for CP {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(CP, u16);

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -167,18 +167,6 @@ impl From<u8> for ClientIdMask {
         Self(value)
     }
 }
-impl TryFrom<u16> for ClientIdMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ClientIdMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ClientIdMask, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -84,18 +84,6 @@ impl From<u8> for Kind {
         Self(value)
     }
 }
-impl TryFrom<u16> for Kind {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Kind {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Event(u8);
@@ -143,18 +131,6 @@ impl From<u8> for Event {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Event {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Event {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(Event, u8);
@@ -207,18 +183,6 @@ impl From<u8> for State {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for State {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for State {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -90,18 +90,6 @@ impl From<u8> for SO {
         Self(value)
     }
 }
-impl TryFrom<u16> for SO {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SO {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SK(u8);
@@ -150,18 +138,6 @@ impl From<u8> for SK {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SK {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SK {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -99,18 +99,6 @@ impl TESTTYPE {
     pub const POSITIVE_COMPARISON: Self = Self(2);
     pub const NEGATIVE_COMPARISON: Self = Self(3);
 }
-impl From<TESTTYPE> for Option<u8> {
-    #[inline]
-    fn from(input: TESTTYPE) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<TESTTYPE> for Option<u16> {
-    #[inline]
-    fn from(input: TESTTYPE) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<TESTTYPE> for u32 {
     #[inline]
     fn from(input: TESTTYPE) -> Self {
@@ -147,18 +135,6 @@ pub struct VALUETYPE(u32);
 impl VALUETYPE {
     pub const ABSOLUTE: Self = Self(0);
     pub const RELATIVE: Self = Self(1);
-}
-impl From<VALUETYPE> for Option<u8> {
-    #[inline]
-    fn from(input: VALUETYPE) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<VALUETYPE> for Option<u16> {
-    #[inline]
-    fn from(input: VALUETYPE) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<VALUETYPE> for u32 {
     #[inline]

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -86,18 +86,6 @@ impl From<u8> for ALARMSTATE {
         Self(value)
     }
 }
-impl TryFrom<u16> for ALARMSTATE {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ALARMSTATE {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 pub type Counter = u32;
 
@@ -253,18 +241,6 @@ impl From<u8> for CA {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for CA {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CA {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(CA, u8);

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -97,12 +97,6 @@ impl From<u16> for ModeFlag {
         Self(value)
     }
 }
-impl TryFrom<u32> for ModeFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ModeFlag, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -150,18 +144,6 @@ impl From<u8> for ClockFlag {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ClockFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ClockFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(ClockFlag, u8);
@@ -212,18 +194,6 @@ impl From<u8> for Permission {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Permission {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Permission {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(Permission, u8);

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -55,12 +55,6 @@ impl ModeFlag {
     pub const DOUBLE_CLOCK: Self = Self(1 << 11);
     pub const HALF_CLOCK: Self = Self(1 << 12);
 }
-impl From<ModeFlag> for Option<u8> {
-    #[inline]
-    fn from(input: ModeFlag) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<ModeFlag> for u16 {
     #[inline]
     fn from(input: ModeFlag) -> Self {

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -193,18 +193,6 @@ impl From<u8> for SaveSetMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for SaveSetMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SaveSetMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SaveSetTarget(u8);
@@ -254,18 +242,6 @@ impl From<u8> for SaveSetTarget {
         Self(value)
     }
 }
-impl TryFrom<u16> for SaveSetTarget {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SaveSetTarget {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SaveSetMapping(u8);
@@ -313,18 +289,6 @@ impl From<u8> for SaveSetMapping {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SaveSetMapping {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SaveSetMapping {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -465,18 +429,6 @@ impl From<u8> for SelectionEvent {
         Self(value)
     }
 }
-impl TryFrom<u16> for SelectionEvent {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SelectionEvent {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectionEventMask(u8);
@@ -525,18 +477,6 @@ impl From<u8> for SelectionEventMask {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SelectionEventMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SelectionEventMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(SelectionEventMask, u8);
@@ -764,18 +704,6 @@ impl From<u8> for CursorNotify {
         Self(value)
     }
 }
-impl TryFrom<u16> for CursorNotify {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CursorNotify {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CursorNotifyMask(u8);
@@ -822,18 +750,6 @@ impl From<u8> for CursorNotifyMask {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for CursorNotifyMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CursorNotifyMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(CursorNotifyMask, u8);
@@ -1152,18 +1068,6 @@ impl From<u8> for RegionEnum {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for RegionEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for RegionEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -3438,18 +3342,6 @@ impl From<u8> for BarrierDirections {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for BarrierDirections {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for BarrierDirections {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(BarrierDirections, u8);

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -251,18 +251,6 @@ impl From<u8> for DeviceUse {
         Self(value)
     }
 }
-impl TryFrom<u16> for DeviceUse {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for DeviceUse {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InputClass(u8);
@@ -317,18 +305,6 @@ impl From<u8> for InputClass {
         Self(value)
     }
 }
-impl TryFrom<u16> for InputClass {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for InputClass {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ValuatorMode(u8);
@@ -376,18 +352,6 @@ impl From<u8> for ValuatorMode {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ValuatorMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ValuatorMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -1661,18 +1625,6 @@ impl From<u8> for PropagateMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for PropagateMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PropagateMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the ChangeDeviceDontPropagateList request
 pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
@@ -2556,18 +2508,6 @@ impl From<u8> for ModifierDevice {
         Self(value)
     }
 }
-impl TryFrom<u16> for ModifierDevice {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ModifierDevice {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the GrabDeviceKey request
 pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
@@ -3112,18 +3052,6 @@ impl From<u8> for DeviceInputMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for DeviceInputMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for DeviceInputMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the AllowDeviceEvents request
 pub const ALLOW_DEVICE_EVENTS_REQUEST: u8 = 19;
@@ -3456,18 +3384,6 @@ impl From<u8> for FeedbackClass {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for FeedbackClass {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for FeedbackClass {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -5439,18 +5355,6 @@ impl From<u8> for ChangeFeedbackControlMask {
         Self(value)
     }
 }
-impl TryFrom<u16> for ChangeFeedbackControlMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ChangeFeedbackControlMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ChangeFeedbackControlMask, u8);
 
 /// Opcode for the ChangeFeedbackControl request
@@ -6450,18 +6354,6 @@ impl From<u8> for ValuatorStateModeMask {
         Self(value)
     }
 }
-impl TryFrom<u16> for ValuatorStateModeMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ValuatorStateModeMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ValuatorStateModeMask, u8);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7195,12 +7087,6 @@ impl From<u16> for DeviceControl {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for DeviceControl {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -9101,18 +8987,6 @@ impl From<u8> for PropertyFormat {
         Self(value)
     }
 }
-impl TryFrom<u16> for PropertyFormat {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PropertyFormat {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChangeDevicePropertyAux {
@@ -10179,12 +10053,6 @@ impl From<u16> for HierarchyChangeType {
         Self(value)
     }
 }
-impl TryFrom<u32> for HierarchyChangeType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChangeMode(u8);
@@ -10232,18 +10100,6 @@ impl From<u8> for ChangeMode {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ChangeMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ChangeMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -11420,12 +11276,6 @@ impl From<u16> for DeviceClassType {
         Self(value)
     }
 }
-impl TryFrom<u32> for DeviceClassType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeviceType(u16);
@@ -11478,12 +11328,6 @@ impl From<u16> for DeviceType {
         Self(value)
     }
 }
-impl TryFrom<u32> for DeviceType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScrollFlags(u8);
@@ -11531,18 +11375,6 @@ impl From<u8> for ScrollFlags {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ScrollFlags {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ScrollFlags {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(ScrollFlags, u8);
@@ -11595,12 +11427,6 @@ impl From<u16> for ScrollType {
         Self(value)
     }
 }
-impl TryFrom<u32> for ScrollType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TouchMode(u8);
@@ -11648,18 +11474,6 @@ impl From<u8> for TouchMode {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for TouchMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for TouchMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -13200,18 +13014,6 @@ impl From<u8> for EventMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for EventMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for EventMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the XIAllowEvents request
 pub const XI_ALLOW_EVENTS_REQUEST: u8 = 53;
@@ -13365,18 +13167,6 @@ impl From<u8> for GrabMode22 {
         Self(value)
     }
 }
-impl TryFrom<u16> for GrabMode22 {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GrabMode22 {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrabType(u8);
@@ -13427,18 +13217,6 @@ impl From<u8> for GrabType {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for GrabType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GrabType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -14907,18 +14685,6 @@ impl From<u8> for MoreEventsMask {
         Self(value)
     }
 }
-impl TryFrom<u16> for MoreEventsMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for MoreEventsMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(MoreEventsMask, u8);
 
 /// Opcode for the DeviceKeyPress event
@@ -15196,18 +14962,6 @@ impl From<u8> for ClassesReportedMask {
         Self(value)
     }
 }
-impl TryFrom<u16> for ClassesReportedMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ClassesReportedMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ClassesReportedMask, u8);
 
 /// Opcode for the DeviceStateNotify event
@@ -15452,18 +15206,6 @@ impl From<u8> for ChangeDevice {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ChangeDevice {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ChangeDevice {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -15755,18 +15497,6 @@ impl From<u8> for DeviceChange {
         Self(value)
     }
 }
-impl TryFrom<u16> for DeviceChange {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for DeviceChange {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the DevicePresenceNotify event
 pub const DEVICE_PRESENCE_NOTIFY_EVENT: u8 = 15;
@@ -15985,18 +15715,6 @@ impl From<u8> for ChangeReason {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ChangeReason {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ChangeReason {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -16416,18 +16134,6 @@ impl From<u8> for NotifyMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for NotifyMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for NotifyMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NotifyDetail(u8);
@@ -16481,18 +16187,6 @@ impl From<u8> for NotifyDetail {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for NotifyDetail {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for NotifyDetail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -16644,18 +16338,6 @@ impl From<u8> for HierarchyMask {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for HierarchyMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for HierarchyMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(HierarchyMask, u8);
@@ -16825,18 +16507,6 @@ impl From<u8> for PropertyFlag {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for PropertyFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PropertyFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -17397,18 +17067,6 @@ impl From<u8> for BarrierFlags {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for BarrierFlags {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for BarrierFlags {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(BarrierFlags, u8);

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -7047,12 +7047,6 @@ impl DeviceControl {
     pub const ENABLE: Self = Self(4);
     pub const ABSAREA: Self = Self(5);
 }
-impl From<DeviceControl> for Option<u8> {
-    #[inline]
-    fn from(input: DeviceControl) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<DeviceControl> for u16 {
     #[inline]
     fn from(input: DeviceControl) -> Self {
@@ -10011,12 +10005,6 @@ impl HierarchyChangeType {
     pub const ATTACH_SLAVE: Self = Self(3);
     pub const DETACH_SLAVE: Self = Self(4);
 }
-impl From<HierarchyChangeType> for Option<u8> {
-    #[inline]
-    fn from(input: HierarchyChangeType) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<HierarchyChangeType> for u16 {
     #[inline]
     fn from(input: HierarchyChangeType) -> Self {
@@ -10938,18 +10926,6 @@ impl XIEventMask {
     pub const BARRIER_HIT: Self = Self(1 << 25);
     pub const BARRIER_LEAVE: Self = Self(1 << 26);
 }
-impl From<XIEventMask> for Option<u8> {
-    #[inline]
-    fn from(input: XIEventMask) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<XIEventMask> for Option<u16> {
-    #[inline]
-    fn from(input: XIEventMask) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<XIEventMask> for u32 {
     #[inline]
     fn from(input: XIEventMask) -> Self {
@@ -11234,12 +11210,6 @@ impl DeviceClassType {
     pub const SCROLL: Self = Self(3);
     pub const TOUCH: Self = Self(8);
 }
-impl From<DeviceClassType> for Option<u8> {
-    #[inline]
-    fn from(input: DeviceClassType) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<DeviceClassType> for u16 {
     #[inline]
     fn from(input: DeviceClassType) -> Self {
@@ -11285,12 +11255,6 @@ impl DeviceType {
     pub const SLAVE_POINTER: Self = Self(3);
     pub const SLAVE_KEYBOARD: Self = Self(4);
     pub const FLOATING_SLAVE: Self = Self(5);
-}
-impl From<DeviceType> for Option<u8> {
-    #[inline]
-    fn from(input: DeviceType) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<DeviceType> for u16 {
     #[inline]
@@ -11384,12 +11348,6 @@ pub struct ScrollType(u16);
 impl ScrollType {
     pub const VERTICAL: Self = Self(1);
     pub const HORIZONTAL: Self = Self(2);
-}
-impl From<ScrollType> for Option<u8> {
-    #[inline]
-    fn from(input: ScrollType) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<ScrollType> for u16 {
     #[inline]
@@ -13224,18 +13182,6 @@ impl From<u8> for GrabType {
 pub struct ModifierMask(u32);
 impl ModifierMask {
     pub const ANY: Self = Self(1 << 31);
-}
-impl From<ModifierMask> for Option<u8> {
-    #[inline]
-    fn from(input: ModifierMask) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<ModifierMask> for Option<u16> {
-    #[inline]
-    fn from(input: ModifierMask) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<ModifierMask> for u32 {
     #[inline]
@@ -15783,18 +15729,6 @@ pub struct KeyEventFlags(u32);
 impl KeyEventFlags {
     pub const KEY_REPEAT: Self = Self(1 << 16);
 }
-impl From<KeyEventFlags> for Option<u8> {
-    #[inline]
-    fn from(input: KeyEventFlags) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<KeyEventFlags> for Option<u16> {
-    #[inline]
-    fn from(input: KeyEventFlags) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<KeyEventFlags> for u32 {
     #[inline]
     fn from(input: KeyEventFlags) -> Self {
@@ -15932,18 +15866,6 @@ pub type KeyReleaseEvent = KeyPressEvent;
 pub struct PointerEventFlags(u32);
 impl PointerEventFlags {
     pub const POINTER_EMULATED: Self = Self(1 << 16);
-}
-impl From<PointerEventFlags> for Option<u8> {
-    #[inline]
-    fn from(input: PointerEventFlags) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<PointerEventFlags> for Option<u16> {
-    #[inline]
-    fn from(input: PointerEventFlags) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<PointerEventFlags> for u32 {
     #[inline]
@@ -16700,18 +16622,6 @@ impl TouchEventFlags {
     pub const TOUCH_PENDING_END: Self = Self(1 << 16);
     pub const TOUCH_EMULATING_POINTER: Self = Self(1 << 17);
 }
-impl From<TouchEventFlags> for Option<u8> {
-    #[inline]
-    fn from(input: TouchEventFlags) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<TouchEventFlags> for Option<u16> {
-    #[inline]
-    fn from(input: TouchEventFlags) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<TouchEventFlags> for u32 {
     #[inline]
     fn from(input: TouchEventFlags) -> Self {
@@ -16853,18 +16763,6 @@ pub type TouchEndEvent = TouchBeginEvent;
 pub struct TouchOwnershipFlags(u32);
 impl TouchOwnershipFlags {
     pub const NONE: Self = Self(0);
-}
-impl From<TouchOwnershipFlags> for Option<u8> {
-    #[inline]
-    fn from(input: TouchOwnershipFlags) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<TouchOwnershipFlags> for Option<u16> {
-    #[inline]
-    fn from(input: TouchOwnershipFlags) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<TouchOwnershipFlags> for u32 {
     #[inline]

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -101,12 +101,6 @@ impl EventType {
     pub const ACCESS_X_NOTIFY: Self = Self(1 << 10);
     pub const EXTENSION_DEVICE_NOTIFY: Self = Self(1 << 11);
 }
-impl From<EventType> for Option<u8> {
-    #[inline]
-    fn from(input: EventType) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<EventType> for u16 {
     #[inline]
     fn from(input: EventType) -> Self {
@@ -375,12 +369,6 @@ impl StatePart {
     pub const COMPAT_LOOKUP_MODS: Self = Self(1 << 12);
     pub const POINTER_BUTTONS: Self = Self(1 << 13);
 }
-impl From<StatePart> for Option<u8> {
-    #[inline]
-    fn from(input: StatePart) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<StatePart> for u16 {
     #[inline]
     fn from(input: StatePart) -> Self {
@@ -436,12 +424,6 @@ impl BoolCtrl {
     pub const OVERLAY2_MASK: Self = Self(1 << 11);
     pub const IGNORE_GROUP_LOCK_MASK: Self = Self(1 << 12);
 }
-impl From<BoolCtrl> for Option<u8> {
-    #[inline]
-    fn from(input: BoolCtrl) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<BoolCtrl> for u16 {
     #[inline]
     fn from(input: BoolCtrl) -> Self {
@@ -488,18 +470,6 @@ impl Control {
     pub const IGNORE_LOCK_MODS: Self = Self(1 << 29);
     pub const PER_KEY_REPEAT: Self = Self(1 << 30);
     pub const CONTROLS_ENABLED: Self = Self(1 << 31);
-}
-impl From<Control> for Option<u8> {
-    #[inline]
-    fn from(input: Control) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<Control> for Option<u16> {
-    #[inline]
-    fn from(input: Control) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<Control> for u32 {
     #[inline]
@@ -549,12 +519,6 @@ impl AXOption {
     pub const BK_REJECT_FB: Self = Self(1 << 10);
     pub const DUMB_BELL: Self = Self(1 << 11);
 }
-impl From<AXOption> for Option<u8> {
-    #[inline]
-    fn from(input: AXOption) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<AXOption> for u16 {
     #[inline]
     fn from(input: AXOption) -> Self {
@@ -601,12 +565,6 @@ impl LedClassResult {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
     pub const LED_FEEDBACK_CLASS: Self = Self(4);
 }
-impl From<LedClassResult> for Option<u8> {
-    #[inline]
-    fn from(input: LedClassResult) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<LedClassResult> for u16 {
     #[inline]
     fn from(input: LedClassResult) -> Self {
@@ -651,12 +609,6 @@ impl LedClass {
     pub const LED_FEEDBACK_CLASS: Self = Self(4);
     pub const DFLT_XI_CLASS: Self = Self(768);
     pub const ALL_XI_CLASSES: Self = Self(1280);
-}
-impl From<LedClass> for Option<u8> {
-    #[inline]
-    fn from(input: LedClass) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<LedClass> for u16 {
     #[inline]
@@ -753,12 +705,6 @@ impl BellClass {
     pub const BELL_FEEDBACK_CLASS: Self = Self(5);
     pub const DFLT_XI_CLASS: Self = Self(768);
 }
-impl From<BellClass> for Option<u8> {
-    #[inline]
-    fn from(input: BellClass) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<BellClass> for u16 {
     #[inline]
     fn from(input: BellClass) -> Self {
@@ -808,12 +754,6 @@ impl ID {
     pub const ALL_XI_CLASS: Self = Self(1280);
     pub const ALL_XI_ID: Self = Self(1536);
     pub const XI_NONE: Self = Self(65280);
-}
-impl From<ID> for Option<u8> {
-    #[inline]
-    fn from(input: ID) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<ID> for u16 {
     #[inline]
@@ -1237,12 +1177,6 @@ impl VMod {
     pub const M2: Self = Self(1 << 2);
     pub const M1: Self = Self(1 << 1);
     pub const M0: Self = Self(1 << 0);
-}
-impl From<VMod> for Option<u8> {
-    #[inline]
-    fn from(input: VMod) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<VMod> for u16 {
     #[inline]
@@ -1737,12 +1671,6 @@ impl NameDetail {
     pub const VIRTUAL_MOD_NAMES: Self = Self(1 << 11);
     pub const GROUP_NAMES: Self = Self(1 << 12);
     pub const RG_NAMES: Self = Self(1 << 13);
-}
-impl From<NameDetail> for Option<u8> {
-    #[inline]
-    fn from(input: NameDetail) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<NameDetail> for u16 {
     #[inline]

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -84,18 +84,6 @@ impl From<u8> for Const {
         Self(value)
     }
 }
-impl TryFrom<u16> for Const {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Const {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventType(u16);
@@ -155,12 +143,6 @@ impl From<u16> for EventType {
         Self(value)
     }
 }
-impl TryFrom<u32> for EventType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(EventType, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -210,18 +192,6 @@ impl From<u8> for NKNDetail {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for NKNDetail {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for NKNDetail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(NKNDetail, u8);
@@ -277,18 +247,6 @@ impl From<u8> for AXNDetail {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for AXNDetail {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for AXNDetail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(AXNDetail, u8);
@@ -347,18 +305,6 @@ impl From<u8> for MapPart {
         Self(value)
     }
 }
-impl TryFrom<u16> for MapPart {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for MapPart {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(MapPart, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -407,18 +353,6 @@ impl From<u8> for SetMapFlags {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SetMapFlags {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SetMapFlags {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(SetMapFlags, u8);
@@ -483,12 +417,6 @@ impl From<u16> for StatePart {
         Self(value)
     }
 }
-impl TryFrom<u32> for StatePart {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(StatePart, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -548,12 +476,6 @@ impl From<u16> for BoolCtrl {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for BoolCtrl {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(BoolCtrl, u16);
@@ -669,12 +591,6 @@ impl From<u16> for AXOption {
         Self(value)
     }
 }
-impl TryFrom<u32> for AXOption {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(AXOption, u16);
 
 pub type DeviceSpec = u16;
@@ -725,12 +641,6 @@ impl From<u16> for LedClassResult {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for LedClassResult {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -784,12 +694,6 @@ impl From<u16> for LedClass {
         Self(value)
     }
 }
-impl TryFrom<u32> for LedClass {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 pub type LedClassSpec = u16;
 
@@ -841,18 +745,6 @@ impl From<u8> for BellClassResult {
         Self(value)
     }
 }
-impl TryFrom<u16> for BellClassResult {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for BellClassResult {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BellClass(u16);
@@ -901,12 +793,6 @@ impl From<u16> for BellClass {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for BellClass {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -965,12 +851,6 @@ impl From<u16> for ID {
         Self(value)
     }
 }
-impl TryFrom<u32> for ID {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 pub type IDSpec = u16;
 
@@ -1024,18 +904,6 @@ impl From<u8> for Group {
         Self(value)
     }
 }
-impl TryFrom<u16> for Group {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Group {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Groups(u8);
@@ -1083,18 +951,6 @@ impl From<u8> for Groups {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Groups {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Groups {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -1148,18 +1004,6 @@ impl From<u8> for SetOfGroup {
         Self(value)
     }
 }
-impl TryFrom<u16> for SetOfGroup {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SetOfGroup {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(SetOfGroup, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1207,18 +1051,6 @@ impl From<u8> for SetOfGroups {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SetOfGroups {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SetOfGroups {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(SetOfGroups, u8);
@@ -1270,18 +1102,6 @@ impl From<u8> for GroupsWrap {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for GroupsWrap {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GroupsWrap {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(GroupsWrap, u8);
@@ -1340,18 +1160,6 @@ impl From<u8> for VModsHigh {
         Self(value)
     }
 }
-impl TryFrom<u16> for VModsHigh {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for VModsHigh {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(VModsHigh, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1406,18 +1214,6 @@ impl From<u8> for VModsLow {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for VModsLow {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for VModsLow {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(VModsLow, u8);
@@ -1484,12 +1280,6 @@ impl From<u16> for VMod {
         Self(value)
     }
 }
-impl TryFrom<u32> for VMod {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(VMod, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1546,18 +1336,6 @@ impl From<u8> for Explicit {
         Self(value)
     }
 }
-impl TryFrom<u16> for Explicit {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Explicit {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(Explicit, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1611,18 +1389,6 @@ impl From<u8> for SymInterpretMatch {
         Self(value)
     }
 }
-impl TryFrom<u16> for SymInterpretMatch {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SymInterpretMatch {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SymInterpMatch(u8);
@@ -1670,18 +1436,6 @@ impl From<u8> for SymInterpMatch {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SymInterpMatch {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SymInterpMatch {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -1732,18 +1486,6 @@ impl From<u8> for IMFlag {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for IMFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for IMFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(IMFlag, u8);
@@ -1799,18 +1541,6 @@ impl From<u8> for IMModsWhich {
         Self(value)
     }
 }
-impl TryFrom<u16> for IMModsWhich {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for IMModsWhich {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(IMModsWhich, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1862,18 +1592,6 @@ impl From<u8> for IMGroupsWhich {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for IMGroupsWhich {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for IMGroupsWhich {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(IMGroupsWhich, u8);
@@ -2000,18 +1718,6 @@ impl From<u8> for CMDetail {
         Self(value)
     }
 }
-impl TryFrom<u16> for CMDetail {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CMDetail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(CMDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2074,12 +1780,6 @@ impl From<u16> for NameDetail {
         Self(value)
     }
 }
-impl TryFrom<u32> for NameDetail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(NameDetail, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2136,18 +1836,6 @@ impl From<u8> for GBNDetail {
         Self(value)
     }
 }
-impl TryFrom<u16> for GBNDetail {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GBNDetail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(GBNDetail, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2201,18 +1889,6 @@ impl From<u8> for XIFeature {
         Self(value)
     }
 }
-impl TryFrom<u16> for XIFeature {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for XIFeature {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(XIFeature, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2264,18 +1940,6 @@ impl From<u8> for PerClientFlag {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for PerClientFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PerClientFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(PerClientFlag, u8);
@@ -2985,18 +2649,6 @@ impl From<u8> for BehaviorType {
         Self(value)
     }
 }
-impl TryFrom<u16> for BehaviorType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for BehaviorType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct SetBehavior {
@@ -3683,18 +3335,6 @@ impl From<u8> for DoodadType {
         Self(value)
     }
 }
-impl TryFrom<u16> for DoodadType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for DoodadType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Listing {
@@ -3857,18 +3497,6 @@ impl From<u8> for Error {
         Self(value)
     }
 }
-impl TryFrom<u16> for Error {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Error {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the Keyboard error
 pub const KEYBOARD_ERROR: u8 = 0;
@@ -3921,18 +3549,6 @@ impl From<u8> for SA {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SA {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SA {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(SA, u8);
@@ -4002,18 +3618,6 @@ impl From<u8> for SAType {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SAType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SAType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -4223,18 +3827,6 @@ impl From<u8> for SAMovePtrFlag {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SAMovePtrFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SAMovePtrFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(SAMovePtrFlag, u8);
@@ -4452,18 +4044,6 @@ impl From<u8> for SASetPtrDfltFlag {
         Self(value)
     }
 }
-impl TryFrom<u16> for SASetPtrDfltFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SASetPtrDfltFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(SASetPtrDfltFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4570,18 +4150,6 @@ impl From<u8> for SAIsoLockFlag {
         Self(value)
     }
 }
-impl TryFrom<u16> for SAIsoLockFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SAIsoLockFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(SAIsoLockFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4632,18 +4200,6 @@ impl From<u8> for SAIsoLockNoAffect {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SAIsoLockNoAffect {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SAIsoLockNoAffect {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(SAIsoLockNoAffect, u8);
@@ -4804,18 +4360,6 @@ impl From<u8> for SwitchScreenFlag {
         Self(value)
     }
 }
-impl TryFrom<u16> for SwitchScreenFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SwitchScreenFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(SwitchScreenFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4918,18 +4462,6 @@ impl From<u8> for BoolCtrlsHigh {
         Self(value)
     }
 }
-impl TryFrom<u16> for BoolCtrlsHigh {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for BoolCtrlsHigh {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(BoolCtrlsHigh, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4984,18 +4516,6 @@ impl From<u8> for BoolCtrlsLow {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for BoolCtrlsLow {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for BoolCtrlsLow {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(BoolCtrlsLow, u8);
@@ -5100,18 +4620,6 @@ impl From<u8> for ActionMessageFlag {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ActionMessageFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ActionMessageFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(ActionMessageFlag, u8);
@@ -5335,18 +4843,6 @@ impl From<u8> for LockDeviceFlags {
         Self(value)
     }
 }
-impl TryFrom<u16> for LockDeviceFlags {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for LockDeviceFlags {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(LockDeviceFlags, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -5454,18 +4950,6 @@ impl From<u8> for SAValWhat {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SAValWhat {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SAValWhat {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -192,18 +192,6 @@ impl From<u8> for EvMask {
         Self(value)
     }
 }
-impl TryFrom<u16> for EvMask {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for EvMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(EvMask, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -258,18 +246,6 @@ impl From<u8> for Detail {
         Self(value)
     }
 }
-impl TryFrom<u16> for Detail {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Detail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Attr(u8);
@@ -322,18 +298,6 @@ impl From<u8> for Attr {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Attr {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Attr {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -347,18 +347,6 @@ impl From<u8> for VisualClass {
         Self(value)
     }
 }
-impl TryFrom<u16> for VisualClass {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for VisualClass {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Visualtype {
@@ -972,18 +960,6 @@ impl From<u8> for ImageOrder {
         Self(value)
     }
 }
-impl TryFrom<u16> for ImageOrder {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ImageOrder {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Setup {
@@ -1184,12 +1160,6 @@ impl From<u16> for ModMask {
         Self(value)
     }
 }
-impl TryFrom<u32> for ModMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ModMask, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1251,12 +1221,6 @@ impl From<u16> for KeyButMask {
         Self(value)
     }
 }
-impl TryFrom<u32> for KeyButMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(KeyButMask, u16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1304,18 +1268,6 @@ impl From<u8> for WindowEnum {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for WindowEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for WindowEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -1504,12 +1456,6 @@ impl From<u16> for ButtonMask {
         Self(value)
     }
 }
-impl TryFrom<u32> for ButtonMask {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ButtonMask, u16);
 
 /// Opcode for the ButtonPress event
@@ -1691,18 +1637,6 @@ impl From<u8> for Motion {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Motion {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Motion {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -1890,18 +1824,6 @@ impl From<u8> for NotifyDetail {
         Self(value)
     }
 }
-impl TryFrom<u16> for NotifyDetail {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for NotifyDetail {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NotifyMode(u8);
@@ -1951,18 +1873,6 @@ impl From<u8> for NotifyMode {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for NotifyMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for NotifyMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -2596,18 +2506,6 @@ impl From<u8> for Visibility {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Visibility {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Visibility {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -3697,18 +3595,6 @@ impl From<u8> for Place {
         Self(value)
     }
 }
-impl TryFrom<u16> for Place {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Place {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the CirculateNotify event
 pub const CIRCULATE_NOTIFY_EVENT: u8 = 26;
@@ -3857,18 +3743,6 @@ impl From<u8> for Property {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Property {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Property {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -4100,18 +3974,6 @@ impl From<u8> for Time {
         Self(value)
     }
 }
-impl TryFrom<u16> for Time {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Time {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AtomEnum(u8);
@@ -4227,18 +4089,6 @@ impl From<u8> for AtomEnum {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for AtomEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for AtomEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -4473,18 +4323,6 @@ impl From<u8> for ColormapState {
         Self(value)
     }
 }
-impl TryFrom<u16> for ColormapState {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ColormapState {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ColormapEnum(u8);
@@ -4531,18 +4369,6 @@ impl From<u8> for ColormapEnum {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ColormapEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ColormapEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -4950,18 +4776,6 @@ impl From<u8> for Mapping {
         Self(value)
     }
 }
-impl TryFrom<u16> for Mapping {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Mapping {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the MappingNotify event
 pub const MAPPING_NOTIFY_EVENT: u8 = 34;
@@ -5194,12 +5008,6 @@ impl From<u16> for WindowClass {
         Self(value)
     }
 }
-impl TryFrom<u32> for WindowClass {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// # Fields
 ///
@@ -5330,12 +5138,6 @@ impl From<u16> for CW {
     #[inline]
     fn from(value: u16) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u32> for CW {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u16::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(CW, u16);
@@ -6553,18 +6355,6 @@ impl From<u8> for MapState {
         Self(value)
     }
 }
-impl TryFrom<u16> for MapState {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for MapState {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the GetWindowAttributes request
 pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
@@ -6961,18 +6751,6 @@ impl From<u8> for SetMode {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for SetMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for SetMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -7679,18 +7457,6 @@ impl From<u8> for ConfigWindow {
         Self(value)
     }
 }
-impl TryFrom<u16> for ConfigWindow {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ConfigWindow {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ConfigWindow, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8158,18 +7924,6 @@ impl From<u8> for Circulate {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Circulate {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Circulate {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -9051,18 +8805,6 @@ impl From<u8> for PropMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for PropMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PropMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the ChangeProperty request
 pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
@@ -9420,18 +9162,6 @@ impl From<u8> for GetPropertyType {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for GetPropertyType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GetPropertyType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -10719,18 +10449,6 @@ impl From<u8> for GrabMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for GrabMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GrabMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GrabStatus(u8);
@@ -10783,18 +10501,6 @@ impl From<u8> for GrabStatus {
         Self(value)
     }
 }
-impl TryFrom<u16> for GrabStatus {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GrabStatus {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CursorEnum(u8);
@@ -10841,18 +10547,6 @@ impl From<u8> for CursorEnum {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for CursorEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CursorEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -11329,18 +11023,6 @@ impl From<u8> for ButtonIndex {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ButtonIndex {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ButtonIndex {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -12158,18 +11840,6 @@ impl From<u8> for Grab {
         Self(value)
     }
 }
-impl TryFrom<u16> for Grab {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Grab {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the GrabKey request
 pub const GRAB_KEY_REQUEST: u8 = 33;
@@ -12643,18 +12313,6 @@ impl From<u8> for Allow {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Allow {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Allow {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -13591,18 +13249,6 @@ impl From<u8> for InputFocus {
         Self(value)
     }
 }
-impl TryFrom<u16> for InputFocus {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for InputFocus {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the SetInputFocus request
 pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
@@ -14178,18 +13824,6 @@ impl From<u8> for FontDraw {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for FontDraw {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for FontDraw {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -17677,18 +17311,6 @@ impl From<u8> for ClipOrdering {
         Self(value)
     }
 }
-impl TryFrom<u16> for ClipOrdering {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ClipOrdering {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the SetClipRectangles request
 pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
@@ -18344,18 +17966,6 @@ impl From<u8> for CoordMode {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for CoordMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CoordMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -19095,18 +18705,6 @@ impl From<u8> for PolyShape {
         Self(value)
     }
 }
-impl TryFrom<u16> for PolyShape {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PolyShape {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the FillPoly request
 pub const FILL_POLY_REQUEST: u8 = 69;
@@ -19521,18 +19119,6 @@ impl From<u8> for ImageFormat {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ImageFormat {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ImageFormat {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -20459,18 +20045,6 @@ impl From<u8> for ColormapAlloc {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ColormapAlloc {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ColormapAlloc {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -21704,18 +21278,6 @@ impl From<u8> for ColorFlag {
         Self(value)
     }
 }
-impl TryFrom<u16> for ColorFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ColorFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(ColorFlag, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22335,18 +21897,6 @@ impl From<u8> for PixmapEnum {
         Self(value)
     }
 }
-impl TryFrom<u16> for PixmapEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for PixmapEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 93;
@@ -22536,18 +22086,6 @@ impl From<u8> for FontEnum {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for FontEnum {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for FontEnum {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -23007,18 +22545,6 @@ impl From<u8> for QueryShapeOf {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for QueryShapeOf {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for QueryShapeOf {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -23676,18 +23202,6 @@ impl From<u8> for KB {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for KB {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for KB {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(KB, u8);
@@ -24463,18 +23977,6 @@ impl From<u8> for Blanking {
         Self(value)
     }
 }
-impl TryFrom<u16> for Blanking {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Blanking {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Exposures(u8);
@@ -24523,18 +24025,6 @@ impl From<u8> for Exposures {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Exposures {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Exposures {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -24770,18 +24260,6 @@ impl From<u8> for HostMode {
         Self(value)
     }
 }
-impl TryFrom<u16> for HostMode {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for HostMode {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Family(u8);
@@ -24832,18 +24310,6 @@ impl From<u8> for Family {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Family {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Family {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -25154,18 +24620,6 @@ impl From<u8> for AccessControl {
         Self(value)
     }
 }
-impl TryFrom<u16> for AccessControl {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for AccessControl {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the SetAccessControl request
 pub const SET_ACCESS_CONTROL_REQUEST: u8 = 111;
@@ -25279,18 +24733,6 @@ impl From<u8> for CloseDown {
         Self(value)
     }
 }
-impl TryFrom<u16> for CloseDown {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for CloseDown {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the SetCloseDownMode request
 pub const SET_CLOSE_DOWN_MODE_REQUEST: u8 = 112;
@@ -25400,18 +24842,6 @@ impl From<u8> for Kill {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for Kill {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Kill {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -25665,18 +25095,6 @@ impl From<u8> for ScreenSaver {
         Self(value)
     }
 }
-impl TryFrom<u16> for ScreenSaver {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ScreenSaver {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 /// Opcode for the ForceScreenSaver request
 pub const FORCE_SCREEN_SAVER_REQUEST: u8 = 115;
@@ -25788,18 +25206,6 @@ impl From<u8> for MappingStatus {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for MappingStatus {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for MappingStatus {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -26063,18 +25469,6 @@ impl From<u8> for MapIndex {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for MapIndex {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for MapIndex {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -514,18 +514,6 @@ impl EventMask {
     pub const COLOR_MAP_CHANGE: Self = Self(1 << 23);
     pub const OWNER_GRAB_BUTTON: Self = Self(1 << 24);
 }
-impl From<EventMask> for Option<u8> {
-    #[inline]
-    fn from(input: EventMask) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<EventMask> for Option<u16> {
-    #[inline]
-    fn from(input: EventMask) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<EventMask> for u32 {
     #[inline]
     fn from(input: EventMask) -> Self {
@@ -564,18 +552,6 @@ impl BackingStore {
     pub const NOT_USEFUL: Self = Self(0);
     pub const WHEN_MAPPED: Self = Self(1);
     pub const ALWAYS: Self = Self(2);
-}
-impl From<BackingStore> for Option<u8> {
-    #[inline]
-    fn from(input: BackingStore) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<BackingStore> for Option<u16> {
-    #[inline]
-    fn from(input: BackingStore) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<BackingStore> for u32 {
     #[inline]
@@ -1118,12 +1094,6 @@ impl ModMask {
     pub const M5: Self = Self(1 << 7);
     pub const ANY: Self = Self(1 << 15);
 }
-impl From<ModMask> for Option<u8> {
-    #[inline]
-    fn from(input: ModMask) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<ModMask> for u16 {
     #[inline]
     fn from(input: ModMask) -> Self {
@@ -1178,12 +1148,6 @@ impl KeyButMask {
     pub const BUTTON3: Self = Self(1 << 10);
     pub const BUTTON4: Self = Self(1 << 11);
     pub const BUTTON5: Self = Self(1 << 12);
-}
-impl From<KeyButMask> for Option<u8> {
-    #[inline]
-    fn from(input: KeyButMask) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<KeyButMask> for u16 {
     #[inline]
@@ -1413,12 +1377,6 @@ impl ButtonMask {
     pub const M4: Self = Self(1 << 11);
     pub const M5: Self = Self(1 << 12);
     pub const ANY: Self = Self(1 << 15);
-}
-impl From<ButtonMask> for Option<u8> {
-    #[inline]
-    fn from(input: ButtonMask) -> Self {
-        u8::try_from(input.0).ok()
-    }
 }
 impl From<ButtonMask> for u16 {
     #[inline]
@@ -4966,12 +4924,6 @@ impl WindowClass {
     pub const INPUT_OUTPUT: Self = Self(1);
     pub const INPUT_ONLY: Self = Self(2);
 }
-impl From<WindowClass> for Option<u8> {
-    #[inline]
-    fn from(input: WindowClass) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<WindowClass> for u16 {
     #[inline]
     fn from(input: WindowClass) -> Self {
@@ -5098,12 +5050,6 @@ impl CW {
     pub const COLORMAP: Self = Self(1 << 13);
     pub const CURSOR: Self = Self(1 << 14);
 }
-impl From<CW> for Option<u8> {
-    #[inline]
-    fn from(input: CW) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
 impl From<CW> for u16 {
     #[inline]
     fn from(input: CW) -> Self {
@@ -5182,18 +5128,6 @@ impl Gravity {
     pub const SOUTH: Self = Self(8);
     pub const SOUTH_EAST: Self = Self(9);
     pub const STATIC: Self = Self(10);
-}
-impl From<Gravity> for Option<u8> {
-    #[inline]
-    fn from(input: Gravity) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<Gravity> for Option<u16> {
-    #[inline]
-    fn from(input: Gravity) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<Gravity> for u32 {
     #[inline]
@@ -7467,18 +7401,6 @@ impl StackMode {
     pub const TOP_IF: Self = Self(2);
     pub const BOTTOM_IF: Self = Self(3);
     pub const OPPOSITE: Self = Self(4);
-}
-impl From<StackMode> for Option<u8> {
-    #[inline]
-    fn from(input: StackMode) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<StackMode> for Option<u16> {
-    #[inline]
-    fn from(input: StackMode) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<StackMode> for u32 {
     #[inline]
@@ -15292,18 +15214,6 @@ impl GC {
     pub const DASH_LIST: Self = Self(1 << 21);
     pub const ARC_MODE: Self = Self(1 << 22);
 }
-impl From<GC> for Option<u8> {
-    #[inline]
-    fn from(input: GC) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<GC> for Option<u16> {
-    #[inline]
-    fn from(input: GC) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<GC> for u32 {
     #[inline]
     fn from(input: GC) -> Self {
@@ -15356,18 +15266,6 @@ impl GX {
     pub const NAND: Self = Self(14);
     pub const SET: Self = Self(15);
 }
-impl From<GX> for Option<u8> {
-    #[inline]
-    fn from(input: GX) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<GX> for Option<u16> {
-    #[inline]
-    fn from(input: GX) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<GX> for u32 {
     #[inline]
     fn from(input: GX) -> Self {
@@ -15405,18 +15303,6 @@ impl LineStyle {
     pub const SOLID: Self = Self(0);
     pub const ON_OFF_DASH: Self = Self(1);
     pub const DOUBLE_DASH: Self = Self(2);
-}
-impl From<LineStyle> for Option<u8> {
-    #[inline]
-    fn from(input: LineStyle) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<LineStyle> for Option<u16> {
-    #[inline]
-    fn from(input: LineStyle) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<LineStyle> for u32 {
     #[inline]
@@ -15457,18 +15343,6 @@ impl CapStyle {
     pub const ROUND: Self = Self(2);
     pub const PROJECTING: Self = Self(3);
 }
-impl From<CapStyle> for Option<u8> {
-    #[inline]
-    fn from(input: CapStyle) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<CapStyle> for Option<u16> {
-    #[inline]
-    fn from(input: CapStyle) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<CapStyle> for u32 {
     #[inline]
     fn from(input: CapStyle) -> Self {
@@ -15506,18 +15380,6 @@ impl JoinStyle {
     pub const MITER: Self = Self(0);
     pub const ROUND: Self = Self(1);
     pub const BEVEL: Self = Self(2);
-}
-impl From<JoinStyle> for Option<u8> {
-    #[inline]
-    fn from(input: JoinStyle) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<JoinStyle> for Option<u16> {
-    #[inline]
-    fn from(input: JoinStyle) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<JoinStyle> for u32 {
     #[inline]
@@ -15558,18 +15420,6 @@ impl FillStyle {
     pub const STIPPLED: Self = Self(2);
     pub const OPAQUE_STIPPLED: Self = Self(3);
 }
-impl From<FillStyle> for Option<u8> {
-    #[inline]
-    fn from(input: FillStyle) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<FillStyle> for Option<u16> {
-    #[inline]
-    fn from(input: FillStyle) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<FillStyle> for u32 {
     #[inline]
     fn from(input: FillStyle) -> Self {
@@ -15606,18 +15456,6 @@ pub struct FillRule(u32);
 impl FillRule {
     pub const EVEN_ODD: Self = Self(0);
     pub const WINDING: Self = Self(1);
-}
-impl From<FillRule> for Option<u8> {
-    #[inline]
-    fn from(input: FillRule) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<FillRule> for Option<u16> {
-    #[inline]
-    fn from(input: FillRule) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<FillRule> for u32 {
     #[inline]
@@ -15656,18 +15494,6 @@ impl SubwindowMode {
     pub const CLIP_BY_CHILDREN: Self = Self(0);
     pub const INCLUDE_INFERIORS: Self = Self(1);
 }
-impl From<SubwindowMode> for Option<u8> {
-    #[inline]
-    fn from(input: SubwindowMode) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<SubwindowMode> for Option<u16> {
-    #[inline]
-    fn from(input: SubwindowMode) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<SubwindowMode> for u32 {
     #[inline]
     fn from(input: SubwindowMode) -> Self {
@@ -15704,18 +15530,6 @@ pub struct ArcMode(u32);
 impl ArcMode {
     pub const CHORD: Self = Self(0);
     pub const PIE_SLICE: Self = Self(1);
-}
-impl From<ArcMode> for Option<u8> {
-    #[inline]
-    fn from(input: ArcMode) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<ArcMode> for Option<u16> {
-    #[inline]
-    fn from(input: ArcMode) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<ArcMode> for u32 {
     #[inline]
@@ -23212,18 +23026,6 @@ impl LedMode {
     pub const OFF: Self = Self(0);
     pub const ON: Self = Self(1);
 }
-impl From<LedMode> for Option<u8> {
-    #[inline]
-    fn from(input: LedMode) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<LedMode> for Option<u16> {
-    #[inline]
-    fn from(input: LedMode) -> Self {
-        u16::try_from(input.0).ok()
-    }
-}
 impl From<LedMode> for u32 {
     #[inline]
     fn from(input: LedMode) -> Self {
@@ -23261,18 +23063,6 @@ impl AutoRepeatMode {
     pub const OFF: Self = Self(0);
     pub const ON: Self = Self(1);
     pub const DEFAULT: Self = Self(2);
-}
-impl From<AutoRepeatMode> for Option<u8> {
-    #[inline]
-    fn from(input: AutoRepeatMode) -> Self {
-        u8::try_from(input.0).ok()
-    }
-}
-impl From<AutoRepeatMode> for Option<u16> {
-    #[inline]
-    fn from(input: AutoRepeatMode) -> Self {
-        u16::try_from(input.0).ok()
-    }
 }
 impl From<AutoRepeatMode> for u32 {
     #[inline]

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -91,18 +91,6 @@ impl From<u8> for Type {
         Self(value)
     }
 }
-impl TryFrom<u16> for Type {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for Type {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 bitmask_binop!(Type, u8);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,18 +139,6 @@ impl From<u8> for ImageFormatInfoType {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ImageFormatInfoType {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ImageFormatInfoType {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -214,18 +190,6 @@ impl From<u8> for ImageFormatInfoFormat {
         Self(value)
     }
 }
-impl TryFrom<u16> for ImageFormatInfoFormat {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ImageFormatInfoFormat {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AttributeFlag(u8);
@@ -273,18 +237,6 @@ impl From<u8> for AttributeFlag {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for AttributeFlag {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for AttributeFlag {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 bitmask_binop!(AttributeFlag, u8);
@@ -340,18 +292,6 @@ impl From<u8> for VideoNotifyReason {
         Self(value)
     }
 }
-impl TryFrom<u16> for VideoNotifyReason {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for VideoNotifyReason {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScanlineOrder(u8);
@@ -399,18 +339,6 @@ impl From<u8> for ScanlineOrder {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for ScanlineOrder {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for ScanlineOrder {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 
@@ -464,18 +392,6 @@ impl From<u8> for GrabPortStatus {
     #[inline]
     fn from(value: u8) -> Self {
         Self(value)
-    }
-}
-impl TryFrom<u16> for GrabPortStatus {
-    type Error = ParseError;
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
-    }
-}
-impl TryFrom<u32> for GrabPortStatus {
-    type Error = ParseError;
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        u8::try_from(value).or(Err(ParseError::InvalidValue)).map(Self)
     }
 }
 


### PR DESCRIPTION
Due to #545, I looked into the trait impls that we generate for enums. This PR removes some that seem unnecessary.

I also wanted to remove things like the following:
```rs
impl From<VisualClass> for Option<u8> {
    #[inline]
    fn from(input: VisualClass) -> Self {
        Some(input.0)
    }
}
```
However, this kind of impl is actually used here (some of the examples fail to compile when the impl is removed):
```rs
impl CreateWindowAux {
    [...]
    /// Set the `do_not_propogate_mask` field of this structure.
    pub fn do_not_propogate_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
        self.do_not_propogate_mask = value.into();
        self
    }

```