### PR TITLE
Generate wrapper objects for extension resources

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String
         let mut ns_out = Output::new();
         let wrapper_info = resources::for_extension(&ns.header);
         namespace::generate(
-            &module,
+            module,
             &ns,
             &caches,
             &mut ns_out,

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -53,7 +53,14 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String
     for ns in module.sorted_namespaces() {
         let mut ns_out = Output::new();
         let wrapper_info = resources::for_extension(&ns.header);
-        namespace::generate(&ns, &caches, &mut ns_out, &mut enum_cases, wrapper_info);
+        namespace::generate(
+            &module,
+            &ns,
+            &caches,
+            &mut ns_out,
+            &mut enum_cases,
+            wrapper_info,
+        );
         out_map.insert(
             PathBuf::from(format!("{}.rs", ns.header)),
             ns_out.into_data(),

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -7,6 +7,7 @@ mod output;
 mod error_events;
 mod namespace;
 mod requests_replies;
+mod resources;
 mod special_cases;
 
 use output::Output;
@@ -51,10 +52,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> HashMap<PathBuf, String
     let mut enum_cases = HashMap::new();
     for ns in module.sorted_namespaces() {
         let mut ns_out = Output::new();
-        let wrapper_info = match ns.ext_info {
-            None => &XPROTO_RESOURCES[..],
-            Some(_) => &[],
-        };
+        let wrapper_info = resources::for_extension(&ns.header);
         namespace::generate(&ns, &caches, &mut ns_out, &mut enum_cases, wrapper_info);
         out_map.insert(
             PathBuf::from(format!("{}.rs", ns.header)),
@@ -223,78 +221,6 @@ struct CreateInfo<'a> {
 
 struct ResourceInfo<'a> {
     resource_name: &'a str,
-    create_requests: [Option<CreateInfo<'a>>; 2],
+    create_requests: &'a [CreateInfo<'a>],
     free_request: &'a str,
 }
-
-const XPROTO_RESOURCES: [ResourceInfo<'static>; 6] = [
-    ResourceInfo {
-        resource_name: "Pixmap",
-        create_requests: [
-            Some(CreateInfo {
-                request_name: "CreatePixmap",
-                created_argument: "pid",
-            }),
-            None,
-        ],
-        free_request: "FreePixmap",
-    },
-    ResourceInfo {
-        resource_name: "Window",
-        create_requests: [
-            Some(CreateInfo {
-                request_name: "CreateWindow",
-                created_argument: "wid",
-            }),
-            None,
-        ],
-        free_request: "DestroyWindow",
-    },
-    ResourceInfo {
-        resource_name: "Font",
-        create_requests: [
-            Some(CreateInfo {
-                request_name: "OpenFont",
-                created_argument: "fid",
-            }),
-            None,
-        ],
-        free_request: "CloseFont",
-    },
-    ResourceInfo {
-        resource_name: "Gcontext",
-        create_requests: [
-            Some(CreateInfo {
-                request_name: "CreateGC",
-                created_argument: "cid",
-            }),
-            None,
-        ],
-        free_request: "FreeGC",
-    },
-    ResourceInfo {
-        resource_name: "Colormap",
-        create_requests: [
-            Some(CreateInfo {
-                request_name: "CreateColormap",
-                created_argument: "mid",
-            }),
-            None,
-        ],
-        free_request: "FreeColormap",
-    },
-    ResourceInfo {
-        resource_name: "Cursor",
-        create_requests: [
-            Some(CreateInfo {
-                request_name: "CreateCursor",
-                created_argument: "cid",
-            }),
-            Some(CreateInfo {
-                request_name: "CreateGlyphCursor",
-                created_argument: "cid",
-            }),
-        ],
-        free_request: "FreeCursor",
-    },
-];

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -31,16 +31,18 @@ use helpers::{
 
 /// Generate a Rust module for namespace `ns`.
 pub(super) fn generate(
+    module: &xcbgen::defs::Module,
     ns: &xcbdefs::Namespace,
     caches: &RefCell<Caches>,
     out: &mut Output,
     enum_cases: &mut EnumCases,
     resource_info: &[super::ResourceInfo<'_>],
 ) {
-    NamespaceGenerator::new(ns, caches).generate(out, enum_cases, resource_info);
+    NamespaceGenerator::new(module, ns, caches).generate(out, enum_cases, resource_info);
 }
 
 struct NamespaceGenerator<'ns, 'c> {
+    module: &'ns xcbgen::defs::Module,
     ns: &'ns xcbdefs::Namespace,
     caches: &'c RefCell<Caches>,
 
@@ -50,13 +52,18 @@ struct NamespaceGenerator<'ns, 'c> {
 
 impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
     #[inline]
-    fn new(ns: &'ns xcbdefs::Namespace, caches: &'c RefCell<Caches>) -> Self {
+    fn new(
+        module: &'ns xcbgen::defs::Module,
+        ns: &'ns xcbdefs::Namespace,
+        caches: &'c RefCell<Caches>,
+    ) -> Self {
         let option_name = if ns.header == "present" {
             "std::option::Option"
         } else {
             "Option"
         };
         NamespaceGenerator {
+            module,
             ns,
             caches,
             option_name,

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -95,7 +95,7 @@ pub(super) fn generate(
     outln!(out, "impl<'c, C: X11Connection> {}<'c, C>", wrapper);
     outln!(out, "{{");
     out.indented(|out| {
-        for create_request in info.create_requests.iter().flatten() {
+        for create_request in info.create_requests.iter() {
             generate_creator(
                 generator,
                 out,

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -128,7 +128,7 @@ pub(super) fn generate(
     );
     out.indented(|out| {
         outln!(out, "fn drop(&mut self) {{");
-        outln!(out.indent(), "let _ = (self.0).{}(self.1);", free_function);
+        outln!(out.indent(), "let _ = {}(self.0, self.1);", free_function);
         outln!(out, "}}");
     });
     outln!(out, "}}");
@@ -290,7 +290,7 @@ fn generate_creator(
     );
     outln!(
         out.indent(),
-        "let cookie = conn.{}({})?;",
+        "let cookie = {}(conn, {})?;",
         function_name,
         forward_args_with_resource.join(", "),
     );

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -211,7 +211,6 @@ fn generate_creator(
             }
             xcbdefs::FieldDef::List(list_field) => {
                 let field_name = to_rust_variable_name(&list_field.name);
-                assert!(generator.rust_value_type_is_u8(&list_field.element_type));
                 let element_type =
                     generator.field_value_type_to_rust_type(&list_field.element_type);
                 let field_type = if let Some(list_len) = list_field.length() {

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -218,7 +218,13 @@ fn generate_creator(
             xcbdefs::FieldDef::Pad(_) => unimplemented!(),
             xcbdefs::FieldDef::Expr(_) => unimplemented!(),
             xcbdefs::FieldDef::VirtualLen(_) => unimplemented!(),
-            xcbdefs::FieldDef::Fd(_) => unimplemented!(),
+            xcbdefs::FieldDef::Fd(fd_field) => {
+                let generic_param = format!("{}", char::from(letter_iter.next().unwrap()));
+                let where_ = format!("{}: Into<RawFdContainer>", generic_param);
+                generics.push(generic_param.clone());
+                wheres.push(where_);
+                (fd_field.name.clone(), generic_param)
+            }
             xcbdefs::FieldDef::FdList(_) => unimplemented!(),
             xcbdefs::FieldDef::Normal(normal_field) => {
                 let rust_field_name = to_rust_variable_name(&normal_field.name);

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -169,7 +169,7 @@ fn generate_creator(
         .as_ref()
         .map(|ns| ext_has_feature(&ns.header))
         .unwrap_or(false);
-    let request_ns = request_ns.as_ref().map(|ns| &**ns).unwrap_or(generator.ns);
+    let request_ns = request_ns.as_deref().unwrap_or(generator.ns);
     let request_def = Rc::clone(
         request_ns
             .request_defs

--- a/generator/src/generator/resources.rs
+++ b/generator/src/generator/resources.rs
@@ -8,7 +8,7 @@ pub(super) fn for_extension(extension: &str) -> &'static [ResourceInfo<'static>]
         .unwrap_or(&[])
 }
 
-const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 3] = [
+const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 4] = [
     (
         "xproto",
         &[
@@ -88,6 +88,39 @@ const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 3] = [
                 created_argument: "context",
             }],
             free_request: "FreeContext",
+        }],
+    ),
+    (
+        "xfixes",
+        &[ResourceInfo {
+            resource_name: "Region",
+            create_requests: &[
+                CreateInfo {
+                    request_name: "CreateRegion",
+                    created_argument: "region",
+                },
+                CreateInfo {
+                    request_name: "CreateRegionFromBitmap",
+                    created_argument: "region",
+                },
+                CreateInfo {
+                    request_name: "CreateRegionFromWindow",
+                    created_argument: "region",
+                },
+                CreateInfo {
+                    request_name: "CreateRegionFromGC",
+                    created_argument: "region",
+                },
+                CreateInfo {
+                    request_name: "CreateRegionFromPicture",
+                    created_argument: "region",
+                },
+                CreateInfo {
+                    request_name: "composite:CreateRegionFromBorderClip",
+                    created_argument: "region",
+                },
+            ],
+            free_request: "DestroyRegion",
         }],
     ),
 ];

--- a/generator/src/generator/resources.rs
+++ b/generator/src/generator/resources.rs
@@ -8,62 +8,75 @@ pub(super) fn for_extension(extension: &str) -> &'static [ResourceInfo<'static>]
         .unwrap_or(&[])
 }
 
-const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 1] = [(
-    "xproto",
-    &[
-        ResourceInfo {
-            resource_name: "Pixmap",
-            create_requests: &[CreateInfo {
-                request_name: "CreatePixmap",
-                created_argument: "pid",
-            }],
-            free_request: "FreePixmap",
-        },
-        ResourceInfo {
-            resource_name: "Window",
-            create_requests: &[CreateInfo {
-                request_name: "CreateWindow",
-                created_argument: "wid",
-            }],
-            free_request: "DestroyWindow",
-        },
-        ResourceInfo {
-            resource_name: "Font",
-            create_requests: &[CreateInfo {
-                request_name: "OpenFont",
-                created_argument: "fid",
-            }],
-            free_request: "CloseFont",
-        },
-        ResourceInfo {
-            resource_name: "Gcontext",
-            create_requests: &[CreateInfo {
-                request_name: "CreateGC",
-                created_argument: "cid",
-            }],
-            free_request: "FreeGC",
-        },
-        ResourceInfo {
-            resource_name: "Colormap",
-            create_requests: &[CreateInfo {
-                request_name: "CreateColormap",
-                created_argument: "mid",
-            }],
-            free_request: "FreeColormap",
-        },
-        ResourceInfo {
-            resource_name: "Cursor",
-            create_requests: &[
-                CreateInfo {
-                    request_name: "CreateCursor",
+const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 2] = [
+    (
+        "xproto",
+        &[
+            ResourceInfo {
+                resource_name: "Pixmap",
+                create_requests: &[CreateInfo {
+                    request_name: "CreatePixmap",
+                    created_argument: "pid",
+                }],
+                free_request: "FreePixmap",
+            },
+            ResourceInfo {
+                resource_name: "Window",
+                create_requests: &[CreateInfo {
+                    request_name: "CreateWindow",
+                    created_argument: "wid",
+                }],
+                free_request: "DestroyWindow",
+            },
+            ResourceInfo {
+                resource_name: "Font",
+                create_requests: &[CreateInfo {
+                    request_name: "OpenFont",
+                    created_argument: "fid",
+                }],
+                free_request: "CloseFont",
+            },
+            ResourceInfo {
+                resource_name: "Gcontext",
+                create_requests: &[CreateInfo {
+                    request_name: "CreateGC",
                     created_argument: "cid",
-                },
-                CreateInfo {
-                    request_name: "CreateGlyphCursor",
-                    created_argument: "cid",
-                },
-            ],
-            free_request: "FreeCursor",
-        },
-    ],
-)];
+                }],
+                free_request: "FreeGC",
+            },
+            ResourceInfo {
+                resource_name: "Colormap",
+                create_requests: &[CreateInfo {
+                    request_name: "CreateColormap",
+                    created_argument: "mid",
+                }],
+                free_request: "FreeColormap",
+            },
+            ResourceInfo {
+                resource_name: "Cursor",
+                create_requests: &[
+                    CreateInfo {
+                        request_name: "CreateCursor",
+                        created_argument: "cid",
+                    },
+                    CreateInfo {
+                        request_name: "CreateGlyphCursor",
+                        created_argument: "cid",
+                    },
+                ],
+                free_request: "FreeCursor",
+            },
+        ],
+    ),
+    (
+        "damage",
+        &[ResourceInfo {
+            resource_name: "Damage",
+            create_requests: &[CreateInfo {
+                request_name: "Create",
+                created_argument: "damage",
+            }],
+            free_request: "Destroy",
+        }],
+    ),
+];

--- a/generator/src/generator/resources.rs
+++ b/generator/src/generator/resources.rs
@@ -1,0 +1,69 @@
+use super::{CreateInfo, ResourceInfo};
+
+pub(super) fn for_extension(extension: &str) -> &'static [ResourceInfo<'static>] {
+    EXTENSION_RESOURCES
+        .iter()
+        .find(|(ext, _)| extension == *ext)
+        .map(|(_, info)| *info)
+        .unwrap_or(&[])
+}
+
+const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 1] = [(
+    "xproto",
+    &[
+        ResourceInfo {
+            resource_name: "Pixmap",
+            create_requests: &[CreateInfo {
+                request_name: "CreatePixmap",
+                created_argument: "pid",
+            }],
+            free_request: "FreePixmap",
+        },
+        ResourceInfo {
+            resource_name: "Window",
+            create_requests: &[CreateInfo {
+                request_name: "CreateWindow",
+                created_argument: "wid",
+            }],
+            free_request: "DestroyWindow",
+        },
+        ResourceInfo {
+            resource_name: "Font",
+            create_requests: &[CreateInfo {
+                request_name: "OpenFont",
+                created_argument: "fid",
+            }],
+            free_request: "CloseFont",
+        },
+        ResourceInfo {
+            resource_name: "Gcontext",
+            create_requests: &[CreateInfo {
+                request_name: "CreateGC",
+                created_argument: "cid",
+            }],
+            free_request: "FreeGC",
+        },
+        ResourceInfo {
+            resource_name: "Colormap",
+            create_requests: &[CreateInfo {
+                request_name: "CreateColormap",
+                created_argument: "mid",
+            }],
+            free_request: "FreeColormap",
+        },
+        ResourceInfo {
+            resource_name: "Cursor",
+            create_requests: &[
+                CreateInfo {
+                    request_name: "CreateCursor",
+                    created_argument: "cid",
+                },
+                CreateInfo {
+                    request_name: "CreateGlyphCursor",
+                    created_argument: "cid",
+                },
+            ],
+            free_request: "FreeCursor",
+        },
+    ],
+)];

--- a/generator/src/generator/resources.rs
+++ b/generator/src/generator/resources.rs
@@ -8,7 +8,7 @@ pub(super) fn for_extension(extension: &str) -> &'static [ResourceInfo<'static>]
         .unwrap_or(&[])
 }
 
-const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 2] = [
+const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 3] = [
     (
         "xproto",
         &[
@@ -77,6 +77,17 @@ const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 2] = [
                 created_argument: "damage",
             }],
             free_request: "Destroy",
+        }],
+    ),
+    (
+        "record",
+        &[ResourceInfo {
+            resource_name: "Context",
+            create_requests: &[CreateInfo {
+                request_name: "CreateContext",
+                created_argument: "context",
+            }],
+            free_request: "FreeContext",
         }],
     ),
 ];

--- a/generator/src/generator/resources.rs
+++ b/generator/src/generator/resources.rs
@@ -8,7 +8,7 @@ pub(super) fn for_extension(extension: &str) -> &'static [ResourceInfo<'static>]
         .unwrap_or(&[])
 }
 
-const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 4] = [
+const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 5] = [
     (
         "xproto",
         &[
@@ -89,6 +89,41 @@ const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 4] = [
             }],
             free_request: "FreeContext",
         }],
+    ),
+    (
+        "sync",
+        &[
+            ResourceInfo {
+                resource_name: "Counter",
+                create_requests: &[CreateInfo {
+                    request_name: "CreateCounter",
+                    created_argument: "id",
+                }],
+                free_request: "DestroyCounter",
+            },
+            ResourceInfo {
+                resource_name: "Alarm",
+                create_requests: &[CreateInfo {
+                    request_name: "CreateAlarm",
+                    created_argument: "id",
+                }],
+                free_request: "DestroyAlarm",
+            },
+            ResourceInfo {
+                resource_name: "Fence",
+                create_requests: &[
+                    CreateInfo {
+                        request_name: "CreateFence",
+                        created_argument: "fence",
+                    },
+                    CreateInfo {
+                        request_name: "dri3:FenceFromFD",
+                        created_argument: "fence",
+                    },
+                ],
+                free_request: "DestroyFence",
+            },
+        ],
     ),
     (
         "xfixes",

--- a/generator/src/generator/resources.rs
+++ b/generator/src/generator/resources.rs
@@ -8,7 +8,7 @@ pub(super) fn for_extension(extension: &str) -> &'static [ResourceInfo<'static>]
         .unwrap_or(&[])
 }
 
-const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 5] = [
+const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 7] = [
     (
         "xproto",
         &[
@@ -88,6 +88,62 @@ const EXTENSION_RESOURCES: [(&str, &[ResourceInfo<'_>]); 5] = [
                 created_argument: "context",
             }],
             free_request: "FreeContext",
+        }],
+    ),
+    (
+        "render",
+        &[
+            ResourceInfo {
+                resource_name: "Picture",
+                create_requests: &[
+                    CreateInfo {
+                        request_name: "CreatePicture",
+                        created_argument: "pid",
+                    },
+                    CreateInfo {
+                        request_name: "CreateSolidFill",
+                        created_argument: "picture",
+                    },
+                    CreateInfo {
+                        request_name: "CreateLinearGradient",
+                        created_argument: "picture",
+                    },
+                    CreateInfo {
+                        request_name: "CreateRadialGradient",
+                        created_argument: "picture",
+                    },
+                    CreateInfo {
+                        request_name: "CreateConicalGradient",
+                        created_argument: "picture",
+                    },
+                ],
+                free_request: "FreePicture",
+            },
+            ResourceInfo {
+                resource_name: "Glyphset",
+                create_requests: &[CreateInfo {
+                    request_name: "CreateGlyphSet",
+                    created_argument: "gsid",
+                }],
+                free_request: "FreeGlyphSet",
+            },
+        ],
+    ),
+    (
+        "shm",
+        &[ResourceInfo {
+            resource_name: "Seg",
+            create_requests: &[
+                CreateInfo {
+                    request_name: "Attach",
+                    created_argument: "shmseg",
+                },
+                CreateInfo {
+                    request_name: "AttachFd",
+                    created_argument: "shmseg",
+                },
+            ],
+            free_request: "Detach",
         }],
     ),
     (

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -2563,3 +2563,261 @@ pub trait ConnectionExt: RequestConnection {
 }
 
 impl<C: RequestConnection + ?Sized> ConnectionExt for C {}
+
+/// A RAII-like wrapper around a [Counter].
+///
+/// Instances of this struct represent a Counter that is freed in `Drop`.
+///
+/// Any errors during `Drop` are silently ignored. Most likely an error here means that your
+/// X11 connection is broken and later requests will also fail.
+#[derive(Debug)]
+pub struct CounterWrapper<'c, C: RequestConnection>(&'c C, Counter);
+
+impl<'c, C: RequestConnection> CounterWrapper<'c, C>
+{
+    /// Assume ownership of the given resource and destroy it in `Drop`.
+    pub fn for_counter(conn: &'c C, id: Counter) -> Self {
+        CounterWrapper(conn, id)
+    }
+
+    /// Get the XID of the wrapped resource
+    pub fn counter(&self) -> Counter {
+        self.1
+    }
+
+    /// Assume ownership of the XID of the wrapped resource
+    ///
+    /// This function destroys this wrapper without freeing the underlying resource.
+    pub fn into_counter(self) -> Counter {
+        let id = self.1;
+        std::mem::forget(self);
+        id
+    }
+}
+
+impl<'c, C: X11Connection> CounterWrapper<'c, C>
+{
+
+    /// Create a new Counter and return a Counter wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_counter] that allocates an id for the Counter.
+    /// This function returns the resulting `CounterWrapper` that owns the created Counter and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_counter].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_counter].
+    pub fn create_counter_and_get_cookie(conn: &'c C, initial_value: Int64) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let id = conn.generate_id()?;
+        let cookie = create_counter(conn, id, initial_value)?;
+        Ok((Self::for_counter(conn, id), cookie))
+    }
+
+    /// Create a new Counter and return a Counter wrapper
+    ///
+    /// This is a thin wrapper around [create_counter] that allocates an id for the Counter.
+    /// This function returns the resulting `CounterWrapper` that owns the created Counter and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_counter].
+    pub fn create_counter(conn: &'c C, initial_value: Int64) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_counter_and_get_cookie(conn, initial_value)?.0)
+    }
+}
+
+impl<C: RequestConnection> From<&CounterWrapper<'_, C>> for Counter {
+    fn from(from: &CounterWrapper<'_, C>) -> Self {
+        from.1
+    }
+}
+
+impl<C: RequestConnection> Drop for CounterWrapper<'_, C> {
+    fn drop(&mut self) {
+        let _ = destroy_counter(self.0, self.1);
+    }
+}
+
+/// A RAII-like wrapper around a [Alarm].
+///
+/// Instances of this struct represent a Alarm that is freed in `Drop`.
+///
+/// Any errors during `Drop` are silently ignored. Most likely an error here means that your
+/// X11 connection is broken and later requests will also fail.
+#[derive(Debug)]
+pub struct AlarmWrapper<'c, C: RequestConnection>(&'c C, Alarm);
+
+impl<'c, C: RequestConnection> AlarmWrapper<'c, C>
+{
+    /// Assume ownership of the given resource and destroy it in `Drop`.
+    pub fn for_alarm(conn: &'c C, id: Alarm) -> Self {
+        AlarmWrapper(conn, id)
+    }
+
+    /// Get the XID of the wrapped resource
+    pub fn alarm(&self) -> Alarm {
+        self.1
+    }
+
+    /// Assume ownership of the XID of the wrapped resource
+    ///
+    /// This function destroys this wrapper without freeing the underlying resource.
+    pub fn into_alarm(self) -> Alarm {
+        let id = self.1;
+        std::mem::forget(self);
+        id
+    }
+}
+
+impl<'c, C: X11Connection> AlarmWrapper<'c, C>
+{
+
+    /// Create a new Alarm and return a Alarm wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_alarm] that allocates an id for the Alarm.
+    /// This function returns the resulting `AlarmWrapper` that owns the created Alarm and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_alarm].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_alarm].
+    pub fn create_alarm_and_get_cookie(conn: &'c C, value_list: &CreateAlarmAux) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let id = conn.generate_id()?;
+        let cookie = create_alarm(conn, id, value_list)?;
+        Ok((Self::for_alarm(conn, id), cookie))
+    }
+
+    /// Create a new Alarm and return a Alarm wrapper
+    ///
+    /// This is a thin wrapper around [create_alarm] that allocates an id for the Alarm.
+    /// This function returns the resulting `AlarmWrapper` that owns the created Alarm and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_alarm].
+    pub fn create_alarm(conn: &'c C, value_list: &CreateAlarmAux) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_alarm_and_get_cookie(conn, value_list)?.0)
+    }
+}
+
+impl<C: RequestConnection> From<&AlarmWrapper<'_, C>> for Alarm {
+    fn from(from: &AlarmWrapper<'_, C>) -> Self {
+        from.1
+    }
+}
+
+impl<C: RequestConnection> Drop for AlarmWrapper<'_, C> {
+    fn drop(&mut self) {
+        let _ = destroy_alarm(self.0, self.1);
+    }
+}
+
+/// A RAII-like wrapper around a [Fence].
+///
+/// Instances of this struct represent a Fence that is freed in `Drop`.
+///
+/// Any errors during `Drop` are silently ignored. Most likely an error here means that your
+/// X11 connection is broken and later requests will also fail.
+#[derive(Debug)]
+pub struct FenceWrapper<'c, C: RequestConnection>(&'c C, Fence);
+
+impl<'c, C: RequestConnection> FenceWrapper<'c, C>
+{
+    /// Assume ownership of the given resource and destroy it in `Drop`.
+    pub fn for_fence(conn: &'c C, id: Fence) -> Self {
+        FenceWrapper(conn, id)
+    }
+
+    /// Get the XID of the wrapped resource
+    pub fn fence(&self) -> Fence {
+        self.1
+    }
+
+    /// Assume ownership of the XID of the wrapped resource
+    ///
+    /// This function destroys this wrapper without freeing the underlying resource.
+    pub fn into_fence(self) -> Fence {
+        let id = self.1;
+        std::mem::forget(self);
+        id
+    }
+}
+
+impl<'c, C: X11Connection> FenceWrapper<'c, C>
+{
+
+    /// Create a new Fence and return a Fence wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_fence] that allocates an id for the Fence.
+    /// This function returns the resulting `FenceWrapper` that owns the created Fence and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_fence].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_fence].
+    pub fn create_fence_and_get_cookie(conn: &'c C, drawable: xproto::Drawable, initially_triggered: bool) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let fence = conn.generate_id()?;
+        let cookie = create_fence(conn, drawable, fence, initially_triggered)?;
+        Ok((Self::for_fence(conn, fence), cookie))
+    }
+
+    /// Create a new Fence and return a Fence wrapper
+    ///
+    /// This is a thin wrapper around [create_fence] that allocates an id for the Fence.
+    /// This function returns the resulting `FenceWrapper` that owns the created Fence and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_fence].
+    pub fn create_fence(conn: &'c C, drawable: xproto::Drawable, initially_triggered: bool) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_fence_and_get_cookie(conn, drawable, initially_triggered)?.0)
+    }
+
+    /// Create a new Fence and return a Fence wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [super::dri3::fence_from_fd] that allocates an id for the Fence.
+    /// This function returns the resulting `FenceWrapper` that owns the created Fence and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [super::dri3::fence_from_fd].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [super::dri3::fence_from_fd].
+    #[cfg(feature = "dri3")]
+    pub fn dri3_fence_from_fd_and_get_cookie<A>(conn: &'c C, drawable: xproto::Drawable, initially_triggered: bool, fence_fd: A) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    where
+        A: Into<RawFdContainer>,
+    {
+        let fence = conn.generate_id()?;
+        let cookie = super::dri3::fence_from_fd(conn, drawable, fence, initially_triggered, fence_fd)?;
+        Ok((Self::for_fence(conn, fence), cookie))
+    }
+
+    /// Create a new Fence and return a Fence wrapper
+    ///
+    /// This is a thin wrapper around [super::dri3::fence_from_fd] that allocates an id for the Fence.
+    /// This function returns the resulting `FenceWrapper` that owns the created Fence and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [super::dri3::fence_from_fd].
+    #[cfg(feature = "dri3")]
+    pub fn dri3_fence_from_fd<A>(conn: &'c C, drawable: xproto::Drawable, initially_triggered: bool, fence_fd: A) -> Result<Self, ReplyOrIdError>
+    where
+        A: Into<RawFdContainer>,
+    {
+        Ok(Self::dri3_fence_from_fd_and_get_cookie(conn, drawable, initially_triggered, fence_fd)?.0)
+    }
+}
+#[cfg(feature = "dri3")]
+#[allow(unused_imports)]
+use super::dri3;
+
+impl<C: RequestConnection> From<&FenceWrapper<'_, C>> for Fence {
+    fn from(from: &FenceWrapper<'_, C>) -> Self {
+        from.1
+    }
+}
+
+impl<C: RequestConnection> Drop for FenceWrapper<'_, C> {
+    fn drop(&mut self) {
+        let _ = destroy_fence(self.0, self.1);
+    }
+}

--- a/src/protocol/xfixes.rs
+++ b/src/protocol/xfixes.rs
@@ -3585,3 +3585,217 @@ pub trait ConnectionExt: RequestConnection {
 }
 
 impl<C: RequestConnection + ?Sized> ConnectionExt for C {}
+
+/// A RAII-like wrapper around a [Region].
+///
+/// Instances of this struct represent a Region that is freed in `Drop`.
+///
+/// Any errors during `Drop` are silently ignored. Most likely an error here means that your
+/// X11 connection is broken and later requests will also fail.
+#[derive(Debug)]
+pub struct RegionWrapper<'c, C: RequestConnection>(&'c C, Region);
+
+impl<'c, C: RequestConnection> RegionWrapper<'c, C>
+{
+    /// Assume ownership of the given resource and destroy it in `Drop`.
+    pub fn for_region(conn: &'c C, id: Region) -> Self {
+        RegionWrapper(conn, id)
+    }
+
+    /// Get the XID of the wrapped resource
+    pub fn region(&self) -> Region {
+        self.1
+    }
+
+    /// Assume ownership of the XID of the wrapped resource
+    ///
+    /// This function destroys this wrapper without freeing the underlying resource.
+    pub fn into_region(self) -> Region {
+        let id = self.1;
+        std::mem::forget(self);
+        id
+    }
+}
+
+impl<'c, C: X11Connection> RegionWrapper<'c, C>
+{
+
+    /// Create a new Region and return a Region wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_region] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_region].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region].
+    pub fn create_region_and_get_cookie(conn: &'c C, rectangles: &[xproto::Rectangle]) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let region = conn.generate_id()?;
+        let cookie = create_region(conn, region, rectangles)?;
+        Ok((Self::for_region(conn, region), cookie))
+    }
+
+    /// Create a new Region and return a Region wrapper
+    ///
+    /// This is a thin wrapper around [create_region] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region].
+    pub fn create_region(conn: &'c C, rectangles: &[xproto::Rectangle]) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_region_and_get_cookie(conn, rectangles)?.0)
+    }
+
+    /// Create a new Region and return a Region wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_region_from_bitmap] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_region_from_bitmap].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_bitmap].
+    pub fn create_region_from_bitmap_and_get_cookie(conn: &'c C, bitmap: xproto::Pixmap) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let region = conn.generate_id()?;
+        let cookie = create_region_from_bitmap(conn, region, bitmap)?;
+        Ok((Self::for_region(conn, region), cookie))
+    }
+
+    /// Create a new Region and return a Region wrapper
+    ///
+    /// This is a thin wrapper around [create_region_from_bitmap] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_bitmap].
+    pub fn create_region_from_bitmap(conn: &'c C, bitmap: xproto::Pixmap) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_region_from_bitmap_and_get_cookie(conn, bitmap)?.0)
+    }
+
+    /// Create a new Region and return a Region wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_region_from_window] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_region_from_window].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_window].
+    pub fn create_region_from_window_and_get_cookie(conn: &'c C, window: xproto::Window, kind: shape::SK) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let region = conn.generate_id()?;
+        let cookie = create_region_from_window(conn, region, window, kind)?;
+        Ok((Self::for_region(conn, region), cookie))
+    }
+
+    /// Create a new Region and return a Region wrapper
+    ///
+    /// This is a thin wrapper around [create_region_from_window] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_window].
+    pub fn create_region_from_window(conn: &'c C, window: xproto::Window, kind: shape::SK) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_region_from_window_and_get_cookie(conn, window, kind)?.0)
+    }
+
+    /// Create a new Region and return a Region wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_region_from_gc] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_region_from_gc].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_gc].
+    pub fn create_region_from_gc_and_get_cookie(conn: &'c C, gc: xproto::Gcontext) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let region = conn.generate_id()?;
+        let cookie = create_region_from_gc(conn, region, gc)?;
+        Ok((Self::for_region(conn, region), cookie))
+    }
+
+    /// Create a new Region and return a Region wrapper
+    ///
+    /// This is a thin wrapper around [create_region_from_gc] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_gc].
+    pub fn create_region_from_gc(conn: &'c C, gc: xproto::Gcontext) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_region_from_gc_and_get_cookie(conn, gc)?.0)
+    }
+
+    /// Create a new Region and return a Region wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [create_region_from_picture] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [create_region_from_picture].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_picture].
+    pub fn create_region_from_picture_and_get_cookie(conn: &'c C, picture: render::Picture) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let region = conn.generate_id()?;
+        let cookie = create_region_from_picture(conn, region, picture)?;
+        Ok((Self::for_region(conn, region), cookie))
+    }
+
+    /// Create a new Region and return a Region wrapper
+    ///
+    /// This is a thin wrapper around [create_region_from_picture] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [create_region_from_picture].
+    pub fn create_region_from_picture(conn: &'c C, picture: render::Picture) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::create_region_from_picture_and_get_cookie(conn, picture)?.0)
+    }
+
+    /// Create a new Region and return a Region wrapper and a cookie.
+    ///
+    /// This is a thin wrapper around [super::composite::create_region_from_border_clip] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`. This also returns a `VoidCookie` that comes from the call to
+    /// [super::composite::create_region_from_border_clip].
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [super::composite::create_region_from_border_clip].
+    #[cfg(feature = "composite")]
+    pub fn composite_create_region_from_border_clip_and_get_cookie(conn: &'c C, window: xproto::Window) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
+    {
+        let region = conn.generate_id()?;
+        let cookie = super::composite::create_region_from_border_clip(conn, region, window)?;
+        Ok((Self::for_region(conn, region), cookie))
+    }
+
+    /// Create a new Region and return a Region wrapper
+    ///
+    /// This is a thin wrapper around [super::composite::create_region_from_border_clip] that allocates an id for the Region.
+    /// This function returns the resulting `RegionWrapper` that owns the created Region and frees
+    /// it in `Drop`.
+    ///
+    /// Errors can come from the call to [X11Connection::generate_id] or [super::composite::create_region_from_border_clip].
+    #[cfg(feature = "composite")]
+    pub fn composite_create_region_from_border_clip(conn: &'c C, window: xproto::Window) -> Result<Self, ReplyOrIdError>
+    {
+        Ok(Self::composite_create_region_from_border_clip_and_get_cookie(conn, window)?.0)
+    }
+}
+#[cfg(feature = "composite")]
+#[allow(unused_imports)]
+use super::composite;
+
+impl<C: RequestConnection> From<&RegionWrapper<'_, C>> for Region {
+    fn from(from: &RegionWrapper<'_, C>) -> Self {
+        from.1
+    }
+}
+
+impl<C: RequestConnection> Drop for RegionWrapper<'_, C> {
+    fn drop(&mut self) {
+        let _ = destroy_region(self.0, self.1);
+    }
+}

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -27634,7 +27634,7 @@ impl<'c, C: X11Connection> PixmapWrapper<'c, C>
     pub fn create_pixmap_and_get_cookie(conn: &'c C, depth: u8, drawable: Drawable, width: u16, height: u16) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
     {
         let pid = conn.generate_id()?;
-        let cookie = conn.create_pixmap(depth, pid, drawable, width, height)?;
+        let cookie = create_pixmap(conn, depth, pid, drawable, width, height)?;
         Ok((Self::for_pixmap(conn, pid), cookie))
     }
 
@@ -27659,7 +27659,7 @@ impl<C: RequestConnection> From<&PixmapWrapper<'_, C>> for Pixmap {
 
 impl<C: RequestConnection> Drop for PixmapWrapper<'_, C> {
     fn drop(&mut self) {
-        let _ = (self.0).free_pixmap(self.1);
+        let _ = free_pixmap(self.0, self.1);
     }
 }
 
@@ -27708,7 +27708,7 @@ impl<'c, C: X11Connection> WindowWrapper<'c, C>
     pub fn create_window_and_get_cookie(conn: &'c C, depth: u8, parent: Window, x: i16, y: i16, width: u16, height: u16, border_width: u16, class: WindowClass, visual: Visualid, value_list: &CreateWindowAux) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
     {
         let wid = conn.generate_id()?;
-        let cookie = conn.create_window(depth, wid, parent, x, y, width, height, border_width, class, visual, value_list)?;
+        let cookie = create_window(conn, depth, wid, parent, x, y, width, height, border_width, class, visual, value_list)?;
         Ok((Self::for_window(conn, wid), cookie))
     }
 
@@ -27733,7 +27733,7 @@ impl<C: RequestConnection> From<&WindowWrapper<'_, C>> for Window {
 
 impl<C: RequestConnection> Drop for WindowWrapper<'_, C> {
     fn drop(&mut self) {
-        let _ = (self.0).destroy_window(self.1);
+        let _ = destroy_window(self.0, self.1);
     }
 }
 
@@ -27782,7 +27782,7 @@ impl<'c, C: X11Connection> FontWrapper<'c, C>
     pub fn open_font_and_get_cookie(conn: &'c C, name: &[u8]) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
     {
         let fid = conn.generate_id()?;
-        let cookie = conn.open_font(fid, name)?;
+        let cookie = open_font(conn, fid, name)?;
         Ok((Self::for_font(conn, fid), cookie))
     }
 
@@ -27807,7 +27807,7 @@ impl<C: RequestConnection> From<&FontWrapper<'_, C>> for Font {
 
 impl<C: RequestConnection> Drop for FontWrapper<'_, C> {
     fn drop(&mut self) {
-        let _ = (self.0).close_font(self.1);
+        let _ = close_font(self.0, self.1);
     }
 }
 
@@ -27856,7 +27856,7 @@ impl<'c, C: X11Connection> GcontextWrapper<'c, C>
     pub fn create_gc_and_get_cookie(conn: &'c C, drawable: Drawable, value_list: &CreateGCAux) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
     {
         let cid = conn.generate_id()?;
-        let cookie = conn.create_gc(cid, drawable, value_list)?;
+        let cookie = create_gc(conn, cid, drawable, value_list)?;
         Ok((Self::for_gcontext(conn, cid), cookie))
     }
 
@@ -27881,7 +27881,7 @@ impl<C: RequestConnection> From<&GcontextWrapper<'_, C>> for Gcontext {
 
 impl<C: RequestConnection> Drop for GcontextWrapper<'_, C> {
     fn drop(&mut self) {
-        let _ = (self.0).free_gc(self.1);
+        let _ = free_gc(self.0, self.1);
     }
 }
 
@@ -27930,7 +27930,7 @@ impl<'c, C: X11Connection> ColormapWrapper<'c, C>
     pub fn create_colormap_and_get_cookie(conn: &'c C, alloc: ColormapAlloc, window: Window, visual: Visualid) -> Result<(Self, VoidCookie<'c, C>), ReplyOrIdError>
     {
         let mid = conn.generate_id()?;
-        let cookie = conn.create_colormap(alloc, mid, window, visual)?;
+        let cookie = create_colormap(conn, alloc, mid, window, visual)?;
         Ok((Self::for_colormap(conn, mid), cookie))
     }
 
@@ -27955,7 +27955,7 @@ impl<C: RequestConnection> From<&ColormapWrapper<'_, C>> for Colormap {
 
 impl<C: RequestConnection> Drop for ColormapWrapper<'_, C> {
     fn drop(&mut self) {
-        let _ = (self.0).free_colormap(self.1);
+        let _ = free_colormap(self.0, self.1);
     }
 }
 
@@ -28006,7 +28006,7 @@ impl<'c, C: X11Connection> CursorWrapper<'c, C>
         A: Into<Pixmap>,
     {
         let cid = conn.generate_id()?;
-        let cookie = conn.create_cursor(cid, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x, y)?;
+        let cookie = create_cursor(conn, cid, source, mask, fore_red, fore_green, fore_blue, back_red, back_green, back_blue, x, y)?;
         Ok((Self::for_cursor(conn, cid), cookie))
     }
 
@@ -28037,7 +28037,7 @@ impl<'c, C: X11Connection> CursorWrapper<'c, C>
         A: Into<Font>,
     {
         let cid = conn.generate_id()?;
-        let cookie = conn.create_glyph_cursor(cid, source_font, mask_font, source_char, mask_char, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)?;
+        let cookie = create_glyph_cursor(conn, cid, source_font, mask_font, source_char, mask_char, fore_red, fore_green, fore_blue, back_red, back_green, back_blue)?;
         Ok((Self::for_cursor(conn, cid), cookie))
     }
 
@@ -28064,6 +28064,6 @@ impl<C: RequestConnection> From<&CursorWrapper<'_, C>> for Cursor {
 
 impl<C: RequestConnection> Drop for CursorWrapper<'_, C> {
     fn drop(&mut self) {
-        let _ = (self.0).free_cursor(self.1);
+        let _ = free_cursor(self.0, self.1);
     }
 }


### PR DESCRIPTION
Instead of just generating wrappers just for xproto, this PR also implements wrappers damage, record, render, shm, sync, and xfixes. At least the part of those that fits in the current scheme.

Fixes: https://github.com/psychon/x11rb/issues/78