### PR TITLE
Improve error docs... and make some of the generated code a bit more readable

### DIFF
--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -543,7 +543,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(out, "#[allow(unused_imports)]");
         outln!(
             out,
-            "use crate::x11_utils::{{Request, RequestHeader, Serialize, TryParse, TryParseFd}};"
+            "use crate::x11_utils::{{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize}};"
         );
         outln!(
             out,
@@ -4056,7 +4056,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         outln!(
                             out,
                             "let ({}, remaining) = crate::x11_utils::parse_u8_list({}, \
-                             {}.try_into().or(Err(ParseError::ConversionFailed))?)?;",
+                             {}.try_to_usize()?)?;",
                             rust_field_name,
                             from,
                             self.expr_to_str(
@@ -4098,7 +4098,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     outln!(
                         out,
                         "let ({}, remaining) = crate::x11_utils::parse_list::<{}>(remaining, \
-                         {}.try_into().or(Err(ParseError::ConversionFailed))?)?;",
+                         {}.try_to_usize()?)?;",
                         rust_field_name,
                         rust_element_type,
                         self.expr_to_str(

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -4132,7 +4132,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         outln!(
                             out,
                             "let list_length = \
-                             usize::try_from({}).or(Err(ParseError::ConversionFailed))?;",
+                             {}.try_to_usize()?;",
                             self.expr_to_str(
                                 length_expr,
                                 to_rust_variable_name,
@@ -4198,7 +4198,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
                 outln!(
                     out,
-                    "let fds_len = usize::try_from({}).or(Err(ParseError::ConversionFailed))?;",
+                    "let fds_len = {}.try_to_usize()?;",
                     self.expr_to_str(
                         &fd_list_field.length_expr,
                         to_rust_variable_name,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,14 +62,26 @@ pub enum ParseError {
 
     /// A value was outside of its valid range.
     ///
-    /// When parsing the value of an enumeration, not all possible integer values have a defined
-    /// meaning. This error occurs when an invalid value is encountered in this context.
+    /// There are two kinds of situations where this error can happen:
     ///
-    /// For example, `xproto` has an enumeration `Place` with possible values `OnTop` (0) and
-    /// `OnBottom` (1). Any value other than 0 or 1 generates an `InvalidValue` when parsing.
+    /// 1. The protocol was violated and a nonsensical value was found.
+    /// 2. The user of the API called the wrong parsing function.
+    ///
+    /// Examples for the first kind of error:
+    ///
+    /// - One of a set of values should be present (a `<switch>` in xcb-proto-speal), but none of
+    ///   the `<cases>` matched. This can e.g. happen when parsing
+    ///   [`x11rb::protocol::xinput::InputInfo`].
+    /// - Parsing a request with a length field that is too small for the request header to fit.
+    ///
+    /// Examples for the second kind of error:
+    ///
+    /// - Parsing an X11 error with `response_type != 0`.
+    /// - Parsing an X11 reply with `response_type != 1`.
+    /// - Parsing an X11 request with the wrong value for its `minor_opcode`.
     InvalidValue,
 
-    /// Some file descriptors were expected, but none were received.
+    /// Some file descriptors were expected, but not enough were received.
     MissingFileDescriptors,
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -102,7 +102,7 @@ pub enum ConnectError {
     ///
     /// One situation were this error is used when libxcb indicates an error that does not match
     /// any of the defined error conditions. Thus, libxcb is violating its own API (or new error
-    /// cases were defined, but are not yet handled by x11rb)
+    /// cases were defined, but are not yet handled by x11rb).
     UnknownError,
 
     /// Error while parsing some data, see `ParseError`.
@@ -115,10 +115,10 @@ pub enum ConnectError {
 
     /// Error during parsing of display string.
     ///
-    /// This is `XCB_CONN_CLOSSED_PARSE_ERR`.
+    /// This is `XCB_CONN_CLOSED_PARSE_ERR`.
     DisplayParsingError,
 
-    /// Server does not have a screen matcing the display.
+    /// Server does not have a screen matching the display.
     ///
     /// This is `XCB_CONN_CLOSED_INVALID_SCREEN`.
     InvalidScreen,
@@ -133,7 +133,7 @@ pub enum ConnectError {
 
     /// The server rejected the connection with a `SetupAuthenticate` message.
     SetupAuthenticate(SetupAuthenticate),
-    ///
+
     /// The server rejected the connection with a `SetupFailed` message.
     SetupFailed(SetupFailed),
 }
@@ -188,7 +188,7 @@ pub enum ConnectionError {
     ///
     /// One situation were this error is used when libxcb indicates an error that does not match
     /// any of the defined error conditions. Thus, libxcb is violating its own API (or new error
-    /// cases were defined, but are not yet handled by x11rb)
+    /// cases were defined, but are not yet handled by x11rb).
     UnknownError,
 
     /// An X11 extension was not supported by the server.
@@ -253,7 +253,7 @@ impl From<std::io::Error> for ConnectionError {
 pub enum ReplyError {
     /// Some error occurred on the X11 connection.
     ConnectionError(ConnectionError),
-    /// The X11 server sent an error in response to the request.
+    /// The X11 server sent an error in response to a request.
     X11Error(X11Error),
 }
 
@@ -299,7 +299,7 @@ pub enum ReplyOrIdError {
     IdsExhausted,
     /// Some error occurred on the X11 connection.
     ConnectionError(ConnectionError),
-    /// The X11 server sent an error in response to a XC-MISC request.
+    /// The X11 server sent an error in response to a request.
     X11Error(X11Error),
 }
 

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -509,11 +509,11 @@ impl TryParse for ConnectReply {
         let (driver_name_length, remaining) = u32::try_parse(remaining)?;
         let (device_name_length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
-        let (driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, driver_name_length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, driver_name_length.try_to_usize()?)?;
         let driver_name = driver_name.to_vec();
-        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (driver_name_length.checked_add(3u32).ok_or(ParseError::InvalidExpression)? & (!3u32)).checked_sub(driver_name_length).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (driver_name_length.checked_add(3u32).ok_or(ParseError::InvalidExpression)? & (!3u32)).checked_sub(driver_name_length).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let alignment_pad = alignment_pad.to_vec();
-        let (device_name, remaining) = crate::x11_utils::parse_u8_list(remaining, device_name_length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (device_name, remaining) = crate::x11_utils::parse_u8_list(remaining, device_name_length.try_to_usize()?)?;
         let device_name = device_name.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -911,7 +911,7 @@ impl TryParse for GetBuffersReply {
         let (height, remaining) = u32::try_parse(remaining)?;
         let (count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -1181,7 +1181,7 @@ impl TryParse for GetBuffersWithFormatReply {
         let (height, remaining) = u32::try_parse(remaining)?;
         let (count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (buffers, remaining) = crate::x11_utils::parse_list::<DRI2Buffer>(remaining, count.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -783,8 +783,8 @@ impl TryParse for GetSupportedModifiersReply {
         let (num_window_modifiers, remaining) = u32::try_parse(remaining)?;
         let (num_screen_modifiers, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
-        let (window_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_window_modifiers.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (screen_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_screen_modifiers.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (window_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_window_modifiers.try_to_usize()?)?;
+        let (screen_modifiers, remaining) = crate::x11_utils::parse_list::<u64>(remaining, num_screen_modifiers.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -1125,8 +1125,8 @@ impl TryParseFd for BuffersFromPixmapReply {
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (bpp, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(6..).ok_or(ParseError::InsufficientData)?;
-        let (strides, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (strides, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_to_usize()?)?;
+        let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_to_usize()?)?;
         let fds_len = usize::try_from(nfd).or(Err(ParseError::ConversionFailed))?;
         if fds.len() < fds_len { return Err(ParseError::MissingFileDescriptors) }
         let mut buffers = fds.split_off(fds_len);

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -980,7 +980,7 @@ impl PixmapFromBuffersRequest {
         let (bpp, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (modifier, remaining) = u64::try_parse(remaining)?;
-        let fds_len = usize::try_from(num_buffers).or(Err(ParseError::ConversionFailed))?;
+        let fds_len = num_buffers.try_to_usize()?;
         if fds.len() < fds_len { return Err(ParseError::MissingFileDescriptors) }
         let mut buffers = fds.split_off(fds_len);
         std::mem::swap(fds, &mut buffers);
@@ -1127,7 +1127,7 @@ impl TryParseFd for BuffersFromPixmapReply {
         let remaining = remaining.get(6..).ok_or(ParseError::InsufficientData)?;
         let (strides, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_to_usize()?)?;
         let (offsets, remaining) = crate::x11_utils::parse_list::<u32>(remaining, nfd.try_to_usize()?)?;
-        let fds_len = usize::try_from(nfd).or(Err(ParseError::ConversionFailed))?;
+        let fds_len = nfd.try_to_usize()?;
         if fds.len() < fds_len { return Err(ParseError::MissingFileDescriptors) }
         let mut buffers = fds.split_off(fds_len);
         std::mem::swap(fds, &mut buffers);

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1498,7 +1498,7 @@ impl TryParse for QueryPictFormatsReply {
         let (formats, remaining) = crate::x11_utils::parse_list::<Pictforminfo>(remaining, num_formats.try_to_usize()?)?;
         let (screens, remaining) = crate::x11_utils::parse_list::<Pictscreen>(remaining, num_screens.try_to_usize()?)?;
         let mut remaining = remaining;
-        let list_length = usize::try_from(num_subpixel).or(Err(ParseError::ConversionFailed))?;
+        let list_length = num_subpixel.try_to_usize()?;
         let mut subpixels = Vec::with_capacity(list_length);
         for _ in 0..list_length {
             let (v, new_remaining) = u32::try_parse(remaining)?;

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -1161,7 +1161,7 @@ impl TryParse for GetRectanglesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (rectangles_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, rectangles_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, rectangles_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -318,7 +318,7 @@ impl TryParse for Systemcounter {
         let (counter, remaining) = Counter::try_parse(remaining)?;
         let (resolution, remaining) = Int64::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -672,7 +672,7 @@ impl TryParse for ListSystemCountersReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (counters_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (counters, remaining) = crate::x11_utils::parse_list::<Systemcounter>(remaining, counters_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (counters, remaining) = crate::x11_utils::parse_list::<Systemcounter>(remaining, counters_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -304,7 +304,7 @@ impl TryParse for GetXIDListReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (ids_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (ids, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ids_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (ids, remaining) = crate::x11_utils::parse_list::<u32>(remaining, ids_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -353,7 +353,7 @@ impl TryParse for OpenConnectionReply {
         let (sarea_handle_high, remaining) = u32::try_parse(remaining)?;
         let (bus_id_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (bus_id, remaining) = crate::x11_utils::parse_u8_list(remaining, bus_id_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (bus_id, remaining) = crate::x11_utils::parse_u8_list(remaining, bus_id_len.try_to_usize()?)?;
         let bus_id = bus_id.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -538,7 +538,7 @@ impl TryParse for GetClientDriverNameReply {
         let (client_driver_patch_version, remaining) = u32::try_parse(remaining)?;
         let (client_driver_name_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
-        let (client_driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, client_driver_name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (client_driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, client_driver_name_len.try_to_usize()?)?;
         let client_driver_name = client_driver_name.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -1045,8 +1045,8 @@ impl TryParse for GetDrawableInfoReply {
         let (back_x, remaining) = i16::try_parse(remaining)?;
         let (back_y, remaining) = i16::try_parse(remaining)?;
         let (num_back_clip_rects, remaining) = u32::try_parse(remaining)?;
-        let (clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_clip_rects.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (back_clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_back_clip_rects.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_clip_rects.try_to_usize()?)?;
+        let (back_clip_rects, remaining) = crate::x11_utils::parse_list::<DrmClipRect>(remaining, num_back_clip_rects.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -1181,7 +1181,7 @@ impl TryParse for GetDeviceInfoReply {
         let (framebuffer_size, remaining) = u32::try_parse(remaining)?;
         let (framebuffer_stride, remaining) = u32::try_parse(remaining)?;
         let (device_private_size, remaining) = u32::try_parse(remaining)?;
-        let (device_private, remaining) = crate::x11_utils::parse_list::<u32>(remaining, device_private_size.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (device_private, remaining) = crate::x11_utils::parse_list::<u32>(remaining, device_private_size.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -647,7 +647,7 @@ impl TryParse for QueryScreensReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (number, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (screen_info, remaining) = crate::x11_utils::parse_list::<ScreenInfo>(remaining, number.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (screen_info, remaining) = crate::x11_utils::parse_list::<ScreenInfo>(remaining, number.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -2014,7 +2014,7 @@ impl TryParse for GetDeviceMotionEventsReply {
         let (device_mode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(18..).ok_or(ParseError::InsufficientData)?;
         let mut remaining = remaining;
-        let list_length = usize::try_from(num_events).or(Err(ParseError::ConversionFailed))?;
+        let list_length = num_events.try_to_usize()?;
         let mut events = Vec::with_capacity(list_length);
         for _ in 0..list_length {
             let (v, new_remaining) = DeviceTimeCoord::try_parse(remaining, num_axes)?;

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -2441,9 +2441,9 @@ pub struct CountedString16 {
 impl TryParse for CountedString16 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, length.try_to_usize()?)?;
         let string = string.to_vec();
-        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (u32::from(length).checked_add(5u32).ok_or(ParseError::InvalidExpression)? & (!3u32)).checked_sub(u32::from(length).checked_add(2u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (u32::from(length).checked_add(5u32).ok_or(ParseError::InvalidExpression)? & (!3u32)).checked_sub(u32::from(length).checked_add(2u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let alignment_pad = alignment_pad.to_vec();
         let result = CountedString16 { string, alignment_pad };
         Ok((result, remaining))
@@ -2561,8 +2561,8 @@ impl TryParse for KeyType {
         let (n_map_entries, remaining) = u8::try_parse(remaining)?;
         let (has_preserve, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (map, remaining) = crate::x11_utils::parse_list::<KTMapEntry>(remaining, n_map_entries.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (preserve, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, u32::from(has_preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (map, remaining) = crate::x11_utils::parse_list::<KTMapEntry>(remaining, n_map_entries.try_to_usize()?)?;
+        let (preserve, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, u32::from(has_preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let result = KeyType { mods_mask, mods_mods, mods_vmods, num_levels, has_preserve, map, preserve };
         Ok((result, remaining))
     }
@@ -2625,7 +2625,7 @@ impl TryParse for KeySymMap {
         let (group_info, remaining) = u8::try_parse(remaining)?;
         let (width, remaining) = u8::try_parse(remaining)?;
         let (n_syms, remaining) = u16::try_parse(remaining)?;
-        let (syms, remaining) = crate::x11_utils::parse_list::<xproto::Keysym>(remaining, n_syms.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (syms, remaining) = crate::x11_utils::parse_list::<xproto::Keysym>(remaining, n_syms.try_to_usize()?)?;
         let result = KeySymMap { kt_index, group_info, width, syms };
         Ok((result, remaining))
     }
@@ -3250,8 +3250,8 @@ impl TryParse for SetKeyType {
         let (n_map_entries, remaining) = u8::try_parse(remaining)?;
         let (preserve, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, n_map_entries.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (preserve_entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, u32::from(preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, n_map_entries.try_to_usize()?)?;
+        let (preserve_entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, u32::from(preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let result = SetKeyType { mask, real_mods, virtual_mods, num_levels, preserve, entries, preserve_entries };
         Ok((result, remaining))
     }
@@ -3312,7 +3312,7 @@ impl TryParse for Outline {
         let (n_points, remaining) = u8::try_parse(remaining)?;
         let (corner_radius, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (points, remaining) = crate::x11_utils::parse_list::<xproto::Point>(remaining, n_points.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (points, remaining) = crate::x11_utils::parse_list::<xproto::Point>(remaining, n_points.try_to_usize()?)?;
         let result = Outline { corner_radius, points };
         Ok((result, remaining))
     }
@@ -3369,7 +3369,7 @@ impl TryParse for Shape {
         let (primary_ndx, remaining) = u8::try_parse(remaining)?;
         let (approx_ndx, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (outlines, remaining) = crate::x11_utils::parse_list::<Outline>(remaining, n_outlines.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (outlines, remaining) = crate::x11_utils::parse_list::<Outline>(remaining, n_outlines.try_to_usize()?)?;
         let result = Shape { name, primary_ndx, approx_ndx, outlines };
         Ok((result, remaining))
     }
@@ -3516,7 +3516,7 @@ impl TryParse for OverlayRow {
         let (row_under, remaining) = u8::try_parse(remaining)?;
         let (n_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (keys, remaining) = crate::x11_utils::parse_list::<OverlayKey>(remaining, n_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (keys, remaining) = crate::x11_utils::parse_list::<OverlayKey>(remaining, n_keys.try_to_usize()?)?;
         let result = OverlayRow { row_under, keys };
         Ok((result, remaining))
     }
@@ -3569,7 +3569,7 @@ impl TryParse for Overlay {
         let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (n_rows, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
-        let (rows, remaining) = crate::x11_utils::parse_list::<OverlayRow>(remaining, n_rows.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (rows, remaining) = crate::x11_utils::parse_list::<OverlayRow>(remaining, n_rows.try_to_usize()?)?;
         let result = Overlay { name, rows };
         Ok((result, remaining))
     }
@@ -3626,7 +3626,7 @@ impl TryParse for Row {
         let (n_keys, remaining) = u8::try_parse(remaining)?;
         let (vertical, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (keys, remaining) = crate::x11_utils::parse_list::<Key>(remaining, n_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (keys, remaining) = crate::x11_utils::parse_list::<Key>(remaining, n_keys.try_to_usize()?)?;
         let result = Row { top, left, vertical, keys };
         Ok((result, remaining))
     }
@@ -3745,7 +3745,7 @@ impl TryParse for Listing {
         let value = remaining;
         let (flags, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, length.try_to_usize()?)?;
         let string = string.to_vec();
         // Align offset to multiple of 2
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -3812,8 +3812,8 @@ impl TryParse for DeviceLedInfo {
         let (maps_present, remaining) = u32::try_parse(remaining)?;
         let (phys_indicators, remaining) = u32::try_parse(remaining)?;
         let (state, remaining) = u32::try_parse(remaining)?;
-        let (names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, names_present.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, maps_present.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, names_present.count_ones().try_to_usize()?)?;
+        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, maps_present.count_ones().try_to_usize()?)?;
         let led_class = led_class.into();
         let result = DeviceLedInfo { led_class, led_id, names_present, maps_present, phys_indicators, state, names, maps };
         Ok((result, remaining))
@@ -7940,13 +7940,13 @@ pub struct GetMapMapBitcase3 {
 impl GetMapMapBitcase3 {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions.try_to_usize()?)?;
         let acts_rtrn_count = acts_rtrn_count.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (acts_rtrn_acts, remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (acts_rtrn_acts, remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions.try_to_usize()?)?;
         let result = GetMapMapBitcase3 { acts_rtrn_count, acts_rtrn_acts };
         Ok((result, remaining))
     }
@@ -7969,7 +7969,7 @@ impl GetMapMap {
         let mut outer_remaining = value;
         let types_rtrn = if switch_expr & u32::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
-            let (types_rtrn, remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (types_rtrn, remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(types_rtrn)
         } else {
@@ -7977,7 +7977,7 @@ impl GetMapMap {
         };
         let syms_rtrn = if switch_expr & u32::from(MapPart::KEY_SYMS) != 0 {
             let remaining = outer_remaining;
-            let (syms_rtrn, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (syms_rtrn, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(syms_rtrn)
         } else {
@@ -7992,7 +7992,7 @@ impl GetMapMap {
         };
         let behaviors_rtrn = if switch_expr & u32::from(MapPart::KEY_BEHAVIORS) != 0 {
             let remaining = outer_remaining;
-            let (behaviors_rtrn, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (behaviors_rtrn, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(behaviors_rtrn)
         } else {
@@ -8001,7 +8001,7 @@ impl GetMapMap {
         let vmods_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
             let vmods_rtrn = vmods_rtrn.to_vec();
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -8015,7 +8015,7 @@ impl GetMapMap {
         let explicit_rtrn = if switch_expr & u32::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (explicit_rtrn, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (explicit_rtrn, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_to_usize()?)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -8028,7 +8028,7 @@ impl GetMapMap {
         let modmap_rtrn = if switch_expr & u32::from(MapPart::MODIFIER_MAP) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (modmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (modmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_to_usize()?)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -8040,7 +8040,7 @@ impl GetMapMap {
         };
         let vmodmap_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
             let remaining = outer_remaining;
-            let (vmodmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (vmodmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(vmodmap_rtrn)
         } else {
@@ -8142,13 +8142,13 @@ pub struct SetMapAuxBitcase3 {
 impl SetMapAuxBitcase3 {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (actions_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (actions_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions.try_to_usize()?)?;
         let actions_count = actions_count.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions.try_to_usize()?)?;
         let result = SetMapAuxBitcase3 { actions_count, actions };
         Ok((result, remaining))
     }
@@ -8187,7 +8187,7 @@ impl SetMapAux {
         let mut outer_remaining = value;
         let types = if switch_expr & u32::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
-            let (types, remaining) = crate::x11_utils::parse_list::<SetKeyType>(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (types, remaining) = crate::x11_utils::parse_list::<SetKeyType>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(types)
         } else {
@@ -8195,7 +8195,7 @@ impl SetMapAux {
         };
         let syms = if switch_expr & u32::from(MapPart::KEY_SYMS) != 0 {
             let remaining = outer_remaining;
-            let (syms, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (syms, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(syms)
         } else {
@@ -8210,7 +8210,7 @@ impl SetMapAux {
         };
         let behaviors = if switch_expr & u32::from(MapPart::KEY_BEHAVIORS) != 0 {
             let remaining = outer_remaining;
-            let (behaviors, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (behaviors, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(behaviors)
         } else {
@@ -8219,7 +8219,7 @@ impl SetMapAux {
         let vmods = if switch_expr & u32::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (vmods, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (vmods, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
             let vmods = vmods.to_vec();
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -8232,7 +8232,7 @@ impl SetMapAux {
         };
         let explicit = if switch_expr & u32::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
             let remaining = outer_remaining;
-            let (explicit, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (explicit, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(explicit)
         } else {
@@ -8240,7 +8240,7 @@ impl SetMapAux {
         };
         let modmap = if switch_expr & u32::from(MapPart::MODIFIER_MAP) != 0 {
             let remaining = outer_remaining;
-            let (modmap, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (modmap, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(modmap)
         } else {
@@ -8248,7 +8248,7 @@ impl SetMapAux {
         };
         let vmodmap = if switch_expr & u32::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
             let remaining = outer_remaining;
-            let (vmodmap, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (vmodmap, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(vmodmap)
         } else {
@@ -8752,8 +8752,8 @@ impl TryParse for GetCompatMapReply {
         let (n_si_rtrn, remaining) = u16::try_parse(remaining)?;
         let (n_total_si, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
-        let (si_rtrn, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si_rtrn.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups_rtrn.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (si_rtrn, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si_rtrn.try_to_usize()?)?;
+        let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups_rtrn.count_ones().try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -8866,8 +8866,8 @@ impl<'input> SetCompatMapRequest<'input> {
         let (first_si, remaining) = u16::try_parse(remaining)?;
         let (n_si, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (si, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (group_maps, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (si, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si.try_to_usize()?)?;
+        let (group_maps, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups.count_ones().try_to_usize()?)?;
         let _ = remaining;
         Ok(SetCompatMapRequest {
             device_spec,
@@ -9108,7 +9108,7 @@ impl TryParse for GetIndicatorMapReply {
         let (real_indicators, remaining) = u32::try_parse(remaining)?;
         let (n_indicators, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(15..).ok_or(ParseError::InsufficientData)?;
-        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, which.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, which.count_ones().try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -9186,7 +9186,7 @@ impl<'input> SetIndicatorMapRequest<'input> {
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (which, remaining) = u32::try_parse(remaining)?;
-        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, which.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, which.count_ones().try_to_usize()?)?;
         let _ = remaining;
         Ok(SetIndicatorMapRequest {
             device_spec,
@@ -9632,13 +9632,13 @@ pub struct GetNamesValueListBitcase8 {
 impl GetNamesValueListBitcase8 {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types.try_to_usize()?)?;
         let n_levels_per_type = n_levels_per_type.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).ok_or(ParseError::InvalidExpression))?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let result = GetNamesValueListBitcase8 { n_levels_per_type, kt_level_names };
         Ok((result, remaining))
     }
@@ -9715,7 +9715,7 @@ impl GetNamesValueList {
         };
         let type_names = if switch_expr & u32::from(NameDetail::KEY_TYPE_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (type_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (type_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(type_names)
         } else {
@@ -9730,7 +9730,7 @@ impl GetNamesValueList {
         };
         let indicator_names = if switch_expr & u32::from(NameDetail::INDICATOR_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (indicator_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, indicators.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (indicator_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, indicators.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(indicator_names)
         } else {
@@ -9738,7 +9738,7 @@ impl GetNamesValueList {
         };
         let virtual_mod_names = if switch_expr & u32::from(NameDetail::VIRTUAL_MOD_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, virtual_mods.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, virtual_mods.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(virtual_mod_names)
         } else {
@@ -9746,7 +9746,7 @@ impl GetNamesValueList {
         };
         let groups = if switch_expr & u32::from(NameDetail::GROUP_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (groups, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, group_names.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (groups, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, group_names.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(groups)
         } else {
@@ -9754,7 +9754,7 @@ impl GetNamesValueList {
         };
         let key_names = if switch_expr & u32::from(NameDetail::KEY_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (key_names, remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (key_names, remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(key_names)
         } else {
@@ -9762,7 +9762,7 @@ impl GetNamesValueList {
         };
         let key_aliases = if switch_expr & u32::from(NameDetail::KEY_ALIASES) != 0 {
             let remaining = outer_remaining;
-            let (key_aliases, remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (key_aliases, remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(key_aliases)
         } else {
@@ -9770,7 +9770,7 @@ impl GetNamesValueList {
         };
         let radio_group_names = if switch_expr & u32::from(NameDetail::RG_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_radio_groups.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_radio_groups.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(radio_group_names)
         } else {
@@ -9845,13 +9845,13 @@ pub struct SetNamesAuxBitcase8 {
 impl SetNamesAuxBitcase8 {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types.try_to_usize()?)?;
         let n_levels_per_type = n_levels_per_type.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).ok_or(ParseError::InvalidExpression))?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let result = SetNamesAuxBitcase8 { n_levels_per_type, kt_level_names };
         Ok((result, remaining))
     }
@@ -9944,7 +9944,7 @@ impl SetNamesAux {
         };
         let type_names = if switch_expr & u32::from(NameDetail::KEY_TYPE_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (type_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (type_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(type_names)
         } else {
@@ -9959,7 +9959,7 @@ impl SetNamesAux {
         };
         let indicator_names = if switch_expr & u32::from(NameDetail::INDICATOR_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (indicator_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, indicators.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (indicator_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, indicators.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(indicator_names)
         } else {
@@ -9967,7 +9967,7 @@ impl SetNamesAux {
         };
         let virtual_mod_names = if switch_expr & u32::from(NameDetail::VIRTUAL_MOD_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, virtual_mods.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, virtual_mods.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(virtual_mod_names)
         } else {
@@ -9975,7 +9975,7 @@ impl SetNamesAux {
         };
         let groups = if switch_expr & u32::from(NameDetail::GROUP_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (groups, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, group_names.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (groups, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, group_names.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(groups)
         } else {
@@ -9983,7 +9983,7 @@ impl SetNamesAux {
         };
         let key_names = if switch_expr & u32::from(NameDetail::KEY_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (key_names, remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (key_names, remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(key_names)
         } else {
@@ -9991,7 +9991,7 @@ impl SetNamesAux {
         };
         let key_aliases = if switch_expr & u32::from(NameDetail::KEY_ALIASES) != 0 {
             let remaining = outer_remaining;
-            let (key_aliases, remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (key_aliases, remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(key_aliases)
         } else {
@@ -9999,7 +9999,7 @@ impl SetNamesAux {
         };
         let radio_group_names = if switch_expr & u32::from(NameDetail::RG_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_radio_groups.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_radio_groups.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(radio_group_names)
         } else {
@@ -10632,12 +10632,12 @@ impl TryParse for ListComponentsReply {
         let (n_geometries, remaining) = u16::try_parse(remaining)?;
         let (extra, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(10..).ok_or(ParseError::InsufficientData)?;
-        let (keymaps, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keymaps.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (keycodes, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keycodes.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (types, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (compat_maps, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_compat_maps.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (symbols, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_symbols.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (geometries, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_geometries.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (keymaps, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keymaps.try_to_usize()?)?;
+        let (keycodes, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_keycodes.try_to_usize()?)?;
+        let (types, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_types.try_to_usize()?)?;
+        let (compat_maps, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_compat_maps.try_to_usize()?)?;
+        let (symbols, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_symbols.try_to_usize()?)?;
+        let (geometries, remaining) = crate::x11_utils::parse_list::<Listing>(remaining, n_geometries.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -10832,13 +10832,13 @@ pub struct GetKbdByNameRepliesTypesMapBitcase3 {
 impl GetKbdByNameRepliesTypesMapBitcase3 {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (acts_rtrn_count, remaining) = crate::x11_utils::parse_u8_list(remaining, n_key_actions.try_to_usize()?)?;
         let acts_rtrn_count = acts_rtrn_count.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (acts_rtrn_acts, remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (acts_rtrn_acts, remaining) = crate::x11_utils::parse_list::<Action>(remaining, total_actions.try_to_usize()?)?;
         let result = GetKbdByNameRepliesTypesMapBitcase3 { acts_rtrn_count, acts_rtrn_acts };
         Ok((result, remaining))
     }
@@ -10861,7 +10861,7 @@ impl GetKbdByNameRepliesTypesMap {
         let mut outer_remaining = value;
         let types_rtrn = if switch_expr & u32::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
-            let (types_rtrn, remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (types_rtrn, remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(types_rtrn)
         } else {
@@ -10869,7 +10869,7 @@ impl GetKbdByNameRepliesTypesMap {
         };
         let syms_rtrn = if switch_expr & u32::from(MapPart::KEY_SYMS) != 0 {
             let remaining = outer_remaining;
-            let (syms_rtrn, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (syms_rtrn, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(syms_rtrn)
         } else {
@@ -10884,7 +10884,7 @@ impl GetKbdByNameRepliesTypesMap {
         };
         let behaviors_rtrn = if switch_expr & u32::from(MapPart::KEY_BEHAVIORS) != 0 {
             let remaining = outer_remaining;
-            let (behaviors_rtrn, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (behaviors_rtrn, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(behaviors_rtrn)
         } else {
@@ -10893,7 +10893,7 @@ impl GetKbdByNameRepliesTypesMap {
         let vmods_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
             let vmods_rtrn = vmods_rtrn.to_vec();
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -10907,7 +10907,7 @@ impl GetKbdByNameRepliesTypesMap {
         let explicit_rtrn = if switch_expr & u32::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (explicit_rtrn, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (explicit_rtrn, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_to_usize()?)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -10920,7 +10920,7 @@ impl GetKbdByNameRepliesTypesMap {
         let modmap_rtrn = if switch_expr & u32::from(MapPart::MODIFIER_MAP) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (modmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (modmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_to_usize()?)?;
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -10932,7 +10932,7 @@ impl GetKbdByNameRepliesTypesMap {
         };
         let vmodmap_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
             let remaining = outer_remaining;
-            let (vmodmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (vmodmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(vmodmap_rtrn)
         } else {
@@ -11043,8 +11043,8 @@ impl TryParse for GetKbdByNameRepliesCompatMap {
         let (n_si_rtrn, remaining) = u16::try_parse(remaining)?;
         let (n_total_si, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
-        let (si_rtrn, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si_rtrn.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups_rtrn.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (si_rtrn, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si_rtrn.try_to_usize()?)?;
+        let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups_rtrn.count_ones().try_to_usize()?)?;
         let result = GetKbdByNameRepliesCompatMap { compatmap_type, compat_device_id, compatmap_sequence, compatmap_length, groups_rtrn, first_si_rtrn, n_total_si, si_rtrn, group_rtrn };
         Ok((result, remaining))
     }
@@ -11090,7 +11090,7 @@ impl TryParse for GetKbdByNameRepliesIndicatorMaps {
         let (real_indicators, remaining) = u32::try_parse(remaining)?;
         let (n_indicators, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(15..).ok_or(ParseError::InsufficientData)?;
-        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, n_indicators.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (maps, remaining) = crate::x11_utils::parse_list::<IndicatorMap>(remaining, n_indicators.try_to_usize()?)?;
         let result = GetKbdByNameRepliesIndicatorMaps { indicatormap_type, indicator_device_id, indicatormap_sequence, indicatormap_length, which, real_indicators, maps };
         Ok((result, remaining))
     }
@@ -11124,13 +11124,13 @@ pub struct GetKbdByNameRepliesKeyNamesValueListBitcase8 {
 impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
-        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (n_levels_per_type, remaining) = crate::x11_utils::parse_u8_list(remaining, n_types.try_to_usize()?)?;
         let n_levels_per_type = n_levels_per_type.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).ok_or(ParseError::InvalidExpression))?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let result = GetKbdByNameRepliesKeyNamesValueListBitcase8 { n_levels_per_type, kt_level_names };
         Ok((result, remaining))
     }
@@ -11207,7 +11207,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         };
         let type_names = if switch_expr & u32::from(NameDetail::KEY_TYPE_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (type_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_types.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (type_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(type_names)
         } else {
@@ -11222,7 +11222,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         };
         let indicator_names = if switch_expr & u32::from(NameDetail::INDICATOR_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (indicator_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, indicators.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (indicator_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, indicators.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(indicator_names)
         } else {
@@ -11230,7 +11230,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         };
         let virtual_mod_names = if switch_expr & u32::from(NameDetail::VIRTUAL_MOD_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, virtual_mods.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (virtual_mod_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, virtual_mods.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(virtual_mod_names)
         } else {
@@ -11238,7 +11238,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         };
         let groups = if switch_expr & u32::from(NameDetail::GROUP_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (groups, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, group_names.count_ones().try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (groups, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, group_names.count_ones().try_to_usize()?)?;
             outer_remaining = remaining;
             Some(groups)
         } else {
@@ -11246,7 +11246,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         };
         let key_names = if switch_expr & u32::from(NameDetail::KEY_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (key_names, remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (key_names, remaining) = crate::x11_utils::parse_list::<KeyName>(remaining, n_keys.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(key_names)
         } else {
@@ -11254,7 +11254,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         };
         let key_aliases = if switch_expr & u32::from(NameDetail::KEY_ALIASES) != 0 {
             let remaining = outer_remaining;
-            let (key_aliases, remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (key_aliases, remaining) = crate::x11_utils::parse_list::<KeyAlias>(remaining, n_key_aliases.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(key_aliases)
         } else {
@@ -11262,7 +11262,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         };
         let radio_group_names = if switch_expr & u32::from(NameDetail::RG_NAMES) != 0 {
             let remaining = outer_remaining;
-            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_radio_groups.try_into().or(Err(ParseError::ConversionFailed))?)?;
+            let (radio_group_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_radio_groups.try_to_usize()?)?;
             outer_remaining = remaining;
             Some(radio_group_names)
         } else {
@@ -11621,14 +11621,14 @@ impl TryParse for GetDeviceInfoReply {
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (dev_type, remaining) = xproto::Atom::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (btn_actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, n_btns_rtrn.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (leds, remaining) = crate::x11_utils::parse_list::<DeviceLedInfo>(remaining, n_device_led_f_bs.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (btn_actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, n_btns_rtrn.try_to_usize()?)?;
+        let (leds, remaining) = crate::x11_utils::parse_list::<DeviceLedInfo>(remaining, n_device_led_f_bs.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -11757,8 +11757,8 @@ impl<'input> SetDeviceInfoRequest<'input> {
         let (n_btns, remaining) = u8::try_parse(remaining)?;
         let (change, remaining) = u16::try_parse(remaining)?;
         let (n_device_led_f_bs, remaining) = u16::try_parse(remaining)?;
-        let (btn_actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, n_btns.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (leds, remaining) = crate::x11_utils::parse_list::<DeviceLedInfo>(remaining, n_device_led_f_bs.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (btn_actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, n_btns.try_to_usize()?)?;
+        let (leds, remaining) = crate::x11_utils::parse_list::<DeviceLedInfo>(remaining, n_device_led_f_bs.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetDeviceInfoRequest {
             device_spec,
@@ -11877,7 +11877,7 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
         let (flags, remaining) = u32::try_parse(remaining)?;
         let (affect_ctrls, remaining) = u32::try_parse(remaining)?;
         let (ctrls, remaining) = u32::try_parse(remaining)?;
-        let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, msg_length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, msg_length.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetDebuggingFlagsRequest {
             affect_flags,

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -46,14 +46,14 @@ impl TryParse for Printer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
         let (name_len, remaining) = u32::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let name = name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
         let (desc_len, remaining) = u32::try_parse(remaining)?;
-        let (description, remaining) = crate::x11_utils::parse_u8_list(remaining, desc_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (description, remaining) = crate::x11_utils::parse_u8_list(remaining, desc_len.try_to_usize()?)?;
         let description = description.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -529,8 +529,8 @@ impl<'input> PrintGetPrinterListRequest<'input> {
         }
         let (printer_name_len, remaining) = u32::try_parse(value)?;
         let (locale_len, remaining) = u32::try_parse(remaining)?;
-        let (printer_name, remaining) = crate::x11_utils::parse_u8_list(remaining, printer_name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (locale, remaining) = crate::x11_utils::parse_u8_list(remaining, locale_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (printer_name, remaining) = crate::x11_utils::parse_u8_list(remaining, printer_name_len.try_to_usize()?)?;
+        let (locale, remaining) = crate::x11_utils::parse_u8_list(remaining, locale_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(PrintGetPrinterListRequest {
             printer_name: Cow::Borrowed(printer_name),
@@ -574,7 +574,7 @@ impl TryParse for PrintGetPrinterListReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (list_count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (printers, remaining) = crate::x11_utils::parse_list::<Printer>(remaining, list_count.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (printers, remaining) = crate::x11_utils::parse_list::<Printer>(remaining, list_count.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -727,8 +727,8 @@ impl<'input> CreateContextRequest<'input> {
         let (context_id, remaining) = u32::try_parse(value)?;
         let (printer_name_len, remaining) = u32::try_parse(remaining)?;
         let (locale_len, remaining) = u32::try_parse(remaining)?;
-        let (printer_name, remaining) = crate::x11_utils::parse_u8_list(remaining, printer_name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (locale, remaining) = crate::x11_utils::parse_u8_list(remaining, locale_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (printer_name, remaining) = crate::x11_utils::parse_u8_list(remaining, printer_name_len.try_to_usize()?)?;
+        let (locale, remaining) = crate::x11_utils::parse_u8_list(remaining, locale_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(CreateContextRequest {
             context_id,
@@ -1391,9 +1391,9 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
         let (len_data, remaining) = u32::try_parse(remaining)?;
         let (len_fmt, remaining) = u16::try_parse(remaining)?;
         let (len_options, remaining) = u16::try_parse(remaining)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, len_data.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (doc_format, remaining) = crate::x11_utils::parse_u8_list(remaining, len_fmt.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (options, remaining) = crate::x11_utils::parse_u8_list(remaining, len_options.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, len_data.try_to_usize()?)?;
+        let (doc_format, remaining) = crate::x11_utils::parse_u8_list(remaining, len_fmt.try_to_usize()?)?;
+        let (options, remaining) = crate::x11_utils::parse_u8_list(remaining, len_options.try_to_usize()?)?;
         let _ = remaining;
         Ok(PrintPutDocumentDataRequest {
             drawable,
@@ -1521,7 +1521,7 @@ impl TryParse for PrintGetDocumentDataReply {
         let (finished_flag, remaining) = u32::try_parse(remaining)?;
         let (data_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -1948,7 +1948,7 @@ impl TryParse for PrintGetAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (string_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (attributes, remaining) = crate::x11_utils::parse_u8_list(remaining, string_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (attributes, remaining) = crate::x11_utils::parse_u8_list(remaining, string_len.try_to_usize()?)?;
         let attributes = attributes.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -2047,7 +2047,7 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
         let (name_len, remaining) = u32::try_parse(remaining)?;
         let (pool, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(PrintGetOneAttributesRequest {
             context,
@@ -2094,7 +2094,7 @@ impl TryParse for PrintGetOneAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len.try_to_usize()?)?;
         let value = value.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -2409,7 +2409,7 @@ impl TryParse for PrintQueryScreensReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (list_count, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (roots, remaining) = crate::x11_utils::parse_list::<xproto::Window>(remaining, list_count.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (roots, remaining) = crate::x11_utils::parse_list::<xproto::Window>(remaining, list_count.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -22,7 +22,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -453,7 +453,7 @@ impl TryParse for Depth {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (visuals_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
-        let (visuals, remaining) = crate::x11_utils::parse_list::<Visualtype>(remaining, visuals_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (visuals, remaining) = crate::x11_utils::parse_list::<Visualtype>(remaining, visuals_len.try_to_usize()?)?;
         let result = Depth { depth, visuals };
         Ok((result, remaining))
     }
@@ -677,7 +677,7 @@ impl TryParse for Screen {
         let (save_unders, remaining) = bool::try_parse(remaining)?;
         let (root_depth, remaining) = u8::try_parse(remaining)?;
         let (allowed_depths_len, remaining) = u8::try_parse(remaining)?;
-        let (allowed_depths, remaining) = crate::x11_utils::parse_list::<Depth>(remaining, allowed_depths_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (allowed_depths, remaining) = crate::x11_utils::parse_list::<Depth>(remaining, allowed_depths_len.try_to_usize()?)?;
         let backing_stores = backing_stores.into();
         let result = Screen { root, default_colormap, white_pixel, black_pixel, current_input_masks, width_in_pixels, height_in_pixels, width_in_millimeters, height_in_millimeters, min_installed_maps, max_installed_maps, root_visual, backing_stores, save_unders, root_depth, allowed_depths };
         Ok((result, remaining))
@@ -752,13 +752,13 @@ impl TryParse for SetupRequest {
         let (authorization_protocol_name_len, remaining) = u16::try_parse(remaining)?;
         let (authorization_protocol_data_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (authorization_protocol_name, remaining) = crate::x11_utils::parse_u8_list(remaining, authorization_protocol_name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (authorization_protocol_name, remaining) = crate::x11_utils::parse_u8_list(remaining, authorization_protocol_name_len.try_to_usize()?)?;
         let authorization_protocol_name = authorization_protocol_name.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (authorization_protocol_data, remaining) = crate::x11_utils::parse_u8_list(remaining, authorization_protocol_data_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (authorization_protocol_data, remaining) = crate::x11_utils::parse_u8_list(remaining, authorization_protocol_data_len.try_to_usize()?)?;
         let authorization_protocol_data = authorization_protocol_data.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -842,7 +842,7 @@ impl TryParse for SetupFailed {
         let (protocol_major_version, remaining) = u16::try_parse(remaining)?;
         let (protocol_minor_version, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (reason, remaining) = crate::x11_utils::parse_u8_list(remaining, reason_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (reason, remaining) = crate::x11_utils::parse_u8_list(remaining, reason_len.try_to_usize()?)?;
         let reason = reason.to_vec();
         let result = SetupFailed { status, protocol_major_version, protocol_minor_version, length, reason };
         Ok((result, remaining))
@@ -898,7 +898,7 @@ impl TryParse for SetupAuthenticate {
         let (status, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(5..).ok_or(ParseError::InsufficientData)?;
         let (length, remaining) = u16::try_parse(remaining)?;
-        let (reason, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (reason, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let reason = reason.to_vec();
         let result = SetupAuthenticate { status, reason };
         Ok((result, remaining))
@@ -1046,14 +1046,14 @@ impl TryParse for Setup {
         let (min_keycode, remaining) = Keycode::try_parse(remaining)?;
         let (max_keycode, remaining) = Keycode::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
-        let (vendor, remaining) = crate::x11_utils::parse_u8_list(remaining, vendor_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (vendor, remaining) = crate::x11_utils::parse_u8_list(remaining, vendor_len.try_to_usize()?)?;
         let vendor = vendor.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (pixmap_formats, remaining) = crate::x11_utils::parse_list::<Format>(remaining, pixmap_formats_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (roots, remaining) = crate::x11_utils::parse_list::<Screen>(remaining, roots_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (pixmap_formats, remaining) = crate::x11_utils::parse_list::<Format>(remaining, pixmap_formats_len.try_to_usize()?)?;
+        let (roots, remaining) = crate::x11_utils::parse_list::<Screen>(remaining, roots_len.try_to_usize()?)?;
         let image_byte_order = image_byte_order.into();
         let bitmap_format_bit_order = bitmap_format_bit_order.into();
         let result = Setup { status, protocol_major_version, protocol_minor_version, length, release_number, resource_id_base, resource_id_mask, motion_buffer_size, maximum_request_length, image_byte_order, bitmap_format_bit_order, bitmap_format_scanline_unit, bitmap_format_scanline_pad, min_keycode, max_keycode, vendor, pixmap_formats, roots };
@@ -8794,7 +8794,7 @@ impl TryParse for QueryTreeReply {
         let (parent, remaining) = Window::try_parse(remaining)?;
         let (children_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(14..).ok_or(ParseError::InsufficientData)?;
-        let (children, remaining) = crate::x11_utils::parse_list::<Window>(remaining, children_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (children, remaining) = crate::x11_utils::parse_list::<Window>(remaining, children_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -8927,7 +8927,7 @@ impl<'input> InternAtomRequest<'input> {
         let _ = remaining;
         let (name_len, remaining) = u16::try_parse(value)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(InternAtomRequest {
             only_if_exists,
@@ -9114,7 +9114,7 @@ impl TryParse for GetAtomNameReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let name = name.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -9353,7 +9353,7 @@ impl<'input> ChangePropertyRequest<'input> {
         let (format, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
         let (data_len, remaining) = u32::try_parse(remaining)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len.checked_mul(u32::from(format)).ok_or(ParseError::InvalidExpression)?.checked_div(8u32).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len.checked_mul(u32::from(format)).ok_or(ParseError::InvalidExpression)?.checked_div(8u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(ChangePropertyRequest {
             mode,
@@ -10019,7 +10019,7 @@ impl TryParse for GetPropertyReply {
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len.checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len.checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let value = value.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -10120,7 +10120,7 @@ impl TryParse for ListPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (atoms_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::InsufficientData)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, atoms_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, atoms_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -13374,7 +13374,7 @@ impl TryParse for GetMotionEventsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (events_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (events, remaining) = crate::x11_utils::parse_list::<Timecoord>(remaining, events_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (events, remaining) = crate::x11_utils::parse_list::<Timecoord>(remaining, events_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -14202,7 +14202,7 @@ impl<'input> OpenFontRequest<'input> {
         let (fid, remaining) = Font::try_parse(value)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(OpenFontRequest {
             fid,
@@ -14613,8 +14613,8 @@ impl TryParse for QueryFontReply {
         let (font_ascent, remaining) = i16::try_parse(remaining)?;
         let (font_descent, remaining) = i16::try_parse(remaining)?;
         let (char_infos_len, remaining) = u32::try_parse(remaining)?;
-        let (properties, remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (char_infos, remaining) = crate::x11_utils::parse_list::<Charinfo>(remaining, char_infos_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len.try_to_usize()?)?;
+        let (char_infos, remaining) = crate::x11_utils::parse_list::<Charinfo>(remaining, char_infos_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -14879,7 +14879,7 @@ pub struct Str {
 impl TryParse for Str {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name_len, remaining) = u8::try_parse(remaining)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let name = name.to_vec();
         let result = Str { name };
         Ok((result, remaining))
@@ -14988,7 +14988,7 @@ impl<'input> ListFontsRequest<'input> {
         let _ = remaining;
         let (max_names, remaining) = u16::try_parse(value)?;
         let (pattern_len, remaining) = u16::try_parse(remaining)?;
-        let (pattern, remaining) = crate::x11_utils::parse_u8_list(remaining, pattern_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (pattern, remaining) = crate::x11_utils::parse_u8_list(remaining, pattern_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(ListFontsRequest {
             max_names,
@@ -15048,7 +15048,7 @@ impl TryParse for ListFontsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (names_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::InsufficientData)?;
-        let (names, remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -15149,7 +15149,7 @@ impl<'input> ListFontsWithInfoRequest<'input> {
         let _ = remaining;
         let (max_names, remaining) = u16::try_parse(value)?;
         let (pattern_len, remaining) = u16::try_parse(remaining)?;
-        let (pattern, remaining) = crate::x11_utils::parse_u8_list(remaining, pattern_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (pattern, remaining) = crate::x11_utils::parse_u8_list(remaining, pattern_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(ListFontsWithInfoRequest {
             max_names,
@@ -15248,8 +15248,8 @@ impl TryParse for ListFontsWithInfoReply {
         let (font_ascent, remaining) = i16::try_parse(remaining)?;
         let (font_descent, remaining) = i16::try_parse(remaining)?;
         let (replies_hint, remaining) = u32::try_parse(remaining)?;
-        let (properties, remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<Fontprop>(remaining, properties_len.try_to_usize()?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let name = name.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -15351,7 +15351,7 @@ impl<'input> SetFontPathRequest<'input> {
         let _ = remaining;
         let (font_qty, remaining) = u16::try_parse(value)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (font, remaining) = crate::x11_utils::parse_list::<Str>(remaining, font_qty.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (font, remaining) = crate::x11_utils::parse_list::<Str>(remaining, font_qty.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetFontPathRequest {
             font: Cow::Owned(font),
@@ -15448,7 +15448,7 @@ impl TryParse for GetFontPathReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (path_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::InsufficientData)?;
-        let (path, remaining) = crate::x11_utils::parse_list::<Str>(remaining, path_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (path, remaining) = crate::x11_utils::parse_list::<Str>(remaining, path_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -17792,7 +17792,7 @@ impl<'input> SetDashesRequest<'input> {
         let (gc, remaining) = Gcontext::try_parse(value)?;
         let (dash_offset, remaining) = u16::try_parse(remaining)?;
         let (dashes_len, remaining) = u16::try_parse(remaining)?;
-        let (dashes, remaining) = crate::x11_utils::parse_u8_list(remaining, dashes_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (dashes, remaining) = crate::x11_utils::parse_u8_list(remaining, dashes_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetDashesRequest {
             gc,
@@ -19996,7 +19996,7 @@ impl TryParse for GetImageReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (visual, remaining) = Visualid::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -20350,7 +20350,7 @@ impl<'input> ImageText8Request<'input> {
         let (gc, remaining) = Gcontext::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, string_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (string, remaining) = crate::x11_utils::parse_u8_list(remaining, string_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(ImageText8Request {
             drawable,
@@ -20529,7 +20529,7 @@ impl<'input> ImageText16Request<'input> {
         let (gc, remaining) = Gcontext::try_parse(remaining)?;
         let (x, remaining) = i16::try_parse(remaining)?;
         let (y, remaining) = i16::try_parse(remaining)?;
-        let (string, remaining) = crate::x11_utils::parse_list::<Char2b>(remaining, string_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (string, remaining) = crate::x11_utils::parse_list::<Char2b>(remaining, string_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(ImageText16Request {
             drawable,
@@ -21109,7 +21109,7 @@ impl TryParse for ListInstalledColormapsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (cmaps_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::InsufficientData)?;
-        let (cmaps, remaining) = crate::x11_utils::parse_list::<Colormap>(remaining, cmaps_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (cmaps, remaining) = crate::x11_utils::parse_list::<Colormap>(remaining, cmaps_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -21367,7 +21367,7 @@ impl<'input> AllocNamedColorRequest<'input> {
         let (cmap, remaining) = Colormap::try_parse(value)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(AllocNamedColorRequest {
             cmap,
@@ -21541,8 +21541,8 @@ impl TryParse for AllocColorCellsReply {
         let (pixels_len, remaining) = u16::try_parse(remaining)?;
         let (masks_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (pixels, remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
-        let (masks, remaining) = crate::x11_utils::parse_list::<u32>(remaining, masks_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (pixels, remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len.try_to_usize()?)?;
+        let (masks, remaining) = crate::x11_utils::parse_list::<u32>(remaining, masks_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -21709,7 +21709,7 @@ impl TryParse for AllocColorPlanesReply {
         let (green_mask, remaining) = u32::try_parse(remaining)?;
         let (blue_mask, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
-        let (pixels, remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (pixels, remaining) = crate::x11_utils::parse_list::<u32>(remaining, pixels_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -22120,7 +22120,7 @@ impl<'input> StoreNamedColorRequest<'input> {
         let (pixel, remaining) = u32::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(StoreNamedColorRequest {
             flags,
@@ -22309,7 +22309,7 @@ impl TryParse for QueryColorsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (colors_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::InsufficientData)?;
-        let (colors, remaining) = crate::x11_utils::parse_list::<Rgb>(remaining, colors_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (colors, remaining) = crate::x11_utils::parse_list::<Rgb>(remaining, colors_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -22402,7 +22402,7 @@ impl<'input> LookupColorRequest<'input> {
         let (cmap, remaining) = Colormap::try_parse(value)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(LookupColorRequest {
             cmap,
@@ -23390,7 +23390,7 @@ impl<'input> QueryExtensionRequest<'input> {
         let _ = remaining;
         let (name_len, remaining) = u16::try_parse(value)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, name_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(QueryExtensionRequest {
             name: Cow::Borrowed(name),
@@ -23551,7 +23551,7 @@ impl TryParse for ListExtensionsReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (names, remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (names, remaining) = crate::x11_utils::parse_list::<Str>(remaining, names_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -23644,7 +23644,7 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
         let (first_keycode, remaining) = Keycode::try_parse(value)?;
         let (keysyms_per_keycode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, u32::from(keycode_count).checked_mul(u32::from(keysyms_per_keycode)).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, u32::from(keycode_count).checked_mul(u32::from(keysyms_per_keycode)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(ChangeKeyboardMappingRequest {
             keycode_count,
@@ -23765,7 +23765,7 @@ impl TryParse for GetKeyboardMappingReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (keysyms, remaining) = crate::x11_utils::parse_list::<Keysym>(remaining, length.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -25072,7 +25072,7 @@ impl<'input> ChangeHostsRequest<'input> {
         let family = family.into();
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (address_len, remaining) = u16::try_parse(remaining)?;
-        let (address, remaining) = crate::x11_utils::parse_u8_list(remaining, address_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (address, remaining) = crate::x11_utils::parse_u8_list(remaining, address_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(ChangeHostsRequest {
             mode,
@@ -25115,7 +25115,7 @@ impl TryParse for Host {
         let (family, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (address_len, remaining) = u16::try_parse(remaining)?;
-        let (address, remaining) = crate::x11_utils::parse_u8_list(remaining, address_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (address, remaining) = crate::x11_utils::parse_u8_list(remaining, address_len.try_to_usize()?)?;
         let address = address.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -25237,7 +25237,7 @@ impl TryParse for ListHostsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (hosts_len, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(22..).ok_or(ParseError::InsufficientData)?;
-        let (hosts, remaining) = crate::x11_utils::parse_list::<Host>(remaining, hosts_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (hosts, remaining) = crate::x11_utils::parse_list::<Host>(remaining, hosts_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -25741,7 +25741,7 @@ impl<'input> RotatePropertiesRequest<'input> {
         let (window, remaining) = Window::try_parse(value)?;
         let (atoms_len, remaining) = u16::try_parse(remaining)?;
         let (delta, remaining) = i16::try_parse(remaining)?;
-        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, atoms_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (atoms, remaining) = crate::x11_utils::parse_list::<Atom>(remaining, atoms_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(RotatePropertiesRequest {
             window,
@@ -26001,7 +26001,7 @@ impl<'input> SetPointerMappingRequest<'input> {
         let remaining = &[header.minor_opcode];
         let (map_len, remaining) = u8::try_parse(remaining)?;
         let _ = remaining;
-        let (map, remaining) = crate::x11_utils::parse_u8_list(value, map_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (map, remaining) = crate::x11_utils::parse_u8_list(value, map_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetPointerMappingRequest {
             map: Cow::Borrowed(map),
@@ -26128,7 +26128,7 @@ impl TryParse for GetPointerMappingReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (map, remaining) = crate::x11_utils::parse_u8_list(remaining, map_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (map, remaining) = crate::x11_utils::parse_u8_list(remaining, map_len.try_to_usize()?)?;
         let map = map.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -26280,7 +26280,7 @@ impl<'input> SetModifierMappingRequest<'input> {
         let remaining = &[header.minor_opcode];
         let (keycodes_per_modifier, remaining) = u8::try_parse(remaining)?;
         let _ = remaining;
-        let (keycodes, remaining) = crate::x11_utils::parse_u8_list(value, u32::from(keycodes_per_modifier).checked_mul(8u32).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (keycodes, remaining) = crate::x11_utils::parse_u8_list(value, u32::from(keycodes_per_modifier).checked_mul(8u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetModifierMappingRequest {
             keycodes: Cow::Borrowed(keycodes),
@@ -26407,7 +26407,7 @@ impl TryParse for GetModifierMappingReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (keycodes, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(keycodes_per_modifier).checked_mul(8u32).ok_or(ParseError::InvalidExpression)?.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (keycodes, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(keycodes_per_modifier).checked_mul(8u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let keycodes = keycodes.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -188,7 +188,7 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
             return Err(ParseError::InvalidValue);
         }
         let (context_len, remaining) = u32::try_parse(value)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetDeviceCreateContextRequest {
             context: Cow::Borrowed(context),
@@ -283,7 +283,7 @@ impl TryParse for GetDeviceCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -374,7 +374,7 @@ impl<'input> SetDeviceContextRequest<'input> {
         }
         let (device, remaining) = u32::try_parse(value)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetDeviceContextRequest {
             device,
@@ -483,7 +483,7 @@ impl TryParse for GetDeviceContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -567,7 +567,7 @@ impl<'input> SetWindowCreateContextRequest<'input> {
             return Err(ParseError::InvalidValue);
         }
         let (context_len, remaining) = u32::try_parse(value)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetWindowCreateContextRequest {
             context: Cow::Borrowed(context),
@@ -662,7 +662,7 @@ impl TryParse for GetWindowCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -776,7 +776,7 @@ impl TryParse for GetWindowContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -822,13 +822,13 @@ impl TryParse for ListItem {
         let (name, remaining) = xproto::Atom::try_parse(remaining)?;
         let (object_context_len, remaining) = u32::try_parse(remaining)?;
         let (data_context_len, remaining) = u32::try_parse(remaining)?;
-        let (object_context, remaining) = crate::x11_utils::parse_u8_list(remaining, object_context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (object_context, remaining) = crate::x11_utils::parse_u8_list(remaining, object_context_len.try_to_usize()?)?;
         let object_context = object_context.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
-        let (data_context, remaining) = crate::x11_utils::parse_u8_list(remaining, data_context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (data_context, remaining) = crate::x11_utils::parse_u8_list(remaining, data_context_len.try_to_usize()?)?;
         let data_context = data_context.to_vec();
         // Align offset to multiple of 4
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
@@ -943,7 +943,7 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
             return Err(ParseError::InvalidValue);
         }
         let (context_len, remaining) = u32::try_parse(value)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetPropertyCreateContextRequest {
             context: Cow::Borrowed(context),
@@ -1038,7 +1038,7 @@ impl TryParse for GetPropertyCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -1122,7 +1122,7 @@ impl<'input> SetPropertyUseContextRequest<'input> {
             return Err(ParseError::InvalidValue);
         }
         let (context_len, remaining) = u32::try_parse(value)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetPropertyUseContextRequest {
             context: Cow::Borrowed(context),
@@ -1217,7 +1217,7 @@ impl TryParse for GetPropertyUseContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -1340,7 +1340,7 @@ impl TryParse for GetPropertyContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -1463,7 +1463,7 @@ impl TryParse for GetPropertyDataContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -1577,7 +1577,7 @@ impl TryParse for ListPropertiesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (properties_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (properties, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, properties_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (properties, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, properties_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -1660,7 +1660,7 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
             return Err(ParseError::InvalidValue);
         }
         let (context_len, remaining) = u32::try_parse(value)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetSelectionCreateContextRequest {
             context: Cow::Borrowed(context),
@@ -1755,7 +1755,7 @@ impl TryParse for GetSelectionCreateContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -1839,7 +1839,7 @@ impl<'input> SetSelectionUseContextRequest<'input> {
             return Err(ParseError::InvalidValue);
         }
         let (context_len, remaining) = u32::try_parse(value)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let _ = remaining;
         Ok(SetSelectionUseContextRequest {
             context: Cow::Borrowed(context),
@@ -1934,7 +1934,7 @@ impl TryParse for GetSelectionUseContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -2048,7 +2048,7 @@ impl TryParse for GetSelectionContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -2162,7 +2162,7 @@ impl TryParse for GetSelectionDataContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -2265,7 +2265,7 @@ impl TryParse for ListSelectionsReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (selections_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (selections, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, selections_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (selections, remaining) = crate::x11_utils::parse_list::<ListItem>(remaining, selections_len.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -2378,7 +2378,7 @@ impl TryParse for GetClientContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (context_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (context, remaining) = crate::x11_utils::parse_u8_list(remaining, context_len.try_to_usize()?)?;
         let context = context.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -17,7 +17,7 @@ use std::io::IoSlice;
 #[allow(unused_imports)]
 use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
-use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
+use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd, TryIntoUSize};
 use crate::connection::{BufWithFds, PiecewiseBuf, RequestConnection};
 #[allow(unused_imports)]
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
@@ -294,7 +294,7 @@ impl TryParse for ListSurfaceTypesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (surfaces, remaining) = crate::x11_utils::parse_list::<SurfaceInfo>(remaining, num.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (surfaces, remaining) = crate::x11_utils::parse_list::<SurfaceInfo>(remaining, num.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -452,7 +452,7 @@ impl TryParse for CreateContextReply {
         let (height_actual, remaining) = u16::try_parse(remaining)?;
         let (flags_return, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -637,7 +637,7 @@ impl TryParse for CreateSurfaceReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -856,7 +856,7 @@ impl TryParse for CreateSubpictureReply {
         let (component_order, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
         let component_order = <[u8; 4]>::try_from(component_order).unwrap();
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -1043,7 +1043,7 @@ impl TryParse for ListSubpictureTypesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (types, remaining) = crate::x11_utils::parse_list::<xv::ImageFormatInfo>(remaining, num.try_into().or(Err(ParseError::ConversionFailed))?)?;
+        let (types, remaining) = crate::x11_utils::parse_list::<xv::ImageFormatInfo>(remaining, num.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/src/x11_utils.rs
+++ b/src/x11_utils.rs
@@ -508,6 +508,25 @@ macro_rules! bitmask_binop {
     };
 }
 
+/// Wrapper around TryInto that produces a ParseError.
+///
+/// This trait shortens `x.try_into().or(Err(ParseError::ConversionFailed))` to `x.try_to_usize()`.
+pub(crate) trait TryIntoUSize: TryInto<usize> {
+    /// Attempt the conversion
+    fn try_to_usize(self) -> Result<usize, ParseError> {
+        self.try_into().or(Err(ParseError::ConversionFailed))
+    }
+}
+
+impl TryIntoUSize for u8 {}
+impl TryIntoUSize for u16 {}
+impl TryIntoUSize for u32 {}
+impl TryIntoUSize for u64 {}
+impl TryIntoUSize for i8 {}
+impl TryIntoUSize for i16 {}
+impl TryIntoUSize for i32 {}
+impl TryIntoUSize for i64 {}
+
 /// A helper macro for managing atoms
 ///
 /// If we need to use multiple atoms, one would normally write code such as


### PR DESCRIPTION
For a while now I had "improve docs for `ParseError`" on my to do list. I finally tackled this. For this, I looked at the generated code and checked when each of the errors could appear. I also found some types in the docs for `ConnectError`. Thus, this is now a PR with four commits and only one of them is about what I actually wanted to do...