### PR TITLE
X11 Resource Manager support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ cursor = ["render"]
 # Enable utility functions in `x11rb::image` for working with image data.
 image = []
 
+# FOO TODO
+resource_manager = []
+
 dl-libxcb = ["allow-unsafe-code", "libloading", "once_cell"]
 
 # Enable this feature to enable all the X11 extensions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,8 @@ cursor = ["render"]
 # Enable utility functions in `x11rb::image` for working with image data.
 image = []
 
-# FOO TODO
+# Enable utility functions in `x11rb::resource_manager` for querying the
+# resource databases.
 resource_manager = []
 
 dl-libxcb = ["allow-unsafe-code", "libloading", "once_cell"]
@@ -111,7 +112,7 @@ xv = ["shm"]
 xvmc = ["xv"]
 
 [package.metadata.docs.rs]
-features = [ "all-extensions", "allow-unsafe-code", "cursor", "image" ]
+features = [ "all-extensions", "allow-unsafe-code", "cursor", "image", "resource_manager" ]
 
 [[example]]
 name = "generic_events"

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::match_like_matches_macro)]
-
 //! Find the right cursor file from a cursor name
 
 // Based on libxcb-cursor's load_cursor.c which has:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,8 @@ pub mod wrapper;
 #[rustfmt::skip]
 #[allow(missing_docs)]
 pub mod protocol;
+#[cfg(feature = "resource_manager")]
+pub mod resource_manager;
 
 use connection::Connection;
 use errors::ConnectError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@
 //! Additionally, the following flags exist:
 //! * `allow-unsafe-code`: Enable features that require `unsafe`. Without this flag,
 //!   `x11rb::xcb_ffi::XCBConnection` and some support code for it are unavailable.
+//! * `cursor`: Enable the code in [x11rb::cursor] for loading cursor files.
+//! * `resource_manager`: Enable the code in [x11rb::resource_manager] for loading and querying the
+//!   X11 resource database.
 //! * `dl-libxcb`: Enabling this feature will prevent from libxcb being linked to the
 //!   resulting executable. Instead libxcb will be dynamically loaded at runtime.
 //!   This feature adds the `x11rb::xcb_ffi::load_libxcb` function, that allows load

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,8 @@
 #![allow(
     // This suggests a method that was stabilised in Rust 1.45, while our MSRV is 1.40.
     clippy::manual_strip,
+    // This suggests a macro that was stabilised in Rust 1.42, while our MSRV is 1.40.
+    clippy::match_like_matches_macro,
 )]
 #![cfg_attr(not(feature = "allow-unsafe-code"), forbid(unsafe_code))]
 

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -114,7 +114,7 @@ mod test {
             (b"urxvt.keysym.Control-Shift-Up: perl:font:increment", "urxvt.keysym.Control-Shift-Up", "", Some(b"perl:font:increment")),
             (b"rofi.normal: #000000, #000000, #000000, #000000", "rofi.normal", "", Some(b"#000000, #000000, #000000, #000000")),
         ];
-        let mut success = true;
+        let mut failures = 0;
         for &(data, resource, class, expected) in &tests {
             let mut entries = Vec::new();
             let database = parse_database(data, &mut entries, |_, _| unreachable!());
@@ -125,11 +125,11 @@ mod test {
                 eprintln!("Expected: {:?}", expected.map(print_string));
                 eprintln!("Got:      {:?}", result.map(print_string));
                 eprintln!();
-                success = false;
+                failures += 1;
             }
         }
-        if !success {
-            panic!()
+        if failures != 0 {
+            panic!("Had {} failures", failures)
         }
     }
 

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -117,7 +117,7 @@ mod test {
         let mut failures = 0;
         for &(data, resource, class, expected) in &tests {
             let mut entries = Vec::new();
-            let database = parse_database(data, &mut entries, |_, _| unreachable!());
+            parse_database(data, &mut entries, |_, _| unreachable!());
             let result = match_entry(&entries, resource, class);
             if result != expected {
                 eprintln!("While testing resource '{}' and class '{}' with the following input:", resource, class);

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -1,0 +1,131 @@
+use super::{Binding, Component, Entry};
+
+fn match_entry<'a>(database: &'a [Entry], resource: &str, class: &str) -> Option<&'a [u8]> {
+    todo!()
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::Database;
+    use super::match_entry;
+
+    // Most tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
+    // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_match.c
+
+    #[test]
+    fn test_non_match() {
+        // Non-matches / Errors
+        let tests = [
+            (b"", "", ""),
+        ];
+        for &(database, resource, class) in &tests {
+            let database = Database::new_from_data(database);
+            assert_eq!(None, match_entry(&database.entries, resource, class));
+        }
+    }
+
+    #[test]
+    fn test_matches() {
+        let tests: [(&[u8], _, _, Option<&[u8]>); 67] = [
+            // Xlib returns the match here, despite the query violating the specs.
+            (b"First.second: 1", "First.second", "First.second.third", None),
+            (b"", "First.second", "", None),
+            (b"First.second: 1", "First.third", "", None),
+            (b"First.second: 1", "First", "", None),
+            (b"First: 1", "First.second", "", None),
+            (b"First.?.fourth: 1", "First.second.third.fourth", "", None),
+            (b"First*?.third: 1", "First.third", "", None),
+            (b"First: 1", "first", "", None),
+            (b"First: 1", "", "first", None),
+
+            // Duplicate entries
+            (b"First: 1\nFirst: 2\nFirst: 3\n", "First", "", Some(b"3")),
+            (b"First: 1\nSecond: 2\nSecond: 3\nThird: 4\n", "Second", "", Some(b"3")),
+
+            /* Basic matching */
+            (b"First: 1", "First", "", Some(b"1")),
+            (b"First.second: 1", "First.second", "", Some(b"1")),
+            (b"?.second: 1", "First.second", "", Some(b"1")),
+            (b"First.?.third: 1", "First.second.third", "", Some(b"1")),
+            (b"First.?.?.fourth: 1", "First.second.third.fourth", "", Some(b"1")),
+            (b"*second: 1", "First.second", "", Some(b"1")),
+            (b".second: 1", "First.second", "", None),
+            (b"*third: 1", "First.second.third", "", Some(b"1")),
+            (b"First*second: 1", "First.second", "", Some(b"1")),
+            (b"First*third: 1", "First.second.third", "", Some(b"1")),
+            (b"First*fourth: 1", "First.second.third.fourth", "", Some(b"1")),
+            (b"First*?.third: 1", "First.second.third", "", Some(b"1")),
+            (b"First: 1", "Second", "First", Some(b"1")),
+            (b"First.second: 1", "First.third", "first.second", Some(b"1")),
+            (b"First.second.third: 1", "First.third.third", "first.second.fourth", Some(b"1")),
+            (b"First*third*fifth: 1", "First.second.third.fourth.third.fifth", "", Some(b"1")),
+            (b"First: x\\\ny", "First", "", Some(b"xy")),
+            (b"! First: x", "First", "", None),
+            (b"# First: x", "First", "", None),
+            (b"First:", "First", "", Some(b"")),
+            (b"First: ", "First", "", Some(b"")),
+            (b"First: \t ", "First", "", Some(b"")),
+
+            // Consecutive bindings
+            (b"*.bar: 1", "foo.foo.bar", "", Some(b"1")),
+            (b"...bar: 1", "foo.bar", "", None),
+            (b"...bar: 1", "foo.foo.foo.bar", "", None),
+            (b"***bar: 1", "foo.bar", "", Some(b"1")),
+            (b".*.bar: 1", "foo.bar", "", Some(b"1")),
+            (b".*.bar: 1", "foo.foo.bar", "", Some(b"1")),
+            (b"..*bar: 1", "foo.foo.foo.foo.bar", "", Some(b"1")),
+            (b"a.*.z: 1", "a.b.c.d.e.f.z", "", Some(b"1")),
+            (b"a...z: 1", "a.z", "", Some(b"1")),
+            (b"a...z: 1", "a.b.z", "", None),
+
+            // Matching among multiple entries
+            (b"First: 1\nSecond: 2\n", "First", "", Some(b"1")),
+            (b"First: 1\nSecond: 2\n", "Second", "", Some(b"2")),
+
+            // Greediness
+            (b"a*c.e: 1", "a.b.c.d.c.e", "", Some(b"1")),
+            (b"a*c.e: 1", "a.b.c.c.e", "", Some(b"1")),
+            (b"a*?.e: 1", "a.b.c.e", "", Some(b"1")),
+            (b"a*c*e: 1", "a.b.c.d.c.d.e.d.e", "", Some(b"1")),
+
+            // Precedence rules
+            // Rule 1
+            (b"First.second.third: 1\nFirst*third: 2\n", "First.second.third", "", Some(b"1")),
+            (b"First*third: 2\nFirst.second.third: 1\n", "First.second.third", "", Some(b"1")),
+            (b"First.second.third: 1\nFirst*third: 2\n", "x.x.x", "First.second.third", Some(b"1")),
+            (b"First*third: 2\nFirst.second.third: 1\n", "x.x.x", "First.second.third", Some(b"1")),
+
+            // Rule 2
+            (b"First.second: 1\nFirst.third: 2\n", "First.second", "First.third", Some(b"1")),
+            (b"First.third: 2\nFirst.second: 1\n", "First.second", "First.third", Some(b"1")),
+            (b"First.second.third: 1\nFirst.?.third: 2\n", "First.second.third", "", Some(b"1")),
+            (b"First.?.third: 2\nFirst.second.third: 1\n", "First.second.third", "", Some(b"1")),
+            (b"First.second.third: 1\nFirst.?.third: 2\n", "x.x.x", "First.second.third", Some(b"1")),
+            (b"First.?.third: 2\nFirst.second.third: 1\n", "x.x.x", "First.second.third", Some(b"1")),
+
+            // Rule 3
+            (b"First.second: 1\nFirst*second: 2\n", "First.second", "", Some(b"1")),
+            (b"First*second: 2\nFirst.second: 1\n", "First.second", "", Some(b"1")),
+
+            // Some real world examples. May contain duplicates to the above tests.
+
+            // From the specification:
+            // https://tronche.com/gui/x/xlib/resource-manager/matching-rules.html
+            (b"xmh*Paned*activeForeground: red\n\
+              *incorporate.Foreground: blue\n\
+              xmh.toc*Command*activeForeground: green\n\
+              xmh.toc*?.Foreground: white\n\
+              xmh.toc*Command.activeForeground: black",
+              "xmh.toc.messagefunctions.incorporate.activeForeground", "Xmh.Paned.Box.Command.Foreground", Some(b"black")),
+            (b"urxvt*background: [95]#000", "urxvt.background", "", Some(b"[95]#000")),
+            (b"urxvt*scrollBar_right:true", "urxvt.scrollBar_right", "", Some(b"true")),
+            (b"urxvt*cutchars:    '\"'()*<>[]{|}", "urxvt.cutchars", "", Some(b"'\"'()*<>[]{|}")),
+            (b"urxvt.keysym.Control-Shift-Up: perl:font:increment", "urxvt.keysym.Control-Shift-Up", "", Some(b"perl:font:increment")),
+            (b"rofi.normal: #000000, #000000, #000000, #000000", "rofi.normal", "", Some(b"#000000, #000000, #000000, #000000")),
+        ];
+        for &(database, resource, class, result) in &tests {
+            let database = Database::new_from_data(database);
+            assert_eq!(result, match_entry(&database.entries, resource, class));
+        }
+    }
+}

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -576,7 +576,7 @@ mod test {
             ),
         ];
         let mut failures = 0;
-        for &(data, resource, class, expected) in &tests {
+        for &(data, resource, class, expected) in tests.iter() {
             let mut entries = Vec::new();
             parse_database(data, &mut entries, |_, _| unreachable!());
             let result = match_entry(&entries, resource, class);

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -196,7 +196,7 @@ fn compare_matches(match1: &[MatchKind], match2: &[MatchKind]) -> Ordering {
     use HowMatched::*;
     use MatchKind::*;
 
-    assert_eq!(match1.len(), match2.len(), "Both matches should have the same length TODO: This is incorrect thanks to instance/class, I think");
+    assert_eq!(match1.len(), match2.len(), "Both matches should have the same length (which is guaranteed by the current implementation of check_match())");
     for (m1, m2) in match1.iter().zip(match2.iter()) {
         match (m1, m2) {
             // Precedence rule #1: Matching components (including wildcard '?') outweighs loose bindings ('*')
@@ -346,6 +346,8 @@ mod test {
 
             // Own tests
             (b"*foo.bar: 1", "bar", "", None),
+            (b"First.Second.Third: 1\nFirst.Second: 2", "First.Second.Third", "First.Second", Some(b"1")),
+            (b"First.Second.Third: 1\nFirst.Second: 2", "First.Second", "First.Second.Third", Some(b"1")),
         ];
         let mut failures = 0;
         for &(data, resource, class, expected) in &tests {

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use super::{Binding, Component, Entry};
-use super::parser::parse_resource;
+use super::parser::parse_query;
 
 pub(crate) struct ZipLongest<A, B> {
     a: A,
@@ -220,8 +220,8 @@ fn compare_matches(match1: &[MatchKind], match2: &[MatchKind]) -> Ordering {
 }
 
 pub(crate) fn match_entry<'a>(database: &'a [Entry], resource: &str, class: &str) -> Option<&'a [u8]> {
-    let resource = parse_resource(resource.as_bytes())?;
-    let class = parse_resource(class.as_bytes())?;
+    let resource = parse_query(resource.as_bytes())?;
+    let class = parse_query(class.as_bytes())?;
     database.iter()
         // Filter for entries that match the query (and record some info on how they match)
         .flat_map(|entry| {

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -14,9 +14,9 @@ mod test {
 
     #[test]
     fn test_matches() {
-        let tests: [(&[u8], _, _, Option<&[u8]>); 68] = [
+        let tests = [
             // Non-matches / Errors
-            (b"", "", "", None),
+            (&b""[..], "", "", None),
 
             // Xlib returns the match here, despite the query violating the specs.
             (b"First.second: 1", "First.second", "First.second.third", None),
@@ -30,7 +30,7 @@ mod test {
             (b"First: 1", "", "first", None),
 
             // Duplicate entries
-            (b"First: 1\nFirst: 2\nFirst: 3\n", "First", "", Some(b"3")),
+            (b"First: 1\nFirst: 2\nFirst: 3\n", "First", "", Some(&b"3"[..])),
             (b"First: 1\nSecond: 2\nSecond: 3\nThird: 4\n", "Second", "", Some(b"3")),
 
             /* Basic matching */

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -16,7 +16,7 @@ mod zip_longest {
     pub(super) fn zip_longest<'a, T>(
         a: &'a [T],
         b: &'a [T],
-    ) -> impl Iterator<Item=(Option<&'a T>, Option<&'a T>)> + 'a {
+    ) -> impl Iterator<Item = (Option<&'a T>, Option<&'a T>)> + 'a {
         ZipLongest {
             a: a.iter(),
             b: b.iter(),
@@ -240,17 +240,36 @@ fn compare_matches(match1: &[MatchKind], match2: &[MatchKind]) -> Ordering {
 
     fn rule2(match1: &MatchKind, match2: &MatchKind) -> Ordering {
         // Precedence rule #2a: Matching instance outweighs both matching class and wildcard
-        if let Matched(MatchComponent { how_matched: Instance, .. }) = match1 {
-            if let Matched(MatchComponent { how_matched: Class, .. }) = match2 {
+        if let Matched(MatchComponent {
+            how_matched: Instance,
+            preceding_binding: _,
+        }) = match1
+        {
+            if let Matched(MatchComponent {
+                how_matched: Class,
+                preceding_binding: _,
+            }) = match2
+            {
                 return Ordering::Greater;
             }
-            if let Matched(MatchComponent { how_matched: Wildcard, .. }) = match2 {
+            if let Matched(MatchComponent {
+                how_matched: Wildcard,
+                ..
+            }) = match2
+            {
                 return Ordering::Greater;
             }
         }
         // Precedence rule #2b: Matching class outweighs wildcard
-        if let Matched(MatchComponent { how_matched: Class, .. }) = match1 {
-            if let Matched(MatchComponent { how_matched: Wildcard, .. }) = match2 {
+        if let Matched(MatchComponent {
+            how_matched: Class, ..
+        }) = match1
+        {
+            if let Matched(MatchComponent {
+                how_matched: Wildcard,
+                ..
+            }) = match2
+            {
                 return Ordering::Greater;
             }
         }
@@ -259,8 +278,16 @@ fn compare_matches(match1: &[MatchKind], match2: &[MatchKind]) -> Ordering {
 
     fn rule3(match1: &MatchKind, match2: &MatchKind) -> Ordering {
         // Precedence rule #3: A preceding exact match outweights a preceding '*'
-        if let Matched(MatchComponent { preceding_binding: Tight, .. }) = match1 {
-            if let Matched(MatchComponent { preceding_binding: Loose, .. }) = match2 {
+        if let Matched(MatchComponent {
+            preceding_binding: Tight,
+            ..
+        }) = match1
+        {
+            if let Matched(MatchComponent {
+                preceding_binding: Loose,
+                ..
+            }) = match2
+            {
                 return Ordering::Greater;
             }
         }
@@ -299,7 +326,6 @@ pub(crate) fn match_entry<'a>(
                 .into_iter()
                 .max_by(|match1, match2| compare_matches(match1, match2));
             best_match.map(|m| (entry, m))
-
         })
         .max_by(|(_, match1), (_, match2)| compare_matches(match1, match2))
         .map(|(entry, _)| &entry.value[..])

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -88,10 +88,6 @@ fn check_match(entry: &Entry, resource: &[String], class: &[String]) -> bool {
     // component in the entry (index + 1). When we have a loose binding, we can accept
     // the current component by staying in the same state (index).
     let mut indicies = vec![0];
-    if let Some((Binding::Loose, _)) = entry.components.get(0) {
-        // First binding is loose, so we could "start anywhere" with the match
-        indicies.extend(1..entry.components.len());
-    }
     // Go through the components and match them
     for (resource, class) in zip_longest(resource, class) {
         let mut next_indicies = Vec::new();
@@ -240,6 +236,9 @@ mod test {
             (b"urxvt*cutchars:    '\"'()*<>[]{|}", "urxvt.cutchars", "", Some(b"'\"'()*<>[]{|}")),
             (b"urxvt.keysym.Control-Shift-Up: perl:font:increment", "urxvt.keysym.Control-Shift-Up", "", Some(b"perl:font:increment")),
             (b"rofi.normal: #000000, #000000, #000000, #000000", "rofi.normal", "", Some(b"#000000, #000000, #000000, #000000")),
+
+            // Own tests
+            (b"*foo.bar: 1", "bar", "", None),
         ];
         let mut failures = 0;
         for &(data, resource, class, expected) in &tests {

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -13,32 +13,11 @@ mod test {
     // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_match.c
 
     #[test]
-    fn test_non_match() {
-        // Non-matches / Errors
-        let tests = [
-            (b"", "", ""),
-        ];
-        let mut success = true;
-        for &(data, resource, class) in &tests {
-            let mut entries = Vec::new();
-            let database = parse_database(data, &mut entries, |_, _| unreachable!());
-            let result = match_entry(&entries, resource, class);
-            if !result.is_none() {
-                eprintln!("While testing {}", print_string(data));
-                eprintln!("Expected: None");
-                eprintln!("Got:      {:?}", result.map(print_string));
-                eprintln!();
-                success = false;
-            }
-        }
-        if !success {
-            panic!()
-        }
-    }
-
-    #[test]
     fn test_matches() {
-        let tests: [(&[u8], _, _, Option<&[u8]>); 67] = [
+        let tests: [(&[u8], _, _, Option<&[u8]>); 68] = [
+            // Non-matches / Errors
+            (b"", "", "", None),
+
             // Xlib returns the match here, despite the query violating the specs.
             (b"First.second: 1", "First.second", "First.second.third", None),
             (b"", "First.second", "", None),

--- a/src/resource_manager/matcher.rs
+++ b/src/resource_manager/matcher.rs
@@ -1,7 +1,56 @@
 use super::{Binding, Component, Entry};
+use super::parser::parse_resource;
 
-fn match_entry<'a>(database: &'a [Entry], resource: &str, class: &str) -> Option<&'a [u8]> {
-    todo!()
+pub(crate) fn match_entry<'a>(database: &'a [Entry], resource: &str, class: &str) -> Option<&'a [u8]> {
+    let resource = parse_resource(resource.as_bytes())?;
+    let class = parse_resource(class.as_bytes())?;
+    if class.is_empty() {
+        database.iter()
+            .filter(|entry| {
+                // The idea is to check if a nondeterministic finite automaton accepts a given
+                // word. We have a set of current states (indicies). This describes where in the
+                // entry we are while trying to match. When we have a match, we go to the next
+                // component in the entry (index + 1). When we have a loose binding, we can accept
+                // the current component by staying in the same state (index).
+                let mut indicies = vec![0];
+                if let Some((Binding::Loose, _)) = entry.components.get(0) {
+                    // First binding is loose, so we could "start anywhere" with the match
+                    indicies.extend(1..entry.components.len());
+                }
+                // Go through the components and match them
+                for component in resource.iter() {
+                    let mut next_indicies = Vec::new();
+                    for index in indicies {
+                        if index == entry.components.len() {
+                            // We are at the end of the entry and thus cannot continue this match
+                            continue;
+                        }
+                        match entry.components[index].0 {
+                            // We have to match here, no way around that.
+                            Binding::Tight => {}
+                            // We could "eat" this with the loose binding by staying in the state
+                            Binding::Loose => next_indicies.push(index)
+                        }
+                        // Does the component match?
+                        let matches = match entry.components[index].1 {
+                            Component::Wildcard => true,
+                            Component::Normal(ref s) => s == component,
+                        };
+                        if matches {
+                            // Yes, the component matches and we go to the next state
+                            next_indicies.push(index + 1);
+                        }
+                    }
+                    indicies = next_indicies;
+                }
+                // We have a match if we reached the end of the components
+                indicies.contains(&entry.components.len())
+            })
+            .last()
+            .map(|entry| &entry.value[..])
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -1,0 +1,106 @@
+//! X11 resource manager library.
+//!
+//! The code in this module is only available when the `resource_manager` feature of the library is
+//! enabled.
+
+#![allow(missing_docs)] // FIXME remove this
+
+use crate::connection::Connection;
+use crate::errors::ReplyError;
+
+mod parser;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Binding {
+    Tight,
+    Loose,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Component {
+    Normal(String), // Actually just a-z, A-Z, 0-9 and _ or - is allowed
+    Wildcard,
+}
+
+#[derive(Debug, Clone)]
+struct Entry {
+    components: Vec<(Binding, Component)>,
+    value: Vec<u8>,
+}
+
+/// A resource database.
+#[derive(Debug, Default, Clone)]
+pub struct Database {
+    entries: Vec<Entry>,
+}
+
+impl Database {
+    pub fn new_from_default(conn: impl Connection) -> Result<Self, ReplyError> {
+        let _ = conn;
+        todo!()
+    }
+
+    pub fn new_from_resource_manager_property(conn: impl Connection) -> Result<Self, ReplyError> {
+        let _ = conn;
+        todo!()
+    }
+
+    pub fn new_from_data(data: &[u8]) -> Self {
+        let _ = data;
+        todo!()
+    }
+
+    pub fn new_from_file(todo: ()) -> Self {
+        // I think it would be better to replace this with "from reader"? Or remove it completely?
+        let _ = todo;
+        todo!()
+    }
+
+    pub fn to_string(&self) -> String {
+        let _ = self;
+        todo!()
+    }
+
+    pub fn combine(&self, target: &mut Self, overwrite: bool) {
+        let _ = (target, overwrite);
+        todo!()
+    }
+
+    pub fn put_resource(&mut self, resource: &str, value: &[u8]) {
+        let _ = (resource, value);
+        todo!()
+    }
+
+    pub fn put_resource_line(&mut self, line: &[u8]) {
+        let _ = line;
+        todo!()
+    }
+
+    pub fn get_bytes(&self, resource_name: &str, resource_class: &str) -> &[u8] {
+        let _ = (resource_name, resource_class);
+        todo!()
+    }
+
+    pub fn get_string(&self, resource_name: &str, resource_class: &str) -> &str {
+        let _ = (resource_name, resource_class);
+        todo!()
+    }
+
+    pub fn get_bool(&self, resource_name: &str, resource_class: &str) -> bool {
+        let _ = (resource_name, resource_class);
+        todo!()
+    }
+
+    pub fn get_value<T>(&self, resource_name: &str, resource_class: &str) -> Result<T, T::Err>
+        where T: std::str::FromStr
+    {
+        let _ = (resource_name, resource_class);
+        T::from_str(self.get_string(resource_name, resource_class))
+    }
+}
+
+// API: [u8] or str?
+// It seems that the value is "a bunch of bytes" (with one extra rule - no zero bytes, but
+// everything else is possible via escape sequences). The resource itself is less than ascii.
+
+// TODO: Add an API so that no file I/O is done

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -286,7 +286,7 @@ impl Database {
         resource_class: &str,
     ) -> Result<Option<T>, T::Err>
     where
-         T: FromStr,
+        T: FromStr,
     {
         self.get_string(resource_name, resource_class)
             .map(T::from_str)

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -23,7 +23,7 @@ enum Component {
     Wildcard,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct Entry {
     components: Vec<(Binding, Component)>,
     value: Vec<u8>,

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -47,6 +47,8 @@ pub(crate) struct Entry {
 }
 
 /// A X11 resource database.
+///
+/// The recommended way to load a database is through [`Database::new_from_default`].
 #[derive(Debug, Default, Clone)]
 pub struct Database {
     entries: Vec<Entry>,
@@ -222,7 +224,8 @@ impl Database {
     /// ```
     /// use x11rb::resource_manager::Database;
     /// fn get_print_attributes(db: &Database) -> u8 {
-    ///     db.get_value("XTerm.vt100.printAttributes", "XTerm.VT100.PrintAttributes").ok().flatten().unwrap_or(1)
+    ///     db.get_value("XTerm.vt100.printAttributes", "XTerm.VT100.PrintAttributes")
+    ///             .ok().flatten().unwrap_or(1)
     /// }
     /// ```
     /// If no value is found, `Ok(None)` is returned. Otherwise, the result from

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -9,6 +9,7 @@ use crate::connection::Connection;
 use crate::errors::ReplyError;
 
 mod parser;
+mod matcher;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Binding {

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -44,7 +44,7 @@ pub struct Database {
 }
 
 impl Database {
-    pub fn new_from_default(conn: impl Connection) -> Result<Self, ReplyError> {
+    pub fn new_from_default(conn: &impl Connection) -> Result<Self, ReplyError> {
         let cur_dir = Path::new(".");
 
         // 1. Try to load the RESOURCE_MANAGER property
@@ -100,7 +100,7 @@ impl Database {
         Ok(Self { entries })
     }
 
-    pub fn new_from_resource_manager(conn: impl Connection) -> Result<Option<Self>, ReplyError> {
+    pub fn new_from_resource_manager(conn: &impl Connection) -> Result<Option<Self>, ReplyError> {
         let max_length = 100_000_000; // This is what Xlib does, so it must be correct (tm)
         let window = conn.setup().roots[0].root;
         let property = conn.

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -24,7 +24,7 @@ enum Component {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-struct Entry {
+pub(crate) struct Entry {
     components: Vec<(Binding, Component)>,
     value: Vec<u8>,
 }

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -604,7 +604,7 @@ mod test {
             (b"First: 1\n!Foo", vec![expected_entry.clone()]),
             (b"!First: 1\nbar\n\n\n", Vec::new()),
             (b"!bar\nFirst: 1\nbaz", vec![expected_entry.clone()]),
-            (b"First :\\\n \\\n\\\n1\n", vec![expected_entry.clone()]),
+            (b"First :\\\n \\\n\\\n1\n", vec![expected_entry]),
             (
                 b"First: \\\n  1\\\n2\n",
                 vec![Entry {

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -8,7 +8,7 @@ fn is_octal_digit(c: u8) -> bool {
 }
 
 fn allowed_in_quark_name(c: u8) -> bool {
-    c.is_ascii_alphanumeric() || c == b'-' && c == b'_'
+    c.is_ascii_alphanumeric() || c == b'-' || c == b'_'
 }
 
 fn parse_with_matcher<M>(data: &[u8], matcher: M) -> (&[u8], &[u8])
@@ -266,6 +266,14 @@ mod test {
                 "second".to_string(),
             ]),
             (b"", Vec::new()),
+            (b"urxvt.scrollBar_right",  vec![
+                "urxvt".to_string(),
+                "scrollBar_right".to_string(),
+            ]),
+            (b"urxvt.Control-Shift-Up",  vec![
+                "urxvt".to_string(),
+                "Control-Shift-Up".to_string(),
+            ]),
         ];
         for (data, expected) in tests.iter() {
             let result = parse_resource(*data);

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -185,7 +185,7 @@ fn parse_entry(data: &[u8]) -> (Result<Entry, ()>, &[u8]) {
 mod test {
     use super::{Binding, Component, parse_entry, parse_resource};
 
-    // The tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
+    // Most tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
     // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_parser.c
 
     #[test]

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -261,10 +261,11 @@ mod test {
     #[test]
     fn test_parse_resource_success() {
         let tests = [
-            (b"First.second", vec![
+            (&b"First.second"[..], vec![
                 "First".to_string(),
                 "second".to_string(),
             ]),
+            (b"", Vec::new()),
         ];
         for (data, expected) in tests.iter() {
             let result = parse_resource(*data);
@@ -274,8 +275,8 @@ mod test {
 
     #[test]
     fn test_parse_resource_error() {
-        let tests: [&[u8]; 5] = [
-            b"First.second: on",
+        let tests = [
+            &b"First.second: on"[..],
             b"First*second",
             b"First.?.second",
             b"*second",
@@ -291,12 +292,12 @@ mod test {
 
     #[test]
     fn test_parse_entry_success() {
-        let tests: [(&[u8], _, &[u8]); 37] = [
+        let tests = [
             // Basics
             (
-                b"First: 1",
+                &b"First: 1"[..],
                 vec![(Binding::Tight, Component::Normal("First".to_string()))],
-                b"1",
+                &b"1"[..],
             ),
             (
                 b"First.second: 1",
@@ -517,8 +518,8 @@ mod test {
 
     #[test]
     fn test_parse_entry_error() {
-        let tests: [&[u8]; 7] = [
-            b": 1",
+        let tests = [
+            &b": 1"[..],
             b"?: 1",
             b"First",
             b"First second",
@@ -565,9 +566,9 @@ mod test {
             components: vec![(Binding::Tight, Component::Normal("First".to_string()))],
             value: b"1".to_vec(),
         };
-        let tests: [(&[u8], _); 6] = [
+        let tests = [
             (
-                b"First: 1\n\n\n",
+                &b"First: 1\n\n\n"[..],
                 vec![expected_entry.clone()],
             ),
             (
@@ -613,8 +614,8 @@ mod test {
 
     #[test]
     fn test_include() {
-        let tests: [(&[u8], _); 8] = [
-            (b"#include\"test\"", vec![&b"test"[..]]),
+        let tests = [
+            (&b"#include\"test\""[..], vec![&b"test"[..]]),
             (b"#  include   \" test \"   \n#include  \"foo\"", vec![b" test ", b"foo"]),
             (b"#include\"test", Vec::new()),
             (b"#include\"", Vec::new()),

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -1,0 +1,320 @@
+use super::{Binding, Component, Entry};
+
+type Resource = Vec<(Binding, Component)>;
+
+#[derive(Debug)]
+enum Error {
+    Error,
+}
+
+fn parse_resource(data: &[u8]) -> Result<(Resource, &[u8]), Error> {
+    let _ = data;
+    todo!()
+}
+
+fn parse_value(data: &[u8]) -> Result<(Entry, &[u8]), Error> {
+    let _ = data;
+    todo!()
+}
+
+fn parse_entry(data: &[u8]) -> Result<(Entry, &[u8]), Error> {
+    let (resource, data) = parse_resource(data)?;
+    // Now... something about expecting a ':'  and then skipping ' '  and '\t'  until the value
+    // begins.
+    // Afterwards:
+    let value = parse_value(data);
+    let _ = (resource, value);
+    todo!()
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Binding, Component, parse_entry, parse_resource};
+
+    // The tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
+    // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_parser.c
+
+    #[test]
+    fn test_parse_resource_success() {
+        let tests = [
+            (b"First.second", vec![
+                (Binding::Tight, Component::Normal("First".to_string())),
+                (Binding::Tight, Component::Normal("second".to_string())),
+            ]),
+        ];
+        for (data, expected) in tests.iter() {
+            match parse_resource(*data) {
+                Ok((result, remaining)) => {
+                    assert_eq!(remaining, b"");
+                    assert_eq!(result, *expected);
+                }
+                Err(err) => panic!("Failed to parse '{:?}': {:?}", data, err)
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_resource_error() {
+        let tests: [&[u8]; 5] = [
+            b"First.second: on",
+            b"First*second",
+            b"First.?.second",
+            b"*second",
+            b"?.second",
+        ];
+        for data in tests.iter() {
+            match parse_resource(*data) {
+                Ok(v) => panic!("Unexpected success parsing '{:?}': {:?}", data, v),
+                Err(_) => {},
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_entry_success() {
+        let tests: [(&[u8], _, &[u8]); 31] = [
+            // Basics
+            (
+                b"First: 1",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"1",
+            ),
+            (
+                b"First.second: 1",
+                vec![
+                    (Binding::Tight, Component::Normal("First".to_string())),
+                    (Binding::Tight, Component::Normal("second".to_string())),
+                ],
+                b"1",
+            ),
+            (
+                b"First..second: 1",
+                vec![
+                    (Binding::Tight, Component::Normal("First".to_string())),
+                    (Binding::Tight, Component::Normal("second".to_string())),
+                ],
+                b"1",
+            ),
+            // Wildcards
+            (
+                b"?.second: 1",
+                vec![
+                    (Binding::Tight, Component::Wildcard),
+                    (Binding::Tight, Component::Normal("second".to_string())),
+                ],
+                b"1",
+            ),
+            (
+                b"First.?.third: 1",
+                vec![
+                    (Binding::Tight, Component::Normal("First".to_string())),
+                    (Binding::Tight, Component::Wildcard),
+                    (Binding::Tight, Component::Normal("third".to_string())),
+                ],
+                b"1",
+            ),
+            // Loose bindings
+            (
+                b"*second: 1",
+                vec![(Binding::Loose, Component::Normal("second".to_string()))],
+                b"1",
+            ),
+            (
+                b"First*third: 1",
+                vec![
+                    (Binding::Tight, Component::Normal("First".to_string())),
+                    (Binding::Loose, Component::Normal("third".to_string())),
+                ],
+                b"1",
+            ),
+            (
+                b"First**third: 1",
+                vec![
+                    (Binding::Tight, Component::Normal("First".to_string())),
+                    (Binding::Loose, Component::Normal("third".to_string())),
+                ],
+                b"1",
+            ),
+            // Combinations
+            (
+                b"First*?.fourth: 1",
+                vec![
+                    (Binding::Tight, Component::Normal("First".to_string())),
+                    (Binding::Loose, Component::Wildcard),
+                    (Binding::Tight, Component::Normal("fourth".to_string())),
+                ],
+                b"1",
+            ),
+            // Values
+            (
+                b"First: 1337",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"1337",
+            ),
+            (
+                b"First: -1337",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"-1337"
+            ),
+            (
+                b"First: 13.37",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"13.37",
+            ),
+            (
+                b"First: value",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"value",
+            ),
+            (
+                b"First: #abcdef",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"#abcdef",
+            ),
+            (
+                b"First: { key: 'value' }",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"{ key: 'value' }",
+            ),
+            (
+                b"First: x?y",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x?y",
+            ),
+            (
+                b"First: x*y",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x*y",
+            ),
+            // Whitespace
+            (
+                b"First:    x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x",
+            ),
+            (
+                b"First: x   ",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x   ",
+            ),
+            (
+                b"First:    x   ",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x   ",
+            ),
+            (
+                b"First:x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x",
+            ),
+            (
+                b"First: \t x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x",
+            ),
+            (
+                b"First: \t x \t",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x \t",
+            ),
+            // Special characters
+            (
+                b"First: \\ x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b" x",
+            ),
+            (
+                b"First: x\\ x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x x",
+            ),
+            (
+                b"First: \\\tx",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\tx",
+            ),
+            (
+                b"First: \\011x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\tx",
+            ),
+            (
+                b"First: x\\\\x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x\\x",
+            ),
+            (
+                b"First: x\\nx",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"x\nx",
+            ),
+            (
+                b"First: \\080",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\\080",
+            ),
+            (
+                b"First: \\00a",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\\00a",
+            ),
+        ];
+        for (data, resource, value) in tests.iter() {
+            run_entry_test(data, resource, value);
+        }
+    }
+
+    #[test]
+    fn test_parse_entry_error() {
+        let tests: [&[u8]; 7] = [
+            b": 1",
+            b"?: 1",
+            b"First",
+            b"First second",
+            b"First.?: 1",
+            b"F\xc3\xb6rst: 1",
+            b"F~rst: 1",
+        ];
+        for data in tests.iter() {
+            match parse_entry(*data) {
+                Ok(v) => panic!("Unexpected success parsing '{:?}': {:?}", data, v),
+                Err(_) => {},
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_large_value() {
+        let value = vec![b'x'; 1025];
+        let mut data = b"First: ".to_vec();
+        data.extend(&value);
+        let resource = (Binding::Tight, Component::Normal("First".to_string()));
+        run_entry_test(&data, &[resource], &value);
+    }
+
+    #[test]
+    fn test_parse_large_resource() {
+        let x = vec![b'x'; 1025];
+        let y = vec![b'y'; 1025];
+        let mut data = x.clone();
+        data.push(b'.');
+        data.extend(&y);
+        data.extend(b": 1");
+        let resource = [
+            (Binding::Tight, Component::Normal(String::from_utf8(x).unwrap())),
+            (Binding::Tight, Component::Normal(String::from_utf8(y).unwrap())),
+        ];
+        run_entry_test(&data, &resource, b"1");
+    }
+
+    fn run_entry_test(data: &[u8], resource: &[(Binding, Component)], value: &[u8]) {
+        match parse_entry(data) {
+            Ok((result, remaining)) => {
+                assert_eq!(remaining, b"");
+                assert_eq!(result.components, resource);
+                assert_eq!(result.value, value);
+            }
+            Err(err) => panic!("Failed to parse '{:?}': {:?}", data, err)
+        }
+    }
+}

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -621,7 +621,7 @@ mod test {
     }
 
     #[test]
-    fn test_include() {
+    fn test_include_parsing() {
         let tests = [
             (&b"#include\"test\""[..], vec![&b"test"[..]]),
             (b"#  include   \" test \"   \n#include  \"foo\"", vec![b" test ", b"foo"]),
@@ -648,6 +648,20 @@ mod test {
         if !success {
             panic!()
         }
+    }
+
+    #[test]
+    fn test_include_additions() {
+        let entry = Entry {
+            components: Vec::new(),
+            value: b"42".to_vec(),
+        };
+        let mut result = Vec::new();
+        parse_database(b"#include\"test\"", &mut result, |file, result| {
+            assert_eq!(file, b"test");
+            result.push(entry.clone());
+        });
+        assert_eq!(result, [entry]);
     }
 
     fn run_entry_test(data: &[u8], resource: &[(Binding, Component)], value: &[u8]) {

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -185,6 +185,7 @@ fn parse_entry(data: &[u8]) -> (Result<Entry, ()>, &[u8]) {
                 Some(b'\t') => value.push(b'\t'),
                 Some(b'n') => value.push(b'\n'),
                 Some(b'\\') => value.push(b'\\'),
+                Some(b'\n') => { /* Continue parsing next line */ },
                 Some(&x) if is_octal_digit(x) => octal = Some((x, None)),
                 Some(&x) => {
                     value.push(b);
@@ -561,7 +562,7 @@ mod test {
             components: vec![(Binding::Tight, Component::Normal("First".to_string()))],
             value: b"1".to_vec(),
         };
-        let tests: [(&[u8], _); 5] = [
+        let tests: [(&[u8], _); 6] = [
             (
                 b"First: 1\n\n\n",
                 vec![expected_entry.clone()],
@@ -581,6 +582,13 @@ mod test {
             (
                 b"First :\\\n \\\n\\\n1\n",
                 vec![expected_entry.clone()],
+            ),
+            (
+                b"First: \\\n  1\\\n2\n",
+                vec![Entry {
+                    components: vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                    value: b"12".to_vec(),
+                }],
             ),
         ];
         let mut success = true;

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -598,7 +598,7 @@ mod test {
         let mut success = true;
         for (data, expected) in tests.iter() {
             let mut result = Vec::new();
-            let database = parse_database(data, &mut result, |_, _| unreachable!());
+            parse_database(data, &mut result, |_, _| unreachable!());
             if &result != expected {
                 eprintln!("While testing {:?}", data);
                 eprintln!("Expected: {:?}", expected);

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -203,7 +203,7 @@ fn parse_entry(data: &[u8]) -> (Result<Entry, ()>, &[u8]) {
     (Ok(entry), &data[index..])
 }
 
-fn parse_database<F>(mut data: &[u8], result: &mut Vec<Entry>, mut include_callback: F)
+pub(crate) fn parse_database<F>(mut data: &[u8], result: &mut Vec<Entry>, mut include_callback: F)
 where
     for<'r> F: FnMut(&'r [u8], &mut Vec<Entry>)
 {

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -223,7 +223,7 @@ mod test {
 
     #[test]
     fn test_parse_entry_success() {
-        let tests: [(&[u8], _, &[u8]); 31] = [
+        let tests: [(&[u8], _, &[u8]); 37] = [
             // Basics
             (
                 b"First: 1",
@@ -408,6 +408,38 @@ mod test {
                 b"First: \\00a",
                 vec![(Binding::Tight, Component::Normal("First".to_string()))],
                 b"\\00a",
+            ),
+            // Own tests
+            // Some more escape tests, e.g. escape at end of input
+            (
+                b"First: \\",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\\",
+            ),
+            (
+                b"First: \\xxx",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\\xxx",
+            ),
+            (
+                b"First: \\1xx",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\\1xx",
+            ),
+            (
+                b"First: \\10x",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\\10x",
+            ),
+            (
+                b"First: \\100",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"@",
+            ),
+            (
+                b"First: \\n",
+                vec![(Binding::Tight, Component::Normal("First".to_string()))],
+                b"\n",
             ),
         ];
         for (data, resource, value) in tests.iter() {

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -279,16 +279,16 @@ mod test {
         let tests = [
             (
                 &b"First.second"[..],
-                vec!["First".to_string(), "second".to_string()]
+                vec!["First".to_string(), "second".to_string()],
             ),
             (b"", Vec::new()),
             (
                 b"urxvt.scrollBar_right",
-                vec!["urxvt".to_string(), "scrollBar_right".to_string()]
+                vec!["urxvt".to_string(), "scrollBar_right".to_string()],
             ),
             (
                 b"urxvt.Control-Shift-Up",
-                vec!["urxvt".to_string(), "Control-Shift-Up".to_string()]
+                vec!["urxvt".to_string(), "Control-Shift-Up".to_string()],
             ),
         ];
         for (data, expected) in tests.iter() {
@@ -682,14 +682,12 @@ mod test {
             (Ok(result), remaining) => {
                 assert_eq!(remaining, b"", "failed to parse {:?}", data);
                 assert_eq!(
-                    result.components,
-                    resource,
+                    result.components, resource,
                     "incorrect components when parsing {:?}",
                     data
                 );
                 assert_eq!(
-                    result.value,
-                    value,
+                    result.value, value,
                     "incorrect value when parsing {:?}",
                     data
                 );

--- a/tests/resource_manager.rs
+++ b/tests/resource_manager.rs
@@ -162,7 +162,7 @@ mod test {
         where
             R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
         {
-            todo!()
+            unimplemented!()
         }
 
         fn send_request_without_reply(
@@ -170,22 +170,22 @@ mod test {
             _: &[IoSlice<'_>],
             _: Vec<RawFdContainer>,
         ) -> Result<VoidCookie<'_, Self>, ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn discard_reply(&self, _: SequenceNumber, _: RequestKind, _: DiscardMode) {
-            todo!()
+            unimplemented!()
         }
 
         fn prefetch_extension_information(&self, _: &'static str) -> Result<(), ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn extension_information(
             &self,
             _: &'static str,
         ) -> Result<Option<ExtensionInformation>, ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn wait_for_reply_or_raw_error(
@@ -218,37 +218,37 @@ mod test {
         }
 
         fn wait_for_reply(&self, _: SequenceNumber) -> Result<Option<Self::Buf>, ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn wait_for_reply_with_fds_raw(
             &self,
             _: SequenceNumber,
         ) -> Result<ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>, ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn check_for_raw_error(
             &self,
             _: SequenceNumber,
         ) -> Result<Option<Self::Buf>, ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn prefetch_maximum_request_bytes(&self) {
-            todo!()
+            unimplemented!()
         }
 
         fn maximum_request_bytes(&self) -> usize {
-            todo!()
+            unimplemented!()
         }
 
         fn parse_error(&self, _: &[u8]) -> Result<X11Error, ParseError> {
-            todo!()
+            unimplemented!()
         }
 
         fn parse_event(&self, _: &[u8]) -> Result<Event, ParseError> {
-            todo!()
+            unimplemented!()
         }
     }
 
@@ -256,17 +256,17 @@ mod test {
         fn wait_for_raw_event_with_sequence(
             &self,
         ) -> Result<RawEventAndSeqNumber<Self::Buf>, ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn poll_for_raw_event_with_sequence(
             &self,
         ) -> Result<Option<RawEventAndSeqNumber<Self::Buf>>, ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn flush(&self) -> Result<(), ConnectionError> {
-            todo!()
+            unimplemented!()
         }
 
         fn setup(&self) -> &Setup {
@@ -274,7 +274,7 @@ mod test {
         }
 
         fn generate_id(&self) -> Result<u32, ReplyOrIdError> {
-            todo!()
+            unimplemented!()
         }
     }
 }

--- a/tests/resource_manager.rs
+++ b/tests/resource_manager.rs
@@ -1,0 +1,285 @@
+#[cfg(feature = "resource_manager")]
+mod test {
+    use std::convert::TryFrom;
+    use std::fs;
+    use std::io::IoSlice;
+    use std::path::{Path, PathBuf};
+
+    use x11rb::connection::{
+        BufWithFds, Connection, DiscardMode, RawEventAndSeqNumber, ReplyOrError, RequestConnection,
+        RequestKind, SequenceNumber,
+    };
+    use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
+    use x11rb::errors::{ConnectionError, ParseError, ReplyOrIdError};
+    use x11rb::protocol::xproto::{Screen, Setup};
+    use x11rb::protocol::Event;
+    use x11rb::resource_manager::Database;
+    use x11rb::utils::RawFdContainer;
+    use x11rb::x11_utils::{ExtensionInformation, Serialize, TryParse, X11Error};
+
+    // Most tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
+    // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_database.c
+
+    /// Get the path to the `target` directory for the current build.
+    ///
+    /// This is inspired by cargo:
+    /// https://github.com/rust-lang/cargo/blob/7302186d7beb2b11bf7366c0aa66269313ebe18f/crates/cargo-test-support/src/paths.rs#L18-L31
+    fn get_temporary_dir(unique_name: &str) -> PathBuf {
+        let mut path = std::env::current_exe().unwrap();
+        while path.file_name().and_then(|n| n.to_str()) != Some("target") {
+            path.pop();
+        }
+        path.push("test_data");
+        path.push(unique_name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn write_file(base: impl AsRef<Path>, path: impl AsRef<Path>, content: &[u8]) -> PathBuf {
+        let mut file_path = PathBuf::from(base.as_ref());
+        file_path.push(path.as_ref());
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(&parent).unwrap();
+        }
+        fs::write(&file_path, content).unwrap();
+        file_path
+    }
+
+    fn database_from_file(file: impl AsRef<Path>) -> Database {
+        // I decided against adding something like this to the API...
+        let file = file.as_ref();
+        let mut include = Vec::new();
+        include.extend(b"#include \"");
+        include.extend(file.file_name().unwrap().to_str().unwrap().bytes());
+        include.extend(b"\"\n");
+        Database::new_from_data_with_base_directory(&include, file.parent().unwrap())
+    }
+
+    fn check_db(db: &Database, queries: &[(&str, &[u8])]) {
+        let mut errors = 0;
+        for (query, expected) in queries {
+            let result = db.get_bytes(query, "");
+            if result != Some(expected) {
+                eprintln!(
+                    "Queried database for \"{}\" and expected {:?}, but got {:?}",
+                    query, expected, result
+                );
+                errors += 1;
+            }
+        }
+        if errors != 0 {
+            panic!("Had {} errors", errors);
+        }
+    }
+
+    #[test]
+    fn relative_include() {
+        let dir = get_temporary_dir("relative_include");
+        let file = write_file(
+            &dir,
+            "Xresources1",
+            b"First: 1\n\n#include \"xresources2\"\n",
+        );
+        write_file(
+            &dir,
+            "xresources2",
+            b"#include \"sub/xresources3\"\nSecond: 2\n",
+        );
+        write_file(
+            &dir,
+            "sub/xresources3",
+            b"Third: 3\n",
+        );
+
+        let db = database_from_file(file);
+        check_db(&db, &[("First", b"1"), ("Second", b"2"), ("Third", b"3")]);
+    }
+
+    #[test]
+    fn include_loop() {
+        let dir = get_temporary_dir("include_loop");
+        let file = write_file(
+            &dir,
+            "loop.xresources",
+            b"First: 1\n! Provoke an endless chain of self-inclusion\n#include \"loop.xresources\"\nSecond: 2\n",
+        );
+        let db = database_from_file(file);
+        check_db(&db, &[("First", b"1")]);
+    }
+
+    #[test]
+    fn home_resolution() {
+        let mut dir = get_temporary_dir("home_resolution");
+        write_file(&dir, ".Xresources", b"First: 1\n");
+        write_file(&dir, "xenvironment", b"Second: 2\n");
+
+        std::env::set_var("HOME", &dir);
+
+        dir.push("xenvironment");
+        std::env::set_var("XENVIRONMENT", dir);
+
+        let conn = mock_connection(None);
+
+        let db = Database::new_from_default(&conn).unwrap();
+        check_db(&db, &[("First", b"1"), ("Second", b"2")]);
+    }
+
+    #[test]
+    fn from_resource_manager() {
+        let conn = mock_connection(Some(b"First: 1\n*Second: 2\n"));
+        let db = Database::new_from_default(&conn).unwrap();
+        check_db(&db, &[("First", b"1"), ("Second", b"2")]);
+    }
+
+    /// Create a mock connection that produces the given answer for queries of the RESOURCE_MANAGER
+    /// property.
+    fn mock_connection(resource_manager: Option<&[u8]>) -> impl Connection {
+        // Ugly way to get a default screen: Parse enough zero bytes
+        let screen = Screen::try_parse(&[0; 100]).unwrap().0;
+        let mut setup = Setup::try_parse(&[0; 100]).unwrap().0;
+        setup.roots.push(screen);
+
+        MockConnection(setup, resource_manager.map(|v| v.to_vec()))
+    }
+
+    struct MockConnection(Setup, Option<Vec<u8>>);
+
+    impl RequestConnection for MockConnection {
+        type Buf = Vec<u8>;
+
+        fn send_request_with_reply<R>(
+            &self,
+            _: &[IoSlice<'_>],
+            _: Vec<RawFdContainer>,
+        ) -> Result<Cookie<'_, Self, R>, ConnectionError>
+        where
+            R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
+        {
+            Ok(Cookie::new(self, 42))
+        }
+
+        fn send_request_with_reply_with_fds<R>(
+            &self,
+            _: &[IoSlice<'_>],
+            _: Vec<RawFdContainer>,
+        ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
+        where
+            R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
+        {
+            todo!()
+        }
+
+        fn send_request_without_reply(
+            &self,
+            _: &[IoSlice<'_>],
+            _: Vec<RawFdContainer>,
+        ) -> Result<VoidCookie<'_, Self>, ConnectionError> {
+            todo!()
+        }
+
+        fn discard_reply(&self, _: SequenceNumber, _: RequestKind, _: DiscardMode) {
+            todo!()
+        }
+
+        fn prefetch_extension_information(&self, _: &'static str) -> Result<(), ConnectionError> {
+            todo!()
+        }
+
+        fn extension_information(
+            &self,
+            _: &'static str,
+        ) -> Result<Option<ExtensionInformation>, ConnectionError> {
+            todo!()
+        }
+
+        fn wait_for_reply_or_raw_error(
+            &self,
+            sequence: SequenceNumber,
+        ) -> Result<ReplyOrError<Self::Buf>, ConnectionError> {
+            let value = self.1.as_ref().map(|v| &v[..]).unwrap_or(&[]);
+            let mut reply = Vec::new();
+            // response type
+            reply.push(1);
+            // format
+            if value.is_empty() {
+                reply.push(0);
+            } else {
+                reply.push(8);
+            }
+            // sequence
+            (sequence as u16).serialize_into(&mut reply);
+            // length
+            0u32.serialize_into(&mut reply);
+            // type (STRING)
+            31u32.serialize_into(&mut reply);
+            // bytes_after
+            0u32.serialize_into(&mut reply);
+            (value.len() as u32).serialize_into(&mut reply);
+            // padding
+            reply.extend([0; 12].iter().copied());
+            reply.extend(value);
+            Ok(ReplyOrError::Reply(reply))
+        }
+
+        fn wait_for_reply(&self, _: SequenceNumber) -> Result<Option<Self::Buf>, ConnectionError> {
+            todo!()
+        }
+
+        fn wait_for_reply_with_fds_raw(
+            &self,
+            _: SequenceNumber,
+        ) -> Result<ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>, ConnectionError>
+        {
+            todo!()
+        }
+
+        fn check_for_raw_error(
+            &self,
+            _: SequenceNumber,
+        ) -> Result<Option<Self::Buf>, ConnectionError> {
+            todo!()
+        }
+
+        fn prefetch_maximum_request_bytes(&self) {
+            todo!()
+        }
+
+        fn maximum_request_bytes(&self) -> usize {
+            todo!()
+        }
+
+        fn parse_error(&self, _: &[u8]) -> Result<X11Error, ParseError> {
+            todo!()
+        }
+
+        fn parse_event(&self, _: &[u8]) -> Result<Event, ParseError> {
+            todo!()
+        }
+    }
+
+    impl Connection for MockConnection {
+        fn wait_for_raw_event_with_sequence(
+            &self,
+        ) -> Result<RawEventAndSeqNumber<Self::Buf>, ConnectionError> {
+            todo!()
+        }
+
+        fn poll_for_raw_event_with_sequence(
+            &self,
+        ) -> Result<Option<RawEventAndSeqNumber<Self::Buf>>, ConnectionError> {
+            todo!()
+        }
+
+        fn flush(&self) -> Result<(), ConnectionError> {
+            todo!()
+        }
+
+        fn setup(&self) -> &Setup {
+            &self.0
+        }
+
+        fn generate_id(&self) -> Result<u32, ReplyOrIdError> {
+            todo!()
+        }
+    }
+}

--- a/tests/resource_manager.rs
+++ b/tests/resource_manager.rs
@@ -85,11 +85,7 @@ mod test {
             "xresources2",
             b"#include \"sub/xresources3\"\nSecond: 2\n",
         );
-        write_file(
-            &dir,
-            "sub/xresources3",
-            b"Third: 3\n",
-        );
+        write_file(&dir, "sub/xresources3", b"Third: 3\n");
 
         let db = database_from_file(file);
         check_db(&db, &[("First", b"1"), ("Second", b"2"), ("Third", b"3")]);
@@ -228,8 +224,7 @@ mod test {
         fn wait_for_reply_with_fds_raw(
             &self,
             _: SequenceNumber,
-        ) -> Result<ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>, ConnectionError>
-        {
+        ) -> Result<ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>, ConnectionError> {
             todo!()
         }
 


### PR DESCRIPTION
Closes: #551 

-----

Hey @Airblader, thank you very much for writing xcb-util-xrm. Before writing this, I had basically no idea about Xrm (although at the time I thought differently) and all I know is from reading the source code. I tried looking at Xlib's source, but... yeah... no. I also pretty much stole all your test cases and came up with almost none of my own.

Are you okay with this or do you see a problem?
(And if you know Rust and have too much time at your hands (which I doubt): What do you think of this implementation?)

(I worked similarly when writing the cursor support in this library, but cursors make so much more sense than Xrm...)

------

Boy, this was more work than I expected. The result also kind of speaks for itself:
```
 Cargo.toml                      |   6 +-
 src/lib.rs                      |   5 +
 src/resource_manager/matcher.rs | 605 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 src/resource_manager/mod.rs     | 392 ++++++++++++++++++++++++++++++++++++++++++++++++
 src/resource_manager/parser.rs  | 698 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 tests/resource_manager.rs       | 285 +++++++++++++++++++++++++++++++++++
 6 files changed, 1990 insertions(+), 1 deletion(-)
```
I bet that there are behavioural differences between this an Xlib / xcb-util-xrm. I also bet that no one will ever notice.

There are definitely internal differences. This code does not try to de-duplicate database entries. The matching algorithm is completely different and does not use recursion, but instead does something similar to the "usual algorithm" for checking if a nondeterministic finite automaton accepts a word. The unit tests claim that my algorithm works...

This PR contains the "raw" commits that I did in the last two weeks on this branch. I did not try to clean up the history, but I am not sure if this really matters.

Anyway, this is definitely enough to query `Xft.dpi`, which is the use case for which I started this.

This code saw exactly zero testing besides what is in this PR. YMMV.

Oh and: I left out some of the API that Xlib / xcb-util-xrm provides, but that does not seem to be used much. For example, this cannot serialise a database into a String, there is no support for combining two databases, there is no API for appending entries to a database, ....

Edit: Yay, CI rustfmt and local rustfmt disagree about how the code should look like. :-(