### PR TITLE
comparison.md: Add xcb-sys

### DIFF
--- a/doc/comparison.md
+++ b/doc/comparison.md
@@ -90,6 +90,10 @@ The [xcb-sys crate](https://crates.io/crates/xcb-sys) uses bindgen to
 automatically generate a Rust API from libxcb's C headers. Everything is unsafe
 and as a user you are basically writing C code in Rust.
 
+Put differently: There is lots of existing documentation (for C code) and
+reference code (written in C) that you can use. It is pretty much directly
+transferable to this library.
+
 
 ## x11rb (this project)
 

--- a/doc/comparison.md
+++ b/doc/comparison.md
@@ -84,6 +84,13 @@ multiple async tasks.
 Another highlight is `no_std` support.
 
 
+## xcb-sys
+
+The [xcb-sys crate](https://crates.io/crates/xcb-sys) uses bindgen to
+automatically generate a Rust API from libxcb's C headers. Everything is unsafe
+and as a user you are basically writing C code in Rust.
+
+
 ## x11rb (this project)
 
 x11rb, the x11 rust bindings, is based on the XML description of the X11


### PR DESCRIPTION
CC @glowcoil I am not really sure what to write here. I think xcb-sys deserves an entry in this list, but what should that entry say?

Assuming the reader knows `bindgen`, I feel like this entry says all there is to say, but I am open to any suggestions. Feel free to just propose a completely different text, if you want.