### PR TITLE
Use a concrete type in `x11rb::connect`

### DIFF
--- a/examples/check_unchecked_requests.rs
+++ b/examples/check_unchecked_requests.rs
@@ -16,7 +16,7 @@ use x11rb::wrapper::ConnectionExt as _;
 const INVALID_WINDOW: u32 = 0;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (conn, _) = x11rb::connect(None).unwrap();
+    let (conn, _) = connect(None).unwrap();
 
     // For requests with responses, there are four possibilities:
 
@@ -81,3 +81,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+include!("integration_test_util/connect.rs");

--- a/examples/display_ppm.rs
+++ b/examples/display_ppm.rs
@@ -118,7 +118,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(arg) => ppm_parser::parse_ppm_file(&arg)?,
     };
 
-    let (conn, screen_num) = x11rb::connect(None)?;
+    let (conn, screen_num) = connect(None)?;
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
     let conn1 = std::sync::Arc::new(conn);
@@ -291,4 +291,5 @@ const BUILTIN_IMAGE: [u8; 35] = [
     0xff, 0xff, 0x00,
 ];
 
+include!("integration_test_util/connect.rs");
 include!("integration_test_util/util.rs");

--- a/examples/generic_events.rs
+++ b/examples/generic_events.rs
@@ -11,7 +11,7 @@ use x11rb::protocol::{present, Event};
 use x11rb::COPY_DEPTH_FROM_PARENT;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (conn, screen_num) = x11rb::connect(None)?;
+    let (conn, screen_num) = connect(None)?;
     let screen = &conn.setup().roots[screen_num];
 
     if conn
@@ -84,3 +84,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+include!("integration_test_util/connect.rs");

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -33,7 +33,7 @@ struct WindowState {
 }
 
 fn main() {
-    let (conn, screen_num) = x11rb::connect(None).unwrap();
+    let (conn, screen_num) = connect(None).unwrap();
     let conn = Arc::new(conn);
     let screen = &conn.setup().roots[screen_num];
 
@@ -275,3 +275,4 @@ fn find_window_by_id(
 }
 
 include!("integration_test_util/util.rs");
+include!("integration_test_util/connect.rs");

--- a/examples/integration_test_util/connect.rs
+++ b/examples/integration_test_util/connect.rs
@@ -1,0 +1,24 @@
+/// Establish a new connection to an X11 server.
+///
+/// Returns a `XCBConnection` if `allow-unsafe-code`, otherwise returns a `RustConnection`.
+/// This function is meant to test code with both connection types. Production code
+/// usually wants to use `x11rb::connect`, `x11rb::rust_connection::RustConnection::connect`
+/// or `x11rb::xcb_ffi::XCBConnection::connect`.
+pub fn connect(
+    dpy_name: Option<&str>,
+) -> Result<(impl x11rb::connection::Connection + Send + Sync, usize), x11rb::errors::ConnectError>
+{
+    #[cfg(feature = "allow-unsafe-code")]
+    {
+        let dpy_name = dpy_name
+            .map(std::ffi::CString::new)
+            .transpose()
+            .map_err(|_| x11rb::errors::ConnectError::DisplayParsingError)?;
+        let dpy_name = dpy_name.as_deref();
+        x11rb::xcb_ffi::XCBConnection::connect(dpy_name)
+    }
+    #[cfg(not(feature = "allow-unsafe-code"))]
+    {
+        x11rb::rust_connection::RustConnection::connect(dpy_name)
+    }
+}

--- a/examples/list_fonts.rs
+++ b/examples/list_fonts.rs
@@ -5,7 +5,7 @@ extern crate x11rb;
 use x11rb::protocol::xproto::{ConnectionExt, FontDraw};
 
 fn main() {
-    let (conn, _) = x11rb::connect(None).unwrap();
+    let (conn, _) = connect(None).unwrap();
 
     println!("DIR  MIN  MAX EXIST DFLT PROP ASC DESC NAME");
     for reply in conn.list_fonts_with_info(u16::max_value(), b"*").unwrap() {
@@ -45,3 +45,5 @@ fn main() {
         );
     }
 }
+
+include!("integration_test_util/connect.rs");

--- a/examples/record.rs
+++ b/examples/record.rs
@@ -26,8 +26,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // From https://www.x.org/releases/X11R7.6/doc/recordproto/record.html:
     // "The typical communication model for a recording client is to open two connections to the
     // server and use one for RC control and the other for reading protocol data."
-    let (ctrl_conn, _) = x11rb::connect(None)?;
-    let (data_conn, _) = x11rb::connect(None)?;
+    let (ctrl_conn, _) = connect(None)?;
+    let (data_conn, _) = connect(None)?;
 
     // Check if the record extension is supported.
     if ctrl_conn
@@ -167,3 +167,5 @@ fn print_reply_data(data: &[u8]) -> Result<(&[u8], bool), ParseError> {
         }
     }
 }
+
+include!("integration_test_util/connect.rs");

--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -145,7 +145,7 @@ fn receive_fd<C: Connection>(conn: &C, screen_num: usize) -> Result<(), ReplyOrI
 
 fn main() {
     let file = make_file().expect("Failed to create temporary file for FD passing");
-    match x11rb::connect(None) {
+    match connect(None) {
         Err(err) => eprintln!("Failed to connect to the X11 server: {}", err),
         Ok((conn, screen_num)) => {
             // Check for SHM 1.2 support (needed for fd passing)
@@ -170,3 +170,5 @@ fn main() {
         }
     }
 }
+
+include!("integration_test_util/connect.rs");

--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -401,7 +401,7 @@ fn become_wm<C: Connection>(conn: &C, screen: &Screen) -> Result<(), ReplyError>
 }
 
 fn main() {
-    let (conn, screen_num) = x11rb::connect(None).unwrap();
+    let (conn, screen_num) = connect(None).unwrap();
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
     let conn1 = std::sync::Arc::new(conn);
@@ -434,4 +434,5 @@ fn main() {
     }
 }
 
+include!("integration_test_util/connect.rs");
 include!("integration_test_util/util.rs");

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -270,7 +270,7 @@ fn create_gc_with_foreground<C: Connection>(
 }
 
 fn main() {
-    let (conn, screen_num) = x11rb::connect(None).expect("Failed to connect to the X11 server");
+    let (conn, screen_num) = connect(None).expect("Failed to connect to the X11 server");
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
     let conn1 = std::sync::Arc::new(conn);
@@ -375,4 +375,5 @@ fn main() {
     }
 }
 
+include!("integration_test_util/connect.rs");
 include!("integration_test_util/util.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,31 +171,17 @@ pub mod resource_manager;
 #[cfg(test)]
 mod test;
 
-use connection::Connection;
 use errors::ConnectError;
 use protocol::xproto::{Keysym, Timestamp};
 
 /// Establish a new connection to an X11 server.
 ///
-/// If a `dpy_name` is provided, it describes the display that should be connected to, for
-/// example `127.0.0.1:1`. If no value is provided, the `$DISPLAY` environment variable is
-/// used.
+/// This function is identical to
+/// [RustConnection::connect](crate::rust_connection::RustConnection::connect).
 pub fn connect(
     dpy_name: Option<&str>,
-) -> Result<(impl Connection + Send + Sync, usize), ConnectError> {
-    #[cfg(feature = "allow-unsafe-code")]
-    {
-        let dpy_name = dpy_name
-            .map(std::ffi::CString::new)
-            .transpose()
-            .map_err(|_| ConnectError::DisplayParsingError)?;
-        let dpy_name = dpy_name.as_deref();
-        xcb_ffi::XCBConnection::connect(dpy_name)
-    }
-    #[cfg(not(feature = "allow-unsafe-code"))]
-    {
-        rust_connection::RustConnection::connect(dpy_name)
-    }
+) -> Result<(rust_connection::RustConnection, usize), ConnectError> {
+    rust_connection::RustConnection::connect(dpy_name)
 }
 
 /// The universal null resource or null atom parameter value for many core X requests


### PR DESCRIPTION
Examples now use their own function to connect with `RustConnection` or `XCBConnection` depending on whether `allow-unsafe-code` is enabled.

Replaces https://github.com/psychon/x11rb/pull/605