### PR TITLE
Fix needless_borrow clippy warning

### DIFF
--- a/cairo-example/src/main.rs
+++ b/cairo-example/src/main.rs
@@ -242,7 +242,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // composite manager starting/stopping at runtime.
     let transparency = composite_manager_running(&conn, screen_num)?;
 
-    let window = create_window(&conn, &screen, &atoms, (width, height), depth, visualid)?;
+    let window = create_window(&conn, screen, &atoms, (width, height), depth, visualid)?;
 
     // Here comes all the interaction between cairo and x11rb:
     let mut visual = find_xcb_visualtype(&conn, visualid).unwrap();

--- a/examples/hypnomoire.rs
+++ b/examples/hypnomoire.rs
@@ -63,7 +63,7 @@ fn main() {
 
     for win in windows.iter() {
         let conn2 = Arc::clone(&conn);
-        let win = Arc::clone(&win);
+        let win = Arc::clone(win);
         thread::spawn(move || run(conn2, win, screen_num, white, black));
     }
 

--- a/examples/xclock_utc.rs
+++ b/examples/xclock_utc.rs
@@ -260,7 +260,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let atoms = Atoms::new(conn)?.reply()?;
 
     let (mut width, mut height) = (100, 100);
-    let win_id = create_window(conn, &screen, &atoms, (width, height))?;
+    let win_id = create_window(conn, screen, &atoms, (width, height))?;
 
     let gc_id = conn.generate_id().unwrap();
     conn.create_gc(gc_id, win_id, &CreateGCAux::default())?;
@@ -293,7 +293,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        redraw(conn, &screen, win_id, gc_id, (width, height))?;
+        redraw(conn, screen, win_id, gc_id, (width, height))?;
         conn.flush()?;
     }
 }

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -32,6 +32,8 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String
     outln!(main_out, "");
     outln!(main_out, "// Clippy does not like some names from the XML.");
     outln!(main_out, "#![allow(clippy::upper_case_acronyms)]");
+    outln!(main_out, "// This is not easy to fix, so ignore it.");
+    outln!(main_out, "#![allow(clippy::needless_borrow)]");
     outln!(main_out, "");
     outln!(main_out, "use std::borrow::Cow;");
     outln!(main_out, "use std::convert::TryInto;");

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -74,7 +74,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         resource_info: &[super::ResourceInfo<'_>],
     ) {
         super::write_code_header(out);
-        header::write_header(out, &self.ns);
+        header::write_header(out, self.ns);
 
         let mut trait_out = Output::new();
 
@@ -172,7 +172,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         } else {
             StructSizeConstraint::Fixed(32)
         };
-        self.emit_event_opcode(name, number, &event_full_def, out);
+        self.emit_event_opcode(name, number, event_full_def, out);
 
         let full_name = format!("{}Event", name);
 
@@ -836,7 +836,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     }
 
     fn generate_type_alias_def(&self, type_alias_def: &xcbdefs::TypeAliasDef, out: &mut Output) {
-        let rust_new_name = self.get_type_alias_rust_name(&type_alias_def);
+        let rust_new_name = self.get_type_alias_rust_name(type_alias_def);
         outln!(
             out,
             "pub type {} = {};",
@@ -919,7 +919,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                             out,
                             "let {} = {}.switch_expr();",
                             dst_var_name,
-                            wrap_field_ref(&switch_field_name),
+                            wrap_field_ref(switch_field_name),
                         );
                     } else {
                         outln!(
@@ -927,7 +927,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                             "let {} = {}::try_from({}.switch_expr()).unwrap();",
                             dst_var_name,
                             rust_field_type,
-                            wrap_field_ref(&switch_field_name),
+                            wrap_field_ref(switch_field_name),
                         );
                     }
                 } else {
@@ -958,7 +958,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                             out,
                             "let {} = {}.switch_expr();",
                             dst_var_name,
-                            wrap_field_ref(&switch_field_name),
+                            wrap_field_ref(switch_field_name),
                         );
                     } else {
                         outln!(
@@ -966,7 +966,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                             "let {} = {}::try_from({}.switch_expr(){}).unwrap();",
                             dst_var_name,
                             rust_field_type,
-                            wrap_field_ref(&switch_field_name),
+                            wrap_field_ref(switch_field_name),
                             op_str,
                         );
                     }

--- a/generator/src/generator/namespace/parse.rs
+++ b/generator/src/generator/namespace/parse.rs
@@ -329,7 +329,7 @@ pub(super) fn can_use_simple_list_parsing(
     type_: &xcbdefs::FieldValueType,
 ) -> bool {
     generator
-        .get_type_parse_params(&type_.type_.get_resolved(), "")
+        .get_type_parse_params(type_.type_.get_resolved(), "")
         .len()
         == 1
         && !needs_post_parse(type_)

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -528,14 +528,14 @@ fn emit_request_struct(
                             } else {
                                 fixed_fields_bytes.push(format!(
                                     "{}_REQUEST",
-                                    super::super::camel_case_to_upper_snake(&name),
+                                    super::super::camel_case_to_upper_snake(name),
                                 ));
                             }
                         } else if normal_field.name == "minor_opcode" {
                             assert!(ns.ext_info.is_some());
                             fixed_fields_bytes.push(format!(
                                 "{}_REQUEST",
-                                super::super::camel_case_to_upper_snake(&name),
+                                super::super::camel_case_to_upper_snake(name),
                             ));
                         } else if normal_field.name == "length" {
                             // the actual length will be calculated later
@@ -955,7 +955,7 @@ fn emit_request_struct(
                 outln!(
                     out,
                     "if header.minor_opcode != {}_REQUEST {{",
-                    super::super::camel_case_to_upper_snake(&name),
+                    super::super::camel_case_to_upper_snake(name),
                 );
                 outln!(out.indent(), "return Err(ParseError::InvalidValue);");
                 outln!(out, "}}");
@@ -965,7 +965,7 @@ fn emit_request_struct(
                 outln!(
                     out,
                     "if header.major_opcode != {}_REQUEST {{",
-                    super::super::camel_case_to_upper_snake(&name),
+                    super::super::camel_case_to_upper_snake(name),
                 );
                 outln!(out.indent(), "return Err(ParseError::InvalidValue);");
                 outln!(out, "}}");

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -13,7 +13,7 @@ pub(super) fn generate(
     info: &ResourceInfo<'_>,
 ) {
     let lower_name = info.resource_name.to_ascii_lowercase();
-    let free_function = camel_case_to_lower_snake(&info.free_request);
+    let free_function = camel_case_to_lower_snake(info.free_request);
     let wrapper = format!("{}Wrapper", info.resource_name);
     outln!(out, "");
     outln!(

--- a/generator/src/generator/namespace/struct_type.rs
+++ b/generator/src/generator/namespace/struct_type.rs
@@ -54,7 +54,7 @@ pub(super) fn emit_struct_type(
                 outln!(
                     out.indent(),
                     "pub {}: {},",
-                    to_rust_variable_name(&field_name),
+                    to_rust_variable_name(field_name),
                     field_type
                 );
             }
@@ -268,7 +268,7 @@ pub(super) fn emit_struct_type(
                     field_type
                 );
                 out.indented(|out| {
-                    outln!(out, "self.{}.len()", to_rust_variable_name(&list_name));
+                    outln!(out, "self.{}.len()", to_rust_variable_name(list_name));
                     match op {
                         DeducibleLengthFieldOp::None => {}
                         DeducibleLengthFieldOp::Mul(n) => {

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -966,7 +966,7 @@ fn case_has_single_visible_field(
         .fields
         .borrow()
         .iter()
-        .filter(|case_field| generator.field_is_visible(case_field, &deducible_fields))
+        .filter(|case_field| generator.field_is_visible(case_field, deducible_fields))
         .count();
     assert!(num_visible_fields > 0);
     num_visible_fields == 1

--- a/src/image.rs
+++ b/src/image.rs
@@ -702,7 +702,7 @@ impl<'a> Image<'a> {
         }
         .send(conn)?
         .reply()?;
-        Ok(Self::get_from_reply(&conn.setup(), width, height, reply)?)
+        Ok(Self::get_from_reply(conn.setup(), width, height, reply)?)
     }
 
     /// Construct an `Image` from a `GetImageReply`.
@@ -770,7 +770,7 @@ impl<'a> Image<'a> {
                 dst_y: dst_y + i16::try_from(y_offset).unwrap(),
                 left_pad: 0, // Must always be 0 for ZPixmap
                 depth: self.depth,
-                data: Cow::Borrowed(&data),
+                data: Cow::Borrowed(data),
             };
             result.push(request.send(conn)?);
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -8,6 +8,8 @@
 
 // Clippy does not like some names from the XML.
 #![allow(clippy::upper_case_acronyms)]
+// This is not easy to fix, so ignore it.
+#![allow(clippy::needless_borrow)]
 
 use std::borrow::Cow;
 use std::convert::TryInto;

--- a/src/rust_connection/packet_reader.rs
+++ b/src/rust_connection/packet_reader.rs
@@ -48,7 +48,7 @@ impl PacketReader {
             let initial_packet = &self.pending_packet[0..MINIMAL_PACKET_LENGTH]
                 .try_into()
                 .unwrap();
-            let extra = extra_length(&initial_packet);
+            let extra = extra_length(initial_packet);
             assert_eq!(self.pending_packet.len(), MINIMAL_PACKET_LENGTH + extra);
 
             out_packets.push(std::mem::replace(

--- a/xcbgen-rs/src/resolver/type_resolver.rs
+++ b/xcbgen-rs/src/resolver/type_resolver.rs
@@ -334,26 +334,26 @@ impl<'a> TypeResolver<'a> {
         if let Some(header) = header {
             if header == ns.header {
                 let event = ns
-                    .get_event(&name)
+                    .get_event(name)
                     .ok_or_else(|| ResolveError::UnknownEventName(named_event.name().into()))?;
                 named_event.set_resolved(event);
             } else {
                 let imported_ns = ns
-                    .get_import(&header)
+                    .get_import(header)
                     .ok_or_else(|| ResolveError::UnknownEventName(named_event.name().into()))?;
                 let event = imported_ns
-                    .get_event(&name)
+                    .get_event(name)
                     .ok_or_else(|| ResolveError::UnknownEventName(named_event.name().into()))?;
                 named_event.set_resolved(event);
             }
             Ok(())
         } else {
-            let event = if let Some(event) = ns.get_event(&name) {
+            let event = if let Some(event) = ns.get_event(name) {
                 event
             } else {
                 let mut event = None;
                 for imported_ns in ns.imports.borrow().values().map(defs::Import::ns) {
-                    if let Some(event_in_import) = imported_ns.get_event(&name) {
+                    if let Some(event_in_import) = imported_ns.get_event(name) {
                         if event.is_some() {
                             return Err(ResolveError::AmbiguousEventName(
                                 named_event.name().into(),
@@ -378,26 +378,26 @@ impl<'a> TypeResolver<'a> {
         if let Some(header) = header {
             if header == ns.header {
                 let error = ns
-                    .get_error(&name)
+                    .get_error(name)
                     .ok_or_else(|| ResolveError::UnknownErrorName(named_error.name().into()))?;
                 named_error.set_resolved(error);
             } else {
                 let imported_ns = ns
-                    .get_import(&header)
+                    .get_import(header)
                     .ok_or_else(|| ResolveError::UnknownErrorName(named_error.name().into()))?;
                 let error = imported_ns
-                    .get_error(&name)
+                    .get_error(name)
                     .ok_or_else(|| ResolveError::UnknownErrorName(named_error.name().into()))?;
                 named_error.set_resolved(error);
             }
             Ok(())
         } else {
-            let error = if let Some(error) = ns.get_error(&name) {
+            let error = if let Some(error) = ns.get_error(name) {
                 error
             } else {
                 let mut error = None;
                 for imported_ns in ns.imports.borrow().values().map(defs::Import::ns) {
-                    if let Some(error_in_import) = imported_ns.get_error(&name) {
+                    if let Some(error_in_import) = imported_ns.get_error(name) {
                         if error.is_some() {
                             return Err(ResolveError::AmbiguousErrorName(
                                 named_error.name().into(),
@@ -423,15 +423,15 @@ impl<'a> TypeResolver<'a> {
         if let Some(header) = header {
             if header == ns.header {
                 let type_ = ns
-                    .get_type(&name)
+                    .get_type(name)
                     .ok_or_else(|| ResolveError::UnknownTypeName(named_type.name().into()))?;
                 named_type.set_resolved(type_);
             } else {
                 let imported_ns = ns
-                    .get_import(&header)
+                    .get_import(header)
                     .ok_or_else(|| ResolveError::UnknownTypeName(named_type.name().into()))?;
                 let type_ = imported_ns
-                    .get_type(&name)
+                    .get_type(name)
                     .ok_or_else(|| ResolveError::UnknownTypeName(named_type.name().into()))?;
                 named_type.set_resolved(type_);
             }
@@ -452,12 +452,12 @@ impl<'a> TypeResolver<'a> {
                 "double" => defs::TypeRef::BuiltIn(defs::BuiltInType::Double),
                 "void" => defs::TypeRef::BuiltIn(defs::BuiltInType::Void),
                 _ => {
-                    if let Some(type_) = ns.get_type(&name) {
+                    if let Some(type_) = ns.get_type(name) {
                         type_
                     } else {
                         let mut type_ = None;
                         for imported_ns in ns.imports.borrow().values().map(defs::Import::ns) {
-                            if let Some(type_in_import) = imported_ns.get_type(&name) {
+                            if let Some(type_in_import) = imported_ns.get_type(name) {
                                 if type_.is_some() {
                                     return Err(ResolveError::AmbiguousTypeName(
                                         named_type.name().into(),


### PR DESCRIPTION
```
error: this expression borrows a reference (`&[u8; 32]`) that is immediately dereferenced by the compiler
  --> src/rust_connection/packet_reader.rs:51:38
   |
51 |             let extra = extra_length(&initial_packet);
   |                                      ^^^^^^^^^^^^^^^ help: change this to: `initial_packet`
   |
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

Signed-off-by: Uli Schlachter <psychon@znc.in>