### PR TITLE
Tiny documentation fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,14 @@ xv = ["shm"]
 xvmc = ["xv"]
 
 [package.metadata.docs.rs]
-features = [ "all-extensions", "allow-unsafe-code", "cursor", "image", "resource_manager" ]
+features = [
+    "all-extensions",
+    "allow-unsafe-code",
+    "cursor",
+    "dl-libxcb",
+    "image",
+    "resource_manager",
+]
 
 [[example]]
 name = "generic_events"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
 //! * `image`: Enable the code in [x11rb::image] for working with pixel image data.
 //! * `dl-libxcb`: Enabling this feature will prevent from libxcb being linked to the
 //!   resulting executable. Instead libxcb will be dynamically loaded at runtime.
-//!   This feature adds the `x11rb::xcb_ffi::load_libxcb` function, that allows load
+//!   This feature adds the `x11rb::xcb_ffi::load_libxcb` function, that allows to load
 //!   libxcb and check for success or failure.
 //!
 //! # Integrating x11rb with an Event Loop


### PR DESCRIPTION
A typo is fixed and the `dl-libxcb` feature is included for docs.rs.