### PR TITLE
cursor: Use the new resource_manager feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ features = ["winsock2"]
 allow-unsafe-code = ["libc"]
 
 # Enable utility functions in `x11rb::cursor` for loading mouse cursors.
-cursor = ["render"]
+cursor = ["render", "resource_manager"]
 
 # Enable utility functions in `x11rb::image` for working with image data.
 image = []
@@ -128,7 +128,7 @@ required-features = ["shape"]
 
 [[example]]
 name = "simple_window"
-required-features = ["cursor"]
+required-features = ["cursor", "resource_manager"]
 
 [[example]]
 name = "display_ppm"

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -4,6 +4,7 @@ use x11rb::connection::Connection;
 use x11rb::cursor::Handle as CursorHandle;
 use x11rb::protocol::xproto::*;
 use x11rb::protocol::Event;
+use x11rb::resource_manager::Database;
 use x11rb::wrapper::ConnectionExt as _;
 
 fn main() {
@@ -16,7 +17,8 @@ fn main() {
     let screen = &conn.setup().roots[screen_num];
     let win_id = conn.generate_id().unwrap();
     let gc_id = conn.generate_id().unwrap();
-    let cursor_handle = CursorHandle::new(conn, screen_num).unwrap();
+    let resource_db = Database::new_from_default(conn).unwrap();
+    let cursor_handle = CursorHandle::new(conn, screen_num, &resource_db).unwrap();
 
     let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS").unwrap();
     let wm_delete_window = conn.intern_atom(false, b"WM_DELETE_WINDOW").unwrap();


### PR DESCRIPTION
The cursor code contains a half-working hack to get some values out of
the resource database. This commit removes that hack and instead makes
the cursor depend on the resource_manager feature that we now have. The
public API is changed accordingly.

Signed-off-by: Uli Schlachter <psychon@znc.in>