### PR TITLE
Add RAII resource wrappers

### DIFF
--- a/examples/shared_memory.rs
+++ b/examples/shared_memory.rs
@@ -55,8 +55,17 @@ fn get_shared_memory_content_at_offset<C: Connection>(
     )?;
     let pixmap = PixmapWrapper::for_pixmap(conn, pixmap);
 
-    let image =
-        xproto::get_image(conn, ImageFormat::Z_PIXMAP, pixmap.pixmap(), 0, 0, width, 1, !0)?.reply()?;
+    let image = xproto::get_image(
+        conn,
+        ImageFormat::Z_PIXMAP,
+        pixmap.pixmap(),
+        0,
+        0,
+        width,
+        1,
+        !0,
+    )?
+    .reply()?;
     Ok(image.data)
 }
 

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -7,7 +7,7 @@ use x11rb::errors::{ConnectionError, ReplyOrIdError};
 use x11rb::protocol::shape::{self, ConnectionExt as _};
 use x11rb::protocol::xproto::*;
 use x11rb::protocol::Event;
-use x11rb::wrapper::ConnectionExt as _;
+use x11rb::wrapper::{ConnectionExt as _, GcontextWrapper, PixmapWrapper};
 use x11rb::COPY_DEPTH_FROM_PARENT;
 
 const PUPIL_SIZE: i16 = 50;
@@ -153,41 +153,16 @@ fn compute_pupils(window_size: (u16, u16), mouse_position: (i16, i16)) -> ((i16,
     )
 }
 
-struct FreePixmap<'c, C: Connection>(&'c C, Pixmap);
-impl<C: Connection> Drop for FreePixmap<'_, C> {
-    fn drop(&mut self) {
-        self.0.free_pixmap(self.1).unwrap();
-    }
-}
-struct FreeGc<'c, C: Connection>(&'c C, Gcontext);
-impl<C: Connection> Drop for FreeGc<'_, C> {
-    fn drop(&mut self) {
-        self.0.free_gc(self.1).unwrap();
-    }
-}
-
-fn create_pixmap_wrapper<C: Connection>(
-    conn: &C,
-    depth: u8,
-    drawable: Drawable,
-    size: (u16, u16),
-) -> Result<FreePixmap<C>, ReplyOrIdError> {
-    let pixmap = conn.generate_id()?;
-    conn.create_pixmap(depth, pixmap, drawable, size.0, size.1)?;
-    Ok(FreePixmap(conn, pixmap))
-}
-
 fn shape_window<C: Connection>(
     conn: &C,
     win_id: Window,
     window_size: (u16, u16),
 ) -> Result<(), ReplyOrIdError> {
     // Create a pixmap for the shape
-    let pixmap = create_pixmap_wrapper(conn, 1, win_id, window_size)?;
+    let pixmap = PixmapWrapper::create_pixmap(conn, 1, win_id, window_size.0, window_size.1)?;
 
     // Fill the pixmap with what will indicate "transparent"
-    let gc = create_gc_with_foreground(conn, pixmap.1, 0)?;
-    let _free_gc = FreeGc(conn, gc);
+    let gc = create_gc_with_foreground(conn, pixmap.pixmap(), 0)?;
 
     let rect = Rectangle {
         x: 0,
@@ -195,15 +170,15 @@ fn shape_window<C: Connection>(
         width: window_size.0,
         height: window_size.1,
     };
-    conn.poly_fill_rectangle(pixmap.1, gc, &[rect])?;
+    conn.poly_fill_rectangle(pixmap.pixmap(), gc.gc(), &[rect])?;
 
     // Draw the eyes as "not transparent"
     let values = ChangeGCAux::new().foreground(1);
-    conn.change_gc(gc, &values)?;
-    draw_eyes(conn, pixmap.1, gc, gc, window_size)?;
+    conn.change_gc(gc.gc(), &values)?;
+    draw_eyes(conn, pixmap.pixmap(), gc.gc(), gc.gc(), window_size)?;
 
     // Set the shape of the window
-    conn.shape_mask(shape::SO::SET, shape::SK::BOUNDING, win_id, 0, 0, pixmap.1)?;
+    conn.shape_mask(shape::SO::SET, shape::SK::BOUNDING, win_id, 0, 0, &pixmap)?;
     Ok(())
 }
 
@@ -260,13 +235,14 @@ fn create_gc_with_foreground<C: Connection>(
     conn: &C,
     win_id: Window,
     foreground: u32,
-) -> Result<Gcontext, ReplyOrIdError> {
-    let gc = conn.generate_id()?;
-    let gc_aux = CreateGCAux::new()
-        .graphics_exposures(0)
-        .foreground(foreground);
-    conn.create_gc(gc, win_id, &gc_aux)?;
-    Ok(gc)
+) -> Result<GcontextWrapper<'_, C>, ReplyOrIdError> {
+    GcontextWrapper::create_gc(
+        conn,
+        win_id,
+        &CreateGCAux::new()
+            .graphics_exposures(0)
+            .foreground(foreground),
+    )
 }
 
 fn main() {
@@ -291,7 +267,7 @@ fn main() {
         wm_delete_window.reply().unwrap().atom,
     );
     let win_id = setup_window(conn, screen, window_size, wm_protocols, wm_delete_window).unwrap();
-    let mut pixmap = create_pixmap_wrapper(conn, screen.root_depth, win_id, window_size).unwrap();
+    let mut pixmap = PixmapWrapper::create_pixmap(conn, screen.root_depth, win_id, window_size.0, window_size.1).unwrap();
 
     let black_gc = create_gc_with_foreground(conn, win_id, screen.black_pixel).unwrap();
     let white_gc = create_gc_with_foreground(conn, win_id, screen.white_pixel).unwrap();
@@ -316,7 +292,7 @@ fn main() {
                 }
                 Event::ConfigureNotify(event) => {
                     window_size = (event.width, event.height);
-                    pixmap = create_pixmap_wrapper(conn, screen.root_depth, win_id, window_size)
+                    pixmap = PixmapWrapper::create_pixmap(conn, screen.root_depth, win_id, window_size.0, window_size.1)
                         .unwrap();
                     need_reshape = true;
                 }
@@ -352,14 +328,14 @@ fn main() {
         if need_repaint {
             // Draw new pupils
             let pos = compute_pupils(window_size, mouse_position);
-            draw_eyes(conn, pixmap.1, black_gc, white_gc, window_size).unwrap();
-            draw_pupils(conn, pixmap.1, black_gc, pos).unwrap();
+            draw_eyes(conn, pixmap.pixmap(), black_gc.gc(), white_gc.gc(), window_size).unwrap();
+            draw_pupils(conn, pixmap.pixmap(), black_gc.gc(), pos).unwrap();
 
             // Copy drawing from pixmap to window
             conn.copy_area(
-                pixmap.1,
+                pixmap.pixmap(),
                 win_id,
-                white_gc,
+                white_gc.gc(),
                 0,
                 0,
                 0,

--- a/examples/xeyes.rs
+++ b/examples/xeyes.rs
@@ -267,7 +267,14 @@ fn main() {
         wm_delete_window.reply().unwrap().atom,
     );
     let win_id = setup_window(conn, screen, window_size, wm_protocols, wm_delete_window).unwrap();
-    let mut pixmap = PixmapWrapper::create_pixmap(conn, screen.root_depth, win_id, window_size.0, window_size.1).unwrap();
+    let mut pixmap = PixmapWrapper::create_pixmap(
+        conn,
+        screen.root_depth,
+        win_id,
+        window_size.0,
+        window_size.1,
+    )
+    .unwrap();
 
     let black_gc = create_gc_with_foreground(conn, win_id, screen.black_pixel).unwrap();
     let white_gc = create_gc_with_foreground(conn, win_id, screen.white_pixel).unwrap();
@@ -292,8 +299,14 @@ fn main() {
                 }
                 Event::ConfigureNotify(event) => {
                     window_size = (event.width, event.height);
-                    pixmap = PixmapWrapper::create_pixmap(conn, screen.root_depth, win_id, window_size.0, window_size.1)
-                        .unwrap();
+                    pixmap = PixmapWrapper::create_pixmap(
+                        conn,
+                        screen.root_depth,
+                        win_id,
+                        window_size.0,
+                        window_size.1,
+                    )
+                    .unwrap();
                     need_reshape = true;
                 }
                 Event::MotionNotify(event) => {
@@ -328,7 +341,14 @@ fn main() {
         if need_repaint {
             // Draw new pupils
             let pos = compute_pupils(window_size, mouse_position);
-            draw_eyes(conn, pixmap.pixmap(), black_gc.gc(), white_gc.gc(), window_size).unwrap();
+            draw_eyes(
+                conn,
+                pixmap.pixmap(),
+                black_gc.gc(),
+                white_gc.gc(),
+                window_size,
+            )
+            .unwrap();
             draw_pupils(conn, pixmap.pixmap(), black_gc.gc(), pos).unwrap();
 
             // Copy drawing from pixmap to window

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -181,7 +181,7 @@ macro_rules! resource_wrapper {
         }
         impl<'c, C: Connection> Drop for $name<'c, C> {
             fn drop(&mut self) {
-                let _ = self.0.$freer(self.1);
+                let _ = (self.0).$freer(self.1);
             }
         }
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -152,6 +152,7 @@ macro_rules! resource_wrapper {
         pub struct $name:ident: $inner:ty,
         wrap: $wrapper:ident,
         get: $getter:ident,
+        consume: $consumer:ident,
         free: $freer:ident,
     } => {
         $(#[$meta])*
@@ -171,6 +172,15 @@ macro_rules! resource_wrapper {
             /// Get the XID of the wrapped resource
             pub fn $getter(&self) -> $inner {
                 self.1
+            }
+
+            /// Assume ownership of the XID of the wrapped resource
+            ///
+            /// This function destroys this wrapper without freeing the underlying resource.
+            pub fn $consumer(self) -> $inner {
+                let id = self.1;
+                std::mem::forget(self);
+                id
             }
         }
 
@@ -194,6 +204,7 @@ resource_wrapper! {
     pub struct PixmapWrapper: xproto::Pixmap,
     wrap: for_pixmap,
     get: pixmap,
+    consume: into_pixmap,
     free: free_pixmap,
 }
 
@@ -243,6 +254,7 @@ resource_wrapper! {
     pub struct WindowWrapper: Window,
     wrap: for_window,
     get: window,
+    consume: into_window,
     free: destroy_window,
 }
 
@@ -331,6 +343,7 @@ resource_wrapper! {
     pub struct FontWrapper: xproto::Font,
     wrap: for_font,
     get: font,
+    consume: into_font,
     free: close_font,
 }
 
@@ -371,6 +384,7 @@ resource_wrapper! {
     pub struct GcontextWrapper: xproto::Gcontext,
     wrap: for_gc,
     get: gc,
+    consume: into_gc,
     free: free_gc,
 }
 
@@ -416,6 +430,7 @@ resource_wrapper! {
     pub struct ColormapWrapper: xproto::Colormap,
     wrap: for_colormap,
     get: colormap,
+    consume: into_colormap,
     free: free_colormap,
 }
 
@@ -463,6 +478,7 @@ resource_wrapper! {
     pub struct CursorWrapper: xproto::Cursor,
     wrap: for_cursor,
     get: cursor,
+    consume: into_cursor,
     free: free_cursor,
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -255,6 +255,7 @@ impl<'c, C: Connection> WindowWrapper<'c, C> {
     /// [xproto::create_window].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_window].
+    #[allow(clippy::too_many_arguments)]
     pub fn create_window_and_get_cookie<'input>(
         conn: &'c C,
         depth: u8,
@@ -292,6 +293,7 @@ impl<'c, C: Connection> WindowWrapper<'c, C> {
     /// it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_window].
+    #[allow(clippy::too_many_arguments)]
     pub fn create_window<'input>(
         conn: &'c C,
         depth: u8,
@@ -473,6 +475,7 @@ impl<'c, C: Connection> CursorWrapper<'c, C> {
     /// [xproto::create_cursor].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_cursor].
+    #[allow(clippy::too_many_arguments)]
     pub fn create_cursor_and_get_cookie<A: Into<xproto::Pixmap>>(
         conn: &'c C,
         source: xproto::Pixmap,
@@ -501,6 +504,7 @@ impl<'c, C: Connection> CursorWrapper<'c, C> {
     /// it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_cursor].
+    #[allow(clippy::too_many_arguments)]
     pub fn create_cursor<A: Into<xproto::Pixmap>>(
         conn: &'c C,
         source: xproto::Pixmap,
@@ -529,6 +533,7 @@ impl<'c, C: Connection> CursorWrapper<'c, C> {
     /// [xproto::create_glyph_cursor].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_glyph_cursor].
+    #[allow(clippy::too_many_arguments)]
     pub fn create_glyph_cursor_and_get_cookie<A: Into<xproto::Font>>(
         conn: &'c C,
         source_font: xproto::Font,
@@ -566,6 +571,7 @@ impl<'c, C: Connection> CursorWrapper<'c, C> {
     /// and frees it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_glyph_cursor].
+    #[allow(clippy::too_many_arguments)]
     pub fn create_glyph_cursor<A: Into<xproto::Font>>(
         conn: &'c C,
         source_font: xproto::Font,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -4,8 +4,9 @@ use std::convert::TryInto;
 use std::marker::PhantomData;
 
 use super::cookie::VoidCookie;
-use super::errors::{ConnectionError, ReplyError};
-use super::protocol::xproto::{Atom, ConnectionExt as XProtoConnectionExt, PropMode, Window};
+use super::connection::Connection;
+use super::errors::{ConnectionError, ReplyError, ReplyOrIdError};
+use super::protocol::xproto::{self, Atom, ConnectionExt as XProtoConnectionExt, PropMode, Window};
 use super::x11_utils::TryParse;
 
 /// Iterator implementation used by `GetPropertyReply`.
@@ -144,3 +145,321 @@ pub trait ConnectionExt: XProtoConnectionExt {
     }
 }
 impl<C: XProtoConnectionExt + ?Sized> ConnectionExt for C {}
+
+macro_rules! resource_wrapper {
+    {
+        $(#[$meta:meta])*
+        pub struct $name:ident: $inner:ty,
+        wrap: $wrapper:ident,
+        get: $getter:ident,
+        free: $freer:ident,
+    } => {
+        $(#[$meta])*
+        ///
+        /// Any errors during `Drop` are silently ignored. Most likely an error here means that your
+        /// X11 connection is broken and later requests will also fail.
+        #[derive(Debug)]
+        pub struct $name<'c, C: Connection>(&'c C, $inner);
+
+        impl<'c, C: Connection> $name<'c, C>
+        {
+            /// Assume ownership of the given resource and destroy it in `Drop`.
+            pub fn $wrapper(conn: &'c C, id: $inner) -> Self {
+                $name(conn, id)
+            }
+
+            /// Get the XID of the wrapped resource
+            pub fn $getter(&self) -> $inner {
+                self.1
+            }
+        }
+
+        impl<C: Connection> From<&$name<'_, C>> for $inner {
+            fn from(from: &$name<'_, C>) -> Self {
+                from.1
+            }
+        }
+        impl<'c, C: Connection> Drop for $name<'c, C> {
+            fn drop(&mut self) {
+                let _ = self.0.$freer(self.1);
+            }
+        }
+    }
+}
+
+resource_wrapper! {
+    /// A RAII-like wrapper around a [xproto::Pixmap].
+    ///
+    /// Instances of this struct represent a pixmap that is freed in `Drop`.
+    pub struct PixmapWrapper: xproto::Pixmap,
+    wrap: for_pixmap,
+    get: pixmap,
+    free: free_pixmap,
+}
+
+impl<'c, C: Connection> PixmapWrapper<'c, C>
+{
+    /// Create a new pixmap and return a pixmap wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [xproto::create_pixmap] that allocates a id for the pixmap.
+    /// This function returns the resulting `PixmapWrapper` that owns the created pixmap and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [xproto::create_pixmap].
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_pixmap].
+    pub fn create_pixmap_and_get_cookie(conn: &'c C, depth: u8, drawable: u32, width: u16, height: u16) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+        let id = conn.generate_id()?;
+        let cookie = conn.create_pixmap(depth, id, drawable, width, height)?;
+        Ok((Self::for_pixmap(conn, id), cookie))
+    }
+
+    /// Create a new pixmap and return a pixmap wrapper
+    ///
+    /// This is a thin wrapper around [xproto::create_pixmap] that allocates a id for the pixmap.
+    /// This function returns the resulting `PixmapWrapper` that owns the created pixmap and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_pixmap].
+    pub fn create_pixmap(conn: &'c C, depth: u8, drawable: u32, width: u16, height: u16) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_pixmap_and_get_cookie(conn, depth, drawable, width, height)?.0)
+    }
+}
+
+resource_wrapper! {
+    /// A RAII-like wrapper around a [Window].
+    ///
+    /// Instances of this struct represent a window that is freed in `Drop`.
+    pub struct WindowWrapper: Window,
+    wrap: for_window,
+    get: window,
+    free: destroy_window,
+}
+
+impl<'c, C: Connection> WindowWrapper<'c, C>
+{
+    /// Create a new window and return a window wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [xproto::create_window] that allocates a id for the window.
+    /// This function returns the resulting `WindowWrapper` that owns the created window and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [xproto::create_window].
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_window].
+    pub fn create_window_and_get_cookie<'input>(
+        conn: &'c C,
+        depth: u8,
+        parent: Window,
+        x: i16,
+        y: i16,
+        width: u16,
+        height: u16,
+        border_width: u16,
+        class: xproto::WindowClass,
+        visual: xproto::Visualid,
+        value_list: &'input xproto::CreateWindowAux,
+    ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+        let id = conn.generate_id()?;
+        let cookie = conn.create_window(depth, id, parent, x, y, width, height, border_width, class, visual, value_list)?;
+        Ok((Self::for_window(conn, id), cookie))
+    }
+
+    /// Create a new window and return a window wrapper
+    ///
+    /// This is a thin wrapper around [xproto::create_window] that allocates a id for the window.
+    /// This function returns the resulting `WindowWrapper` that owns the created window and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_window].
+    pub fn create_window<'input>(
+        conn: &'c C,
+        depth: u8,
+        parent: Window,
+        x: i16,
+        y: i16,
+        width: u16,
+        height: u16,
+        border_width: u16,
+        class: xproto::WindowClass,
+        visual: xproto::Visualid,
+        value_list: &'input xproto::CreateWindowAux,
+    ) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_window_and_get_cookie(conn, depth, parent, x, y, width, height, border_width, class, visual, value_list)?.0)
+    }
+}
+
+resource_wrapper! {
+    /// A RAII-like wrapper around a [xproto::Font].
+    ///
+    /// Instances of this struct represent a font that is freed in `Drop`.
+    pub struct FontWrapper: xproto::Font,
+    wrap: for_font,
+    get: font,
+    free: close_font,
+}
+
+impl<'c, C: Connection> FontWrapper<'c, C>
+{
+    /// Create a new font and return a font wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [xproto::create_font] that allocates a id for the font.
+    /// This function returns the resulting `FontWrapper` that owns the created font and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [xproto::create_font].
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_font].
+    pub fn open_font_and_get_cookie<'input>(conn: &'c C, name: &'input [u8]) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+        let id = conn.generate_id()?;
+        let cookie = conn.open_font(id, name)?;
+        Ok((Self::for_font(conn, id), cookie))
+    }
+
+    /// Create a new font and return a font wrapper
+    ///
+    /// This is a thin wrapper around [xproto::create_font] that allocates a id for the font.
+    /// This function returns the resulting `FontWrapper` that owns the created font and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_font].
+    pub fn open_font<'input>(conn: &'c C, name: &'input [u8]) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::open_font_and_get_cookie(conn, name)?.0)
+    }
+}
+
+resource_wrapper! {
+    /// A RAII-like wrapper around a [xproto::Gcontext].
+    ///
+    /// Instances of this struct represent a graphics context that is freed in `Drop`.
+    pub struct GcontextWrapper: xproto::Gcontext,
+    wrap: for_gc,
+    get: gc,
+    free: free_gc,
+}
+
+impl<'c, C: Connection> GcontextWrapper<'c, C>
+{
+    /// Create a new graphics context and return a graphics context wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [xproto::create_gc] that allocates a id for the graphics
+    /// context. This function returns the resulting `GcontextWrapper` that owns the created
+    /// graphics context and frees it in `Drop`. This also returns a `VoidCookie` that comes from
+    /// the call to [xproto::create_gc].
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_gc].
+    pub fn create_gc_and_get_cookie<'input>(conn: &'c C, drawable: xproto::Drawable, value_list: &'input xproto::CreateGCAux) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+        let id = conn.generate_id()?;
+        let cookie = conn.create_gc(id, drawable, value_list)?;
+        Ok((Self::for_gc(conn, id), cookie))
+    }
+
+    /// Create a new graphics context and return a graphics context wrapper
+    ///
+    /// This is a thin wrapper around [xproto::create_gc] that allocates a id for the graphics
+    /// context. This function returns the resulting `GcontextWrapper` that owns the created
+    /// graphics context and frees it in `Drop`.
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_gc].
+    pub fn create_gc<'input>(conn: &'c C, drawable: xproto::Drawable, value_list: &'input xproto::CreateGCAux) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_gc_and_get_cookie(conn, drawable, value_list)?.0)
+    }
+}
+
+resource_wrapper! {
+    /// A RAII-like wrapper around a [xproto::Colormap].
+    ///
+    /// Instances of this struct represent a colormap that is freed in `Drop`.
+    pub struct ColormapWrapper: xproto::Colormap,
+    wrap: for_colormap,
+    get: colormap,
+    free: free_colormap,
+}
+
+impl<'c, C: Connection> ColormapWrapper<'c, C>
+{
+    /// Create a new colormap and return a colormap wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [xproto::create_colormap] that allocates a id for the
+    /// colormap. This function returns the resulting `ColormapWrapper` that owns the created
+    /// colormap and frees it in `Drop`. This also returns a `VoidCookie` that comes from the call
+    /// to [xproto::create_colormap].
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_colormap].
+    pub fn create_colormap_and_get_cookie(conn: &'c C, alloc: xproto::ColormapAlloc, window: Window, visual: xproto::Visualid) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+        let id = conn.generate_id()?;
+        let cookie = conn.create_colormap(alloc, id, window, visual)?;
+        Ok((Self::for_colormap(conn, id), cookie))
+    }
+
+    /// Create a new colormap and return a colormap wrapper
+    ///
+    /// This is a thin wrapper around [xproto::create_colormap] that allocates a id for the
+    /// colormap. This function returns the resulting `ColormapWrapper` that owns the created
+    /// colormap and frees it in `Drop`.
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_colormap].
+    pub fn create_colormap(conn: &'c C, alloc: xproto::ColormapAlloc, window: Window, visual: xproto::Visualid) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_colormap_and_get_cookie(conn, alloc, window, visual)?.0)
+    }
+}
+
+resource_wrapper! {
+    /// A RAII-like wrapper around a [xproto::Cursor].
+    ///
+    /// Instances of this struct represent a graphics context that is freed in `Drop`.
+    pub struct CursorWrapper: xproto::Cursor,
+    wrap: for_cursor,
+    get: cursor,
+    free: free_cursor,
+}
+
+impl<'c, C: Connection> CursorWrapper<'c, C>
+{
+    /// Create a new cursor and return a cursor wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [xproto::create_cursor] that allocates a id for the cursor.
+    /// This function returns the resulting `CursorWrapper` that owns the created cursor and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [xproto::create_cursor].
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_cursor].
+    pub fn create_cursor_and_get_cookie<A: Into<xproto::Pixmap>>(conn: &'c C, source: xproto::Pixmap, mask: A, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+        let id = conn.generate_id()?;
+        let cookie = conn.create_cursor(id, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x, y)?;
+        Ok((Self::for_cursor(conn, id), cookie))
+    }
+
+    /// Create a new cursor and return a cursor wrapper
+    ///
+    /// This is a thin wrapper around [xproto::create_cursor] that allocates a id for the cursor.
+    /// This function returns the resulting `CursorWrapper` that owns the created cursor and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_cursor].
+    pub fn create_cursor<A: Into<xproto::Pixmap>>(conn: &'c C, source: xproto::Pixmap, mask: A, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_cursor_and_get_cookie(conn, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x, y)?.0)
+    }
+
+    /// Create a new cursor and return a cursor wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [xproto::create_glyph_cursor] that allocates a id for the
+    /// cursor. This function returns the resulting `CursorWrapper` that owns the created cursor
+    /// and frees it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [xproto::create_glyph_cursor].
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_glyph_cursor].
+    pub fn create_glyph_cursor_and_get_cookie<A: Into<xproto::Font>>(conn: &'c C, source_font: xproto::Font, mask_font: A, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+        let id = conn.generate_id()?;
+        let cookie = conn.create_glyph_cursor(id, source_font, mask_font, source_char, mask_char, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)?;
+        Ok((Self::for_cursor(conn, id), cookie))
+    }
+
+    /// Create a new cursor and return a cursor wrapper
+    ///
+    /// This is a thin wrapper around [xproto::create_glyph_cursor] that allocates a id for the
+    /// cursor. This function returns the resulting `CursorWrapper` that owns the created cursor
+    /// and frees it in `Drop`.
+    ///
+    /// Errors can come from the call to [Connection::generate_id] or [xproto::create_glyph_cursor].
+    pub fn create_glyph_cursor<A: Into<xproto::Font>>(conn: &'c C, source_font: xproto::Font, mask_font: A, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_glyph_cursor_and_get_cookie(conn, source_font, mask_font, source_char, mask_char, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)?.0)
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,8 +3,8 @@
 use std::convert::TryInto;
 use std::marker::PhantomData;
 
-use super::cookie::VoidCookie;
 use super::connection::Connection;
+use super::cookie::VoidCookie;
 use super::errors::{ConnectionError, ReplyError, ReplyOrIdError};
 use super::protocol::xproto::{self, Atom, ConnectionExt as XProtoConnectionExt, PropMode, Window};
 use super::x11_utils::TryParse;
@@ -197,8 +197,7 @@ resource_wrapper! {
     free: free_pixmap,
 }
 
-impl<'c, C: Connection> PixmapWrapper<'c, C>
-{
+impl<'c, C: Connection> PixmapWrapper<'c, C> {
     /// Create a new pixmap and return a pixmap wrapper and a cookie.
     ///
     /// This is a thin wrapper around [xproto::create_pixmap] that allocates a id for the pixmap.
@@ -207,7 +206,13 @@ impl<'c, C: Connection> PixmapWrapper<'c, C>
     /// [xproto::create_pixmap].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_pixmap].
-    pub fn create_pixmap_and_get_cookie(conn: &'c C, depth: u8, drawable: u32, width: u16, height: u16) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+    pub fn create_pixmap_and_get_cookie(
+        conn: &'c C,
+        depth: u8,
+        drawable: u32,
+        width: u16,
+        height: u16,
+    ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
         let id = conn.generate_id()?;
         let cookie = conn.create_pixmap(depth, id, drawable, width, height)?;
         Ok((Self::for_pixmap(conn, id), cookie))
@@ -220,7 +225,13 @@ impl<'c, C: Connection> PixmapWrapper<'c, C>
     /// it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_pixmap].
-    pub fn create_pixmap(conn: &'c C, depth: u8, drawable: u32, width: u16, height: u16) -> Result<Self, ReplyOrIdError> {
+    pub fn create_pixmap(
+        conn: &'c C,
+        depth: u8,
+        drawable: u32,
+        width: u16,
+        height: u16,
+    ) -> Result<Self, ReplyOrIdError> {
         Ok(Self::create_pixmap_and_get_cookie(conn, depth, drawable, width, height)?.0)
     }
 }
@@ -235,8 +246,7 @@ resource_wrapper! {
     free: destroy_window,
 }
 
-impl<'c, C: Connection> WindowWrapper<'c, C>
-{
+impl<'c, C: Connection> WindowWrapper<'c, C> {
     /// Create a new window and return a window wrapper and a cookie.
     ///
     /// This is a thin wrapper around [xproto::create_window] that allocates a id for the window.
@@ -259,7 +269,19 @@ impl<'c, C: Connection> WindowWrapper<'c, C>
         value_list: &'input xproto::CreateWindowAux,
     ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
         let id = conn.generate_id()?;
-        let cookie = conn.create_window(depth, id, parent, x, y, width, height, border_width, class, visual, value_list)?;
+        let cookie = conn.create_window(
+            depth,
+            id,
+            parent,
+            x,
+            y,
+            width,
+            height,
+            border_width,
+            class,
+            visual,
+            value_list,
+        )?;
         Ok((Self::for_window(conn, id), cookie))
     }
 
@@ -283,7 +305,20 @@ impl<'c, C: Connection> WindowWrapper<'c, C>
         visual: xproto::Visualid,
         value_list: &'input xproto::CreateWindowAux,
     ) -> Result<Self, ReplyOrIdError> {
-        Ok(Self::create_window_and_get_cookie(conn, depth, parent, x, y, width, height, border_width, class, visual, value_list)?.0)
+        Ok(Self::create_window_and_get_cookie(
+            conn,
+            depth,
+            parent,
+            x,
+            y,
+            width,
+            height,
+            border_width,
+            class,
+            visual,
+            value_list,
+        )?
+        .0)
     }
 }
 
@@ -297,8 +332,7 @@ resource_wrapper! {
     free: close_font,
 }
 
-impl<'c, C: Connection> FontWrapper<'c, C>
-{
+impl<'c, C: Connection> FontWrapper<'c, C> {
     /// Create a new font and return a font wrapper and a cookie.
     ///
     /// This is a thin wrapper around [xproto::create_font] that allocates a id for the font.
@@ -307,7 +341,10 @@ impl<'c, C: Connection> FontWrapper<'c, C>
     /// [xproto::create_font].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_font].
-    pub fn open_font_and_get_cookie<'input>(conn: &'c C, name: &'input [u8]) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+    pub fn open_font_and_get_cookie<'input>(
+        conn: &'c C,
+        name: &'input [u8],
+    ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
         let id = conn.generate_id()?;
         let cookie = conn.open_font(id, name)?;
         Ok((Self::for_font(conn, id), cookie))
@@ -335,8 +372,7 @@ resource_wrapper! {
     free: free_gc,
 }
 
-impl<'c, C: Connection> GcontextWrapper<'c, C>
-{
+impl<'c, C: Connection> GcontextWrapper<'c, C> {
     /// Create a new graphics context and return a graphics context wrapper and a cookie.
     ///
     /// This is a thin wrapper around [xproto::create_gc] that allocates a id for the graphics
@@ -345,7 +381,11 @@ impl<'c, C: Connection> GcontextWrapper<'c, C>
     /// the call to [xproto::create_gc].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_gc].
-    pub fn create_gc_and_get_cookie<'input>(conn: &'c C, drawable: xproto::Drawable, value_list: &'input xproto::CreateGCAux) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+    pub fn create_gc_and_get_cookie<'input>(
+        conn: &'c C,
+        drawable: xproto::Drawable,
+        value_list: &'input xproto::CreateGCAux,
+    ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
         let id = conn.generate_id()?;
         let cookie = conn.create_gc(id, drawable, value_list)?;
         Ok((Self::for_gc(conn, id), cookie))
@@ -358,7 +398,11 @@ impl<'c, C: Connection> GcontextWrapper<'c, C>
     /// graphics context and frees it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_gc].
-    pub fn create_gc<'input>(conn: &'c C, drawable: xproto::Drawable, value_list: &'input xproto::CreateGCAux) -> Result<Self, ReplyOrIdError> {
+    pub fn create_gc<'input>(
+        conn: &'c C,
+        drawable: xproto::Drawable,
+        value_list: &'input xproto::CreateGCAux,
+    ) -> Result<Self, ReplyOrIdError> {
         Ok(Self::create_gc_and_get_cookie(conn, drawable, value_list)?.0)
     }
 }
@@ -373,8 +417,7 @@ resource_wrapper! {
     free: free_colormap,
 }
 
-impl<'c, C: Connection> ColormapWrapper<'c, C>
-{
+impl<'c, C: Connection> ColormapWrapper<'c, C> {
     /// Create a new colormap and return a colormap wrapper and a cookie.
     ///
     /// This is a thin wrapper around [xproto::create_colormap] that allocates a id for the
@@ -383,7 +426,12 @@ impl<'c, C: Connection> ColormapWrapper<'c, C>
     /// to [xproto::create_colormap].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_colormap].
-    pub fn create_colormap_and_get_cookie(conn: &'c C, alloc: xproto::ColormapAlloc, window: Window, visual: xproto::Visualid) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+    pub fn create_colormap_and_get_cookie(
+        conn: &'c C,
+        alloc: xproto::ColormapAlloc,
+        window: Window,
+        visual: xproto::Visualid,
+    ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
         let id = conn.generate_id()?;
         let cookie = conn.create_colormap(alloc, id, window, visual)?;
         Ok((Self::for_colormap(conn, id), cookie))
@@ -396,7 +444,12 @@ impl<'c, C: Connection> ColormapWrapper<'c, C>
     /// colormap and frees it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_colormap].
-    pub fn create_colormap(conn: &'c C, alloc: xproto::ColormapAlloc, window: Window, visual: xproto::Visualid) -> Result<Self, ReplyOrIdError> {
+    pub fn create_colormap(
+        conn: &'c C,
+        alloc: xproto::ColormapAlloc,
+        window: Window,
+        visual: xproto::Visualid,
+    ) -> Result<Self, ReplyOrIdError> {
         Ok(Self::create_colormap_and_get_cookie(conn, alloc, window, visual)?.0)
     }
 }
@@ -411,8 +464,7 @@ resource_wrapper! {
     free: free_cursor,
 }
 
-impl<'c, C: Connection> CursorWrapper<'c, C>
-{
+impl<'c, C: Connection> CursorWrapper<'c, C> {
     /// Create a new cursor and return a cursor wrapper and a cookie.
     ///
     /// This is a thin wrapper around [xproto::create_cursor] that allocates a id for the cursor.
@@ -421,9 +473,24 @@ impl<'c, C: Connection> CursorWrapper<'c, C>
     /// [xproto::create_cursor].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_cursor].
-    pub fn create_cursor_and_get_cookie<A: Into<xproto::Pixmap>>(conn: &'c C, source: xproto::Pixmap, mask: A, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+    pub fn create_cursor_and_get_cookie<A: Into<xproto::Pixmap>>(
+        conn: &'c C,
+        source: xproto::Pixmap,
+        mask: A,
+        fore_red: u16,
+        fore_green: u16,
+        fore_blue: u16,
+        back_red: u16,
+        back_green: u16,
+        back_blue: u16,
+        x: u16,
+        y: u16,
+    ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
         let id = conn.generate_id()?;
-        let cookie = conn.create_cursor(id, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x, y)?;
+        let cookie = conn.create_cursor(
+            id, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x,
+            y,
+        )?;
         Ok((Self::for_cursor(conn, id), cookie))
     }
 
@@ -434,8 +501,24 @@ impl<'c, C: Connection> CursorWrapper<'c, C>
     /// it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_cursor].
-    pub fn create_cursor<A: Into<xproto::Pixmap>>(conn: &'c C, source: xproto::Pixmap, mask: A, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16, x: u16, y: u16) -> Result<Self, ReplyOrIdError> {
-        Ok(Self::create_cursor_and_get_cookie(conn, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x, y)?.0)
+    pub fn create_cursor<A: Into<xproto::Pixmap>>(
+        conn: &'c C,
+        source: xproto::Pixmap,
+        mask: A,
+        fore_red: u16,
+        fore_green: u16,
+        fore_blue: u16,
+        back_red: u16,
+        back_green: u16,
+        back_blue: u16,
+        x: u16,
+        y: u16,
+    ) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_cursor_and_get_cookie(
+            conn, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue,
+            x, y,
+        )?
+        .0)
     }
 
     /// Create a new cursor and return a cursor wrapper and a cookie.
@@ -446,9 +529,33 @@ impl<'c, C: Connection> CursorWrapper<'c, C>
     /// [xproto::create_glyph_cursor].
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_glyph_cursor].
-    pub fn create_glyph_cursor_and_get_cookie<A: Into<xproto::Font>>(conn: &'c C, source_font: xproto::Font, mask_font: A, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
+    pub fn create_glyph_cursor_and_get_cookie<A: Into<xproto::Font>>(
+        conn: &'c C,
+        source_font: xproto::Font,
+        mask_font: A,
+        source_char: u16,
+        mask_char: u16,
+        fore_red: u16,
+        fore_green: u16,
+        fore_blue: u16,
+        back_red: u16,
+        back_green: u16,
+        back_blue: u16,
+    ) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError> {
         let id = conn.generate_id()?;
-        let cookie = conn.create_glyph_cursor(id, source_font, mask_font, source_char, mask_char, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)?;
+        let cookie = conn.create_glyph_cursor(
+            id,
+            source_font,
+            mask_font,
+            source_char,
+            mask_char,
+            fore_red,
+            fore_green,
+            fore_blue,
+            back_red,
+            back_green,
+            back_blue,
+        )?;
         Ok((Self::for_cursor(conn, id), cookie))
     }
 
@@ -459,7 +566,32 @@ impl<'c, C: Connection> CursorWrapper<'c, C>
     /// and frees it in `Drop`.
     ///
     /// Errors can come from the call to [Connection::generate_id] or [xproto::create_glyph_cursor].
-    pub fn create_glyph_cursor<A: Into<xproto::Font>>(conn: &'c C, source_font: xproto::Font, mask_font: A, source_char: u16, mask_char: u16, fore_red: u16, fore_green: u16, fore_blue: u16, back_red: u16, back_green: u16, back_blue: u16) -> Result<Self, ReplyOrIdError> {
-        Ok(Self::create_glyph_cursor_and_get_cookie(conn, source_font, mask_font, source_char, mask_char, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)?.0)
+    pub fn create_glyph_cursor<A: Into<xproto::Font>>(
+        conn: &'c C,
+        source_font: xproto::Font,
+        mask_font: A,
+        source_char: u16,
+        mask_char: u16,
+        fore_red: u16,
+        fore_green: u16,
+        fore_blue: u16,
+        back_red: u16,
+        back_green: u16,
+        back_blue: u16,
+    ) -> Result<Self, ReplyOrIdError> {
+        Ok(Self::create_glyph_cursor_and_get_cookie(
+            conn,
+            source_font,
+            mask_font,
+            source_char,
+            mask_char,
+            fore_red,
+            fore_green,
+            fore_blue,
+            back_red,
+            back_green,
+            back_blue,
+        )?
+        .0)
     }
 }


### PR DESCRIPTION
This PR implements #78 for the core protocol: This adds e.g. `x11rb::wrapper::WindowWrapper` which, well, wraps a window ID (`u32`). In its `Drop` implementation, this calls `destroy_window`, thus preventing "window leaks".

I am not sure how much I really like this, but here it is in the form of the PR.

Also, there is way too much hand-written code in this PR. I guess I'd prefer if the code generator generated the necessary code for these wrappers. But today is not the day for that...