### PR TITLE
Remove TryFrom<&u8> impls

### DIFF
--- a/generator/src/generator/error_events.rs
+++ b/generator/src/generator/error_events.rs
@@ -207,8 +207,9 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
                     }
                     outln!(
                         out,
-                        "xproto::{}_EVENT => return Ok(Self::{}(event.try_into()?)),",
+                        "xproto::{}_EVENT => return Ok(Self::{}(xproto::{}Event::try_parse(event)?.0)),",
                         super::camel_case_to_upper_snake(event_name),
+                        event_name,
                         event_name,
                     );
                 }
@@ -265,10 +266,12 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
                             }
                             outln!(
                                 out.indent(),
-                                "{}::{}_EVENT => Ok(Self::{}{}(event.try_into()?)),",
+                                "{}::{}_EVENT => Ok(Self::{}{}({}::{}Event::try_parse(event)?.0)),",
                                 ns.header,
                                 super::camel_case_to_upper_snake(event_def.name()),
                                 get_ns_name_prefix(ns),
+                                event_def.name(),
+                                ns.header,
                                 event_def.name(),
                             );
                         }
@@ -292,7 +295,7 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
         out.indented(|out| {
             outln!(
                 out,
-                "let ge_event = xproto::GeGenericEvent::try_from(event)?;"
+                "let ge_event = xproto::GeGenericEvent::try_parse(event)?.0;"
             );
             outln!(out, "let ext_name = ext_info_provider");
             outln!(out.indent(), ".get_from_major_opcode(ge_event.extension)");
@@ -322,10 +325,12 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
                             }
                             outln!(
                                 out.indent(),
-                                "{}::{}_EVENT => Ok(Self::{}{}(event.try_into()?)),",
+                                "{}::{}_EVENT => Ok(Self::{}{}({}::{}Event::try_parse(event)?.0)),",
                                 ns.header,
                                 super::camel_case_to_upper_snake(event_def.name()),
                                 get_ns_name_prefix(ns),
+                                event_def.name(),
+                                ns.header,
                                 event_def.name(),
                             );
                         }

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -30,10 +30,10 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String
     );
     outln!(main_out, "");
     outln!(main_out, "use std::borrow::Cow;");
-    outln!(main_out, "use std::convert::{{TryFrom, TryInto}};");
+    outln!(main_out, "use std::convert::TryInto;");
     outln!(main_out, "use crate::errors::ParseError;");
     outln!(main_out, "use crate::utils::RawFdContainer;");
-    outln!(main_out, "use crate::x11_utils::X11Error;");
+    outln!(main_out, "use crate::x11_utils::{{TryParse, X11Error}};");
     outln!(
         main_out,
         "use crate::x11_utils::{{ExtInfoProvider, ReplyParsingFunction, Request as RequestTrait, RequestHeader}};"

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2271,7 +2271,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     outln!(out.indent(), "// FIXME: event parsing can fail");
                     outln!(
                         out.indent(),
-                        "{}::try_from(value).unwrap()",
+                        "{}::try_parse(value).unwrap().0",
                         rust_event_type,
                     );
                     outln!(out, "}}");

--- a/generator/src/generator/namespace.rs
+++ b/generator/src/generator/namespace.rs
@@ -2765,38 +2765,6 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
 
             outln!(out.indent(), "}}");
             outln!(out, "}}");
-
-            if external_params.is_empty() {
-                let value = if has_fds {
-                    "(&[u8], Vec<RawFdContainer>)"
-                } else {
-                    "&[u8]"
-                };
-                outln!(out, "impl TryFrom<{}> for {} {{", value, name);
-                out.indented(|out| {
-                    outln!(out, "type Error = ParseError;");
-                    outln!(
-                        out,
-                        "fn try_from(value: {}) -> Result<Self, Self::Error> {{",
-                        value
-                    );
-                    out.indented(|out| {
-                        if has_fds {
-                            outln!(out, "let (value, mut fds) = value;");
-                            outln!(out, "Ok(Self::try_parse_fd(value, &mut fds)?.0)");
-                        } else {
-                            outln!(out, "Ok(Self::try_parse(value)?.0)");
-                        }
-                    });
-                    outln!(out, "}}");
-                });
-                outln!(out, "}}");
-            } else {
-                outln!(
-                    out,
-                    "// Skipping TryFrom implementations because of unresolved members",
-                );
-            }
         }
 
         if generate_serialize {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -49,7 +49,7 @@ use crate::errors::{ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::protocol::xproto::Setup;
 use crate::protocol::Event;
 use crate::utils::RawFdContainer;
-use crate::x11_utils::{ExtensionInformation, TryParse, X11Error};
+use crate::x11_utils::{ExtensionInformation, TryParse, TryParseFd, X11Error};
 
 /// Number type used for referring to things that were sent to the server in responses from the
 /// server.
@@ -146,7 +146,7 @@ pub trait RequestConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
     where
-        R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>;
+        R: TryParseFd;
 
     /// Send a request without a reply to the server.
     ///

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -49,7 +49,7 @@ use crate::errors::{ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::protocol::xproto::Setup;
 use crate::protocol::Event;
 use crate::utils::RawFdContainer;
-use crate::x11_utils::{ExtensionInformation, X11Error};
+use crate::x11_utils::{ExtensionInformation, TryParse, X11Error};
 
 /// Number type used for referring to things that were sent to the server in responses from the
 /// server.
@@ -119,7 +119,7 @@ pub trait RequestConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<'_, Self, R>, ConnectionError>
     where
-        R: for<'a> TryFrom<&'a [u8], Error = ParseError>;
+        R: TryParse;
 
     /// Send a request with a reply containing file descriptors to the server.
     ///
@@ -496,7 +496,7 @@ pub enum DiscardMode {
 ///
 ///     fn send_request_with_reply<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>)
 ///     -> Result<Cookie<Self, R>, ConnectionError>
-///     where R: for<'a> TryFrom<&'a [u8], Error=ParseError> {
+///     where R: TryParse {
 ///         Ok(Cookie::new(self, self.send_request(bufs, fds, true, false)?))
 ///     }
 ///

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -436,12 +436,11 @@ pub enum DiscardMode {
 /// Example usage:
 /// ```
 /// use std::io::IoSlice;
-/// use std::convert::TryFrom;
 /// use x11rb::connection::{BufWithFds, RequestConnection, SequenceNumber, compute_length_field};
 /// use x11rb::cookie::{Cookie, CookieWithFds, VoidCookie};
 /// use x11rb::errors::{ParseError, ConnectionError};
 /// use x11rb::utils::RawFdContainer;
-/// use x11rb::x11_utils::ExtensionInformation;
+/// use x11rb::x11_utils::{ExtensionInformation, TryParse, TryParseFd};
 /// # use x11rb::connection::ReplyOrError;
 ///
 /// struct MyConnection();
@@ -502,7 +501,7 @@ pub enum DiscardMode {
 ///
 ///     fn send_request_with_reply_with_fds<R>(&self, bufs: &[IoSlice], fds: Vec<RawFdContainer>)
 ///     -> Result<CookieWithFds<Self, R>, ConnectionError>
-///     where R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error=ParseError> {
+///     where R: TryParseFd {
 ///         Ok(CookieWithFds::new(self, self.send_request(bufs, fds, true, true)?))
 ///     }
 ///

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -299,15 +299,15 @@ macro_rules! multiple_reply_cookie {
                     Err(e) => return Some(Err(e)),
                     Ok(v) => v,
                 };
-                let reply = $reply::try_from(reply.as_ref()).map_err(ReplyError::from);
+                let reply = $reply::try_parse(reply.as_ref());
                 match reply {
                     // Is this an indicator that no more replies follow?
-                    Ok(ref reply) if Self::is_last(&reply) => None,
+                    Ok(ref reply) if Self::is_last(&reply.0) => None,
                     Ok(reply) => {
                         self.0 = Some(cookie);
-                        Some(Ok(reply))
+                        Some(Ok(reply.0))
                     }
-                    Err(e) => Some(Err(e)),
+                    Err(e) => Some(Err(e.into())),
                 }
             }
         }

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -158,7 +158,7 @@ mod test {
     use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
     use crate::errors::{ConnectionError, ParseError};
     use crate::utils::RawFdContainer;
-    use crate::x11_utils::{ExtInfoProvider, ExtensionInformation};
+    use crate::x11_utils::{ExtInfoProvider, ExtensionInformation, TryParse};
 
     use super::{CheckState, ExtensionManager};
 
@@ -173,7 +173,7 @@ mod test {
             _fds: Vec<RawFdContainer>,
         ) -> Result<Cookie<'_, Self, R>, ConnectionError>
         where
-            R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
+            R: TryParse,
         {
             Ok(Cookie::new(self, 1))
         }

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -149,7 +149,6 @@ impl ExtInfoProvider for ExtensionManager {
 #[cfg(test)]
 mod test {
     use std::cell::RefCell;
-    use std::convert::TryFrom;
     use std::io::IoSlice;
 
     use crate::connection::{
@@ -158,7 +157,7 @@ mod test {
     use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
     use crate::errors::{ConnectionError, ParseError};
     use crate::utils::RawFdContainer;
-    use crate::x11_utils::{ExtInfoProvider, ExtensionInformation, TryParse};
+    use crate::x11_utils::{ExtInfoProvider, ExtensionInformation, TryParse, TryParseFd};
 
     use super::{CheckState, ExtensionManager};
 
@@ -184,7 +183,7 @@ mod test {
             _fds: Vec<RawFdContainer>,
         ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
         where
-            R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
+            R: TryParseFd,
         {
             unimplemented!()
         }

--- a/src/protocol/bigreq.rs
+++ b/src/protocol/bigreq.rs
@@ -112,12 +112,6 @@ impl TryParse for EnableReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for EnableReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {

--- a/src/protocol/composite.rs
+++ b/src/protocol/composite.rs
@@ -195,12 +195,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the RedirectWindow request
 pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
@@ -742,12 +736,6 @@ impl TryParse for GetOverlayWindowReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetOverlayWindowReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/damage.rs
+++ b/src/protocol/damage.rs
@@ -204,12 +204,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Create request
 pub const CREATE_REQUEST: u8 = 1;
@@ -552,12 +546,6 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for NotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {

--- a/src/protocol/dpms.rs
+++ b/src/protocol/dpms.rs
@@ -130,12 +130,6 @@ impl TryParse for GetVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Capable request
 pub const CAPABLE_REQUEST: u8 = 1;
@@ -214,12 +208,6 @@ impl TryParse for CapableReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CapableReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -304,12 +292,6 @@ impl TryParse for GetTimeoutsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetTimeoutsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -702,12 +684,6 @@ impl TryParse for InfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for InfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/dri2.rs
+++ b/src/protocol/dri2.rs
@@ -219,12 +219,6 @@ impl TryParse for DRI2Buffer {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DRI2Buffer {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DRI2Buffer {
     type Bytes = [u8; 20];
     fn serialize(&self) -> [u8; 20] {
@@ -278,12 +272,6 @@ impl TryParse for AttachFormat {
         let attachment = attachment.into();
         let result = AttachFormat { attachment, format };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AttachFormat {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for AttachFormat {
@@ -409,12 +397,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Connect request
 pub const CONNECT_REQUEST: u8 = 1;
@@ -523,12 +505,6 @@ impl TryParse for ConnectReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ConnectReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ConnectReply {
@@ -656,12 +632,6 @@ impl TryParse for AuthenticateReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AuthenticateReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -922,12 +892,6 @@ impl TryParse for GetBuffersReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetBuffersReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetBuffersReply {
     /// Get the value of the `count` field.
     ///
@@ -1058,12 +1022,6 @@ impl TryParse for CopyRegionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CopyRegionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetBuffersWithFormat request
 pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
@@ -1190,12 +1148,6 @@ impl TryParse for GetBuffersWithFormatReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetBuffersWithFormatReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetBuffersWithFormatReply {
@@ -1359,12 +1311,6 @@ impl TryParse for SwapBuffersReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SwapBuffersReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetMSC request
 pub const GET_MSC_REQUEST: u8 = 9;
@@ -1463,12 +1409,6 @@ impl TryParse for GetMSCReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetMSCReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1625,12 +1565,6 @@ impl TryParse for WaitMSCReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for WaitMSCReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the WaitSBC request
 pub const WAIT_SBC_REQUEST: u8 = 11;
@@ -1747,12 +1681,6 @@ impl TryParse for WaitSBCReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for WaitSBCReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1931,12 +1859,6 @@ impl TryParse for GetParamReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetParamReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 0;
@@ -1972,12 +1894,6 @@ impl TryParse for BufferSwapCompleteEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for BufferSwapCompleteEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&BufferSwapCompleteEvent> for [u8; 32] {
@@ -2053,12 +1969,6 @@ impl TryParse for InvalidateBuffersEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for InvalidateBuffersEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&InvalidateBuffersEvent> for [u8; 32] {

--- a/src/protocol/dri3.rs
+++ b/src/protocol/dri3.rs
@@ -135,12 +135,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Open request
 pub const OPEN_REQUEST: u8 = 1;
@@ -241,13 +235,6 @@ impl TryParseFd for OpenReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<(&[u8], Vec<RawFdContainer>)> for OpenReply {
-    type Error = ParseError;
-    fn try_from(value: (&[u8], Vec<RawFdContainer>)) -> Result<Self, Self::Error> {
-        let (value, mut fds) = value;
-        Ok(Self::try_parse_fd(value, &mut fds)?.0)
     }
 }
 
@@ -478,13 +465,6 @@ impl TryParseFd for BufferFromPixmapReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<(&[u8], Vec<RawFdContainer>)> for BufferFromPixmapReply {
-    type Error = ParseError;
-    fn try_from(value: (&[u8], Vec<RawFdContainer>)) -> Result<Self, Self::Error> {
-        let (value, mut fds) = value;
-        Ok(Self::try_parse_fd(value, &mut fds)?.0)
-    }
-}
 
 /// Opcode for the FenceFromFD request
 pub const FENCE_FROM_FD_REQUEST: u8 = 4;
@@ -678,13 +658,6 @@ impl TryParseFd for FDFromFenceReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<(&[u8], Vec<RawFdContainer>)> for FDFromFenceReply {
-    type Error = ParseError;
-    fn try_from(value: (&[u8], Vec<RawFdContainer>)) -> Result<Self, Self::Error> {
-        let (value, mut fds) = value;
-        Ok(Self::try_parse_fd(value, &mut fds)?.0)
-    }
-}
 
 /// Opcode for the GetSupportedModifiers request
 pub const GET_SUPPORTED_MODIFIERS_REQUEST: u8 = 6;
@@ -793,12 +766,6 @@ impl TryParse for GetSupportedModifiersReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetSupportedModifiersReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetSupportedModifiersReply {
@@ -1139,13 +1106,6 @@ impl TryParseFd for BuffersFromPixmapReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<(&[u8], Vec<RawFdContainer>)> for BuffersFromPixmapReply {
-    type Error = ParseError;
-    fn try_from(value: (&[u8], Vec<RawFdContainer>)) -> Result<Self, Self::Error> {
-        let (value, mut fds) = value;
-        Ok(Self::try_parse_fd(value, &mut fds)?.0)
     }
 }
 impl BuffersFromPixmapReply {

--- a/src/protocol/ge.rs
+++ b/src/protocol/ge.rs
@@ -131,12 +131,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Extension trait defining the requests of this extension.
 pub trait ConnectionExt: RequestConnection {

--- a/src/protocol/glx.rs
+++ b/src/protocol/glx.rs
@@ -139,12 +139,6 @@ impl TryParse for PbufferClobberEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PbufferClobberEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&PbufferClobberEvent> for [u8; 32] {
     fn from(input: &PbufferClobberEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -234,12 +228,6 @@ impl TryParse for BufferSwapCompleteEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for BufferSwapCompleteEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&BufferSwapCompleteEvent> for [u8; 32] {
@@ -855,12 +843,6 @@ impl TryParse for MakeCurrentReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for MakeCurrentReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the IsDirect request
 pub const IS_DIRECT_REQUEST: u8 = 6;
@@ -950,12 +932,6 @@ impl TryParse for IsDirectReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for IsDirectReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1058,12 +1034,6 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1733,12 +1703,6 @@ impl TryParse for GetVisualConfigsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetVisualConfigsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetVisualConfigsReply {
     /// Get the value of the `length` field.
     ///
@@ -2027,12 +1991,6 @@ impl TryParse for VendorPrivateWithReplyReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for VendorPrivateWithReplyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl VendorPrivateWithReplyReply {
     /// Get the value of the `length` field.
     ///
@@ -2141,12 +2099,6 @@ impl TryParse for QueryExtensionsStringReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryExtensionsStringReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryServerString request
 pub const QUERY_SERVER_STRING_REQUEST: u8 = 19;
@@ -2248,12 +2200,6 @@ impl TryParse for QueryServerStringReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryServerStringReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryServerStringReply {
@@ -2459,12 +2405,6 @@ impl TryParse for GetFBConfigsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetFBConfigsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetFBConfigsReply {
@@ -2868,12 +2808,6 @@ impl TryParse for QueryContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl QueryContextReply {
     /// Get the value of the `num_attribs` field.
     ///
@@ -3006,12 +2940,6 @@ impl TryParse for MakeContextCurrentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for MakeContextCurrentReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -3277,12 +3205,6 @@ impl TryParse for GetDrawableAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetDrawableAttributesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetDrawableAttributesReply {
@@ -4279,12 +4201,6 @@ impl TryParse for GenListsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GenListsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the FeedbackBuffer request
 pub const FEEDBACK_BUFFER_REQUEST: u8 = 105;
@@ -4547,12 +4463,6 @@ impl TryParse for RenderModeReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for RenderModeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl RenderModeReply {
     /// Get the value of the `n` field.
     ///
@@ -4708,12 +4618,6 @@ impl TryParse for FinishReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FinishReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -5041,12 +4945,6 @@ impl TryParse for ReadPixelsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ReadPixelsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl ReadPixelsReply {
     /// Get the value of the `length` field.
     ///
@@ -5167,12 +5065,6 @@ impl TryParse for GetBooleanvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetBooleanvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetBooleanvReply {
     /// Get the value of the `n` field.
     ///
@@ -5285,12 +5177,6 @@ impl TryParse for GetClipPlaneReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetClipPlaneReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetClipPlaneReply {
@@ -5413,12 +5299,6 @@ impl TryParse for GetDoublevReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDoublevReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDoublevReply {
     /// Get the value of the `n` field.
     ///
@@ -5524,12 +5404,6 @@ impl TryParse for GetErrorReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetErrorReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetFloatv request
 pub const GET_FLOATV_REQUEST: u8 = 116;
@@ -5632,12 +5506,6 @@ impl TryParse for GetFloatvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetFloatvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetFloatvReply {
@@ -5757,12 +5625,6 @@ impl TryParse for GetIntegervReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetIntegervReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetIntegervReply {
@@ -5893,12 +5755,6 @@ impl TryParse for GetLightfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetLightfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetLightfvReply {
     /// Get the value of the `n` field.
     ///
@@ -6025,12 +5881,6 @@ impl TryParse for GetLightivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetLightivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetLightivReply {
@@ -6161,12 +6011,6 @@ impl TryParse for GetMapdvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMapdvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetMapdvReply {
     /// Get the value of the `n` field.
     ///
@@ -6293,12 +6137,6 @@ impl TryParse for GetMapfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetMapfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetMapfvReply {
@@ -6429,12 +6267,6 @@ impl TryParse for GetMapivReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMapivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetMapivReply {
     /// Get the value of the `n` field.
     ///
@@ -6561,12 +6393,6 @@ impl TryParse for GetMaterialfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetMaterialfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetMaterialfvReply {
@@ -6697,12 +6523,6 @@ impl TryParse for GetMaterialivReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMaterialivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetMaterialivReply {
     /// Get the value of the `n` field.
     ///
@@ -6820,12 +6640,6 @@ impl TryParse for GetPixelMapfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPixelMapfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetPixelMapfvReply {
@@ -6947,12 +6761,6 @@ impl TryParse for GetPixelMapuivReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetPixelMapuivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetPixelMapuivReply {
     /// Get the value of the `n` field.
     ///
@@ -7072,12 +6880,6 @@ impl TryParse for GetPixelMapusvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetPixelMapusvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetPixelMapusvReply {
     /// Get the value of the `n` field.
     ///
@@ -7191,12 +6993,6 @@ impl TryParse for GetPolygonStippleReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPolygonStippleReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetPolygonStippleReply {
@@ -7316,12 +7112,6 @@ impl TryParse for GetStringReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetStringReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetStringReply {
@@ -7452,12 +7242,6 @@ impl TryParse for GetTexEnvfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetTexEnvfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetTexEnvfvReply {
     /// Get the value of the `n` field.
     ///
@@ -7584,12 +7368,6 @@ impl TryParse for GetTexEnvivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetTexEnvivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetTexEnvivReply {
@@ -7720,12 +7498,6 @@ impl TryParse for GetTexGendvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetTexGendvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetTexGendvReply {
     /// Get the value of the `n` field.
     ///
@@ -7854,12 +7626,6 @@ impl TryParse for GetTexGenfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetTexGenfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetTexGenfvReply {
     /// Get the value of the `n` field.
     ///
@@ -7986,12 +7752,6 @@ impl TryParse for GetTexGenivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetTexGenivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetTexGenivReply {
@@ -8152,12 +7912,6 @@ impl TryParse for GetTexImageReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetTexImageReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetTexImageReply {
     /// Get the value of the `length` field.
     ///
@@ -8287,12 +8041,6 @@ impl TryParse for GetTexParameterfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetTexParameterfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetTexParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -8419,12 +8167,6 @@ impl TryParse for GetTexParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetTexParameterivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetTexParameterivReply {
@@ -8564,12 +8306,6 @@ impl TryParse for GetTexLevelParameterfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetTexLevelParameterfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetTexLevelParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -8707,12 +8443,6 @@ impl TryParse for GetTexLevelParameterivReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetTexLevelParameterivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetTexLevelParameterivReply {
     /// Get the value of the `n` field.
     ///
@@ -8827,12 +8557,6 @@ impl TryParse for IsEnabledReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for IsEnabledReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the IsList request
 pub const IS_LIST_REQUEST: u8 = 141;
@@ -8930,12 +8654,6 @@ impl TryParse for IsListReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for IsListReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -9115,12 +8833,6 @@ impl TryParse for AreTexturesResidentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AreTexturesResidentReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl AreTexturesResidentReply {
@@ -9325,12 +9037,6 @@ impl TryParse for GenTexturesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GenTexturesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GenTexturesReply {
     /// Get the value of the `length` field.
     ///
@@ -9443,12 +9149,6 @@ impl TryParse for IsTextureReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for IsTextureReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -9581,12 +9281,6 @@ impl TryParse for GetColorTableReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetColorTableReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetColorTableReply {
     /// Get the value of the `length` field.
     ///
@@ -9716,12 +9410,6 @@ impl TryParse for GetColorTableParameterfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetColorTableParameterfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetColorTableParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -9848,12 +9536,6 @@ impl TryParse for GetColorTableParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetColorTableParameterivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetColorTableParameterivReply {
@@ -10003,12 +9685,6 @@ impl TryParse for GetConvolutionFilterReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetConvolutionFilterReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetConvolutionFilterReply {
     /// Get the value of the `length` field.
     ///
@@ -10138,12 +9814,6 @@ impl TryParse for GetConvolutionParameterfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetConvolutionParameterfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetConvolutionParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -10270,12 +9940,6 @@ impl TryParse for GetConvolutionParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetConvolutionParameterivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetConvolutionParameterivReply {
@@ -10423,12 +10087,6 @@ impl TryParse for GetSeparableFilterReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetSeparableFilterReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetSeparableFilterReply {
@@ -10582,12 +10240,6 @@ impl TryParse for GetHistogramReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetHistogramReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetHistogramReply {
     /// Get the value of the `length` field.
     ///
@@ -10717,12 +10369,6 @@ impl TryParse for GetHistogramParameterfvReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetHistogramParameterfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetHistogramParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -10849,12 +10495,6 @@ impl TryParse for GetHistogramParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetHistogramParameterivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetHistogramParameterivReply {
@@ -11004,12 +10644,6 @@ impl TryParse for GetMinmaxReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMinmaxReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetMinmaxReply {
     /// Get the value of the `length` field.
     ///
@@ -11137,12 +10771,6 @@ impl TryParse for GetMinmaxParameterfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetMinmaxParameterfvReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetMinmaxParameterfvReply {
@@ -11273,12 +10901,6 @@ impl TryParse for GetMinmaxParameterivReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMinmaxParameterivReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetMinmaxParameterivReply {
     /// Get the value of the `n` field.
     ///
@@ -11404,12 +11026,6 @@ impl TryParse for GetCompressedTexImageARBReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetCompressedTexImageARBReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetCompressedTexImageARBReply {
@@ -11614,12 +11230,6 @@ impl TryParse for GenQueriesARBReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GenQueriesARBReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GenQueriesARBReply {
     /// Get the value of the `length` field.
     ///
@@ -11734,12 +11344,6 @@ impl TryParse for IsQueryARBReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for IsQueryARBReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetQueryivARB request
 pub const GET_QUERYIV_ARB_REQUEST: u8 = 164;
@@ -11851,12 +11455,6 @@ impl TryParse for GetQueryivARBReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetQueryivARBReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetQueryivARBReply {
@@ -11987,12 +11585,6 @@ impl TryParse for GetQueryObjectivARBReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetQueryObjectivARBReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetQueryObjectivARBReply {
     /// Get the value of the `n` field.
     ///
@@ -12119,12 +11711,6 @@ impl TryParse for GetQueryObjectuivARBReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetQueryObjectuivARBReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetQueryObjectuivARBReply {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -7,10 +7,10 @@
 //! definitions from that extension. The core X11 protocol is in [`xproto`](xproto/index.html).
 
 use std::borrow::Cow;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use crate::errors::ParseError;
 use crate::utils::RawFdContainer;
-use crate::x11_utils::X11Error;
+use crate::x11_utils::{TryParse, X11Error};
 use crate::x11_utils::{ExtInfoProvider, ReplyParsingFunction, Request as RequestTrait, RequestHeader};
 
 pub mod xproto;
@@ -7457,39 +7457,39 @@ impl Event {
         // Check if this is a core protocol event or error, or from the generic event extension
         match event_code {
             0 => return Ok(Self::Error(X11Error::try_parse(event, ext_info_provider)?)),
-            xproto::BUTTON_PRESS_EVENT => return Ok(Self::ButtonPress(event.try_into()?)),
-            xproto::BUTTON_RELEASE_EVENT => return Ok(Self::ButtonRelease(event.try_into()?)),
-            xproto::CIRCULATE_NOTIFY_EVENT => return Ok(Self::CirculateNotify(event.try_into()?)),
-            xproto::CIRCULATE_REQUEST_EVENT => return Ok(Self::CirculateRequest(event.try_into()?)),
-            xproto::CLIENT_MESSAGE_EVENT => return Ok(Self::ClientMessage(event.try_into()?)),
-            xproto::COLORMAP_NOTIFY_EVENT => return Ok(Self::ColormapNotify(event.try_into()?)),
-            xproto::CONFIGURE_NOTIFY_EVENT => return Ok(Self::ConfigureNotify(event.try_into()?)),
-            xproto::CONFIGURE_REQUEST_EVENT => return Ok(Self::ConfigureRequest(event.try_into()?)),
-            xproto::CREATE_NOTIFY_EVENT => return Ok(Self::CreateNotify(event.try_into()?)),
-            xproto::DESTROY_NOTIFY_EVENT => return Ok(Self::DestroyNotify(event.try_into()?)),
-            xproto::ENTER_NOTIFY_EVENT => return Ok(Self::EnterNotify(event.try_into()?)),
-            xproto::EXPOSE_EVENT => return Ok(Self::Expose(event.try_into()?)),
-            xproto::FOCUS_IN_EVENT => return Ok(Self::FocusIn(event.try_into()?)),
-            xproto::FOCUS_OUT_EVENT => return Ok(Self::FocusOut(event.try_into()?)),
-            xproto::GRAPHICS_EXPOSURE_EVENT => return Ok(Self::GraphicsExposure(event.try_into()?)),
-            xproto::GRAVITY_NOTIFY_EVENT => return Ok(Self::GravityNotify(event.try_into()?)),
-            xproto::KEY_PRESS_EVENT => return Ok(Self::KeyPress(event.try_into()?)),
-            xproto::KEY_RELEASE_EVENT => return Ok(Self::KeyRelease(event.try_into()?)),
-            xproto::KEYMAP_NOTIFY_EVENT => return Ok(Self::KeymapNotify(event.try_into()?)),
-            xproto::LEAVE_NOTIFY_EVENT => return Ok(Self::LeaveNotify(event.try_into()?)),
-            xproto::MAP_NOTIFY_EVENT => return Ok(Self::MapNotify(event.try_into()?)),
-            xproto::MAP_REQUEST_EVENT => return Ok(Self::MapRequest(event.try_into()?)),
-            xproto::MAPPING_NOTIFY_EVENT => return Ok(Self::MappingNotify(event.try_into()?)),
-            xproto::MOTION_NOTIFY_EVENT => return Ok(Self::MotionNotify(event.try_into()?)),
-            xproto::NO_EXPOSURE_EVENT => return Ok(Self::NoExposure(event.try_into()?)),
-            xproto::PROPERTY_NOTIFY_EVENT => return Ok(Self::PropertyNotify(event.try_into()?)),
-            xproto::REPARENT_NOTIFY_EVENT => return Ok(Self::ReparentNotify(event.try_into()?)),
-            xproto::RESIZE_REQUEST_EVENT => return Ok(Self::ResizeRequest(event.try_into()?)),
-            xproto::SELECTION_CLEAR_EVENT => return Ok(Self::SelectionClear(event.try_into()?)),
-            xproto::SELECTION_NOTIFY_EVENT => return Ok(Self::SelectionNotify(event.try_into()?)),
-            xproto::SELECTION_REQUEST_EVENT => return Ok(Self::SelectionRequest(event.try_into()?)),
-            xproto::UNMAP_NOTIFY_EVENT => return Ok(Self::UnmapNotify(event.try_into()?)),
-            xproto::VISIBILITY_NOTIFY_EVENT => return Ok(Self::VisibilityNotify(event.try_into()?)),
+            xproto::BUTTON_PRESS_EVENT => return Ok(Self::ButtonPress(xproto::ButtonPressEvent::try_parse(event)?.0)),
+            xproto::BUTTON_RELEASE_EVENT => return Ok(Self::ButtonRelease(xproto::ButtonReleaseEvent::try_parse(event)?.0)),
+            xproto::CIRCULATE_NOTIFY_EVENT => return Ok(Self::CirculateNotify(xproto::CirculateNotifyEvent::try_parse(event)?.0)),
+            xproto::CIRCULATE_REQUEST_EVENT => return Ok(Self::CirculateRequest(xproto::CirculateRequestEvent::try_parse(event)?.0)),
+            xproto::CLIENT_MESSAGE_EVENT => return Ok(Self::ClientMessage(xproto::ClientMessageEvent::try_parse(event)?.0)),
+            xproto::COLORMAP_NOTIFY_EVENT => return Ok(Self::ColormapNotify(xproto::ColormapNotifyEvent::try_parse(event)?.0)),
+            xproto::CONFIGURE_NOTIFY_EVENT => return Ok(Self::ConfigureNotify(xproto::ConfigureNotifyEvent::try_parse(event)?.0)),
+            xproto::CONFIGURE_REQUEST_EVENT => return Ok(Self::ConfigureRequest(xproto::ConfigureRequestEvent::try_parse(event)?.0)),
+            xproto::CREATE_NOTIFY_EVENT => return Ok(Self::CreateNotify(xproto::CreateNotifyEvent::try_parse(event)?.0)),
+            xproto::DESTROY_NOTIFY_EVENT => return Ok(Self::DestroyNotify(xproto::DestroyNotifyEvent::try_parse(event)?.0)),
+            xproto::ENTER_NOTIFY_EVENT => return Ok(Self::EnterNotify(xproto::EnterNotifyEvent::try_parse(event)?.0)),
+            xproto::EXPOSE_EVENT => return Ok(Self::Expose(xproto::ExposeEvent::try_parse(event)?.0)),
+            xproto::FOCUS_IN_EVENT => return Ok(Self::FocusIn(xproto::FocusInEvent::try_parse(event)?.0)),
+            xproto::FOCUS_OUT_EVENT => return Ok(Self::FocusOut(xproto::FocusOutEvent::try_parse(event)?.0)),
+            xproto::GRAPHICS_EXPOSURE_EVENT => return Ok(Self::GraphicsExposure(xproto::GraphicsExposureEvent::try_parse(event)?.0)),
+            xproto::GRAVITY_NOTIFY_EVENT => return Ok(Self::GravityNotify(xproto::GravityNotifyEvent::try_parse(event)?.0)),
+            xproto::KEY_PRESS_EVENT => return Ok(Self::KeyPress(xproto::KeyPressEvent::try_parse(event)?.0)),
+            xproto::KEY_RELEASE_EVENT => return Ok(Self::KeyRelease(xproto::KeyReleaseEvent::try_parse(event)?.0)),
+            xproto::KEYMAP_NOTIFY_EVENT => return Ok(Self::KeymapNotify(xproto::KeymapNotifyEvent::try_parse(event)?.0)),
+            xproto::LEAVE_NOTIFY_EVENT => return Ok(Self::LeaveNotify(xproto::LeaveNotifyEvent::try_parse(event)?.0)),
+            xproto::MAP_NOTIFY_EVENT => return Ok(Self::MapNotify(xproto::MapNotifyEvent::try_parse(event)?.0)),
+            xproto::MAP_REQUEST_EVENT => return Ok(Self::MapRequest(xproto::MapRequestEvent::try_parse(event)?.0)),
+            xproto::MAPPING_NOTIFY_EVENT => return Ok(Self::MappingNotify(xproto::MappingNotifyEvent::try_parse(event)?.0)),
+            xproto::MOTION_NOTIFY_EVENT => return Ok(Self::MotionNotify(xproto::MotionNotifyEvent::try_parse(event)?.0)),
+            xproto::NO_EXPOSURE_EVENT => return Ok(Self::NoExposure(xproto::NoExposureEvent::try_parse(event)?.0)),
+            xproto::PROPERTY_NOTIFY_EVENT => return Ok(Self::PropertyNotify(xproto::PropertyNotifyEvent::try_parse(event)?.0)),
+            xproto::REPARENT_NOTIFY_EVENT => return Ok(Self::ReparentNotify(xproto::ReparentNotifyEvent::try_parse(event)?.0)),
+            xproto::RESIZE_REQUEST_EVENT => return Ok(Self::ResizeRequest(xproto::ResizeRequestEvent::try_parse(event)?.0)),
+            xproto::SELECTION_CLEAR_EVENT => return Ok(Self::SelectionClear(xproto::SelectionClearEvent::try_parse(event)?.0)),
+            xproto::SELECTION_NOTIFY_EVENT => return Ok(Self::SelectionNotify(xproto::SelectionNotifyEvent::try_parse(event)?.0)),
+            xproto::SELECTION_REQUEST_EVENT => return Ok(Self::SelectionRequest(xproto::SelectionRequestEvent::try_parse(event)?.0)),
+            xproto::UNMAP_NOTIFY_EVENT => return Ok(Self::UnmapNotify(xproto::UnmapNotifyEvent::try_parse(event)?.0)),
+            xproto::VISIBILITY_NOTIFY_EVENT => return Ok(Self::VisibilityNotify(xproto::VisibilityNotifyEvent::try_parse(event)?.0)),
             xproto::GE_GENERIC_EVENT => return Self::from_generic_event(event, ext_info_provider),
             _ => {}
         }
@@ -7499,98 +7499,98 @@ impl Event {
             #[cfg(feature = "damage")]
             Some((damage::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    damage::NOTIFY_EVENT => Ok(Self::DamageNotify(event.try_into()?)),
+                    damage::NOTIFY_EVENT => Ok(Self::DamageNotify(damage::NotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "dri2")]
             Some((dri2::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    dri2::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::Dri2BufferSwapComplete(event.try_into()?)),
-                    dri2::INVALIDATE_BUFFERS_EVENT => Ok(Self::Dri2InvalidateBuffers(event.try_into()?)),
+                    dri2::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::Dri2BufferSwapComplete(dri2::BufferSwapCompleteEvent::try_parse(event)?.0)),
+                    dri2::INVALIDATE_BUFFERS_EVENT => Ok(Self::Dri2InvalidateBuffers(dri2::InvalidateBuffersEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "glx")]
             Some((glx::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    glx::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::GlxBufferSwapComplete(event.try_into()?)),
-                    glx::PBUFFER_CLOBBER_EVENT => Ok(Self::GlxPbufferClobber(event.try_into()?)),
+                    glx::BUFFER_SWAP_COMPLETE_EVENT => Ok(Self::GlxBufferSwapComplete(glx::BufferSwapCompleteEvent::try_parse(event)?.0)),
+                    glx::PBUFFER_CLOBBER_EVENT => Ok(Self::GlxPbufferClobber(glx::PbufferClobberEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "present")]
             Some((present::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    present::GENERIC_EVENT => Ok(Self::PresentGeneric(event.try_into()?)),
+                    present::GENERIC_EVENT => Ok(Self::PresentGeneric(present::GenericEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "randr")]
             Some((randr::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    randr::NOTIFY_EVENT => Ok(Self::RandrNotify(event.try_into()?)),
-                    randr::SCREEN_CHANGE_NOTIFY_EVENT => Ok(Self::RandrScreenChangeNotify(event.try_into()?)),
+                    randr::NOTIFY_EVENT => Ok(Self::RandrNotify(randr::NotifyEvent::try_parse(event)?.0)),
+                    randr::SCREEN_CHANGE_NOTIFY_EVENT => Ok(Self::RandrScreenChangeNotify(randr::ScreenChangeNotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "screensaver")]
             Some((screensaver::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    screensaver::NOTIFY_EVENT => Ok(Self::ScreensaverNotify(event.try_into()?)),
+                    screensaver::NOTIFY_EVENT => Ok(Self::ScreensaverNotify(screensaver::NotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "shape")]
             Some((shape::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    shape::NOTIFY_EVENT => Ok(Self::ShapeNotify(event.try_into()?)),
+                    shape::NOTIFY_EVENT => Ok(Self::ShapeNotify(shape::NotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "shm")]
             Some((shm::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    shm::COMPLETION_EVENT => Ok(Self::ShmCompletion(event.try_into()?)),
+                    shm::COMPLETION_EVENT => Ok(Self::ShmCompletion(shm::CompletionEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "sync")]
             Some((sync::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    sync::ALARM_NOTIFY_EVENT => Ok(Self::SyncAlarmNotify(event.try_into()?)),
-                    sync::COUNTER_NOTIFY_EVENT => Ok(Self::SyncCounterNotify(event.try_into()?)),
+                    sync::ALARM_NOTIFY_EVENT => Ok(Self::SyncAlarmNotify(sync::AlarmNotifyEvent::try_parse(event)?.0)),
+                    sync::COUNTER_NOTIFY_EVENT => Ok(Self::SyncCounterNotify(sync::CounterNotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xfixes")]
             Some((xfixes::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xfixes::CURSOR_NOTIFY_EVENT => Ok(Self::XfixesCursorNotify(event.try_into()?)),
-                    xfixes::SELECTION_NOTIFY_EVENT => Ok(Self::XfixesSelectionNotify(event.try_into()?)),
+                    xfixes::CURSOR_NOTIFY_EVENT => Ok(Self::XfixesCursorNotify(xfixes::CursorNotifyEvent::try_parse(event)?.0)),
+                    xfixes::SELECTION_NOTIFY_EVENT => Ok(Self::XfixesSelectionNotify(xfixes::SelectionNotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xinput")]
             Some((xinput::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xinput::CHANGE_DEVICE_NOTIFY_EVENT => Ok(Self::XinputChangeDeviceNotify(event.try_into()?)),
-                    xinput::DEVICE_BUTTON_PRESS_EVENT => Ok(Self::XinputDeviceButtonPress(event.try_into()?)),
-                    xinput::DEVICE_BUTTON_RELEASE_EVENT => Ok(Self::XinputDeviceButtonRelease(event.try_into()?)),
-                    xinput::DEVICE_BUTTON_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceButtonStateNotify(event.try_into()?)),
-                    xinput::DEVICE_FOCUS_IN_EVENT => Ok(Self::XinputDeviceFocusIn(event.try_into()?)),
-                    xinput::DEVICE_FOCUS_OUT_EVENT => Ok(Self::XinputDeviceFocusOut(event.try_into()?)),
-                    xinput::DEVICE_KEY_PRESS_EVENT => Ok(Self::XinputDeviceKeyPress(event.try_into()?)),
-                    xinput::DEVICE_KEY_RELEASE_EVENT => Ok(Self::XinputDeviceKeyRelease(event.try_into()?)),
-                    xinput::DEVICE_KEY_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceKeyStateNotify(event.try_into()?)),
-                    xinput::DEVICE_MAPPING_NOTIFY_EVENT => Ok(Self::XinputDeviceMappingNotify(event.try_into()?)),
-                    xinput::DEVICE_MOTION_NOTIFY_EVENT => Ok(Self::XinputDeviceMotionNotify(event.try_into()?)),
-                    xinput::DEVICE_PRESENCE_NOTIFY_EVENT => Ok(Self::XinputDevicePresenceNotify(event.try_into()?)),
-                    xinput::DEVICE_PROPERTY_NOTIFY_EVENT => Ok(Self::XinputDevicePropertyNotify(event.try_into()?)),
-                    xinput::DEVICE_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceStateNotify(event.try_into()?)),
-                    xinput::DEVICE_VALUATOR_EVENT => Ok(Self::XinputDeviceValuator(event.try_into()?)),
-                    xinput::PROXIMITY_IN_EVENT => Ok(Self::XinputProximityIn(event.try_into()?)),
-                    xinput::PROXIMITY_OUT_EVENT => Ok(Self::XinputProximityOut(event.try_into()?)),
+                    xinput::CHANGE_DEVICE_NOTIFY_EVENT => Ok(Self::XinputChangeDeviceNotify(xinput::ChangeDeviceNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_BUTTON_PRESS_EVENT => Ok(Self::XinputDeviceButtonPress(xinput::DeviceButtonPressEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_BUTTON_RELEASE_EVENT => Ok(Self::XinputDeviceButtonRelease(xinput::DeviceButtonReleaseEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_BUTTON_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceButtonStateNotify(xinput::DeviceButtonStateNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_FOCUS_IN_EVENT => Ok(Self::XinputDeviceFocusIn(xinput::DeviceFocusInEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_FOCUS_OUT_EVENT => Ok(Self::XinputDeviceFocusOut(xinput::DeviceFocusOutEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_KEY_PRESS_EVENT => Ok(Self::XinputDeviceKeyPress(xinput::DeviceKeyPressEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_KEY_RELEASE_EVENT => Ok(Self::XinputDeviceKeyRelease(xinput::DeviceKeyReleaseEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_KEY_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceKeyStateNotify(xinput::DeviceKeyStateNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_MAPPING_NOTIFY_EVENT => Ok(Self::XinputDeviceMappingNotify(xinput::DeviceMappingNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_MOTION_NOTIFY_EVENT => Ok(Self::XinputDeviceMotionNotify(xinput::DeviceMotionNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_PRESENCE_NOTIFY_EVENT => Ok(Self::XinputDevicePresenceNotify(xinput::DevicePresenceNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_PROPERTY_NOTIFY_EVENT => Ok(Self::XinputDevicePropertyNotify(xinput::DevicePropertyNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_STATE_NOTIFY_EVENT => Ok(Self::XinputDeviceStateNotify(xinput::DeviceStateNotifyEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_VALUATOR_EVENT => Ok(Self::XinputDeviceValuator(xinput::DeviceValuatorEvent::try_parse(event)?.0)),
+                    xinput::PROXIMITY_IN_EVENT => Ok(Self::XinputProximityIn(xinput::ProximityInEvent::try_parse(event)?.0)),
+                    xinput::PROXIMITY_OUT_EVENT => Ok(Self::XinputProximityOut(xinput::ProximityOutEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
@@ -7600,34 +7600,34 @@ impl Event {
                     return Ok(Self::Unknown(event.to_vec()));
                 }
                 match *event.get(1).ok_or(ParseError::InsufficientData)? {
-                    xkb::ACCESS_X_NOTIFY_EVENT => Ok(Self::XkbAccessXNotify(event.try_into()?)),
-                    xkb::ACTION_MESSAGE_EVENT => Ok(Self::XkbActionMessage(event.try_into()?)),
-                    xkb::BELL_NOTIFY_EVENT => Ok(Self::XkbBellNotify(event.try_into()?)),
-                    xkb::COMPAT_MAP_NOTIFY_EVENT => Ok(Self::XkbCompatMapNotify(event.try_into()?)),
-                    xkb::CONTROLS_NOTIFY_EVENT => Ok(Self::XkbControlsNotify(event.try_into()?)),
-                    xkb::EXTENSION_DEVICE_NOTIFY_EVENT => Ok(Self::XkbExtensionDeviceNotify(event.try_into()?)),
-                    xkb::INDICATOR_MAP_NOTIFY_EVENT => Ok(Self::XkbIndicatorMapNotify(event.try_into()?)),
-                    xkb::INDICATOR_STATE_NOTIFY_EVENT => Ok(Self::XkbIndicatorStateNotify(event.try_into()?)),
-                    xkb::MAP_NOTIFY_EVENT => Ok(Self::XkbMapNotify(event.try_into()?)),
-                    xkb::NAMES_NOTIFY_EVENT => Ok(Self::XkbNamesNotify(event.try_into()?)),
-                    xkb::NEW_KEYBOARD_NOTIFY_EVENT => Ok(Self::XkbNewKeyboardNotify(event.try_into()?)),
-                    xkb::STATE_NOTIFY_EVENT => Ok(Self::XkbStateNotify(event.try_into()?)),
+                    xkb::ACCESS_X_NOTIFY_EVENT => Ok(Self::XkbAccessXNotify(xkb::AccessXNotifyEvent::try_parse(event)?.0)),
+                    xkb::ACTION_MESSAGE_EVENT => Ok(Self::XkbActionMessage(xkb::ActionMessageEvent::try_parse(event)?.0)),
+                    xkb::BELL_NOTIFY_EVENT => Ok(Self::XkbBellNotify(xkb::BellNotifyEvent::try_parse(event)?.0)),
+                    xkb::COMPAT_MAP_NOTIFY_EVENT => Ok(Self::XkbCompatMapNotify(xkb::CompatMapNotifyEvent::try_parse(event)?.0)),
+                    xkb::CONTROLS_NOTIFY_EVENT => Ok(Self::XkbControlsNotify(xkb::ControlsNotifyEvent::try_parse(event)?.0)),
+                    xkb::EXTENSION_DEVICE_NOTIFY_EVENT => Ok(Self::XkbExtensionDeviceNotify(xkb::ExtensionDeviceNotifyEvent::try_parse(event)?.0)),
+                    xkb::INDICATOR_MAP_NOTIFY_EVENT => Ok(Self::XkbIndicatorMapNotify(xkb::IndicatorMapNotifyEvent::try_parse(event)?.0)),
+                    xkb::INDICATOR_STATE_NOTIFY_EVENT => Ok(Self::XkbIndicatorStateNotify(xkb::IndicatorStateNotifyEvent::try_parse(event)?.0)),
+                    xkb::MAP_NOTIFY_EVENT => Ok(Self::XkbMapNotify(xkb::MapNotifyEvent::try_parse(event)?.0)),
+                    xkb::NAMES_NOTIFY_EVENT => Ok(Self::XkbNamesNotify(xkb::NamesNotifyEvent::try_parse(event)?.0)),
+                    xkb::NEW_KEYBOARD_NOTIFY_EVENT => Ok(Self::XkbNewKeyboardNotify(xkb::NewKeyboardNotifyEvent::try_parse(event)?.0)),
+                    xkb::STATE_NOTIFY_EVENT => Ok(Self::XkbStateNotify(xkb::StateNotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xprint")]
             Some((xprint::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xprint::ATTRIBUT_NOTIFY_EVENT => Ok(Self::XprintAttributNotify(event.try_into()?)),
-                    xprint::NOTIFY_EVENT => Ok(Self::XprintNotify(event.try_into()?)),
+                    xprint::ATTRIBUT_NOTIFY_EVENT => Ok(Self::XprintAttributNotify(xprint::AttributNotifyEvent::try_parse(event)?.0)),
+                    xprint::NOTIFY_EVENT => Ok(Self::XprintNotify(xprint::NotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xv")]
             Some((xv::X11_EXTENSION_NAME, ext_info)) => {
                 match event_code - ext_info.first_event {
-                    xv::PORT_NOTIFY_EVENT => Ok(Self::XvPortNotify(event.try_into()?)),
-                    xv::VIDEO_NOTIFY_EVENT => Ok(Self::XvVideoNotify(event.try_into()?)),
+                    xv::PORT_NOTIFY_EVENT => Ok(Self::XvPortNotify(xv::PortNotifyEvent::try_parse(event)?.0)),
+                    xv::VIDEO_NOTIFY_EVENT => Ok(Self::XvVideoNotify(xv::VideoNotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
@@ -7640,7 +7640,7 @@ impl Event {
         event: &[u8],
         ext_info_provider: &dyn ExtInfoProvider,
     ) -> Result<Self, ParseError> {
-        let ge_event = xproto::GeGenericEvent::try_from(event)?;
+        let ge_event = xproto::GeGenericEvent::try_parse(event)?.0;
         let ext_name = ext_info_provider
             .get_from_major_opcode(ge_event.extension)
             .map(|(name, _)| name);
@@ -7648,42 +7648,42 @@ impl Event {
             #[cfg(feature = "present")]
             Some(present::X11_EXTENSION_NAME) => {
                 match ge_event.event_type {
-                    present::COMPLETE_NOTIFY_EVENT => Ok(Self::PresentCompleteNotify(event.try_into()?)),
-                    present::CONFIGURE_NOTIFY_EVENT => Ok(Self::PresentConfigureNotify(event.try_into()?)),
-                    present::IDLE_NOTIFY_EVENT => Ok(Self::PresentIdleNotify(event.try_into()?)),
-                    present::REDIRECT_NOTIFY_EVENT => Ok(Self::PresentRedirectNotify(event.try_into()?)),
+                    present::COMPLETE_NOTIFY_EVENT => Ok(Self::PresentCompleteNotify(present::CompleteNotifyEvent::try_parse(event)?.0)),
+                    present::CONFIGURE_NOTIFY_EVENT => Ok(Self::PresentConfigureNotify(present::ConfigureNotifyEvent::try_parse(event)?.0)),
+                    present::IDLE_NOTIFY_EVENT => Ok(Self::PresentIdleNotify(present::IdleNotifyEvent::try_parse(event)?.0)),
+                    present::REDIRECT_NOTIFY_EVENT => Ok(Self::PresentRedirectNotify(present::RedirectNotifyEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }
             #[cfg(feature = "xinput")]
             Some(xinput::X11_EXTENSION_NAME) => {
                 match ge_event.event_type {
-                    xinput::BARRIER_HIT_EVENT => Ok(Self::XinputBarrierHit(event.try_into()?)),
-                    xinput::BARRIER_LEAVE_EVENT => Ok(Self::XinputBarrierLeave(event.try_into()?)),
-                    xinput::BUTTON_PRESS_EVENT => Ok(Self::XinputButtonPress(event.try_into()?)),
-                    xinput::BUTTON_RELEASE_EVENT => Ok(Self::XinputButtonRelease(event.try_into()?)),
-                    xinput::DEVICE_CHANGED_EVENT => Ok(Self::XinputDeviceChanged(event.try_into()?)),
-                    xinput::ENTER_EVENT => Ok(Self::XinputEnter(event.try_into()?)),
-                    xinput::FOCUS_IN_EVENT => Ok(Self::XinputFocusIn(event.try_into()?)),
-                    xinput::FOCUS_OUT_EVENT => Ok(Self::XinputFocusOut(event.try_into()?)),
-                    xinput::HIERARCHY_EVENT => Ok(Self::XinputHierarchy(event.try_into()?)),
-                    xinput::KEY_PRESS_EVENT => Ok(Self::XinputKeyPress(event.try_into()?)),
-                    xinput::KEY_RELEASE_EVENT => Ok(Self::XinputKeyRelease(event.try_into()?)),
-                    xinput::LEAVE_EVENT => Ok(Self::XinputLeave(event.try_into()?)),
-                    xinput::MOTION_EVENT => Ok(Self::XinputMotion(event.try_into()?)),
-                    xinput::PROPERTY_EVENT => Ok(Self::XinputProperty(event.try_into()?)),
-                    xinput::RAW_BUTTON_PRESS_EVENT => Ok(Self::XinputRawButtonPress(event.try_into()?)),
-                    xinput::RAW_BUTTON_RELEASE_EVENT => Ok(Self::XinputRawButtonRelease(event.try_into()?)),
-                    xinput::RAW_KEY_PRESS_EVENT => Ok(Self::XinputRawKeyPress(event.try_into()?)),
-                    xinput::RAW_KEY_RELEASE_EVENT => Ok(Self::XinputRawKeyRelease(event.try_into()?)),
-                    xinput::RAW_MOTION_EVENT => Ok(Self::XinputRawMotion(event.try_into()?)),
-                    xinput::RAW_TOUCH_BEGIN_EVENT => Ok(Self::XinputRawTouchBegin(event.try_into()?)),
-                    xinput::RAW_TOUCH_END_EVENT => Ok(Self::XinputRawTouchEnd(event.try_into()?)),
-                    xinput::RAW_TOUCH_UPDATE_EVENT => Ok(Self::XinputRawTouchUpdate(event.try_into()?)),
-                    xinput::TOUCH_BEGIN_EVENT => Ok(Self::XinputTouchBegin(event.try_into()?)),
-                    xinput::TOUCH_END_EVENT => Ok(Self::XinputTouchEnd(event.try_into()?)),
-                    xinput::TOUCH_OWNERSHIP_EVENT => Ok(Self::XinputTouchOwnership(event.try_into()?)),
-                    xinput::TOUCH_UPDATE_EVENT => Ok(Self::XinputTouchUpdate(event.try_into()?)),
+                    xinput::BARRIER_HIT_EVENT => Ok(Self::XinputBarrierHit(xinput::BarrierHitEvent::try_parse(event)?.0)),
+                    xinput::BARRIER_LEAVE_EVENT => Ok(Self::XinputBarrierLeave(xinput::BarrierLeaveEvent::try_parse(event)?.0)),
+                    xinput::BUTTON_PRESS_EVENT => Ok(Self::XinputButtonPress(xinput::ButtonPressEvent::try_parse(event)?.0)),
+                    xinput::BUTTON_RELEASE_EVENT => Ok(Self::XinputButtonRelease(xinput::ButtonReleaseEvent::try_parse(event)?.0)),
+                    xinput::DEVICE_CHANGED_EVENT => Ok(Self::XinputDeviceChanged(xinput::DeviceChangedEvent::try_parse(event)?.0)),
+                    xinput::ENTER_EVENT => Ok(Self::XinputEnter(xinput::EnterEvent::try_parse(event)?.0)),
+                    xinput::FOCUS_IN_EVENT => Ok(Self::XinputFocusIn(xinput::FocusInEvent::try_parse(event)?.0)),
+                    xinput::FOCUS_OUT_EVENT => Ok(Self::XinputFocusOut(xinput::FocusOutEvent::try_parse(event)?.0)),
+                    xinput::HIERARCHY_EVENT => Ok(Self::XinputHierarchy(xinput::HierarchyEvent::try_parse(event)?.0)),
+                    xinput::KEY_PRESS_EVENT => Ok(Self::XinputKeyPress(xinput::KeyPressEvent::try_parse(event)?.0)),
+                    xinput::KEY_RELEASE_EVENT => Ok(Self::XinputKeyRelease(xinput::KeyReleaseEvent::try_parse(event)?.0)),
+                    xinput::LEAVE_EVENT => Ok(Self::XinputLeave(xinput::LeaveEvent::try_parse(event)?.0)),
+                    xinput::MOTION_EVENT => Ok(Self::XinputMotion(xinput::MotionEvent::try_parse(event)?.0)),
+                    xinput::PROPERTY_EVENT => Ok(Self::XinputProperty(xinput::PropertyEvent::try_parse(event)?.0)),
+                    xinput::RAW_BUTTON_PRESS_EVENT => Ok(Self::XinputRawButtonPress(xinput::RawButtonPressEvent::try_parse(event)?.0)),
+                    xinput::RAW_BUTTON_RELEASE_EVENT => Ok(Self::XinputRawButtonRelease(xinput::RawButtonReleaseEvent::try_parse(event)?.0)),
+                    xinput::RAW_KEY_PRESS_EVENT => Ok(Self::XinputRawKeyPress(xinput::RawKeyPressEvent::try_parse(event)?.0)),
+                    xinput::RAW_KEY_RELEASE_EVENT => Ok(Self::XinputRawKeyRelease(xinput::RawKeyReleaseEvent::try_parse(event)?.0)),
+                    xinput::RAW_MOTION_EVENT => Ok(Self::XinputRawMotion(xinput::RawMotionEvent::try_parse(event)?.0)),
+                    xinput::RAW_TOUCH_BEGIN_EVENT => Ok(Self::XinputRawTouchBegin(xinput::RawTouchBeginEvent::try_parse(event)?.0)),
+                    xinput::RAW_TOUCH_END_EVENT => Ok(Self::XinputRawTouchEnd(xinput::RawTouchEndEvent::try_parse(event)?.0)),
+                    xinput::RAW_TOUCH_UPDATE_EVENT => Ok(Self::XinputRawTouchUpdate(xinput::RawTouchUpdateEvent::try_parse(event)?.0)),
+                    xinput::TOUCH_BEGIN_EVENT => Ok(Self::XinputTouchBegin(xinput::TouchBeginEvent::try_parse(event)?.0)),
+                    xinput::TOUCH_END_EVENT => Ok(Self::XinputTouchEnd(xinput::TouchEndEvent::try_parse(event)?.0)),
+                    xinput::TOUCH_OWNERSHIP_EVENT => Ok(Self::XinputTouchOwnership(xinput::TouchOwnershipEvent::try_parse(event)?.0)),
+                    xinput::TOUCH_UPDATE_EVENT => Ok(Self::XinputTouchUpdate(xinput::TouchUpdateEvent::try_parse(event)?.0)),
                     _ => Ok(Self::Unknown(event.to_vec())),
                 }
             }

--- a/src/protocol/present.rs
+++ b/src/protocol/present.rs
@@ -426,12 +426,6 @@ impl TryParse for Notify {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Notify {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Notify {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -553,12 +547,6 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1086,12 +1074,6 @@ impl TryParse for QueryCapabilitiesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryCapabilitiesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Generic event
 pub const GENERIC_EVENT: u8 = 0;
@@ -1119,12 +1101,6 @@ impl TryParse for GenericEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GenericEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&GenericEvent> for [u8; 32] {
@@ -1226,12 +1202,6 @@ impl TryParse for ConfigureNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ConfigureNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the CompleteNotify event
 pub const COMPLETE_NOTIFY_EVENT: u16 = 1;
@@ -1274,12 +1244,6 @@ impl TryParse for CompleteNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CompleteNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the IdleNotify event
 pub const IDLE_NOTIFY_EVENT: u16 = 2;
@@ -1315,12 +1279,6 @@ impl TryParse for IdleNotifyEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for IdleNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1396,12 +1354,6 @@ impl TryParse for RedirectNotifyEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for RedirectNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/randr.rs
+++ b/src/protocol/randr.rs
@@ -142,12 +142,6 @@ impl TryParse for ScreenSize {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ScreenSize {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ScreenSize {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -185,12 +179,6 @@ impl TryParse for RefreshRates {
         let (rates, remaining) = crate::x11_utils::parse_list::<u16>(remaining, n_rates.try_to_usize()?)?;
         let result = RefreshRates { rates };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for RefreshRates {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for RefreshRates {
@@ -321,12 +309,6 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -533,12 +515,6 @@ impl TryParse for SetScreenConfigReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SetScreenConfigReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -798,12 +774,6 @@ impl TryParse for GetScreenInfoReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetScreenInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetScreenInfoReply {
     /// Get the value of the `nSizes` field.
     ///
@@ -914,12 +884,6 @@ impl TryParse for GetScreenSizeRangeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetScreenSizeRangeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1132,12 +1096,6 @@ impl TryParse for ModeInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ModeInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ModeInfo {
     type Bytes = [u8; 32];
     fn serialize(&self) -> [u8; 32] {
@@ -1310,12 +1268,6 @@ impl TryParse for GetScreenResourcesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetScreenResourcesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetScreenResourcesReply {
@@ -1560,12 +1512,6 @@ impl TryParse for GetOutputInfoReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetOutputInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetOutputInfoReply {
     /// Get the value of the `num_crtcs` field.
     ///
@@ -1712,12 +1658,6 @@ impl TryParse for ListOutputPropertiesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ListOutputPropertiesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl ListOutputPropertiesReply {
     /// Get the value of the `num_atoms` field.
     ///
@@ -1836,12 +1776,6 @@ impl TryParse for QueryOutputPropertyReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryOutputPropertyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryOutputPropertyReply {
@@ -2327,12 +2261,6 @@ impl TryParse for GetOutputPropertyReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetOutputPropertyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
@@ -2474,12 +2402,6 @@ impl TryParse for CreateModeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CreateModeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -2816,12 +2738,6 @@ impl TryParse for GetCrtcInfoReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetCrtcInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetCrtcInfoReply {
     /// Get the value of the `num_outputs` field.
     ///
@@ -3024,12 +2940,6 @@ impl TryParse for SetCrtcConfigReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetCrtcConfigReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetCrtcGammaSize request
 pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
@@ -3119,12 +3029,6 @@ impl TryParse for GetCrtcGammaSizeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetCrtcGammaSizeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -3221,12 +3125,6 @@ impl TryParse for GetCrtcGammaReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetCrtcGammaReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetCrtcGammaReply {
@@ -3452,12 +3350,6 @@ impl TryParse for GetScreenResourcesCurrentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetScreenResourcesCurrentReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetScreenResourcesCurrentReply {
@@ -3845,12 +3737,6 @@ impl TryParse for GetCrtcTransformReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetCrtcTransformReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetCrtcTransformReply {
     /// Get the value of the `pending_len` field.
     ///
@@ -4019,12 +3905,6 @@ impl TryParse for GetPanningReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPanningReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -4212,12 +4092,6 @@ impl TryParse for SetPanningReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetPanningReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SetOutputPrimary request
 pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
@@ -4382,12 +4256,6 @@ impl TryParse for GetOutputPrimaryReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetOutputPrimaryReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetProviders request
 pub const GET_PROVIDERS_REQUEST: u8 = 32;
@@ -4480,12 +4348,6 @@ impl TryParse for GetProvidersReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetProvidersReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetProvidersReply {
@@ -4682,12 +4544,6 @@ impl TryParse for GetProviderInfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetProviderInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetProviderInfoReply {
@@ -5002,12 +4858,6 @@ impl TryParse for ListProviderPropertiesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ListProviderPropertiesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl ListProviderPropertiesReply {
     /// Get the value of the `num_atoms` field.
     ///
@@ -5126,12 +4976,6 @@ impl TryParse for QueryProviderPropertyReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryProviderPropertyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryProviderPropertyReply {
@@ -5614,12 +5458,6 @@ impl TryParse for GetProviderPropertyReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetProviderPropertyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ScreenChangeNotify event
 pub const SCREEN_CHANGE_NOTIFY_EVENT: u8 = 0;
@@ -5661,12 +5499,6 @@ impl TryParse for ScreenChangeNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ScreenChangeNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&ScreenChangeNotifyEvent> for [u8; 32] {
@@ -5822,12 +5654,6 @@ impl TryParse for CrtcChange {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CrtcChange {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for CrtcChange {
     type Bytes = [u8; 28];
     fn serialize(&self) -> [u8; 28] {
@@ -5915,12 +5741,6 @@ impl TryParse for OutputChange {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for OutputChange {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for OutputChange {
     type Bytes = [u8; 28];
     fn serialize(&self) -> [u8; 28] {
@@ -5999,12 +5819,6 @@ impl TryParse for OutputProperty {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for OutputProperty {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for OutputProperty {
     type Bytes = [u8; 28];
     fn serialize(&self) -> [u8; 28] {
@@ -6069,12 +5883,6 @@ impl TryParse for ProviderChange {
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
         let result = ProviderChange { timestamp, window, provider };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ProviderChange {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ProviderChange {
@@ -6143,12 +5951,6 @@ impl TryParse for ProviderProperty {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ProviderProperty {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ProviderProperty {
     type Bytes = [u8; 28];
     fn serialize(&self) -> [u8; 28] {
@@ -6211,12 +6013,6 @@ impl TryParse for ResourceChange {
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
         let result = ResourceChange { timestamp, window };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ResourceChange {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ResourceChange {
@@ -6291,12 +6087,6 @@ impl TryParse for MonitorInfo {
         let (outputs, remaining) = crate::x11_utils::parse_list::<Output>(remaining, n_output.try_to_usize()?)?;
         let result = MonitorInfo { name, primary, automatic, x, y, width, height, width_in_millimeters, height_in_millimeters, outputs };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for MonitorInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for MonitorInfo {
@@ -6440,12 +6230,6 @@ impl TryParse for GetMonitorsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetMonitorsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetMonitorsReply {
@@ -6745,13 +6529,6 @@ impl TryParseFd for CreateLeaseReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<(&[u8], Vec<RawFdContainer>)> for CreateLeaseReply {
-    type Error = ParseError;
-    fn try_from(value: (&[u8], Vec<RawFdContainer>)) -> Result<Self, Self::Error> {
-        let (value, mut fds) = value;
-        Ok(Self::try_parse_fd(value, &mut fds)?.0)
-    }
-}
 
 /// Opcode for the FreeLease request
 pub const FREE_LEASE_REQUEST: u8 = 46;
@@ -6843,12 +6620,6 @@ impl TryParse for LeaseNotify {
         let remaining = remaining.get(15..).ok_or(ParseError::InsufficientData)?;
         let result = LeaseNotify { timestamp, window, lease, created };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for LeaseNotify {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for LeaseNotify {
@@ -7043,12 +6814,6 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for NotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -50,12 +50,6 @@ impl TryParse for Range8 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Range8 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Range8 {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -84,12 +78,6 @@ impl TryParse for Range16 {
         let (last, remaining) = u16::try_parse(remaining)?;
         let result = Range16 { first, last };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Range16 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Range16 {
@@ -122,12 +110,6 @@ impl TryParse for ExtRange {
         let (minor, remaining) = Range16::try_parse(remaining)?;
         let result = ExtRange { major, minor };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ExtRange {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ExtRange {
@@ -176,12 +158,6 @@ impl TryParse for Range {
         let (client_died, remaining) = bool::try_parse(remaining)?;
         let result = Range { core_requests, core_replies, ext_requests, ext_replies, delivered_events, device_events, errors, client_started, client_died };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Range {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Range {
@@ -376,12 +352,6 @@ impl TryParse for ClientInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ClientInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ClientInfo {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -510,12 +480,6 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -925,12 +889,6 @@ impl TryParse for GetContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetContextReply {
     /// Get the value of the `num_intercepted_clients` field.
     ///
@@ -1047,12 +1005,6 @@ impl TryParse for EnableContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for EnableContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl EnableContextReply {

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -630,12 +630,6 @@ impl TryParse for Directformat {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Directformat {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Directformat {
     type Bytes = [u8; 16];
     fn serialize(&self) -> [u8; 16] {
@@ -698,12 +692,6 @@ impl TryParse for Pictforminfo {
         let type_ = type_.into();
         let result = Pictforminfo { id, type_, depth, direct, colormap };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Pictforminfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Pictforminfo {
@@ -769,12 +757,6 @@ impl TryParse for Pictvisual {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Pictvisual {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Pictvisual {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -812,12 +794,6 @@ impl TryParse for Pictdepth {
         let (visuals, remaining) = crate::x11_utils::parse_list::<Pictvisual>(remaining, num_visuals.try_to_usize()?)?;
         let result = Pictdepth { depth, visuals };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Pictdepth {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Pictdepth {
@@ -865,12 +841,6 @@ impl TryParse for Pictscreen {
         let (depths, remaining) = crate::x11_utils::parse_list::<Pictdepth>(remaining, num_depths.try_to_usize()?)?;
         let result = Pictscreen { fallback, depths };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Pictscreen {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Pictscreen {
@@ -923,12 +893,6 @@ impl TryParse for Indexvalue {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Indexvalue {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Indexvalue {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -979,12 +943,6 @@ impl TryParse for Color {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Color {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Color {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -1025,12 +983,6 @@ impl TryParse for Pointfix {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Pointfix {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Pointfix {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -1065,12 +1017,6 @@ impl TryParse for Linefix {
         let (p2, remaining) = Pointfix::try_parse(remaining)?;
         let result = Linefix { p1, p2 };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Linefix {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Linefix {
@@ -1117,12 +1063,6 @@ impl TryParse for Triangle {
         let (p3, remaining) = Pointfix::try_parse(remaining)?;
         let result = Triangle { p1, p2, p3 };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Triangle {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Triangle {
@@ -1181,12 +1121,6 @@ impl TryParse for Trapezoid {
         let (right, remaining) = Linefix::try_parse(remaining)?;
         let result = Trapezoid { top, bottom, left, right };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Trapezoid {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Trapezoid {
@@ -1267,12 +1201,6 @@ impl TryParse for Glyphinfo {
         let (y_off, remaining) = i16::try_parse(remaining)?;
         let result = Glyphinfo { width, height, x, y, x_off, y_off };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Glyphinfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Glyphinfo {
@@ -1411,12 +1339,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryPictFormats request
 pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
@@ -1514,12 +1436,6 @@ impl TryParse for QueryPictFormatsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryPictFormatsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryPictFormatsReply {
@@ -1653,12 +1569,6 @@ impl TryParse for QueryPictIndexValuesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryPictIndexValuesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryPictIndexValuesReply {
@@ -4371,12 +4281,6 @@ impl TryParse for Transform {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Transform {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Transform {
     type Bytes = [u8; 36];
     fn serialize(&self) -> [u8; 36] {
@@ -4642,12 +4546,6 @@ impl TryParse for QueryFiltersReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryFiltersReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl QueryFiltersReply {
     /// Get the value of the `num_aliases` field.
     ///
@@ -4797,12 +4695,6 @@ impl TryParse for Animcursorelt {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Animcursorelt {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Animcursorelt {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4928,12 +4820,6 @@ impl TryParse for Spanfix {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Spanfix {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Spanfix {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -4974,12 +4860,6 @@ impl TryParse for Trap {
         let (bot, remaining) = Spanfix::try_parse(remaining)?;
         let result = Trap { top, bot };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Trap {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Trap {

--- a/src/protocol/res.rs
+++ b/src/protocol/res.rs
@@ -48,12 +48,6 @@ impl TryParse for Client {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Client {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Client {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -88,12 +82,6 @@ impl TryParse for Type {
         let (count, remaining) = u32::try_parse(remaining)?;
         let result = Type { resource_type, count };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Type {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Type {
@@ -191,12 +179,6 @@ impl TryParse for ClientIdSpec {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ClientIdSpec {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ClientIdSpec {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -232,12 +214,6 @@ impl TryParse for ClientIdValue {
         let (value, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.checked_div(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let result = ClientIdValue { spec, value };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ClientIdValue {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ClientIdValue {
@@ -285,12 +261,6 @@ impl TryParse for ResourceIdSpec {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ResourceIdSpec {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ResourceIdSpec {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -329,12 +299,6 @@ impl TryParse for ResourceSizeSpec {
         let (use_count, remaining) = u32::try_parse(remaining)?;
         let result = ResourceSizeSpec { spec, bytes, ref_count, use_count };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ResourceSizeSpec {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ResourceSizeSpec {
@@ -388,12 +352,6 @@ impl TryParse for ResourceSizeValue {
         let (cross_references, remaining) = crate::x11_utils::parse_list::<ResourceSizeSpec>(remaining, num_cross_references.try_to_usize()?)?;
         let result = ResourceSizeValue { size, cross_references };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ResourceSizeValue {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ResourceSizeValue {
@@ -523,12 +481,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryClients request
 pub const QUERY_CLIENTS_REQUEST: u8 = 1;
@@ -608,12 +560,6 @@ impl TryParse for QueryClientsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryClientsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryClientsReply {
@@ -723,12 +669,6 @@ impl TryParse for QueryClientResourcesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryClientResourcesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl QueryClientResourcesReply {
     /// Get the value of the `num_types` field.
     ///
@@ -836,12 +776,6 @@ impl TryParse for QueryClientPixmapBytesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryClientPixmapBytesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryClientIds request
 pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
@@ -944,12 +878,6 @@ impl TryParse for QueryClientIdsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryClientIdsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryClientIdsReply {
@@ -1079,12 +1007,6 @@ impl TryParse for QueryResourceBytesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryResourceBytesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryResourceBytesReply {

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -314,12 +314,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryInfo request
 pub const QUERY_INFO_REQUEST: u8 = 1;
@@ -419,12 +413,6 @@ impl TryParse for QueryInfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1157,12 +1145,6 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for NotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {

--- a/src/protocol/shape.rs
+++ b/src/protocol/shape.rs
@@ -200,12 +200,6 @@ impl TryParse for NotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for NotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -338,12 +332,6 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -892,12 +880,6 @@ impl TryParse for QueryExtentsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryExtentsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 6;
@@ -1062,12 +1044,6 @@ impl TryParse for InputSelectedReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InputSelectedReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetRectangles request
 pub const GET_RECTANGLES_REQUEST: u8 = 8;
@@ -1171,12 +1147,6 @@ impl TryParse for GetRectanglesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetRectanglesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetRectanglesReply {

--- a/src/protocol/shm.rs
+++ b/src/protocol/shm.rs
@@ -68,12 +68,6 @@ impl TryParse for CompletionEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CompletionEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&CompletionEvent> for [u8; 32] {
     fn from(input: &CompletionEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -215,12 +209,6 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -698,12 +686,6 @@ impl TryParse for GetImageReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetImageReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 5;
@@ -1012,13 +994,6 @@ impl TryParseFd for CreateSegmentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<(&[u8], Vec<RawFdContainer>)> for CreateSegmentReply {
-    type Error = ParseError;
-    fn try_from(value: (&[u8], Vec<RawFdContainer>)) -> Result<Self, Self::Error> {
-        let (value, mut fds) = value;
-        Ok(Self::try_parse_fd(value, &mut fds)?.0)
     }
 }
 

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -277,12 +277,6 @@ impl TryParse for Int64 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Int64 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Int64 {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -326,12 +320,6 @@ impl TryParse for Systemcounter {
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
         let result = Systemcounter { counter, resolution, name };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Systemcounter {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Systemcounter {
@@ -386,12 +374,6 @@ impl TryParse for Trigger {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Trigger {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Trigger {
     type Bytes = [u8; 20];
     fn serialize(&self) -> [u8; 20] {
@@ -442,12 +424,6 @@ impl TryParse for Waitcondition {
         let (event_threshold, remaining) = Int64::try_parse(remaining)?;
         let result = Waitcondition { trigger, event_threshold };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Waitcondition {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Waitcondition {
@@ -596,12 +572,6 @@ impl TryParse for InitializeReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InitializeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ListSystemCounters request
 pub const LIST_SYSTEM_COUNTERS_REQUEST: u8 = 1;
@@ -681,12 +651,6 @@ impl TryParse for ListSystemCountersReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListSystemCountersReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListSystemCountersReply {
@@ -935,12 +899,6 @@ impl TryParse for QueryCounterReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryCounterReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1829,12 +1787,6 @@ impl TryParse for QueryAlarmReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryAlarmReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SetPriority request
 pub const SET_PRIORITY_REQUEST: u8 = 12;
@@ -1997,12 +1949,6 @@ impl TryParse for GetPriorityReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPriorityReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -2374,12 +2320,6 @@ impl TryParse for QueryFenceReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryFenceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the AwaitFence request
 pub const AWAIT_FENCE_REQUEST: u8 = 19;
@@ -2492,12 +2432,6 @@ impl TryParse for CounterNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CounterNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&CounterNotifyEvent> for [u8; 32] {
     fn from(input: &CounterNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2582,12 +2516,6 @@ impl TryParse for AlarmNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AlarmNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&AlarmNotifyEvent> for [u8; 32] {

--- a/src/protocol/xc_misc.rs
+++ b/src/protocol/xc_misc.rs
@@ -130,12 +130,6 @@ impl TryParse for GetVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetXIDRange request
 pub const GET_XID_RANGE_REQUEST: u8 = 1;
@@ -215,12 +209,6 @@ impl TryParse for GetXIDRangeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetXIDRangeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -313,12 +301,6 @@ impl TryParse for GetXIDListReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetXIDListReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetXIDListReply {

--- a/src/protocol/xevie.rs
+++ b/src/protocol/xevie.rs
@@ -131,12 +131,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Start request
 pub const START_REQUEST: u8 = 1;
@@ -224,12 +218,6 @@ impl TryParse for StartReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for StartReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -321,12 +309,6 @@ impl TryParse for EndReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for EndReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Datatype(bool);
@@ -406,12 +388,6 @@ impl TryParse for Event {
         let remaining = remaining.get(32..).ok_or(ParseError::InsufficientData)?;
         let result = Event {  };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Event {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Event {
@@ -648,12 +624,6 @@ impl TryParse for SendReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SendReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
@@ -741,12 +711,6 @@ impl TryParse for SelectInputReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectInputReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/xf86dri.rs
+++ b/src/protocol/xf86dri.rs
@@ -51,12 +51,6 @@ impl TryParse for DrmClipRect {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DrmClipRect {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DrmClipRect {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -166,12 +160,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryDirectRenderingCapable request
 pub const QUERY_DIRECT_RENDERING_CAPABLE_REQUEST: u8 = 1;
@@ -260,12 +248,6 @@ impl TryParse for QueryDirectRenderingCapableReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryDirectRenderingCapableReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -363,12 +345,6 @@ impl TryParse for OpenConnectionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for OpenConnectionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl OpenConnectionReply {
@@ -550,12 +526,6 @@ impl TryParse for GetClientDriverNameReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetClientDriverNameReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetClientDriverNameReply {
     /// Get the value of the `client_driver_name_len` field.
     ///
@@ -677,12 +647,6 @@ impl TryParse for CreateContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CreateContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -856,12 +820,6 @@ impl TryParse for CreateDrawableReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CreateDrawableReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1057,12 +1015,6 @@ impl TryParse for GetDrawableInfoReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDrawableInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDrawableInfoReply {
     /// Get the value of the `num_clip_rects` field.
     ///
@@ -1192,12 +1144,6 @@ impl TryParse for GetDeviceInfoReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDeviceInfoReply {
     /// Get the value of the `device_private_size` field.
     ///
@@ -1310,12 +1256,6 @@ impl TryParse for AuthConnectionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AuthConnectionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/xf86vidmode.rs
+++ b/src/protocol/xf86vidmode.rs
@@ -264,12 +264,6 @@ impl TryParse for ModeInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ModeInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ModeInfo {
     type Bytes = [u8; 48];
     fn serialize(&self) -> [u8; 48] {
@@ -435,12 +429,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetModeLine request
 pub const GET_MODE_LINE_REQUEST: u8 = 1;
@@ -556,12 +544,6 @@ impl TryParse for GetModeLineReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetModeLineReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetModeLineReply {
@@ -942,12 +924,6 @@ impl TryParse for GetMonitorReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMonitorReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetMonitorReply {
     /// Get the value of the `vendor_length` field.
     ///
@@ -1163,12 +1139,6 @@ impl TryParse for GetAllModeLinesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetAllModeLinesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetAllModeLinesReply {
@@ -1910,12 +1880,6 @@ impl TryParse for ValidateModeLineReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ValidateModeLineReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SwitchToMode request
 pub const SWITCH_TO_MODE_REQUEST: u8 = 10;
@@ -2206,12 +2170,6 @@ impl TryParse for GetViewPortReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetViewPortReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SetViewPort request
 pub const SET_VIEW_PORT_REQUEST: u8 = 12;
@@ -2392,12 +2350,6 @@ impl TryParse for GetDotClocksReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetDotClocksReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -2696,12 +2648,6 @@ impl TryParse for GetGammaReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetGammaReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetGammaRamp request
 pub const GET_GAMMA_RAMP_REQUEST: u8 = 17;
@@ -2802,12 +2748,6 @@ impl TryParse for GetGammaRampReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetGammaRampReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -3005,12 +2945,6 @@ impl TryParse for GetGammaRampSizeReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetGammaRampSizeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetPermissions request
 pub const GET_PERMISSIONS_REQUEST: u8 = 20;
@@ -3101,12 +3035,6 @@ impl TryParse for GetPermissionsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPermissionsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -138,12 +138,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct SaveSetMode(u8);
@@ -561,12 +555,6 @@ impl TryParse for SelectionNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SelectionNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&SelectionNotifyEvent> for [u8; 32] {
     fn from(input: &SelectionNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -848,12 +836,6 @@ impl TryParse for CursorNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CursorNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&CursorNotifyEvent> for [u8; 32] {
     fn from(input: &CursorNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -1072,12 +1054,6 @@ impl TryParse for GetCursorImageReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetCursorImageReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -2342,12 +2318,6 @@ impl TryParse for FetchRegionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FetchRegionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl FetchRegionReply {
     /// Get the value of the `length` field.
     ///
@@ -2827,12 +2797,6 @@ impl TryParse for GetCursorNameReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetCursorNameReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetCursorNameReply {
     /// Get the value of the `nbytes` field.
     ///
@@ -2946,12 +2910,6 @@ impl TryParse for GetCursorImageAndNameReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetCursorImageAndNameReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetCursorImageAndNameReply {

--- a/src/protocol/xinerama.rs
+++ b/src/protocol/xinerama.rs
@@ -52,12 +52,6 @@ impl TryParse for ScreenInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ScreenInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ScreenInfo {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -181,12 +175,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 1;
@@ -278,12 +266,6 @@ impl TryParse for GetStateReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetStateReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetScreenCount request
 pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
@@ -373,12 +355,6 @@ impl TryParse for GetScreenCountReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetScreenCountReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -486,12 +462,6 @@ impl TryParse for GetScreenSizeReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetScreenSizeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the IsActive request
 pub const IS_ACTIVE_REQUEST: u8 = 4;
@@ -569,12 +539,6 @@ impl TryParse for IsActiveReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for IsActiveReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -656,12 +620,6 @@ impl TryParse for QueryScreensReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryScreensReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryScreensReply {

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -17552,87 +17552,87 @@ impl EventForSend {
     pub fn as_device_valuator_event(&self) -> DeviceValuatorEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceValuatorEvent::try_from(value).unwrap()
+        DeviceValuatorEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_key_press_event(&self) -> DeviceKeyPressEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceKeyPressEvent::try_from(value).unwrap()
+        DeviceKeyPressEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_key_release_event(&self) -> DeviceKeyReleaseEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceKeyReleaseEvent::try_from(value).unwrap()
+        DeviceKeyReleaseEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_button_press_event(&self) -> DeviceButtonPressEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceButtonPressEvent::try_from(value).unwrap()
+        DeviceButtonPressEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_button_release_event(&self) -> DeviceButtonReleaseEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceButtonReleaseEvent::try_from(value).unwrap()
+        DeviceButtonReleaseEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_motion_notify_event(&self) -> DeviceMotionNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceMotionNotifyEvent::try_from(value).unwrap()
+        DeviceMotionNotifyEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_focus_in_event(&self) -> DeviceFocusInEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceFocusInEvent::try_from(value).unwrap()
+        DeviceFocusInEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_focus_out_event(&self) -> DeviceFocusOutEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceFocusOutEvent::try_from(value).unwrap()
+        DeviceFocusOutEvent::try_parse(value).unwrap().0
     }
     pub fn as_proximity_in_event(&self) -> ProximityInEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        ProximityInEvent::try_from(value).unwrap()
+        ProximityInEvent::try_parse(value).unwrap().0
     }
     pub fn as_proximity_out_event(&self) -> ProximityOutEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        ProximityOutEvent::try_from(value).unwrap()
+        ProximityOutEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_state_notify_event(&self) -> DeviceStateNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceStateNotifyEvent::try_from(value).unwrap()
+        DeviceStateNotifyEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_mapping_notify_event(&self) -> DeviceMappingNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceMappingNotifyEvent::try_from(value).unwrap()
+        DeviceMappingNotifyEvent::try_parse(value).unwrap().0
     }
     pub fn as_change_device_notify_event(&self) -> ChangeDeviceNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        ChangeDeviceNotifyEvent::try_from(value).unwrap()
+        ChangeDeviceNotifyEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_key_state_notify_event(&self) -> DeviceKeyStateNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceKeyStateNotifyEvent::try_from(value).unwrap()
+        DeviceKeyStateNotifyEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_button_state_notify_event(&self) -> DeviceButtonStateNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DeviceButtonStateNotifyEvent::try_from(value).unwrap()
+        DeviceButtonStateNotifyEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_presence_notify_event(&self) -> DevicePresenceNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DevicePresenceNotifyEvent::try_from(value).unwrap()
+        DevicePresenceNotifyEvent::try_parse(value).unwrap().0
     }
     pub fn as_device_property_notify_event(&self) -> DevicePropertyNotifyEvent {
         let value: &[u8] = &self.0;
         // FIXME: event parsing can fail
-        DevicePropertyNotifyEvent::try_from(value).unwrap()
+        DevicePropertyNotifyEvent::try_parse(value).unwrap().0
     }
 }
 impl Serialize for EventForSend {

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -57,12 +57,6 @@ impl TryParse for Fp3232 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Fp3232 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Fp3232 {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -191,12 +185,6 @@ impl TryParse for GetExtensionVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetExtensionVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -409,12 +397,6 @@ impl TryParse for DeviceInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceInfo {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -464,12 +446,6 @@ impl TryParse for KeyInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for KeyInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for KeyInfo {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -516,12 +492,6 @@ impl TryParse for ButtonInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ButtonInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ButtonInfo {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -556,12 +526,6 @@ impl TryParse for AxisInfo {
         let (maximum, remaining) = i32::try_parse(remaining)?;
         let result = AxisInfo { resolution, minimum, maximum };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AxisInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for AxisInfo {
@@ -615,12 +579,6 @@ impl TryParse for ValuatorInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ValuatorInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ValuatorInfo {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -671,12 +629,6 @@ impl TryParse for InputInfoInfoKey {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InputInfoInfoKey {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for InputInfoInfoKey {
     type Bytes = [u8; 6];
     fn serialize(&self) -> [u8; 6] {
@@ -711,12 +663,6 @@ impl TryParse for InputInfoInfoButton {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InputInfoInfoButton {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for InputInfoInfoButton {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -746,12 +692,6 @@ impl TryParse for InputInfoInfoValuator {
         let mode = mode.into();
         let result = InputInfoInfoValuator { mode, motion_size, axes };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for InputInfoInfoValuator {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for InputInfoInfoValuator {
@@ -880,12 +820,6 @@ impl TryParse for InputInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InputInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for InputInfo {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -913,12 +847,6 @@ impl TryParse for DeviceName {
         let string = string.to_vec();
         let result = DeviceName { string };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceName {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceName {
@@ -1041,12 +969,6 @@ impl TryParse for ListInputDevicesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ListInputDevicesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl ListInputDevicesReply {
     /// Get the value of the `devices_len` field.
     ///
@@ -1077,12 +999,6 @@ impl TryParse for InputClassInfo {
         let class_id = class_id.into();
         let result = InputClassInfo { class_id, event_type_base };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for InputClassInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for InputClassInfo {
@@ -1198,12 +1114,6 @@ impl TryParse for OpenDeviceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for OpenDeviceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl OpenDeviceReply {
@@ -1385,12 +1295,6 @@ impl TryParse for SetDeviceModeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SetDeviceModeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1575,12 +1479,6 @@ impl TryParse for GetSelectedExtensionEventsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetSelectedExtensionEventsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetSelectedExtensionEventsReply {
@@ -1857,12 +1755,6 @@ impl TryParse for GetDeviceDontPropagateListReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceDontPropagateListReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDeviceDontPropagateListReply {
     /// Get the value of the `num_classes` field.
     ///
@@ -1892,7 +1784,6 @@ impl DeviceTimeCoord {
         Ok((result, remaining))
     }
 }
-// Skipping TryFrom implementations because of unresolved members
 impl DeviceTimeCoord {
     #[allow(dead_code)]
     fn serialize(&self, num_axes: u8) -> Vec<u8> {
@@ -2032,12 +1923,6 @@ impl TryParse for GetDeviceMotionEventsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceMotionEventsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDeviceMotionEventsReply {
     /// Get the value of the `num_events` field.
     ///
@@ -2147,12 +2032,6 @@ impl TryParse for ChangeKeyboardDeviceReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ChangeKeyboardDeviceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ChangePointerDevice request
 pub const CHANGE_POINTER_DEVICE_REQUEST: u8 = 12;
@@ -2255,12 +2134,6 @@ impl TryParse for ChangePointerDeviceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ChangePointerDeviceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -2419,12 +2292,6 @@ impl TryParse for GrabDeviceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GrabDeviceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -3298,12 +3165,6 @@ impl TryParse for GetDeviceFocusReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceFocusReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SetDeviceFocus request
 pub const SET_DEVICE_FOCUS_REQUEST: u8 = 21;
@@ -3499,12 +3360,6 @@ impl TryParse for KbdFeedbackState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for KbdFeedbackState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for KbdFeedbackState {
     type Bytes = [u8; 52];
     fn serialize(&self) -> [u8; 52] {
@@ -3613,12 +3468,6 @@ impl TryParse for PtrFeedbackState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PtrFeedbackState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for PtrFeedbackState {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -3675,12 +3524,6 @@ impl TryParse for IntegerFeedbackState {
         let class_id = class_id.into();
         let result = IntegerFeedbackState { class_id, feedback_id, len, resolution, min_value, max_value };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for IntegerFeedbackState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for IntegerFeedbackState {
@@ -3743,12 +3586,6 @@ impl TryParse for StringFeedbackState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for StringFeedbackState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for StringFeedbackState {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -3806,12 +3643,6 @@ impl TryParse for BellFeedbackState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for BellFeedbackState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for BellFeedbackState {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -3866,12 +3697,6 @@ impl TryParse for LedFeedbackState {
         let class_id = class_id.into();
         let result = LedFeedbackState { class_id, feedback_id, len, led_mask, led_values };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for LedFeedbackState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for LedFeedbackState {
@@ -3932,12 +3757,6 @@ impl TryParse for FeedbackStateDataKeyboard {
         let auto_repeats = <[u8; 32]>::try_from(auto_repeats).unwrap();
         let result = FeedbackStateDataKeyboard { pitch, duration, led_mask, led_values, global_auto_repeat, click, percent, auto_repeats };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FeedbackStateDataKeyboard {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for FeedbackStateDataKeyboard {
@@ -4030,12 +3849,6 @@ impl TryParse for FeedbackStateDataPointer {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FeedbackStateDataPointer {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for FeedbackStateDataPointer {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4073,12 +3886,6 @@ impl TryParse for FeedbackStateDataString {
         let (keysyms, remaining) = crate::x11_utils::parse_list::<xproto::Keysym>(remaining, num_keysyms.try_to_usize()?)?;
         let result = FeedbackStateDataString { max_symbols, keysyms };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FeedbackStateDataString {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for FeedbackStateDataString {
@@ -4126,12 +3933,6 @@ impl TryParse for FeedbackStateDataInteger {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FeedbackStateDataInteger {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for FeedbackStateDataInteger {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -4173,12 +3974,6 @@ impl TryParse for FeedbackStateDataLed {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FeedbackStateDataLed {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for FeedbackStateDataLed {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4215,12 +4010,6 @@ impl TryParse for FeedbackStateDataBell {
         let (duration, remaining) = u16::try_parse(remaining)?;
         let result = FeedbackStateDataBell { percent, pitch, duration };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FeedbackStateDataBell {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for FeedbackStateDataBell {
@@ -4390,12 +4179,6 @@ impl TryParse for FeedbackState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FeedbackState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for FeedbackState {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -4506,12 +4289,6 @@ impl TryParse for GetFeedbackControlReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetFeedbackControlReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetFeedbackControlReply {
     /// Get the value of the `num_feedbacks` field.
     ///
@@ -4558,12 +4335,6 @@ impl TryParse for KbdFeedbackCtl {
         let class_id = class_id.into();
         let result = KbdFeedbackCtl { class_id, feedback_id, len, key, auto_repeat_mode, key_click_percent, bell_percent, bell_pitch, bell_duration, led_mask, led_values };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KbdFeedbackCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KbdFeedbackCtl {
@@ -4642,12 +4413,6 @@ impl TryParse for PtrFeedbackCtl {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PtrFeedbackCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for PtrFeedbackCtl {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -4702,12 +4467,6 @@ impl TryParse for IntegerFeedbackCtl {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for IntegerFeedbackCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for IntegerFeedbackCtl {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4753,12 +4512,6 @@ impl TryParse for StringFeedbackCtl {
         let class_id = class_id.into();
         let result = StringFeedbackCtl { class_id, feedback_id, len, keysyms };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for StringFeedbackCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for StringFeedbackCtl {
@@ -4818,12 +4571,6 @@ impl TryParse for BellFeedbackCtl {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for BellFeedbackCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for BellFeedbackCtl {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -4878,12 +4625,6 @@ impl TryParse for LedFeedbackCtl {
         let class_id = class_id.into();
         let result = LedFeedbackCtl { class_id, feedback_id, len, led_mask, led_values };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for LedFeedbackCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for LedFeedbackCtl {
@@ -4944,12 +4685,6 @@ impl TryParse for FeedbackCtlDataKeyboard {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FeedbackCtlDataKeyboard {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for FeedbackCtlDataKeyboard {
     type Bytes = [u8; 16];
     fn serialize(&self) -> [u8; 16] {
@@ -5008,12 +4743,6 @@ impl TryParse for FeedbackCtlDataPointer {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FeedbackCtlDataPointer {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for FeedbackCtlDataPointer {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -5050,12 +4779,6 @@ impl TryParse for FeedbackCtlDataString {
         let (keysyms, remaining) = crate::x11_utils::parse_list::<xproto::Keysym>(remaining, num_keysyms.try_to_usize()?)?;
         let result = FeedbackCtlDataString { keysyms };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FeedbackCtlDataString {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for FeedbackCtlDataString {
@@ -5099,12 +4822,6 @@ impl TryParse for FeedbackCtlDataInteger {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FeedbackCtlDataInteger {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for FeedbackCtlDataInteger {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -5132,12 +4849,6 @@ impl TryParse for FeedbackCtlDataLed {
         let (led_values, remaining) = u32::try_parse(remaining)?;
         let result = FeedbackCtlDataLed { led_mask, led_values };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FeedbackCtlDataLed {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for FeedbackCtlDataLed {
@@ -5176,12 +4887,6 @@ impl TryParse for FeedbackCtlDataBell {
         let (duration, remaining) = i16::try_parse(remaining)?;
         let result = FeedbackCtlDataBell { percent, pitch, duration };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FeedbackCtlDataBell {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for FeedbackCtlDataBell {
@@ -5349,12 +5054,6 @@ impl TryParse for FeedbackCtl {
         let (data, remaining) = FeedbackCtlData::try_parse(remaining, class_id)?;
         let result = FeedbackCtl { feedback_id, len, data };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for FeedbackCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for FeedbackCtl {
@@ -5648,12 +5347,6 @@ impl TryParse for GetDeviceKeyMappingReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceKeyMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDeviceKeyMappingReply {
     /// Get the value of the `length` field.
     ///
@@ -5863,12 +5556,6 @@ impl TryParse for GetDeviceModifierMappingReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceModifierMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDeviceModifierMappingReply {
     /// Get the value of the `keycodes_per_modifier` field.
     ///
@@ -5997,12 +5684,6 @@ impl TryParse for SetDeviceModifierMappingReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetDeviceModifierMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetDeviceButtonMapping request
 pub const GET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 28;
@@ -6101,12 +5782,6 @@ impl TryParse for GetDeviceButtonMappingReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetDeviceButtonMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetDeviceButtonMappingReply {
@@ -6235,12 +5910,6 @@ impl TryParse for SetDeviceButtonMappingReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetDeviceButtonMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyState {
@@ -6260,12 +5929,6 @@ impl TryParse for KeyState {
         let class_id = class_id.into();
         let result = KeyState { class_id, len, num_keys, keys };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeyState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KeyState {
@@ -6341,12 +6004,6 @@ impl TryParse for ButtonState {
         let class_id = class_id.into();
         let result = ButtonState { class_id, len, num_buttons, buttons };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ButtonState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ButtonState {
@@ -6482,12 +6139,6 @@ impl TryParse for ValuatorState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ValuatorState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ValuatorState {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -6534,12 +6185,6 @@ impl TryParse for InputStateDataKey {
         let keys = <[u8; 32]>::try_from(keys).unwrap();
         let result = InputStateDataKey { num_keys, keys };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for InputStateDataKey {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for InputStateDataKey {
@@ -6605,12 +6250,6 @@ impl TryParse for InputStateDataButton {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InputStateDataButton {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for InputStateDataButton {
     type Bytes = [u8; 34];
     fn serialize(&self) -> [u8; 34] {
@@ -6671,12 +6310,6 @@ impl TryParse for InputStateDataValuator {
         let (valuators, remaining) = crate::x11_utils::parse_list::<i32>(remaining, num_valuators.try_to_usize()?)?;
         let result = InputStateDataValuator { mode, valuators };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for InputStateDataValuator {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for InputStateDataValuator {
@@ -6804,12 +6437,6 @@ impl TryParse for InputState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InputState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for InputState {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -6917,12 +6544,6 @@ impl TryParse for QueryDeviceStateReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryDeviceStateReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryDeviceStateReply {
@@ -7138,12 +6759,6 @@ impl TryParse for SetDeviceValuatorsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetDeviceValuatorsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct DeviceControl(u16);
@@ -7224,12 +6839,6 @@ impl TryParse for DeviceResolutionState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceResolutionState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceResolutionState {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -7294,12 +6903,6 @@ impl TryParse for DeviceAbsCalibState {
         let control_id = control_id.into();
         let result = DeviceAbsCalibState { control_id, len, min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceAbsCalibState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceAbsCalibState {
@@ -7395,12 +6998,6 @@ impl TryParse for DeviceAbsAreaState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceAbsAreaState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceAbsAreaState {
     type Bytes = [u8; 28];
     fn serialize(&self) -> [u8; 28] {
@@ -7475,12 +7072,6 @@ impl TryParse for DeviceCoreState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceCoreState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceCoreState {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -7526,12 +7117,6 @@ impl TryParse for DeviceEnableState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceEnableState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceEnableState {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -7572,12 +7157,6 @@ impl TryParse for DeviceStateDataResolution {
         let (resolution_max, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators.try_to_usize()?)?;
         let result = DeviceStateDataResolution { resolution_values, resolution_min, resolution_max };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceStateDataResolution {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceStateDataResolution {
@@ -7635,12 +7214,6 @@ impl TryParse for DeviceStateDataAbsCalib {
         let (button_threshold, remaining) = u32::try_parse(remaining)?;
         let result = DeviceStateDataAbsCalib { min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceStateDataAbsCalib {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceStateDataAbsCalib {
@@ -7715,12 +7288,6 @@ impl TryParse for DeviceStateDataCore {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceStateDataCore {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceStateDataCore {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -7759,12 +7326,6 @@ impl TryParse for DeviceStateDataAbsArea {
         let (following, remaining) = u32::try_parse(remaining)?;
         let result = DeviceStateDataAbsArea { offset_x, offset_y, width, height, screen, following };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceStateDataAbsArea {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceStateDataAbsArea {
@@ -7944,12 +7505,6 @@ impl TryParse for DeviceState {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceState {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceState {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -8066,12 +7621,6 @@ impl TryParse for GetDeviceControlReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceControlReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeviceResolutionCtl {
@@ -8091,12 +7640,6 @@ impl TryParse for DeviceResolutionCtl {
         let control_id = control_id.into();
         let result = DeviceResolutionCtl { control_id, len, first_valuator, resolution_values };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceResolutionCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceResolutionCtl {
@@ -8161,12 +7704,6 @@ impl TryParse for DeviceAbsCalibCtl {
         let control_id = control_id.into();
         let result = DeviceAbsCalibCtl { control_id, len, min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceAbsCalibCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceAbsCalibCtl {
@@ -8262,12 +7799,6 @@ impl TryParse for DeviceAbsAreaCtrl {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceAbsAreaCtrl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceAbsAreaCtrl {
     type Bytes = [u8; 28];
     fn serialize(&self) -> [u8; 28] {
@@ -8340,12 +7871,6 @@ impl TryParse for DeviceCoreCtrl {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceCoreCtrl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceCoreCtrl {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -8389,12 +7914,6 @@ impl TryParse for DeviceEnableCtrl {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceEnableCtrl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceEnableCtrl {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -8434,12 +7953,6 @@ impl TryParse for DeviceCtlDataResolution {
         let (resolution_values, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_valuators.try_to_usize()?)?;
         let result = DeviceCtlDataResolution { first_valuator, resolution_values };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceCtlDataResolution {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceCtlDataResolution {
@@ -8496,12 +8009,6 @@ impl TryParse for DeviceCtlDataAbsCalib {
         let (button_threshold, remaining) = u32::try_parse(remaining)?;
         let result = DeviceCtlDataAbsCalib { min_x, max_x, min_y, max_y, flip_x, flip_y, rotation, button_threshold };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceCtlDataAbsCalib {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceCtlDataAbsCalib {
@@ -8574,12 +8081,6 @@ impl TryParse for DeviceCtlDataCore {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceCtlDataCore {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceCtlDataCore {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -8616,12 +8117,6 @@ impl TryParse for DeviceCtlDataAbsArea {
         let (following, remaining) = u32::try_parse(remaining)?;
         let result = DeviceCtlDataAbsArea { offset_x, offset_y, width, height, screen, following };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceCtlDataAbsArea {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceCtlDataAbsArea {
@@ -8801,12 +8296,6 @@ impl TryParse for DeviceCtl {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceCtl {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceCtl {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -8929,12 +8418,6 @@ impl TryParse for ChangeDeviceControlReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ChangeDeviceControlReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ListDeviceProperties request
 pub const LIST_DEVICE_PROPERTIES_REQUEST: u8 = 36;
@@ -9027,12 +8510,6 @@ impl TryParse for ListDevicePropertiesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListDevicePropertiesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListDevicePropertiesReply {
@@ -9625,12 +9102,6 @@ impl TryParse for GetDevicePropertyReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDevicePropertyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Device(bool);
@@ -9719,12 +9190,6 @@ impl TryParse for GroupInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GroupInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for GroupInfo {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -9763,12 +9228,6 @@ impl TryParse for ModifierInfo {
         let (effective, remaining) = u32::try_parse(remaining)?;
         let result = ModifierInfo { base, latched, locked, effective };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ModifierInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ModifierInfo {
@@ -9925,12 +9384,6 @@ impl TryParse for XIQueryPointerReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIQueryPointerReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl XIQueryPointerReply {
@@ -10312,12 +9765,6 @@ impl TryParse for AddMaster {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for AddMaster {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for AddMaster {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -10377,12 +9824,6 @@ impl TryParse for RemoveMaster {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for RemoveMaster {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for RemoveMaster {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -10437,12 +9878,6 @@ impl TryParse for AttachSlave {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for AttachSlave {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for AttachSlave {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -10485,12 +9920,6 @@ impl TryParse for DetachSlave {
         let type_ = type_.into();
         let result = DetachSlave { type_, len, deviceid };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DetachSlave {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DetachSlave {
@@ -10539,12 +9968,6 @@ impl TryParse for HierarchyChangeDataAddMaster {
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
         let result = HierarchyChangeDataAddMaster { send_core, enable, name };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for HierarchyChangeDataAddMaster {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for HierarchyChangeDataAddMaster {
@@ -10598,12 +10021,6 @@ impl TryParse for HierarchyChangeDataRemoveMaster {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for HierarchyChangeDataRemoveMaster {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for HierarchyChangeDataRemoveMaster {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -10644,12 +10061,6 @@ impl TryParse for HierarchyChangeDataAttachSlave {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for HierarchyChangeDataAttachSlave {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for HierarchyChangeDataAttachSlave {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -10678,12 +10089,6 @@ impl TryParse for HierarchyChangeDataDetachSlave {
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let result = HierarchyChangeDataDetachSlave { deviceid };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for HierarchyChangeDataDetachSlave {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for HierarchyChangeDataDetachSlave {
@@ -10811,12 +10216,6 @@ impl TryParse for HierarchyChange {
         let (data, remaining) = HierarchyChangeData::try_parse(remaining, type_)?;
         let result = HierarchyChange { len, data };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for HierarchyChange {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for HierarchyChange {
@@ -11083,12 +10482,6 @@ impl TryParse for XIGetClientPointerReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for XIGetClientPointerReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct XIEventMask(u32);
@@ -11197,12 +10590,6 @@ impl TryParse for EventMask {
         let (mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, mask_len.try_to_usize()?)?;
         let result = EventMask { deviceid, mask };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for EventMask {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for EventMask {
@@ -11419,12 +10806,6 @@ impl TryParse for XIQueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIQueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -11734,12 +11115,6 @@ impl TryParse for ButtonClass {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ButtonClass {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ButtonClass {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -11792,12 +11167,6 @@ impl TryParse for KeyClass {
         let type_ = type_.into();
         let result = KeyClass { type_, len, sourceid, keys };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeyClass {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KeyClass {
@@ -11857,12 +11226,6 @@ impl TryParse for ScrollClass {
         let scroll_type = scroll_type.into();
         let result = ScrollClass { type_, len, sourceid, number, scroll_type, flags, increment };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ScrollClass {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ScrollClass {
@@ -11936,12 +11299,6 @@ impl TryParse for TouchClass {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for TouchClass {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for TouchClass {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -12001,12 +11358,6 @@ impl TryParse for ValuatorClass {
         let mode = mode.into();
         let result = ValuatorClass { type_, len, sourceid, number, label, min, max, value, resolution, mode };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ValuatorClass {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ValuatorClass {
@@ -12097,12 +11448,6 @@ impl TryParse for DeviceClassDataKey {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceClassDataKey {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceClassDataKey {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -12143,12 +11488,6 @@ impl TryParse for DeviceClassDataButton {
         let (labels, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, num_buttons.try_to_usize()?)?;
         let result = DeviceClassDataButton { state, labels };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceClassDataButton {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceClassDataButton {
@@ -12204,12 +11543,6 @@ impl TryParse for DeviceClassDataValuator {
         let mode = mode.into();
         let result = DeviceClassDataValuator { number, label, min, max, value, resolution, mode };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceClassDataValuator {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceClassDataValuator {
@@ -12294,12 +11627,6 @@ impl TryParse for DeviceClassDataScroll {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceClassDataScroll {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceClassDataScroll {
     type Bytes = [u8; 18];
     fn serialize(&self) -> [u8; 18] {
@@ -12349,12 +11676,6 @@ impl TryParse for DeviceClassDataTouch {
         let mode = mode.into();
         let result = DeviceClassDataTouch { mode, num_touches };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceClassDataTouch {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceClassDataTouch {
@@ -12500,12 +11821,6 @@ impl TryParse for DeviceClass {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceClass {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for DeviceClass {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -12552,12 +11867,6 @@ impl TryParse for XIDeviceInfo {
         let type_ = type_.into();
         let result = XIDeviceInfo { deviceid, type_, attachment, enabled, name, classes };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIDeviceInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for XIDeviceInfo {
@@ -12704,12 +12013,6 @@ impl TryParse for XIQueryDeviceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIQueryDeviceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl XIQueryDeviceReply {
@@ -12907,12 +12210,6 @@ impl TryParse for XIGetFocusReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIGetFocusReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -13153,12 +12450,6 @@ impl TryParse for XIGrabDeviceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIGrabDeviceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -13598,12 +12889,6 @@ impl TryParse for GrabModifierInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GrabModifierInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for GrabModifierInfo {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -13826,12 +13111,6 @@ impl TryParse for XIPassiveGrabDeviceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIPassiveGrabDeviceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl XIPassiveGrabDeviceReply {
@@ -14059,12 +13338,6 @@ impl TryParse for XIListPropertiesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for XIListPropertiesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl XIListPropertiesReply {
@@ -14599,12 +13872,6 @@ impl TryParse for XIGetPropertyReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for XIGetPropertyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the XIGetSelectedEvents request
 pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
@@ -14697,12 +13964,6 @@ impl TryParse for XIGetSelectedEventsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for XIGetSelectedEventsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl XIGetSelectedEventsReply {
     /// Get the value of the `num_masks` field.
     ///
@@ -14733,12 +13994,6 @@ impl TryParse for BarrierReleasePointerInfo {
         let (eventid, remaining) = u32::try_parse(remaining)?;
         let result = BarrierReleasePointerInfo { deviceid, barrier, eventid };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for BarrierReleasePointerInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for BarrierReleasePointerInfo {
@@ -14888,12 +14143,6 @@ impl TryParse for DeviceValuatorEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceValuatorEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&DeviceValuatorEvent> for [u8; 32] {
@@ -15052,12 +14301,6 @@ impl TryParse for DeviceKeyPressEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceKeyPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&DeviceKeyPressEvent> for [u8; 32] {
     fn from(input: &DeviceKeyPressEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -15162,12 +14405,6 @@ impl TryParse for DeviceFocusInEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceFocusInEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&DeviceFocusInEvent> for [u8; 32] {
@@ -15344,12 +14581,6 @@ impl TryParse for DeviceStateNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceStateNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&DeviceStateNotifyEvent> for [u8; 32] {
     fn from(input: &DeviceStateNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -15435,12 +14666,6 @@ impl TryParse for DeviceMappingNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceMappingNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&DeviceMappingNotifyEvent> for [u8; 32] {
@@ -15579,12 +14804,6 @@ impl TryParse for ChangeDeviceNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ChangeDeviceNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ChangeDeviceNotifyEvent> for [u8; 32] {
     fn from(input: &ChangeDeviceNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -15658,12 +14877,6 @@ impl TryParse for DeviceKeyStateNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceKeyStateNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&DeviceKeyStateNotifyEvent> for [u8; 32] {
     fn from(input: &DeviceKeyStateNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -15733,12 +14946,6 @@ impl TryParse for DeviceButtonStateNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceButtonStateNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&DeviceButtonStateNotifyEvent> for [u8; 32] {
@@ -15884,12 +15091,6 @@ impl TryParse for DevicePresenceNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DevicePresenceNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&DevicePresenceNotifyEvent> for [u8; 32] {
     fn from(input: &DevicePresenceNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -15967,12 +15168,6 @@ impl TryParse for DevicePropertyNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DevicePropertyNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&DevicePropertyNotifyEvent> for [u8; 32] {
@@ -16121,12 +15316,6 @@ impl TryParse for DeviceChangedEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DeviceChangedEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl DeviceChangedEvent {
     /// Get the value of the `num_classes` field.
     ///
@@ -16248,12 +15437,6 @@ impl TryParse for KeyPressEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeyPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl KeyPressEvent {
@@ -16394,12 +15577,6 @@ impl TryParse for ButtonPressEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ButtonPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ButtonPressEvent {
@@ -16637,12 +15814,6 @@ impl TryParse for EnterEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for EnterEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl EnterEvent {
     /// Get the value of the `buttons_len` field.
     ///
@@ -16763,12 +15934,6 @@ impl TryParse for HierarchyInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for HierarchyInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for HierarchyInfo {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -16836,12 +16001,6 @@ impl TryParse for HierarchyEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for HierarchyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl HierarchyEvent {
@@ -16955,12 +16114,6 @@ impl TryParse for PropertyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PropertyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the RawKeyPress event
 pub const RAW_KEY_PRESS_EVENT: u16 = 13;
@@ -17003,12 +16156,6 @@ impl TryParse for RawKeyPressEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for RawKeyPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl RawKeyPressEvent {
@@ -17072,12 +16219,6 @@ impl TryParse for RawButtonPressEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for RawButtonPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl RawButtonPressEvent {
@@ -17213,12 +16354,6 @@ impl TryParse for TouchBeginEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for TouchBeginEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl TouchBeginEvent {
     /// Get the value of the `buttons_len` field.
     ///
@@ -17344,12 +16479,6 @@ impl TryParse for TouchOwnershipEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for TouchOwnershipEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the RawTouchBegin event
 pub const RAW_TOUCH_BEGIN_EVENT: u16 = 22;
@@ -17392,12 +16521,6 @@ impl TryParse for RawTouchBeginEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for RawTouchBeginEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl RawTouchBeginEvent {
@@ -17533,12 +16656,6 @@ impl TryParse for BarrierHitEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for BarrierHitEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -1933,12 +1933,6 @@ impl TryParse for IndicatorMap {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for IndicatorMap {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for IndicatorMap {
     type Bytes = [u8; 12];
     fn serialize(&self) -> [u8; 12] {
@@ -2330,12 +2324,6 @@ impl TryParse for ModDef {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ModDef {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for ModDef {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -2369,12 +2357,6 @@ impl TryParse for KeyName {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for KeyName {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for KeyName {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -2404,12 +2386,6 @@ impl TryParse for KeyAlias {
         let alias = <[u8; 4]>::try_from(alias).unwrap();
         let result = KeyAlias { real, alias };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeyAlias {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KeyAlias {
@@ -2447,12 +2423,6 @@ impl TryParse for CountedString16 {
         let alignment_pad = alignment_pad.to_vec();
         let result = CountedString16 { string, alignment_pad };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CountedString16 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for CountedString16 {
@@ -2504,12 +2474,6 @@ impl TryParse for KTMapEntry {
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let result = KTMapEntry { active, mods_mask, level, mods_mods, mods_vmods };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KTMapEntry {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KTMapEntry {
@@ -2565,12 +2529,6 @@ impl TryParse for KeyType {
         let (preserve, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, u32::from(has_preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let result = KeyType { mods_mask, mods_mods, mods_vmods, num_levels, has_preserve, map, preserve };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeyType {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KeyType {
@@ -2630,12 +2588,6 @@ impl TryParse for KeySymMap {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for KeySymMap {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for KeySymMap {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -2682,12 +2634,6 @@ impl TryParse for CommonBehavior {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CommonBehavior {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for CommonBehavior {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -2715,12 +2661,6 @@ impl TryParse for DefaultBehavior {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let result = DefaultBehavior { type_ };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DefaultBehavior {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DefaultBehavior {
@@ -2754,12 +2694,6 @@ impl TryParse for RadioGroupBehavior {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for RadioGroupBehavior {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for RadioGroupBehavior {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -2788,12 +2722,6 @@ impl TryParse for OverlayBehavior {
         let (key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let result = OverlayBehavior { type_, key };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for OverlayBehavior {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for OverlayBehavior {
@@ -3051,12 +2979,6 @@ impl TryParse for SetBehavior {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetBehavior {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SetBehavior {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -3090,12 +3012,6 @@ impl TryParse for SetExplicit {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetExplicit {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SetExplicit {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -3124,12 +3040,6 @@ impl TryParse for KeyModMap {
         let (mods, remaining) = u8::try_parse(remaining)?;
         let result = KeyModMap { keycode, mods };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeyModMap {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KeyModMap {
@@ -3161,12 +3071,6 @@ impl TryParse for KeyVModMap {
         let (vmods, remaining) = u16::try_parse(remaining)?;
         let result = KeyVModMap { keycode, vmods };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeyVModMap {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KeyVModMap {
@@ -3202,12 +3106,6 @@ impl TryParse for KTSetMapEntry {
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let result = KTSetMapEntry { level, real_mods, virtual_mods };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KTSetMapEntry {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for KTSetMapEntry {
@@ -3254,12 +3152,6 @@ impl TryParse for SetKeyType {
         let (preserve_entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, u32::from(preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let result = SetKeyType { mask, real_mods, virtual_mods, num_levels, preserve, entries, preserve_entries };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SetKeyType {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SetKeyType {
@@ -3317,12 +3209,6 @@ impl TryParse for Outline {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Outline {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Outline {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -3372,12 +3258,6 @@ impl TryParse for Shape {
         let (outlines, remaining) = crate::x11_utils::parse_list::<Outline>(remaining, n_outlines.try_to_usize()?)?;
         let result = Shape { name, primary_ndx, approx_ndx, outlines };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Shape {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Shape {
@@ -3432,12 +3312,6 @@ impl TryParse for Key {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Key {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Key {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -3479,12 +3353,6 @@ impl TryParse for OverlayKey {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for OverlayKey {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for OverlayKey {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -3519,12 +3387,6 @@ impl TryParse for OverlayRow {
         let (keys, remaining) = crate::x11_utils::parse_list::<OverlayKey>(remaining, n_keys.try_to_usize()?)?;
         let result = OverlayRow { row_under, keys };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for OverlayRow {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for OverlayRow {
@@ -3572,12 +3434,6 @@ impl TryParse for Overlay {
         let (rows, remaining) = crate::x11_utils::parse_list::<OverlayRow>(remaining, n_rows.try_to_usize()?)?;
         let result = Overlay { name, rows };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Overlay {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Overlay {
@@ -3629,12 +3485,6 @@ impl TryParse for Row {
         let (keys, remaining) = crate::x11_utils::parse_list::<Key>(remaining, n_keys.try_to_usize()?)?;
         let result = Row { top, left, vertical, keys };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Row {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Row {
@@ -3755,12 +3605,6 @@ impl TryParse for Listing {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Listing {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Listing {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -3817,12 +3661,6 @@ impl TryParse for DeviceLedInfo {
         let led_class = led_class.into();
         let result = DeviceLedInfo { led_class, led_id, names_present, maps_present, phys_indicators, state, names, maps };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for DeviceLedInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for DeviceLedInfo {
@@ -4082,12 +3920,6 @@ impl TryParse for SANoAction {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SANoAction {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SANoAction {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4131,12 +3963,6 @@ impl TryParse for SASetMods {
         let type_ = type_.into();
         let result = SASetMods { type_, flags, mask, real_mods, vmods_high, vmods_low };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SASetMods {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SASetMods {
@@ -4190,12 +4016,6 @@ impl TryParse for SASetGroup {
         let type_ = type_.into();
         let result = SASetGroup { type_, flags, group };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SASetGroup {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SASetGroup {
@@ -4312,12 +4132,6 @@ impl TryParse for SAMovePtr {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SAMovePtr {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SAMovePtr {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4369,12 +4183,6 @@ impl TryParse for SAPtrBtn {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SAPtrBtn {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SAPtrBtn {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4419,12 +4227,6 @@ impl TryParse for SALockPtrBtn {
         let type_ = type_.into();
         let result = SALockPtrBtn { type_, flags, button };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SALockPtrBtn {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SALockPtrBtn {
@@ -4530,12 +4332,6 @@ impl TryParse for SASetPtrDflt {
         let type_ = type_.into();
         let result = SASetPtrDflt { type_, flags, affect, value };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SASetPtrDflt {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SASetPtrDflt {
@@ -4720,12 +4516,6 @@ impl TryParse for SAIsoLock {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SAIsoLock {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SAIsoLock {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -4772,12 +4562,6 @@ impl TryParse for SATerminate {
         let type_ = type_.into();
         let result = SATerminate { type_ };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SATerminate {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SATerminate {
@@ -4876,12 +4660,6 @@ impl TryParse for SASwitchScreen {
         let type_ = type_.into();
         let result = SASwitchScreen { type_, flags, new_screen };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SASwitchScreen {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SASwitchScreen {
@@ -5064,12 +4842,6 @@ impl TryParse for SASetControls {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SASetControls {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SASetControls {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -5177,12 +4949,6 @@ impl TryParse for SAActionMessage {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SAActionMessage {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SAActionMessage {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -5231,12 +4997,6 @@ impl TryParse for SARedirectKey {
         let type_ = type_.into();
         let result = SARedirectKey { type_, newkey, mask, real_modifiers, vmods_mask_high, vmods_mask_low, vmods_high, vmods_low };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SARedirectKey {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SARedirectKey {
@@ -5293,12 +5053,6 @@ impl TryParse for SADeviceBtn {
         let type_ = type_.into();
         let result = SADeviceBtn { type_, flags, count, button, device };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SADeviceBtn {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SADeviceBtn {
@@ -5408,12 +5162,6 @@ impl TryParse for SALockDeviceBtn {
         let type_ = type_.into();
         let result = SALockDeviceBtn { type_, flags, button, device };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SALockDeviceBtn {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SALockDeviceBtn {
@@ -5539,12 +5287,6 @@ impl TryParse for SADeviceValuator {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SADeviceValuator {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SADeviceValuator {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -5595,12 +5337,6 @@ impl TryParse for SIAction {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SIAction {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SIAction {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -5642,12 +5378,6 @@ impl TryParse for SymInterpret {
         let (action, remaining) = SIAction::try_parse(remaining)?;
         let result = SymInterpret { sym, mods, match_, virtual_mod, flags, action };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SymInterpret {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SymInterpret {
@@ -6100,12 +5830,6 @@ impl TryParse for UseExtensionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for UseExtensionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SelectEventsAuxBitcase1 {
@@ -6118,12 +5842,6 @@ impl TryParse for SelectEventsAuxBitcase1 {
         let (new_keyboard_details, remaining) = u16::try_parse(remaining)?;
         let result = SelectEventsAuxBitcase1 { affect_new_keyboard, new_keyboard_details };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase1 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SelectEventsAuxBitcase1 {
@@ -6157,12 +5875,6 @@ impl TryParse for SelectEventsAuxBitcase2 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase2 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SelectEventsAuxBitcase2 {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -6192,12 +5904,6 @@ impl TryParse for SelectEventsAuxBitcase3 {
         let (ctrl_details, remaining) = u32::try_parse(remaining)?;
         let result = SelectEventsAuxBitcase3 { affect_ctrls, ctrl_details };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase3 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SelectEventsAuxBitcase3 {
@@ -6235,12 +5941,6 @@ impl TryParse for SelectEventsAuxBitcase4 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase4 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SelectEventsAuxBitcase4 {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -6274,12 +5974,6 @@ impl TryParse for SelectEventsAuxBitcase5 {
         let (indicator_map_details, remaining) = u32::try_parse(remaining)?;
         let result = SelectEventsAuxBitcase5 { affect_indicator_map, indicator_map_details };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase5 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SelectEventsAuxBitcase5 {
@@ -6317,12 +6011,6 @@ impl TryParse for SelectEventsAuxBitcase6 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase6 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SelectEventsAuxBitcase6 {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -6354,12 +6042,6 @@ impl TryParse for SelectEventsAuxBitcase7 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase7 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SelectEventsAuxBitcase7 {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -6387,12 +6069,6 @@ impl TryParse for SelectEventsAuxBitcase8 {
         let (bell_details, remaining) = u8::try_parse(remaining)?;
         let result = SelectEventsAuxBitcase8 { affect_bell, bell_details };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase8 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SelectEventsAuxBitcase8 {
@@ -6424,12 +6100,6 @@ impl TryParse for SelectEventsAuxBitcase9 {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase9 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SelectEventsAuxBitcase9 {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -6457,12 +6127,6 @@ impl TryParse for SelectEventsAuxBitcase10 {
         let (access_x_details, remaining) = u16::try_parse(remaining)?;
         let result = SelectEventsAuxBitcase10 { affect_access_x, access_x_details };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase10 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SelectEventsAuxBitcase10 {
@@ -6494,12 +6158,6 @@ impl TryParse for SelectEventsAuxBitcase11 {
         let (extdev_details, remaining) = u16::try_parse(remaining)?;
         let result = SelectEventsAuxBitcase11 { affect_ext_dev, extdev_details };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectEventsAuxBitcase11 {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SelectEventsAuxBitcase11 {
@@ -7141,12 +6799,6 @@ impl TryParse for GetStateReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetStateReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the LatchLockState request
 pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
@@ -7407,12 +7059,6 @@ impl TryParse for GetControlsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetControlsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -7951,7 +7597,6 @@ impl GetMapMapBitcase3 {
         Ok((result, remaining))
     }
 }
-// Skipping TryFrom implementations because of unresolved members
 #[derive(Debug, Clone, Default)]
 pub struct GetMapMap {
     pub types_rtrn: Option<Vec<KeyType>>,
@@ -8127,12 +7772,6 @@ impl TryParse for GetMapReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMapReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct SetMapAuxBitcase3 {
@@ -8153,7 +7792,6 @@ impl SetMapAuxBitcase3 {
         Ok((result, remaining))
     }
 }
-// Skipping TryFrom implementations because of unresolved members
 impl SetMapAuxBitcase3 {
     #[allow(dead_code)]
     fn serialize(&self, n_key_actions: u8, total_actions: u16) -> Vec<u8> {
@@ -8764,12 +8402,6 @@ impl TryParse for GetCompatMapReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetCompatMapReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetCompatMapReply {
     /// Get the value of the `nSIRtrn` field.
     ///
@@ -9005,12 +8637,6 @@ impl TryParse for GetIndicatorStateReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetIndicatorStateReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetIndicatorMap request
 pub const GET_INDICATOR_MAP_REQUEST: u8 = 13;
@@ -9117,12 +8743,6 @@ impl TryParse for GetIndicatorMapReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetIndicatorMapReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -9360,12 +8980,6 @@ impl TryParse for GetNamedIndicatorReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetNamedIndicatorReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -9643,7 +9257,6 @@ impl GetNamesValueListBitcase8 {
         Ok((result, remaining))
     }
 }
-// Skipping TryFrom implementations because of unresolved members
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GetNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
@@ -9830,12 +9443,6 @@ impl TryParse for GetNamesReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetNamesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetNamesAuxBitcase8 {
@@ -9856,7 +9463,6 @@ impl SetNamesAuxBitcase8 {
         Ok((result, remaining))
     }
 }
-// Skipping TryFrom implementations because of unresolved members
 impl SetNamesAuxBitcase8 {
     #[allow(dead_code)]
     fn serialize(&self, n_types: u8) -> Vec<u8> {
@@ -10527,12 +10133,6 @@ impl TryParse for PerClientFlagsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PerClientFlagsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ListComponents request
 pub const LIST_COMPONENTS_REQUEST: u8 = 22;
@@ -10646,12 +10246,6 @@ impl TryParse for ListComponentsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListComponentsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListComponentsReply {
@@ -10843,7 +10437,6 @@ impl GetKbdByNameRepliesTypesMapBitcase3 {
         Ok((result, remaining))
     }
 }
-// Skipping TryFrom implementations because of unresolved members
 #[derive(Debug, Clone, Default)]
 pub struct GetKbdByNameRepliesTypesMap {
     pub types_rtrn: Option<Vec<KeyType>>,
@@ -11013,12 +10606,6 @@ impl TryParse for GetKbdByNameRepliesTypes {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetKbdByNameRepliesTypes {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetKbdByNameRepliesCompatMap {
     pub compatmap_type: u8,
@@ -11047,12 +10634,6 @@ impl TryParse for GetKbdByNameRepliesCompatMap {
         let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups_rtrn.count_ones().try_to_usize()?)?;
         let result = GetKbdByNameRepliesCompatMap { compatmap_type, compat_device_id, compatmap_sequence, compatmap_length, groups_rtrn, first_si_rtrn, n_total_si, si_rtrn, group_rtrn };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetKbdByNameRepliesCompatMap {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetKbdByNameRepliesCompatMap {
@@ -11095,12 +10676,6 @@ impl TryParse for GetKbdByNameRepliesIndicatorMaps {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetKbdByNameRepliesIndicatorMaps {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetKbdByNameRepliesIndicatorMaps {
     /// Get the value of the `nIndicators` field.
     ///
@@ -11135,7 +10710,6 @@ impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
         Ok((result, remaining))
     }
 }
-// Skipping TryFrom implementations because of unresolved members
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GetKbdByNameRepliesKeyNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
@@ -11316,12 +10890,6 @@ impl TryParse for GetKbdByNameRepliesKeyNames {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetKbdByNameRepliesKeyNames {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetKbdByNameRepliesGeometry {
     pub geometry_type: u8,
@@ -11364,12 +10932,6 @@ impl TryParse for GetKbdByNameRepliesGeometry {
         let (label_font, remaining) = CountedString16::try_parse(remaining)?;
         let result = GetKbdByNameRepliesGeometry { geometry_type, geometry_device_id, geometry_sequence, geometry_length, name, geometry_found, width_mm, height_mm, n_properties, n_colors, n_shapes, n_sections, n_doodads, n_key_aliases, base_color_ndx, label_color_ndx, label_font };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetKbdByNameRepliesGeometry {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 #[derive(Debug, Clone, Default)]
@@ -11460,12 +11022,6 @@ impl TryParse for GetKbdByNameReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetKbdByNameReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -11637,12 +11193,6 @@ impl TryParse for GetDeviceInfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetDeviceInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetDeviceInfoReply {
@@ -11946,12 +11496,6 @@ impl TryParse for SetDebuggingFlagsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetDebuggingFlagsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the NewKeyboardNotify event
 pub const NEW_KEYBOARD_NOTIFY_EVENT: u8 = 0;
@@ -11993,12 +11537,6 @@ impl TryParse for NewKeyboardNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for NewKeyboardNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&NewKeyboardNotifyEvent> for [u8; 32] {
@@ -12120,12 +11658,6 @@ impl TryParse for MapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for MapNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&MapNotifyEvent> for [u8; 32] {
@@ -12261,12 +11793,6 @@ impl TryParse for StateNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for StateNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&StateNotifyEvent> for [u8; 32] {
     fn from(input: &StateNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -12378,12 +11904,6 @@ impl TryParse for ControlsNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ControlsNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ControlsNotifyEvent> for [u8; 32] {
     fn from(input: &ControlsNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -12472,12 +11992,6 @@ impl TryParse for IndicatorStateNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for IndicatorStateNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&IndicatorStateNotifyEvent> for [u8; 32] {
     fn from(input: &IndicatorStateNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -12558,12 +12072,6 @@ impl TryParse for IndicatorMapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for IndicatorMapNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&IndicatorMapNotifyEvent> for [u8; 32] {
@@ -12669,12 +12177,6 @@ impl TryParse for NamesNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for NamesNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&NamesNotifyEvent> for [u8; 32] {
     fn from(input: &NamesNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -12768,12 +12270,6 @@ impl TryParse for CompatMapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CompatMapNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&CompatMapNotifyEvent> for [u8; 32] {
@@ -12870,12 +12366,6 @@ impl TryParse for BellNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for BellNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&BellNotifyEvent> for [u8; 32] {
@@ -12975,12 +12465,6 @@ impl TryParse for ActionMessageEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ActionMessageEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ActionMessageEvent> for [u8; 32] {
     fn from(input: &ActionMessageEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -13067,12 +12551,6 @@ impl TryParse for AccessXNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AccessXNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&AccessXNotifyEvent> for [u8; 32] {
@@ -13172,12 +12650,6 @@ impl TryParse for ExtensionDeviceNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ExtensionDeviceNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&ExtensionDeviceNotifyEvent> for [u8; 32] {

--- a/src/protocol/xprint.rs
+++ b/src/protocol/xprint.rs
@@ -63,12 +63,6 @@ impl TryParse for Printer {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Printer {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Printer {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -463,12 +457,6 @@ impl TryParse for PrintQueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PrintQueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the PrintGetPrinterList request
 pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
@@ -583,12 +571,6 @@ impl TryParse for PrintGetPrinterListReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for PrintGetPrinterListReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl PrintGetPrinterListReply {
@@ -903,12 +885,6 @@ impl TryParse for PrintGetContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PrintGetContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the PrintDestroyContext request
 pub const PRINT_DESTROY_CONTEXT_REQUEST: u8 = 5;
@@ -1051,12 +1027,6 @@ impl TryParse for PrintGetScreenOfContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for PrintGetScreenOfContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -1533,12 +1503,6 @@ impl TryParse for PrintGetDocumentDataReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PrintGetDocumentDataReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl PrintGetDocumentDataReply {
     /// Get the value of the `dataLen` field.
     ///
@@ -1851,12 +1815,6 @@ impl TryParse for PrintInputSelectedReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PrintInputSelectedReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the PrintGetAttributes request
 pub const PRINT_GET_ATTRIBUTES_REQUEST: u8 = 17;
@@ -1958,12 +1916,6 @@ impl TryParse for PrintGetAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for PrintGetAttributesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl PrintGetAttributesReply {
@@ -2104,12 +2056,6 @@ impl TryParse for PrintGetOneAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for PrintGetOneAttributesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl PrintGetOneAttributesReply {
@@ -2333,12 +2279,6 @@ impl TryParse for PrintGetPageDimensionsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PrintGetPageDimensionsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the PrintQueryScreens request
 pub const PRINT_QUERY_SCREENS_REQUEST: u8 = 22;
@@ -2418,12 +2358,6 @@ impl TryParse for PrintQueryScreensReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for PrintQueryScreensReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl PrintQueryScreensReply {
@@ -2541,12 +2475,6 @@ impl TryParse for PrintSetImageResolutionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PrintSetImageResolutionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the PrintGetImageResolution request
 pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
@@ -2637,12 +2565,6 @@ impl TryParse for PrintGetImageResolutionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PrintGetImageResolutionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
@@ -2667,12 +2589,6 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for NotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {
@@ -2746,12 +2662,6 @@ impl TryParse for AttributNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AttributNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&AttributNotifyEvent> for [u8; 32] {

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -42,12 +42,6 @@ impl TryParse for Char2b {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Char2b {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Char2b {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
@@ -110,12 +104,6 @@ impl TryParse for Point {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Point {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Point {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
@@ -150,12 +138,6 @@ impl TryParse for Rectangle {
         let (height, remaining) = u16::try_parse(remaining)?;
         let result = Rectangle { x, y, width, height };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Rectangle {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Rectangle {
@@ -204,12 +186,6 @@ impl TryParse for Arc {
         let (angle2, remaining) = i16::try_parse(remaining)?;
         let result = Arc { x, y, width, height, angle1, angle2 };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Arc {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Arc {
@@ -261,12 +237,6 @@ impl TryParse for Format {
         let remaining = remaining.get(5..).ok_or(ParseError::InsufficientData)?;
         let result = Format { depth, bits_per_pixel, scanline_pad };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Format {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Format {
@@ -386,12 +356,6 @@ impl TryParse for Visualtype {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Visualtype {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Visualtype {
     type Bytes = [u8; 24];
     fn serialize(&self) -> [u8; 24] {
@@ -456,12 +420,6 @@ impl TryParse for Depth {
         let (visuals, remaining) = crate::x11_utils::parse_list::<Visualtype>(remaining, visuals_len.try_to_usize()?)?;
         let result = Depth { depth, visuals };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Depth {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Depth {
@@ -683,12 +641,6 @@ impl TryParse for Screen {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Screen {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Screen {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -768,12 +720,6 @@ impl TryParse for SetupRequest {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetupRequest {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SetupRequest {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -848,12 +794,6 @@ impl TryParse for SetupFailed {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetupFailed {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SetupFailed {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -902,12 +842,6 @@ impl TryParse for SetupAuthenticate {
         let reason = reason.to_vec();
         let result = SetupAuthenticate { status, reason };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SetupAuthenticate {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for SetupAuthenticate {
@@ -1058,12 +992,6 @@ impl TryParse for Setup {
         let bitmap_format_bit_order = bitmap_format_bit_order.into();
         let result = Setup { status, protocol_major_version, protocol_minor_version, length, release_number, resource_id_base, resource_id_mask, motion_buffer_size, maximum_request_length, image_byte_order, bitmap_format_bit_order, bitmap_format_scanline_unit, bitmap_format_scanline_pad, min_keycode, max_keycode, vendor, pixmap_formats, roots };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Setup {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Setup {
@@ -1410,12 +1338,6 @@ impl TryParse for KeyPressEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for KeyPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&KeyPressEvent> for [u8; 32] {
     fn from(input: &KeyPressEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -1604,12 +1526,6 @@ impl TryParse for ButtonPressEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ButtonPressEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ButtonPressEvent> for [u8; 32] {
     fn from(input: &ButtonPressEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -1794,12 +1710,6 @@ impl TryParse for MotionNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for MotionNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&MotionNotifyEvent> for [u8; 32] {
@@ -2051,12 +1961,6 @@ impl TryParse for EnterNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for EnterNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&EnterNotifyEvent> for [u8; 32] {
     fn from(input: &EnterNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2155,12 +2059,6 @@ impl TryParse for FocusInEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for FocusInEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&FocusInEvent> for [u8; 32] {
     fn from(input: &FocusInEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2233,12 +2131,6 @@ impl TryParse for KeymapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for KeymapNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&KeymapNotifyEvent> for [u8; 32] {
@@ -2334,12 +2226,6 @@ impl TryParse for ExposeEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ExposeEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ExposeEvent> for [u8; 32] {
     fn from(input: &ExposeEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2430,12 +2316,6 @@ impl TryParse for GraphicsExposureEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GraphicsExposureEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&GraphicsExposureEvent> for [u8; 32] {
     fn from(input: &GraphicsExposureEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2516,12 +2396,6 @@ impl TryParse for NoExposureEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for NoExposureEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&NoExposureEvent> for [u8; 32] {
@@ -2660,12 +2534,6 @@ impl TryParse for VisibilityNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for VisibilityNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&VisibilityNotifyEvent> for [u8; 32] {
     fn from(input: &VisibilityNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2750,12 +2618,6 @@ impl TryParse for CreateNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CreateNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&CreateNotifyEvent> for [u8; 32] {
@@ -2848,12 +2710,6 @@ impl TryParse for DestroyNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for DestroyNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&DestroyNotifyEvent> for [u8; 32] {
     fn from(input: &DestroyNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2941,12 +2797,6 @@ impl TryParse for UnmapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for UnmapNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&UnmapNotifyEvent> for [u8; 32] {
@@ -3038,12 +2888,6 @@ impl TryParse for MapNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for MapNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&MapNotifyEvent> for [u8; 32] {
     fn from(input: &MapNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3128,12 +2972,6 @@ impl TryParse for MapRequestEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for MapRequestEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&MapRequestEvent> for [u8; 32] {
     fn from(input: &MapRequestEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3214,12 +3052,6 @@ impl TryParse for ReparentNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ReparentNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&ReparentNotifyEvent> for [u8; 32] {
@@ -3336,12 +3168,6 @@ impl TryParse for ConfigureNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ConfigureNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ConfigureNotifyEvent> for [u8; 32] {
     fn from(input: &ConfigureNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3438,12 +3264,6 @@ impl TryParse for ConfigureRequestEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ConfigureRequestEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ConfigureRequestEvent> for [u8; 32] {
     fn from(input: &ConfigureRequestEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3529,12 +3349,6 @@ impl TryParse for GravityNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GravityNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&GravityNotifyEvent> for [u8; 32] {
     fn from(input: &GravityNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3610,12 +3424,6 @@ impl TryParse for ResizeRequestEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ResizeRequestEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&ResizeRequestEvent> for [u8; 32] {
@@ -3769,12 +3577,6 @@ impl TryParse for CirculateNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CirculateNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&CirculateNotifyEvent> for [u8; 32] {
@@ -3931,12 +3733,6 @@ impl TryParse for PropertyNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for PropertyNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&PropertyNotifyEvent> for [u8; 32] {
     fn from(input: &PropertyNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -4012,12 +3808,6 @@ impl TryParse for SelectionClearEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectionClearEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&SelectionClearEvent> for [u8; 32] {
@@ -4352,12 +4142,6 @@ impl TryParse for SelectionRequestEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SelectionRequestEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&SelectionRequestEvent> for [u8; 32] {
     fn from(input: &SelectionRequestEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -4439,12 +4223,6 @@ impl TryParse for SelectionNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for SelectionNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&SelectionNotifyEvent> for [u8; 32] {
@@ -4658,12 +4436,6 @@ impl TryParse for ColormapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ColormapNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&ColormapNotifyEvent> for [u8; 32] {
@@ -4916,12 +4688,6 @@ impl TryParse for ClientMessageEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ClientMessageEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&ClientMessageEvent> for [u8; 32] {
     fn from(input: &ClientMessageEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -5067,12 +4833,6 @@ impl TryParse for MappingNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for MappingNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&MappingNotifyEvent> for [u8; 32] {
     fn from(input: &MappingNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -5154,12 +4914,6 @@ impl TryParse for GeGenericEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GeGenericEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -6855,12 +6609,6 @@ impl TryParse for GetWindowAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetWindowAttributesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -8622,12 +8370,6 @@ impl TryParse for GetGeometryReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetGeometryReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryTree request
 pub const QUERY_TREE_REQUEST: u8 = 15;
@@ -8803,12 +8545,6 @@ impl TryParse for QueryTreeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryTreeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryTreeReply {
@@ -9025,12 +8761,6 @@ impl TryParse for InternAtomReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for InternAtomReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetAtomName request
 pub const GET_ATOM_NAME_REQUEST: u8 = 17;
@@ -9124,12 +8854,6 @@ impl TryParse for GetAtomNameReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetAtomNameReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetAtomNameReply {
@@ -10031,12 +9755,6 @@ impl TryParse for GetPropertyReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetPropertyReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 21;
@@ -10129,12 +9847,6 @@ impl TryParse for ListPropertiesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListPropertiesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListPropertiesReply {
@@ -10426,12 +10138,6 @@ impl TryParse for GetSelectionOwnerReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetSelectionOwnerReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -11336,12 +11042,6 @@ impl TryParse for GrabPointerReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GrabPointerReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the UngrabPointer request
 pub const UNGRAB_POINTER_REQUEST: u8 = 27;
@@ -12221,12 +11921,6 @@ impl TryParse for GrabKeyboardReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GrabKeyboardReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -13217,12 +12911,6 @@ impl TryParse for QueryPointerReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryPointerReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Timecoord {
@@ -13237,12 +12925,6 @@ impl TryParse for Timecoord {
         let (y, remaining) = i16::try_parse(remaining)?;
         let result = Timecoord { time, x, y };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Timecoord {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Timecoord {
@@ -13385,12 +13067,6 @@ impl TryParse for GetMotionEventsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetMotionEventsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetMotionEventsReply {
     /// Get the value of the `events_len` field.
     ///
@@ -13524,12 +13200,6 @@ impl TryParse for TranslateCoordinatesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for TranslateCoordinatesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -14027,12 +13697,6 @@ impl TryParse for GetInputFocusReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetInputFocusReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryKeymap request
 pub const QUERY_KEYMAP_REQUEST: u8 = 44;
@@ -14113,12 +13777,6 @@ impl TryParse for QueryKeymapReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryKeymapReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -14389,12 +14047,6 @@ impl TryParse for Fontprop {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Fontprop {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Fontprop {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -14437,12 +14089,6 @@ impl TryParse for Charinfo {
         let (attributes, remaining) = u16::try_parse(remaining)?;
         let result = Charinfo { left_side_bearing, right_side_bearing, character_width, ascent, descent, attributes };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Charinfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Charinfo {
@@ -14624,12 +14270,6 @@ impl TryParse for QueryFontReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryFontReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryFontReply {
@@ -14865,12 +14505,6 @@ impl TryParse for QueryTextExtentsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryTextExtentsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Str {
@@ -14883,12 +14517,6 @@ impl TryParse for Str {
         let name = name.to_vec();
         let result = Str { name };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Str {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Str {
@@ -15057,12 +14685,6 @@ impl TryParse for ListFontsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListFontsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListFontsReply {
@@ -15262,12 +14884,6 @@ impl TryParse for ListFontsWithInfoReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ListFontsWithInfoReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl ListFontsWithInfoReply {
     /// Get the value of the `name_len` field.
     ///
@@ -15457,12 +15073,6 @@ impl TryParse for GetFontPathReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetFontPathReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetFontPathReply {
@@ -18857,12 +18467,6 @@ impl TryParse for Segment {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Segment {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Segment {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -20008,12 +19612,6 @@ impl TryParse for GetImageReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetImageReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetImageReply {
     /// Get the value of the `length` field.
     ///
@@ -21120,12 +20718,6 @@ impl TryParse for ListInstalledColormapsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for ListInstalledColormapsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl ListInstalledColormapsReply {
     /// Get the value of the `cmaps_len` field.
     ///
@@ -21300,12 +20892,6 @@ impl TryParse for AllocColorReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for AllocColorReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the AllocNamedColor request
 pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
@@ -21432,12 +21018,6 @@ impl TryParse for AllocNamedColorReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for AllocNamedColorReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the AllocColorCells request
 pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
@@ -21551,12 +21131,6 @@ impl TryParse for AllocColorCellsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AllocColorCellsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl AllocColorCellsReply {
@@ -21718,12 +21292,6 @@ impl TryParse for AllocColorPlanesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AllocColorPlanesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl AllocColorPlanesReply {
@@ -21920,12 +21488,6 @@ impl TryParse for Coloritem {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let result = Coloritem { pixel, red, green, blue, flags };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Coloritem {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Coloritem {
@@ -22173,12 +21735,6 @@ impl TryParse for Rgb {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Rgb {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Rgb {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -22320,12 +21876,6 @@ impl TryParse for QueryColorsReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryColorsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl QueryColorsReply {
     /// Get the value of the `colors_len` field.
     ///
@@ -22463,12 +22013,6 @@ impl TryParse for LookupColorReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for LookupColorReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -23308,12 +22852,6 @@ impl TryParse for QueryBestSizeReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryBestSizeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryExtension request
 pub const QUERY_EXTENSION_REQUEST: u8 = 98;
@@ -23474,12 +23012,6 @@ impl TryParse for QueryExtensionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryExtensionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ListExtensions request
 pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
@@ -23560,12 +23092,6 @@ impl TryParse for ListExtensionsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListExtensionsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListExtensionsReply {
@@ -23774,12 +23300,6 @@ impl TryParse for GetKeyboardMappingReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetKeyboardMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetKeyboardMappingReply {
@@ -24334,12 +23854,6 @@ impl TryParse for GetKeyboardControlReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetKeyboardControlReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 104;
@@ -24577,12 +24091,6 @@ impl TryParse for GetPointerControlReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPointerControlReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -24883,12 +24391,6 @@ impl TryParse for GetScreenSaverReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetScreenSaverReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct HostMode(u8);
@@ -25126,12 +24628,6 @@ impl TryParse for Host {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Host {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Host {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -25247,12 +24743,6 @@ impl TryParse for ListHostsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListHostsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListHostsReply {
@@ -26051,12 +25541,6 @@ impl TryParse for SetPointerMappingReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetPointerMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetPointerMapping request
 pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
@@ -26138,12 +25622,6 @@ impl TryParse for GetPointerMappingReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPointerMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetPointerMappingReply {
@@ -26330,12 +25808,6 @@ impl TryParse for SetModifierMappingReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SetModifierMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the GetModifierMapping request
 pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
@@ -26417,12 +25889,6 @@ impl TryParse for GetModifierMappingReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetModifierMappingReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetModifierMappingReply {

--- a/src/protocol/xselinux.rs
+++ b/src/protocol/xselinux.rs
@@ -131,12 +131,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SetDeviceCreateContext request
 pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
@@ -293,12 +287,6 @@ impl TryParse for GetDeviceCreateContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetDeviceCreateContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetDeviceCreateContextReply {
@@ -495,12 +483,6 @@ impl TryParse for GetDeviceContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetDeviceContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetDeviceContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -674,12 +656,6 @@ impl TryParse for GetWindowCreateContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetWindowCreateContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetWindowCreateContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -788,12 +764,6 @@ impl TryParse for GetWindowContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetWindowContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetWindowContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -836,12 +806,6 @@ impl TryParse for ListItem {
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
         let result = ListItem { name, object_context, data_context };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListItem {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ListItem {
@@ -1050,12 +1014,6 @@ impl TryParse for GetPropertyCreateContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetPropertyCreateContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetPropertyCreateContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1229,12 +1187,6 @@ impl TryParse for GetPropertyUseContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetPropertyUseContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetPropertyUseContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1350,12 +1302,6 @@ impl TryParse for GetPropertyContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetPropertyContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetPropertyContextReply {
@@ -1475,12 +1421,6 @@ impl TryParse for GetPropertyDataContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetPropertyDataContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetPropertyDataContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1586,12 +1526,6 @@ impl TryParse for ListPropertiesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListPropertiesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListPropertiesReply {
@@ -1767,12 +1701,6 @@ impl TryParse for GetSelectionCreateContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetSelectionCreateContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetSelectionCreateContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1946,12 +1874,6 @@ impl TryParse for GetSelectionUseContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetSelectionUseContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetSelectionUseContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -2058,12 +1980,6 @@ impl TryParse for GetSelectionContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetSelectionContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetSelectionContextReply {
@@ -2174,12 +2090,6 @@ impl TryParse for GetSelectionDataContextReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetSelectionDataContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl GetSelectionDataContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -2274,12 +2184,6 @@ impl TryParse for ListSelectionsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListSelectionsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListSelectionsReply {
@@ -2388,12 +2292,6 @@ impl TryParse for GetClientContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GetClientContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl GetClientContextReply {

--- a/src/protocol/xtest.rs
+++ b/src/protocol/xtest.rs
@@ -131,12 +131,6 @@ impl TryParse for GetVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Cursor(bool);
@@ -303,12 +297,6 @@ impl TryParse for CompareCursorReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CompareCursorReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 

--- a/src/protocol/xv.rs
+++ b/src/protocol/xv.rs
@@ -481,12 +481,6 @@ impl TryParse for Rational {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for Rational {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for Rational {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
@@ -522,12 +516,6 @@ impl TryParse for Format {
         let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
         let result = Format { visual, depth };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Format {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Format {
@@ -580,12 +568,6 @@ impl TryParse for AdaptorInfo {
         let (formats, remaining) = crate::x11_utils::parse_list::<Format>(remaining, num_formats.try_to_usize()?)?;
         let result = AdaptorInfo { base_id, num_ports, type_, name, formats };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AdaptorInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for AdaptorInfo {
@@ -666,12 +648,6 @@ impl TryParse for EncodingInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for EncodingInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for EncodingInfo {
     type Bytes = Vec<u8>;
     fn serialize(&self) -> Vec<u8> {
@@ -730,12 +706,6 @@ impl TryParse for Image {
         let data = data.to_vec();
         let result = Image { id, width, height, pitches, offsets, data };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for Image {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for Image {
@@ -811,12 +781,6 @@ impl TryParse for AttributeInfo {
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
         let result = AttributeInfo { flags, min, max, name };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for AttributeInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for AttributeInfo {
@@ -915,12 +879,6 @@ impl TryParse for ImageFormatInfo {
         let vscanline_order = vscanline_order.into();
         let result = ImageFormatInfo { id, type_, byte_order, guid, bpp, num_planes, depth, red_mask, green_mask, blue_mask, format, y_sample_bits, u_sample_bits, v_sample_bits, vhorz_y_period, vhorz_u_period, vhorz_v_period, vvert_y_period, vvert_u_period, vvert_v_period, vcomp_order, vscanline_order };
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ImageFormatInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl Serialize for ImageFormatInfo {
@@ -1146,12 +1104,6 @@ impl TryParse for VideoNotifyEvent {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for VideoNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl From<&VideoNotifyEvent> for [u8; 32] {
     fn from(input: &VideoNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -1229,12 +1181,6 @@ impl TryParse for PortNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for PortNotifyEvent {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl From<&PortNotifyEvent> for [u8; 32] {
@@ -1368,12 +1314,6 @@ impl TryParse for QueryExtensionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryExtensionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryAdaptors request
 pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
@@ -1464,12 +1404,6 @@ impl TryParse for QueryAdaptorsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryAdaptorsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryAdaptorsReply {
@@ -1577,12 +1511,6 @@ impl TryParse for QueryEncodingsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryEncodingsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryEncodingsReply {
@@ -1699,12 +1627,6 @@ impl TryParse for GrabPortReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for GrabPortReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 
@@ -2693,12 +2615,6 @@ impl TryParse for QueryBestSizeReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryBestSizeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the SetPortAttribute request
 pub const SET_PORT_ATTRIBUTE_REQUEST: u8 = 13;
@@ -2881,12 +2797,6 @@ impl TryParse for GetPortAttributeReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for GetPortAttributeReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the QueryPortAttributes request
 pub const QUERY_PORT_ATTRIBUTES_REQUEST: u8 = 15;
@@ -2979,12 +2889,6 @@ impl TryParse for QueryPortAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryPortAttributesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryPortAttributesReply {
@@ -3092,12 +2996,6 @@ impl TryParse for ListImageFormatsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListImageFormatsReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListImageFormatsReply {
@@ -3236,12 +3134,6 @@ impl TryParse for QueryImageAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for QueryImageAttributesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl QueryImageAttributesReply {

--- a/src/protocol/xvmc.rs
+++ b/src/protocol/xvmc.rs
@@ -68,12 +68,6 @@ impl TryParse for SurfaceInfo {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for SurfaceInfo {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl Serialize for SurfaceInfo {
     type Bytes = [u8; 24];
     fn serialize(&self) -> [u8; 24] {
@@ -207,12 +201,6 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for QueryVersionReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 
 /// Opcode for the ListSurfaceTypes request
 pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
@@ -303,12 +291,6 @@ impl TryParse for ListSurfaceTypesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListSurfaceTypesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListSurfaceTypesReply {
@@ -461,12 +443,6 @@ impl TryParse for CreateContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CreateContextReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl CreateContextReply {
@@ -646,12 +622,6 @@ impl TryParse for CreateSurfaceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for CreateSurfaceReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl CreateSurfaceReply {
@@ -867,12 +837,6 @@ impl TryParse for CreateSubpictureReply {
         Ok((result, remaining))
     }
 }
-impl TryFrom<&[u8]> for CreateSubpictureReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
-    }
-}
 impl CreateSubpictureReply {
     /// Get the value of the `length` field.
     ///
@@ -1052,12 +1016,6 @@ impl TryParse for ListSubpictureTypesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
-    }
-}
-impl TryFrom<&[u8]> for ListSubpictureTypesReply {
-    type Error = ParseError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self::try_parse(value)?.0)
     }
 }
 impl ListSubpictureTypesReply {

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -704,6 +704,8 @@ fn write_setup(
 /// If the server sends a `SetupFailed` or `SetupAuthenticate` packet, these will be returned
 /// as errors.
 fn read_setup(stream: &impl Stream) -> Result<Setup, ConnectError> {
+    use crate::protocol::xproto::{SetupAuthenticate, SetupFailed};
+
     let mut fds = Vec::new();
     let mut setup = vec![0; 8];
     stream.read_exact(&mut setup, &mut fds)?;
@@ -722,11 +724,11 @@ fn read_setup(stream: &impl Stream) -> Result<Setup, ConnectError> {
     }
     match setup[0] {
         // 0 is SetupFailed
-        0 => Err(ConnectError::SetupFailed((&setup[..]).try_into()?)),
+        0 => Err(ConnectError::SetupFailed(SetupFailed::try_parse(&setup[..])?.0)),
         // Success
-        1 => Ok((&setup[..]).try_into()?),
+        1 => Ok(Setup::try_parse(&setup[..])?.0),
         // 2 is SetupAuthenticate
-        2 => Err(ConnectError::SetupAuthenticate((&setup[..]).try_into()?)),
+        2 => Err(ConnectError::SetupAuthenticate(SetupAuthenticate::try_parse(&setup[..])?.0)),
         // Uhm... no other cases are defined
         _ => Err(ParseError::InvalidValue.into()),
     }

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -724,11 +724,15 @@ fn read_setup(stream: &impl Stream) -> Result<Setup, ConnectError> {
     }
     match setup[0] {
         // 0 is SetupFailed
-        0 => Err(ConnectError::SetupFailed(SetupFailed::try_parse(&setup[..])?.0)),
+        0 => Err(ConnectError::SetupFailed(
+            SetupFailed::try_parse(&setup[..])?.0,
+        )),
         // Success
         1 => Ok(Setup::try_parse(&setup[..])?.0),
         // 2 is SetupAuthenticate
-        2 => Err(ConnectError::SetupAuthenticate(SetupAuthenticate::try_parse(&setup[..])?.0)),
+        2 => Err(ConnectError::SetupAuthenticate(
+            SetupAuthenticate::try_parse(&setup[..])?.0,
+        )),
         // Uhm... no other cases are defined
         _ => Err(ParseError::InvalidValue.into()),
     }

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -14,7 +14,7 @@ use crate::extension_manager::ExtensionManager;
 use crate::protocol::bigreq::{ConnectionExt as _, EnableReply};
 use crate::protocol::xproto::{Setup, SetupRequest, GET_INPUT_FOCUS_REQUEST};
 use crate::utils::RawFdContainer;
-use crate::x11_utils::{ExtensionInformation, Serialize};
+use crate::x11_utils::{ExtensionInformation, Serialize, TryParse};
 
 mod id_allocator;
 mod inner;
@@ -451,7 +451,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<'_, Self, Reply>, ConnectionError>
     where
-        Reply: for<'a> TryFrom<&'a [u8], Error = ParseError>,
+        Reply: TryParse,
     {
         Ok(Cookie::new(
             self,

--- a/src/rust_connection/mod.rs
+++ b/src/rust_connection/mod.rs
@@ -1,6 +1,6 @@
 //! A pure-rust implementation of a connection to an X11 server.
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::io::IoSlice;
 use std::sync::{Condvar, Mutex, MutexGuard, TryLockError};
 
@@ -14,7 +14,7 @@ use crate::extension_manager::ExtensionManager;
 use crate::protocol::bigreq::{ConnectionExt as _, EnableReply};
 use crate::protocol::xproto::{Setup, SetupRequest, GET_INPUT_FOCUS_REQUEST};
 use crate::utils::RawFdContainer;
-use crate::x11_utils::{ExtensionInformation, Serialize, TryParse};
+use crate::x11_utils::{ExtensionInformation, Serialize, TryParse, TryParseFd};
 
 mod id_allocator;
 mod inner;
@@ -465,7 +465,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<'_, Self, Reply>, ConnectionError>
     where
-        Reply: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
+        Reply: TryParseFd,
     {
         Ok(CookieWithFds::new(
             self,

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -25,7 +25,7 @@ pub use crate::errors::{ConnectError, ConnectionError, ParseError, ReplyError, R
 use crate::extension_manager::ExtensionManager;
 use crate::protocol::xproto::Setup;
 use crate::utils::{CSlice, RawFdContainer};
-use crate::x11_utils::{ExtensionInformation, TryParse};
+use crate::x11_utils::{ExtensionInformation, TryParse, TryParseFd};
 
 mod pending_errors;
 mod raw_ffi;
@@ -370,7 +370,7 @@ impl RequestConnection for XCBConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
     where
-        R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
+        R: TryParseFd,
     {
         Ok(CookieWithFds::new(
             self,

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is only available when the `allow-unsafe-code` feature is enabled.
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::ffi::CStr;
 use std::io::{Error as IOError, ErrorKind, IoSlice};
 use std::os::raw::c_int;
@@ -158,7 +158,7 @@ impl XCBConnection {
         let length = usize::from(length) * 4 + 8;
 
         let slice = from_raw_parts(wrapper.as_ptr(), length);
-        let result = Setup::try_from(&*slice)?;
+        let result = Setup::try_parse(&*slice)?.0;
 
         Ok(result)
     }

--- a/src/xcb_ffi/mod.rs
+++ b/src/xcb_ffi/mod.rs
@@ -25,7 +25,7 @@ pub use crate::errors::{ConnectError, ConnectionError, ParseError, ReplyError, R
 use crate::extension_manager::ExtensionManager;
 use crate::protocol::xproto::Setup;
 use crate::utils::{CSlice, RawFdContainer};
-use crate::x11_utils::ExtensionInformation;
+use crate::x11_utils::{ExtensionInformation, TryParse};
 
 mod pending_errors;
 mod raw_ffi;
@@ -356,7 +356,7 @@ impl RequestConnection for XCBConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<'_, Self, R>, ConnectionError>
     where
-        R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
+        R: TryParse,
     {
         Ok(Cookie::new(
             self,

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -69,7 +69,7 @@ impl RequestConnection for FakeConnection {
         fds: Vec<RawFdContainer>,
     ) -> Result<Cookie<Self, R>, ConnectionError>
     where
-        R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
+        R: TryParse,
     {
         Ok(Cookie::new(self, self.internal_send_request(bufs, fds)?))
     }

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::convert::TryFrom;
 use std::io::IoSlice;
 use std::ops::Deref;
 
@@ -252,7 +251,7 @@ fn test_send_event() -> Result<(), ConnectionError> {
         11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
         24, 25, 26, 27, 28, 29, 30,
     ];
-    let event = KeymapNotifyEvent::try_from(&buffer[..])?;
+    let event = KeymapNotifyEvent::try_parse(&buffer[..])?.0;
 
     // "Send" it
     let conn = FakeConnection::default();

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -13,7 +13,7 @@ use x11rb::protocol::xproto::{
     ClientMessageData, ConnectionExt, KeymapNotifyEvent, Segment, SetupAuthenticate,
 };
 use x11rb::utils::RawFdContainer;
-use x11rb::x11_utils::{ExtensionInformation, Serialize, TryParse};
+use x11rb::x11_utils::{ExtensionInformation, Serialize, TryParse, TryParseFd};
 
 #[derive(Debug)]
 struct SavedRequest {
@@ -80,7 +80,7 @@ impl RequestConnection for FakeConnection {
         _fds: Vec<RawFdContainer>,
     ) -> Result<CookieWithFds<Self, R>, ConnectionError>
     where
-        R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
+        R: TryParseFd,
     {
         unimplemented!()
     }

--- a/tests/resource_manager.rs
+++ b/tests/resource_manager.rs
@@ -149,7 +149,7 @@ mod test {
             _: Vec<RawFdContainer>,
         ) -> Result<Cookie<'_, Self, R>, ConnectionError>
         where
-            R: for<'a> TryFrom<&'a [u8], Error = ParseError>,
+            R: TryParse,
         {
             Ok(Cookie::new(self, 42))
         }

--- a/tests/resource_manager.rs
+++ b/tests/resource_manager.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "resource_manager")]
 mod test {
-    use std::convert::TryFrom;
     use std::fs;
     use std::io::IoSlice;
     use std::path::{Path, PathBuf};
@@ -15,7 +14,7 @@ mod test {
     use x11rb::protocol::Event;
     use x11rb::resource_manager::Database;
     use x11rb::utils::RawFdContainer;
-    use x11rb::x11_utils::{ExtensionInformation, Serialize, TryParse, X11Error};
+    use x11rb::x11_utils::{ExtensionInformation, Serialize, TryParse, TryParseFd, X11Error};
 
     // Most tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
     // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_database.c
@@ -160,7 +159,7 @@ mod test {
             _: Vec<RawFdContainer>,
         ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
         where
-            R: for<'a> TryFrom<(&'a [u8], Vec<RawFdContainer>), Error = ParseError>,
+            R: TryParseFd,
         {
             unimplemented!()
         }


### PR DESCRIPTION
This implements / fixes #478, as suggested by @khuey. I'm not really sure what I think of this

Pro:
```
 42 files changed, 180 insertions(+), 4055 deletions(-)
```
Con: There is stuff like this in the diff (ButtonPress is actually kinda okay, other lines get a lot longer):
```diff
-            xproto::BUTTON_PRESS_EVENT => return Ok(Self::ButtonPress(event.try_into()?)),
+            xproto::BUTTON_PRESS_EVENT => return Ok(Self::ButtonPress(xproto::ButtonPressEvent::try_parse(event)?.0))
```