### PR TITLE
Fix some doc links

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,9 +69,9 @@ pub enum ParseError {
     ///
     /// Examples for the first kind of error:
     ///
-    /// - One of a set of values should be present (a `<switch>` in xcb-proto-speal), but none of
+    /// - One of a set of values should be present (a `<switch>` in xcb-proto-speak), but none of
     ///   the `<cases>` matched. This can e.g. happen when parsing
-    ///   [`x11rb::protocol::xinput::InputInfo`].
+    ///   [`crate::protocol::xinput::InputInfo`].
     /// - Parsing a request with a length field that is too small for the request header to fit.
     ///
     /// Examples for the second kind of error:

--- a/src/image.rs
+++ b/src/image.rs
@@ -678,8 +678,8 @@ impl<'a> Image<'a> {
 
     /// Get an image from the X11 server.
     ///
-    /// This function sends a [`GetImage`](crate::protocol::xproto::GetImage) request, waits for
-    /// its response and wraps it in a new `Image`.
+    /// This function sends a [`GetImage`](crate::protocol::xproto::GetImageRequest) request, waits
+    /// for its response and wraps it in a new `Image`.
     ///
     /// The returned image contains the rectangle with top left corner `(x, y)` and size `(width,
     /// height)` of the given `drawable`.
@@ -730,8 +730,8 @@ impl<'a> Image<'a> {
 
     /// Put an image to the X11 server.
     ///
-    /// This function sends a [`PutImage`](crate::protocol::xproto::PutImage) request. This will
-    /// upload this image to the given `drawable` to position `(dst_x, dst_y)`.
+    /// This function sends a [`PutImage`](crate::protocol::xproto::PutImageRequest) request. This
+    /// will upload this image to the given `drawable` to position `(dst_x, dst_y)`.
     ///
     /// The server's maximum request size is honored. This means that a too large `PutImage`
     /// request is automatically split up into smaller pieces. Thus, if this function returns an
@@ -857,7 +857,7 @@ impl<'a> Image<'a> {
     /// Set a single pixel in this image.
     ///
     /// The pixel at position `(x, y)` will be set to the value `pixel`. `pixel` is truncated to
-    /// this image's [`bits_per_pixel()`].
+    /// this image's [`Self::bits_per_pixel`].
     ///
     /// If the image was constructed from a `Cow::Borrowed` access to its pixel data, this causes
     /// the whole pixel data to be copied. See [`Image::new`] and [`Image::data_mut`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,13 +100,13 @@
 //! Additionally, the following flags exist:
 //! * `allow-unsafe-code`: Enable features that require `unsafe`. Without this flag,
 //!   `x11rb::xcb_ffi::XCBConnection` and some support code for it are unavailable.
-//! * `cursor`: Enable the code in [x11rb::cursor] for loading cursor files.
-//! * `resource_manager`: Enable the code in [x11rb::resource_manager] for loading and querying the
+//! * `cursor`: Enable the code in [crate::cursor] for loading cursor files.
+//! * `resource_manager`: Enable the code in [crate::resource_manager] for loading and querying the
 //!   X11 resource database.
-//! * `image`: Enable the code in [x11rb::image] for working with pixel image data.
+//! * `image`: Enable the code in [crate::image] for working with pixel image data.
 //! * `dl-libxcb`: Enabling this feature will prevent from libxcb being linked to the
 //!   resulting executable. Instead libxcb will be dynamically loaded at runtime.
-//!   This feature adds the `x11rb::xcb_ffi::load_libxcb` function, that allows to load
+//!   This feature adds the [`crate::xcb_ffi::load_libxcb`] function, that allows to load
 //!   libxcb and check for success or failure.
 //!
 //! # Integrating x11rb with an Event Loop

--- a/src/resource_manager/mod.rs
+++ b/src/resource_manager/mod.rs
@@ -178,7 +178,7 @@ impl Database {
     /// This function parses data like `Some.Entry: Value\n#include "some_file"\n` and returns the
     /// resulting resource database. Parsing cannot fail since unparsable lines are simply ignored.
     ///
-    /// See [`new_from_data_with_base_directory`] for a version that allows to provide a path that
+    /// See [`Self::new_from_data_with_base_directory`] for a version that allows to provide a path that
     /// is used for resolving relative `#include` statements.
     pub fn new_from_data(data: &[u8]) -> Self {
         let mut entries = Vec::new();


### PR DESCRIPTION
This happens when one actually starts looking at the warning that
rustdoc --all-features produces...

Signed-off-by: Uli Schlachter <psychon@znc.in>