### PR TITLE
Revert "Disable clippy beta on CI"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,8 +31,7 @@ jobs:
        matrix:
          include:
            - rust: stable
-           #fixme: beta was disabled due to the false positive from https://github.com/rust-lang/rust/issues/79498
-           #- rust: beta
+           - rust: beta
              #fixme: remove this hack
              clippy_args: -A clippy::manual_strip
      steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
       - status-success=big-endian-test
       - status-success=build (1.40.0)
       - status-success=build (stable)
-      - status-success=clippy-rustfmt (stable, -A clippy::manual_strip)
+      - status-success=clippy-rustfmt (stable)
       - status-success=code_gen
     actions:
       merge:


### PR DESCRIPTION
This reverts commit 2f1b9b0dd34d1bd857efef8186855e56d69adccc.

The latest beta should no longer have this issue.

Edit: Fixes #563