### PR TITLE
Make bitmask_binop! return the wrapper type

### DIFF
--- a/generator/src/generator/special_cases.rs
+++ b/generator/src/generator/special_cases.rs
@@ -67,7 +67,7 @@ pub(super) fn handle_request(request_def: &xcbdefs::RequestDef, out: &mut Output
 /// }};
 /// assert!(reply.value{width}().is_none());
 /// ```
-pub fn value{width}<'a>(&'a self) -> Option<impl Iterator<Item=u{width}> + 'a> {{
+pub fn value{width}(&self) -> Option<impl Iterator<Item=u{width}> + '_> {{
     if self.format == {width} {{
         Some(crate::wrapper::PropertyIterator::new(&self.value))
     }} else {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,10 @@
     // Not everything in x11rb::protocol has doc comments
     missing_docs,
 )]
+#![allow(
+    // This suggests a method that was stabilised in Rust 1.45, while our MSRV is 1.40.
+    clippy::manual_strip,
+)]
 #![cfg_attr(not(feature = "allow-unsafe-code"), forbid(unsafe_code))]
 
 // Only contains documentation, but no "actual rust"

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -9380,7 +9380,7 @@ impl GetPropertyReply {
     /// };
     /// assert!(reply.value8().is_none());
     /// ```
-    pub fn value8<'a>(&'a self) -> Option<impl Iterator<Item=u8> + 'a> {
+    pub fn value8(&self) -> Option<impl Iterator<Item=u8> + '_> {
         if self.format == 8 {
             Some(crate::wrapper::PropertyIterator::new(&self.value))
         } else {
@@ -9431,7 +9431,7 @@ impl GetPropertyReply {
     /// };
     /// assert!(reply.value16().is_none());
     /// ```
-    pub fn value16<'a>(&'a self) -> Option<impl Iterator<Item=u16> + 'a> {
+    pub fn value16(&self) -> Option<impl Iterator<Item=u16> + '_> {
         if self.format == 16 {
             Some(crate::wrapper::PropertyIterator::new(&self.value))
         } else {
@@ -9481,7 +9481,7 @@ impl GetPropertyReply {
     /// };
     /// assert!(reply.value32().is_none());
     /// ```
-    pub fn value32<'a>(&'a self) -> Option<impl Iterator<Item=u32> + 'a> {
+    pub fn value32(&self) -> Option<impl Iterator<Item=u32> + '_> {
         if self.format == 32 {
             Some(crate::wrapper::PropertyIterator::new(&self.value))
         } else {

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -478,26 +478,31 @@ impl<T: Serialize> Serialize for [T] {
 macro_rules! bitmask_binop {
     ($t:ty, $u:ty) => {
         impl std::ops::BitOr for $t {
-            type Output = $u;
+            type Output = $t;
             fn bitor(self, other: Self) -> Self::Output {
-                Self::Output::from(self) | Self::Output::from(other)
+                Self::from(<$u>::from(self) | <$u>::from(other))
             }
         }
         impl std::ops::BitOr<$u> for $t {
-            type Output = $u;
+            type Output = $t;
             fn bitor(self, other: $u) -> Self::Output {
-                Self::Output::from(self) | other
+                self | Self::from(other)
             }
         }
         impl std::ops::BitOr<$t> for $u {
-            type Output = $u;
+            type Output = $t;
             fn bitor(self, other: $t) -> Self::Output {
-                self | Self::Output::from(other)
+                <$t>::from(self) | other
             }
         }
         impl std::ops::BitOrAssign<$t> for $u {
             fn bitor_assign(&mut self, other: $t) {
                 *self |= Self::from(other)
+            }
+        }
+        impl std::ops::BitOrAssign<$u> for $t {
+            fn bitor_assign(&mut self, other: $u) {
+                *self = *self | Self::from(other)
             }
         }
     };


### PR DESCRIPTION
Before this commit, the invocation bitmask_binop!(ConfigWindow, u8);
would expand to the following:

        impl std::ops::BitOr for ConfigWindow {
            type Output = u8;
            fn bitor(self, other: Self) -> Self::Output {
                Self::Output::from(self) | Self::Output::from(other)
            }
        }
        impl std::ops::BitOr<u8> for ConfigWindow {
            type Output = u8;
            fn bitor(self, other: u8) -> Self::Output {
                Self::Output::from(self) | other
            }
        }
        impl std::ops::BitOr<ConfigWindow> for u8 {
            type Output = u8;
            fn bitor(self, other: ConfigWindow) -> Self::Output {
                self | Self::Output::from(other)
            }
        }
        impl std::ops::BitOrAssign<ConfigWindow> for u8 {
            fn bitor_assign(&mut self, other: ConfigWindow) {
                *self |= Self::from(other)
            }
        }

This commit changes the code to instead expand to:

        impl std::ops::BitOr for ConfigWindow {
            type Output = ConfigWindow;
            fn bitor(self, other: Self) -> Self::Output {
                Self::from(<u8>::from(self) | <u8>::from(other))
            }
        }
        impl std::ops::BitOr<u8> for ConfigWindow {
            type Output = ConfigWindow;
            fn bitor(self, other: u8) -> Self::Output {
                self | Self::from(other)
            }
        }
        impl std::ops::BitOr<ConfigWindow> for u8 {
            type Output = ConfigWindow;
            fn bitor(self, other: ConfigWindow) -> Self::Output {
                <ConfigWindow>::from(self) | other
            }
        }
        impl std::ops::BitOrAssign<ConfigWindow> for u8 {
            fn bitor_assign(&mut self, other: ConfigWindow) {
                *self |= Self::from(other)
            }
        }
        impl std::ops::BitOrAssign<u8> for ConfigWindow {
            fn bitor_assign(&mut self, other: u8) {
                *self = *self | Self::from(other)
            }
        }

The main differences are:
- Previously, the Output type of BitOr was u8, while now it is
  ConfigWindow.
- There is a new implementation for "ConfigWindow |= u8".

Both of these changes are only possible due to recent change to
represent enums as newtypes around an integer. Previously, they were
Rust enums, which meant that we could not represent combinations of
masks. The new newtypes allow this.

Signed-off-by: Uli Schlachter <psychon@znc.in>