### PR TITLE
Disable clippy beta on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,8 @@ jobs:
        matrix:
          include:
            - rust: stable
-           - rust: beta
+           #fixme: beta was disabled due to the false positive from https://github.com/rust-lang/rust/issues/79498
+           #- rust: beta
              #fixme: remove this hack
              clippy_args: -A clippy::manual_strip
      steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
       - status-success=big-endian-test
       - status-success=build (1.40.0)
       - status-success=build (stable)
-      - status-success=clippy-rustfmt (stable)
+      - status-success=clippy-rustfmt (stable, -A clippy::manual_strip)
       - status-success=code_gen
     actions:
       merge:


### PR DESCRIPTION
[0] triggers a false-positive that prevents progress. Since I have no
good idea what to do about that, my bad idea is to just disable this
part of CI:

[0]: https://github.com/psychon/x11rb/pull/561
[1]: https://github.com/rust-lang/rust/issues/79498

Signed-off-by: Uli Schlachter <psychon@znc.in>