### PR TITLE
Fix an XInput API regression: Missing From impls to convert to numbers

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2353,7 +2353,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
         let (raw_type, smaller_types, larger_types): (&str, &[&str], &[&str]) =
             match global_enum_size {
-                1 => ("bool", &[], &["u8", "u16", "u32", "u64"]),
+                1 => ("bool", &[], &["u8", "u16", "u32"]),
                 8 => ("u8", &[], &["u16", "u32"]),
                 16 => ("u16", &["u8"], &["u32"]),
                 32 => ("u32", &["u8", "u16"], &[]),

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2353,7 +2353,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
         let (raw_type, smaller_types, larger_types): (&str, &[&str], &[&str]) =
             match global_enum_size {
-                1 => ("bool", &[], &[]),
+                1 => ("bool", &[], &["u8", "u16", "u32", "u64"]),
                 8 => ("u8", &[], &["u16", "u32"]),
                 16 => ("u16", &["u8"], &["u32"]),
                 32 => ("u32", &["u8", "u16"], &[]),

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -346,6 +346,54 @@ impl From<Datatype> for Option<bool> {
         Some(input.0)
     }
 }
+impl From<Datatype> for u8 {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        u8::from(input.0)
+    }
+}
+impl From<Datatype> for Option<u8> {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        Some(u8::from(input.0))
+    }
+}
+impl From<Datatype> for u16 {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        u16::from(input.0)
+    }
+}
+impl From<Datatype> for Option<u16> {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        Some(u16::from(input.0))
+    }
+}
+impl From<Datatype> for u32 {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        u32::from(input.0)
+    }
+}
+impl From<Datatype> for Option<u32> {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        Some(u32::from(input.0))
+    }
+}
+impl From<Datatype> for u64 {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        u64::from(input.0)
+    }
+}
+impl From<Datatype> for Option<u64> {
+    #[inline]
+    fn from(input: Datatype) -> Self {
+        Some(u64::from(input.0))
+    }
+}
 impl From<bool> for Datatype {
     #[inline]
     fn from(value: bool) -> Self {

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -382,18 +382,6 @@ impl From<Datatype> for Option<u32> {
         Some(u32::from(input.0))
     }
 }
-impl From<Datatype> for u64 {
-    #[inline]
-    fn from(input: Datatype) -> Self {
-        u64::from(input.0)
-    }
-}
-impl From<Datatype> for Option<u64> {
-    #[inline]
-    fn from(input: Datatype) -> Self {
-        Some(u64::from(input.0))
-    }
-}
 impl From<bool> for Datatype {
     #[inline]
     fn from(value: bool) -> Self {

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -9521,6 +9521,54 @@ impl From<Device> for Option<bool> {
         Some(input.0)
     }
 }
+impl From<Device> for u8 {
+    #[inline]
+    fn from(input: Device) -> Self {
+        u8::from(input.0)
+    }
+}
+impl From<Device> for Option<u8> {
+    #[inline]
+    fn from(input: Device) -> Self {
+        Some(u8::from(input.0))
+    }
+}
+impl From<Device> for u16 {
+    #[inline]
+    fn from(input: Device) -> Self {
+        u16::from(input.0)
+    }
+}
+impl From<Device> for Option<u16> {
+    #[inline]
+    fn from(input: Device) -> Self {
+        Some(u16::from(input.0))
+    }
+}
+impl From<Device> for u32 {
+    #[inline]
+    fn from(input: Device) -> Self {
+        u32::from(input.0)
+    }
+}
+impl From<Device> for Option<u32> {
+    #[inline]
+    fn from(input: Device) -> Self {
+        Some(u32::from(input.0))
+    }
+}
+impl From<Device> for u64 {
+    #[inline]
+    fn from(input: Device) -> Self {
+        u64::from(input.0)
+    }
+}
+impl From<Device> for Option<u64> {
+    #[inline]
+    fn from(input: Device) -> Self {
+        Some(u64::from(input.0))
+    }
+}
 impl From<bool> for Device {
     #[inline]
     fn from(value: bool) -> Self {
@@ -12654,6 +12702,54 @@ impl From<GrabOwner> for Option<bool> {
     #[inline]
     fn from(input: GrabOwner) -> Self {
         Some(input.0)
+    }
+}
+impl From<GrabOwner> for u8 {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        u8::from(input.0)
+    }
+}
+impl From<GrabOwner> for Option<u8> {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        Some(u8::from(input.0))
+    }
+}
+impl From<GrabOwner> for u16 {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        u16::from(input.0)
+    }
+}
+impl From<GrabOwner> for Option<u16> {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        Some(u16::from(input.0))
+    }
+}
+impl From<GrabOwner> for u32 {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        u32::from(input.0)
+    }
+}
+impl From<GrabOwner> for Option<u32> {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        Some(u32::from(input.0))
+    }
+}
+impl From<GrabOwner> for u64 {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        u64::from(input.0)
+    }
+}
+impl From<GrabOwner> for Option<u64> {
+    #[inline]
+    fn from(input: GrabOwner) -> Self {
+        Some(u64::from(input.0))
     }
 }
 impl From<bool> for GrabOwner {

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -9557,18 +9557,6 @@ impl From<Device> for Option<u32> {
         Some(u32::from(input.0))
     }
 }
-impl From<Device> for u64 {
-    #[inline]
-    fn from(input: Device) -> Self {
-        u64::from(input.0)
-    }
-}
-impl From<Device> for Option<u64> {
-    #[inline]
-    fn from(input: Device) -> Self {
-        Some(u64::from(input.0))
-    }
-}
 impl From<bool> for Device {
     #[inline]
     fn from(value: bool) -> Self {
@@ -12738,18 +12726,6 @@ impl From<GrabOwner> for Option<u32> {
     #[inline]
     fn from(input: GrabOwner) -> Self {
         Some(u32::from(input.0))
-    }
-}
-impl From<GrabOwner> for u64 {
-    #[inline]
-    fn from(input: GrabOwner) -> Self {
-        u64::from(input.0)
-    }
-}
-impl From<GrabOwner> for Option<u64> {
-    #[inline]
-    fn from(input: GrabOwner) -> Self {
-        Some(u64::from(input.0))
     }
 }
 impl From<bool> for GrabOwner {

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -172,18 +172,6 @@ impl From<GetDoc> for Option<u32> {
         Some(u32::from(input.0))
     }
 }
-impl From<GetDoc> for u64 {
-    #[inline]
-    fn from(input: GetDoc) -> Self {
-        u64::from(input.0)
-    }
-}
-impl From<GetDoc> for Option<u64> {
-    #[inline]
-    fn from(input: GetDoc) -> Self {
-        Some(u64::from(input.0))
-    }
-}
 impl From<bool> for GetDoc {
     #[inline]
     fn from(value: bool) -> Self {

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -136,6 +136,54 @@ impl From<GetDoc> for Option<bool> {
         Some(input.0)
     }
 }
+impl From<GetDoc> for u8 {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        u8::from(input.0)
+    }
+}
+impl From<GetDoc> for Option<u8> {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        Some(u8::from(input.0))
+    }
+}
+impl From<GetDoc> for u16 {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        u16::from(input.0)
+    }
+}
+impl From<GetDoc> for Option<u16> {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        Some(u16::from(input.0))
+    }
+}
+impl From<GetDoc> for u32 {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        u32::from(input.0)
+    }
+}
+impl From<GetDoc> for Option<u32> {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        Some(u32::from(input.0))
+    }
+}
+impl From<GetDoc> for u64 {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        u64::from(input.0)
+    }
+}
+impl From<GetDoc> for Option<u64> {
+    #[inline]
+    fn from(input: GetDoc) -> Self {
+        Some(u64::from(input.0))
+    }
+}
 impl From<bool> for GetDoc {
     #[inline]
     fn from(value: bool) -> Self {

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -5106,6 +5106,54 @@ impl From<BackPixmap> for Option<bool> {
         Some(input.0)
     }
 }
+impl From<BackPixmap> for u8 {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        u8::from(input.0)
+    }
+}
+impl From<BackPixmap> for Option<u8> {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        Some(u8::from(input.0))
+    }
+}
+impl From<BackPixmap> for u16 {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        u16::from(input.0)
+    }
+}
+impl From<BackPixmap> for Option<u16> {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        Some(u16::from(input.0))
+    }
+}
+impl From<BackPixmap> for u32 {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        u32::from(input.0)
+    }
+}
+impl From<BackPixmap> for Option<u32> {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        Some(u32::from(input.0))
+    }
+}
+impl From<BackPixmap> for u64 {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        u64::from(input.0)
+    }
+}
+impl From<BackPixmap> for Option<u64> {
+    #[inline]
+    fn from(input: BackPixmap) -> Self {
+        Some(u64::from(input.0))
+    }
+}
 impl From<bool> for BackPixmap {
     #[inline]
     fn from(value: bool) -> Self {
@@ -10061,6 +10109,54 @@ impl From<SendEventDest> for Option<bool> {
     #[inline]
     fn from(input: SendEventDest) -> Self {
         Some(input.0)
+    }
+}
+impl From<SendEventDest> for u8 {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        u8::from(input.0)
+    }
+}
+impl From<SendEventDest> for Option<u8> {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        Some(u8::from(input.0))
+    }
+}
+impl From<SendEventDest> for u16 {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        u16::from(input.0)
+    }
+}
+impl From<SendEventDest> for Option<u16> {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        Some(u16::from(input.0))
+    }
+}
+impl From<SendEventDest> for u32 {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        u32::from(input.0)
+    }
+}
+impl From<SendEventDest> for Option<u32> {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        Some(u32::from(input.0))
+    }
+}
+impl From<SendEventDest> for u64 {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        u64::from(input.0)
+    }
+}
+impl From<SendEventDest> for Option<u64> {
+    #[inline]
+    fn from(input: SendEventDest) -> Self {
+        Some(u64::from(input.0))
     }
 }
 impl From<bool> for SendEventDest {

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -5142,18 +5142,6 @@ impl From<BackPixmap> for Option<u32> {
         Some(u32::from(input.0))
     }
 }
-impl From<BackPixmap> for u64 {
-    #[inline]
-    fn from(input: BackPixmap) -> Self {
-        u64::from(input.0)
-    }
-}
-impl From<BackPixmap> for Option<u64> {
-    #[inline]
-    fn from(input: BackPixmap) -> Self {
-        Some(u64::from(input.0))
-    }
-}
 impl From<bool> for BackPixmap {
     #[inline]
     fn from(value: bool) -> Self {
@@ -10145,18 +10133,6 @@ impl From<SendEventDest> for Option<u32> {
     #[inline]
     fn from(input: SendEventDest) -> Self {
         Some(u32::from(input.0))
-    }
-}
-impl From<SendEventDest> for u64 {
-    #[inline]
-    fn from(input: SendEventDest) -> Self {
-        u64::from(input.0)
-    }
-}
-impl From<SendEventDest> for Option<u64> {
-    #[inline]
-    fn from(input: SendEventDest) -> Self {
-        Some(u64::from(input.0))
     }
 }
 impl From<bool> for SendEventDest {

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -192,18 +192,6 @@ impl From<Cursor> for Option<u32> {
         Some(u32::from(input.0))
     }
 }
-impl From<Cursor> for u64 {
-    #[inline]
-    fn from(input: Cursor) -> Self {
-        u64::from(input.0)
-    }
-}
-impl From<Cursor> for Option<u64> {
-    #[inline]
-    fn from(input: Cursor) -> Self {
-        Some(u64::from(input.0))
-    }
-}
 impl From<bool> for Cursor {
     #[inline]
     fn from(value: bool) -> Self {

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -156,6 +156,54 @@ impl From<Cursor> for Option<bool> {
         Some(input.0)
     }
 }
+impl From<Cursor> for u8 {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        u8::from(input.0)
+    }
+}
+impl From<Cursor> for Option<u8> {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        Some(u8::from(input.0))
+    }
+}
+impl From<Cursor> for u16 {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        u16::from(input.0)
+    }
+}
+impl From<Cursor> for Option<u16> {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        Some(u16::from(input.0))
+    }
+}
+impl From<Cursor> for u32 {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        u32::from(input.0)
+    }
+}
+impl From<Cursor> for Option<u32> {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        Some(u32::from(input.0))
+    }
+}
+impl From<Cursor> for u64 {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        u64::from(input.0)
+    }
+}
+impl From<Cursor> for Option<u64> {
+    #[inline]
+    fn from(input: Cursor) -> Self {
+        Some(u64::from(input.0))
+    }
+}
 impl From<bool> for Cursor {
     #[inline]
     fn from(value: bool) -> Self {

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -334,3 +334,10 @@ fn test_serialize_setup_authenticate() {
     ];
     assert_eq!(&setup_bytes[..], &setup.serialize()[..]);
 }
+
+#[cfg(feature = "xinput")]
+#[allow(dead_code)]
+fn compile_test(conn: &impl RequestConnection) {
+    use x11rb::protocol::xinput::{xi_query_device, Device};
+    let _ = xi_query_device(conn, Device::ALL);
+}


### PR DESCRIPTION
This fixes the issue reported in the following comment: https://github.com/psychon/x11rb/pull/545#issuecomment-729207032

> I think this broke e.g. xinput_xi_query_device to which I should be able to pass Device::ALL but I cannot.