### PR TITLE
Add a helper for handling ConfigureRequestEvent

### DIFF
--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -306,19 +306,10 @@ impl<'a, C: Connection> WMState<'a, C> {
             let _ = state;
             unimplemented!();
         }
-        let mut aux = ConfigureWindowAux::default();
-        if event.value_mask & u16::from(ConfigWindow::X) != 0 {
-            aux = aux.x(i32::from(event.x));
-        }
-        if event.value_mask & u16::from(ConfigWindow::Y) != 0 {
-            aux = aux.y(i32::from(event.y));
-        }
-        if event.value_mask & u16::from(ConfigWindow::WIDTH) != 0 {
-            aux = aux.width(u32::from(event.width));
-        }
-        if event.value_mask & u16::from(ConfigWindow::HEIGHT) != 0 {
-            aux = aux.height(u32::from(event.height));
-        }
+        // Allow clients to change everything, except sibling / stack mode
+        let aux = ConfigureWindowAux::from_configure_request(&event)
+            .sibling(None)
+            .stack_mode(None);
         println!("Configure: {:?}", aux);
         self.conn.configure_window(event.window, &aux)?;
         Ok(())

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -896,6 +896,8 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             outln!(out, "}}");
         }
 
+        special_cases::handle_request_switch(request_def, switch_field, &aux_name, out);
+
         outln!(out, "");
     }
 

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -8047,6 +8047,38 @@ impl ConfigureWindowAux {
         self
     }
 }
+impl ConfigureWindowAux {
+    /// Construct from a [`ConfigureRequestEvent`].
+    ///
+    /// This function construct a new `ConfigureWindowAux` instance by accepting all requested
+    /// changes from a `ConfigureRequestEvent`. This function is useful for window managers that want
+    /// to handle `ConfigureRequestEvent`s.
+    pub fn from_configure_request(event: &ConfigureRequestEvent) -> Self {
+        let mut result = Self::new();
+        if event.value_mask & u16::from(ConfigWindow::X) != 0 {
+            result = result.x(i32::from(event.x));
+        }
+        if event.value_mask & u16::from(ConfigWindow::Y) != 0 {
+            result = result.y(i32::from(event.y));
+        }
+        if event.value_mask & u16::from(ConfigWindow::WIDTH) != 0 {
+            result = result.width(u32::from(event.width));
+        }
+        if event.value_mask & u16::from(ConfigWindow::HEIGHT) != 0 {
+            result = result.height(u32::from(event.height));
+        }
+        if event.value_mask & u16::from(ConfigWindow::BORDER_WIDTH) != 0 {
+            result = result.border_width(u32::from(event.border_width));
+        }
+        if event.value_mask & u16::from(ConfigWindow::SIBLING) != 0 {
+            result = result.sibling(event.sibling);
+        }
+        if event.value_mask & u16::from(ConfigWindow::STACK_MODE) != 0 {
+            result = result.stack_mode(event.stack_mode);
+        }
+        result
+    }
+}
 
 /// Opcode for the ConfigureWindow request
 pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;


### PR DESCRIPTION
First commit's commit message:

This commit adds a new constructor to ConfigureWindowAux that constructs it from a ConfigureRequestEvent.
