### PR TITLE
Remove some unwrap()s from the generated code

### DIFF
--- a/generator/src/generator/namespace/expr_to_str.rs
+++ b/generator/src/generator/namespace/expr_to_str.rs
@@ -217,7 +217,12 @@ fn expr_to_str_impl(
         xcbdefs::Expression::EnumRef(enum_ref_expr) => {
             let rust_enum_type = generator.type_to_rust_type(enum_ref_expr.enum_.get_resolved());
             let rust_variant_name = ename_to_rust(&enum_ref_expr.variant);
-            format!("u32::from({}::{})", rust_enum_type, rust_variant_name)
+            format!(
+                "{}::from({}::{})",
+                cast_to_type.unwrap_or("u32"),
+                rust_enum_type,
+                rust_variant_name,
+            )
         }
         xcbdefs::Expression::PopCount(pop_count_expr) => {
             let arg = expr_to_str_impl(

--- a/generator/src/generator/namespace/expr_to_str.rs
+++ b/generator/src/generator/namespace/expr_to_str.rs
@@ -44,7 +44,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.lhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     ),
                     expr_to_str_impl(
@@ -52,7 +52,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.rhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         false,
                     ),
                     err_handler,
@@ -64,7 +64,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.lhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     ),
                     expr_to_str_impl(
@@ -72,7 +72,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.rhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         false,
                     ),
                     err_handler,
@@ -84,7 +84,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.lhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     ),
                     expr_to_str_impl(
@@ -92,7 +92,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.rhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         false,
                     ),
                     err_handler,
@@ -104,7 +104,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.lhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     ),
                     expr_to_str_impl(
@@ -112,7 +112,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.rhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         false,
                     ),
                     err_handler,
@@ -123,7 +123,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.lhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     );
                     let rhs_str = expr_to_str_impl(
@@ -131,7 +131,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.rhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     );
                     if needs_parens {
@@ -146,7 +146,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.lhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     );
                     let rhs_str = expr_to_str_impl(
@@ -154,7 +154,7 @@ fn expr_to_str_impl(
                         &bin_op_expr.rhs,
                         wrap_field_ref,
                         panic_on_overflow,
-                        Some("u32"),
+                        Some(cast_to_type.unwrap_or("u32")),
                         true,
                     );
                     if needs_parens {
@@ -175,7 +175,7 @@ fn expr_to_str_impl(
                     &unary_op_expr.rhs,
                     wrap_field_ref,
                     panic_on_overflow,
-                    Some("u32"),
+                    Some(cast_to_type.unwrap_or("u32")),
                     true,
                 );
                 if needs_parens {

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -950,7 +950,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 &*or_expr,
                                 &mut wrap_field_ref,
                                 true,
-                                false,
+                                None,
                                 true,
                             )
                         ),

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -20,7 +20,7 @@ mod serialize;
 mod struct_type;
 mod switch;
 
-use expr_to_str::expr_to_str;
+use expr_to_str::{expr_to_str, expr_type};
 
 use helpers::{
     ename_to_camel_case, ename_to_rust, gather_deducible_fields, postfix_var_name, prefix_var_name,

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -917,22 +917,13 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 if let xcbdefs::FieldDef::Normal(normal_field) = field {
                     let field_type = normal_field.type_.type_.get_resolved();
                     let rust_field_type = self.type_to_rust_type(field_type);
-                    if let xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card32) = field_type {
-                        outln!(
-                            out,
-                            "let {} = {}.switch_expr();",
-                            dst_var_name,
-                            wrap_field_ref(switch_field_name),
-                        );
-                    } else {
-                        outln!(
-                            out,
-                            "let {} = {}::from({}.switch_expr());",
-                            dst_var_name,
-                            rust_field_type,
-                            wrap_field_ref(switch_field_name),
-                        );
-                    }
+                    outln!(
+                        out,
+                        "let {}: {} = {}.switch_expr();",
+                        dst_var_name,
+                        rust_field_type,
+                        wrap_field_ref(switch_field_name),
+                    );
                 } else {
                     unreachable!();
                 }
@@ -955,24 +946,14 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                             )
                         ),
                     };
-                    if let xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card32) = field_type {
-                        assert!(op_str.is_empty());
-                        outln!(
-                            out,
-                            "let {} = {}.switch_expr();",
-                            dst_var_name,
-                            wrap_field_ref(switch_field_name),
-                        );
-                    } else {
-                        outln!(
-                            out,
-                            "let {} = {}::from({}.switch_expr(){});",
-                            dst_var_name,
-                            rust_field_type,
-                            wrap_field_ref(switch_field_name),
-                            op_str,
-                        );
-                    }
+                    outln!(
+                        out,
+                        "let {}: {} = {}.switch_expr(){};",
+                        dst_var_name,
+                        rust_field_type,
+                        wrap_field_ref(switch_field_name),
+                        op_str,
+                    );
                 } else {
                     unreachable!();
                 }

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -927,7 +927,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     } else {
                         outln!(
                             out,
-                            "let {} = {}::try_from({}.switch_expr()).unwrap();",
+                            "let {} = {}::from({}.switch_expr());",
                             dst_var_name,
                             rust_field_type,
                             wrap_field_ref(switch_field_name),

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -950,7 +950,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 &*or_expr,
                                 &mut wrap_field_ref,
                                 true,
-                                None,
+                                Some(&rust_field_type),
                                 true,
                             )
                         ),
@@ -966,7 +966,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     } else {
                         outln!(
                             out,
-                            "let {} = {}::try_from({}.switch_expr(){}).unwrap();",
+                            "let {} = {}::from({}.switch_expr(){});",
                             dst_var_name,
                             rust_field_type,
                             wrap_field_ref(switch_field_name),

--- a/generator/src/generator/namespace/parse.rs
+++ b/generator/src/generator/namespace/parse.rs
@@ -95,7 +95,7 @@ pub(super) fn emit_field_parse(
                             length_expr,
                             to_rust_variable_name,
                             false,
-                            false,
+                            None,
                             true,
                         ),
                     );
@@ -138,7 +138,7 @@ pub(super) fn emit_field_parse(
                         list_field.length_expr.as_ref().unwrap(),
                         to_rust_variable_name,
                         false,
-                        false,
+                        None,
                         true,
                     ),
                 );
@@ -170,7 +170,7 @@ pub(super) fn emit_field_parse(
                             length_expr,
                             to_rust_variable_name,
                             false,
-                            false,
+                            None,
                             false,
                         ),
                     );
@@ -236,7 +236,7 @@ pub(super) fn emit_field_parse(
                     &fd_list_field.length_expr,
                     to_rust_variable_name,
                     false,
-                    false,
+                    None,
                     false,
                 ),
             );

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -690,7 +690,7 @@ fn emit_request_struct(
                                     &expr_field.expr,
                                     to_rust_variable_name,
                                     true,
-                                    true,
+                                    Some("u32"),
                                     true,
                                 ),
                             );

--- a/generator/src/generator/namespace/serialize.rs
+++ b/generator/src/generator/namespace/serialize.rs
@@ -329,6 +329,7 @@ pub(super) fn emit_assert_for_field_serialize(
 pub(super) fn emit_assert_for_switch_serialize(
     generator: &NamespaceGenerator<'_, '_>,
     switch: &xcbdefs::SwitchField,
+    switch_expr_type: &str,
     out: &mut Output,
 ) {
     let rust_field_name = to_rust_variable_name(&switch.name);
@@ -337,7 +338,7 @@ pub(super) fn emit_assert_for_switch_serialize(
         &switch.expr,
         to_rust_variable_name,
         true,
-        Some("u32"),
+        Some(switch_expr_type),
         false,
     );
     outln!(

--- a/generator/src/generator/namespace/serialize.rs
+++ b/generator/src/generator/namespace/serialize.rs
@@ -274,7 +274,7 @@ pub(super) fn emit_assert_for_field_serialize(
                     list_field.length_expr.as_ref().unwrap(),
                     &mut wrap_field_ref,
                     true,
-                    false,
+                    None,
                     false,
                 );
                 outln!(
@@ -307,7 +307,7 @@ pub(super) fn emit_assert_for_field_serialize(
                     &fd_list_field.length_expr,
                     &mut wrap_field_ref,
                     true,
-                    false,
+                    None,
                     false,
                 );
                 outln!(
@@ -337,7 +337,7 @@ pub(super) fn emit_assert_for_switch_serialize(
         &switch.expr,
         to_rust_variable_name,
         true,
-        true,
+        Some("u32"),
         false,
     );
     outln!(

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -288,7 +288,7 @@ pub(super) fn emit_switch_type(
                                 &case.exprs[0],
                                 to_rust_variable_name,
                                 true,
-                                true,
+                                Some("u32"),
                                 false,
                             ),
                         );
@@ -320,7 +320,7 @@ pub(super) fn emit_switch_type(
                                 &case.exprs[0],
                                 to_rust_variable_name,
                                 true,
-                                true,
+                                Some("u32"),
                                 false,
                             ),
                         );
@@ -381,7 +381,7 @@ fn emit_switch_try_parse(
                     &switch.expr,
                     to_rust_variable_name,
                     false,
-                    true,
+                    Some("u32"),
                     false,
                 ),
             );
@@ -396,7 +396,7 @@ fn emit_switch_try_parse(
                             &case.exprs[0],
                             to_rust_variable_name,
                             false,
-                            true,
+                            Some("u32"),
                             true,
                         ),
                     );
@@ -407,7 +407,7 @@ fn emit_switch_try_parse(
                             expr,
                             to_rust_variable_name,
                             false,
-                            true,
+                            Some("u32"),
                             true,
                         ));
                         case_expr_str.push_str(" != 0");
@@ -488,7 +488,7 @@ fn emit_switch_try_parse(
                             &case.exprs[0],
                             to_rust_variable_name,
                             false,
-                            true,
+                            Some("u32"),
                             true,
                         ),
                     );
@@ -499,7 +499,7 @@ fn emit_switch_try_parse(
                             expr,
                             to_rust_variable_name,
                             false,
-                            true,
+                            Some("u32"),
                             true,
                         ));
                     }

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -109,7 +109,20 @@ pub(super) fn emit_switch_type(
     }
 
     // Figure out the return type for switch_expr()
-    let switch_expr_type = "u32";
+    let switch_expr_type = match &switch.expr {
+        xcbdefs::Expression::FieldRef(field) => match field.resolved.get().unwrap().field_type {
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card8) => "u8",
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card16) => "u16",
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card32) => "u32",
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card64) => "u64",
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int8) => "i8",
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int16) => "i16",
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int32) => "i32",
+            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int64) => "i64",
+            _ => "u32",
+        },
+        _ => "u32",
+    };
 
     if let Some(doc) = doc {
         outln!(out, "/// {}", doc);
@@ -415,7 +428,7 @@ fn emit_switch_try_parse(
                             &case.exprs[0],
                             to_rust_variable_name,
                             false,
-                            Some("u32"),
+                            Some(switch_expr_type),
                             true,
                         ),
                     );
@@ -426,7 +439,7 @@ fn emit_switch_try_parse(
                             expr,
                             to_rust_variable_name,
                             false,
-                            Some("u32"),
+                            Some(switch_expr_type),
                             true,
                         ));
                         case_expr_str.push_str(" != 0");
@@ -507,7 +520,7 @@ fn emit_switch_try_parse(
                             &case.exprs[0],
                             to_rust_variable_name,
                             false,
-                            Some("u32"),
+                            Some(switch_expr_type),
                             true,
                         ),
                     );
@@ -518,7 +531,7 @@ fn emit_switch_try_parse(
                             expr,
                             to_rust_variable_name,
                             false,
-                            Some("u32"),
+                            Some(switch_expr_type),
                             true,
                         ));
                     }

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use xcbgen::defs as xcbdefs;
 
 use super::{
-    expr_to_str, gather_deducible_fields, parse, serialize, struct_type, to_rust_type_name,
-    to_rust_variable_name, CaseInfo, DeducibleField, Derives, FieldContainer, NamespaceGenerator,
-    Output, StructSizeConstraint,
+    expr_to_str, expr_type, gather_deducible_fields, parse, serialize, struct_type,
+    to_rust_type_name, to_rust_variable_name, CaseInfo, DeducibleField, Derives, FieldContainer,
+    NamespaceGenerator, Output, StructSizeConstraint,
 };
 
 pub(super) fn emit_switch_type(
@@ -1004,32 +1004,5 @@ fn needs_match_by_value(field: &xcbdefs::FieldDef) -> bool {
             }
         }
         _ => false,
-    }
-}
-
-fn expr_type<'a>(expr: &xcbdefs::Expression, fallback: &'a str) -> &'a str {
-    match expr {
-        xcbdefs::Expression::FieldRef(field) => match field.resolved.get().unwrap().field_type {
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card8) => "u8",
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card16) => "u16",
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card32) => "u32",
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Card64) => "u64",
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int8) => "i8",
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int16) => "i16",
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int32) => "i32",
-            xcbdefs::TypeRef::BuiltIn(xcbdefs::BuiltInType::Int64) => "i64",
-            _ => "u32",
-        },
-        xcbdefs::Expression::UnaryOp(op) => expr_type(&op.rhs, fallback),
-        xcbdefs::Expression::BinaryOp(op) => {
-            let lhs = expr_type(&op.lhs, fallback);
-            let rhs = expr_type(&op.rhs, fallback);
-            if lhs == rhs {
-                lhs
-            } else {
-                fallback
-            }
-        }
-        _ => "u32",
     }
 }

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -108,6 +108,9 @@ pub(super) fn emit_switch_type(
         }
     }
 
+    // Figure out the return type for switch_expr()
+    let switch_expr_type = "u32";
+
     if let Some(doc) = doc {
         outln!(out, "/// {}", doc);
     }
@@ -200,12 +203,12 @@ pub(super) fn emit_switch_type(
             "/// Trying to use `serialize` or `serialize_into` with this variant",
         );
         outln!(out.indent(), "/// will raise a panic.");
-        outln!(out.indent(), "InvalidValue(u32),");
+        outln!(out.indent(), "InvalidValue({}),", switch_expr_type);
         outln!(out, "}}");
     }
 
     if generate_try_parse {
-        emit_switch_try_parse(generator, switch, name, &case_infos, out);
+        emit_switch_try_parse(generator, switch, name, &case_infos, switch_expr_type, out);
     }
 
     if switch.kind == xcbdefs::SwitchKind::Case {
@@ -254,9 +257,24 @@ pub(super) fn emit_switch_type(
 
     if generate_serialize {
         if let Some(size) = switch.size() {
-            emit_fixed_size_switch_serialize(generator, switch, name, &case_infos, size, out);
+            emit_fixed_size_switch_serialize(
+                generator,
+                switch,
+                name,
+                &case_infos,
+                switch_expr_type,
+                size,
+                out,
+            );
         } else {
-            emit_variable_size_switch_serialize(generator, switch, name, &case_infos, out);
+            emit_variable_size_switch_serialize(
+                generator,
+                switch,
+                name,
+                &case_infos,
+                switch_expr_type,
+                out,
+            );
         }
     }
 
@@ -266,7 +284,7 @@ pub(super) fn emit_switch_type(
     if generate_switch_expr_fn {
         outln!(out, "impl {} {{", name);
         out.indented(|out| {
-            outln!(out, "fn switch_expr(&self) -> u32 {{");
+            outln!(out, "fn switch_expr(&self) -> {} {{", switch_expr_type);
             out.indented(|out| {
                 if switch.kind == xcbdefs::SwitchKind::Case {
                     outln!(out, "match self {{");
@@ -288,7 +306,7 @@ pub(super) fn emit_switch_type(
                                 &case.exprs[0],
                                 to_rust_variable_name,
                                 true,
-                                Some("u32"),
+                                Some(switch_expr_type),
                                 false,
                             ),
                         );
@@ -320,7 +338,7 @@ pub(super) fn emit_switch_type(
                                 &case.exprs[0],
                                 to_rust_variable_name,
                                 true,
-                                Some("u32"),
+                                Some(switch_expr_type),
                                 false,
                             ),
                         );
@@ -342,6 +360,7 @@ fn emit_switch_try_parse(
     switch: &xcbdefs::SwitchField,
     name: &str,
     case_infos: &[CaseInfo],
+    switch_expr_type: &str,
     out: &mut Output,
 ) {
     let external_params = switch.external_params.borrow();
@@ -381,7 +400,7 @@ fn emit_switch_try_parse(
                     &switch.expr,
                     to_rust_variable_name,
                     false,
-                    Some("u32"),
+                    Some(switch_expr_type),
                     false,
                 ),
             );
@@ -596,6 +615,7 @@ fn emit_fixed_size_switch_serialize(
     switch: &xcbdefs::SwitchField,
     name: &str,
     case_infos: &[CaseInfo],
+    switch_expr_type: &str,
     size: u32,
     out: &mut Output,
 ) {
@@ -622,7 +642,7 @@ fn emit_fixed_size_switch_serialize(
             size,
         );
         out.indented(|out| {
-            serialize::emit_assert_for_switch_serialize(generator, switch, out);
+            serialize::emit_assert_for_switch_serialize(generator, switch, switch_expr_type, out);
             outln!(out, "match self {{");
             out.indented(|out| {
                 for (case, case_info) in switch.cases.iter().zip(case_infos.iter()) {
@@ -742,6 +762,7 @@ fn emit_variable_size_switch_serialize(
     switch: &xcbdefs::SwitchField,
     name: &str,
     case_infos: &[CaseInfo],
+    switch_expr_type: &str,
     out: &mut Output,
 ) {
     let external_params = switch.external_params.borrow();
@@ -781,7 +802,7 @@ fn emit_variable_size_switch_serialize(
             ext_params_arg_defs
         );
         out.indented(|out| {
-            serialize::emit_assert_for_switch_serialize(generator, switch, out);
+            serialize::emit_assert_for_switch_serialize(generator, switch, switch_expr_type, out);
             if switch.kind == xcbdefs::SwitchKind::BitCase {
                 for (case, case_info) in switch.cases.iter().zip(case_infos.iter()) {
                     match case_info {

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1896,7 +1896,7 @@ impl<'input> CreatePictureRequest<'input> {
         let pid_bytes = self.pid.serialize();
         let drawable_bytes = self.drawable.serialize();
         let format_bytes = self.format.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             major_opcode,
@@ -2294,7 +2294,7 @@ impl<'input> ChangePictureRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let picture_bytes = self.picture.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             major_opcode,

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -852,7 +852,7 @@ impl<'input> SetAttributesRequest<'input> {
         let class_bytes = (u16::from(self.class) as u8).serialize();
         let depth_bytes = self.depth.serialize();
         let visual_bytes = self.visual.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             major_opcode,

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -1273,7 +1273,7 @@ impl<'input> CreateAlarmRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let id_bytes = self.id.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             major_opcode,
@@ -1513,7 +1513,7 @@ impl<'input> ChangeAlarmRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let id_bytes = self.id.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             major_opcode,

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -843,7 +843,7 @@ impl Serialize for InputInfo {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
-        let class_id = u8::from(self.info.switch_expr());
+        let class_id: u8 = self.info.switch_expr();
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.info.serialize_into(bytes, class_id);
@@ -4113,7 +4113,7 @@ impl Serialize for FeedbackState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let class_id = u8::from(self.data.switch_expr());
+        let class_id: u8 = self.data.switch_expr();
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
@@ -4996,7 +4996,7 @@ impl Serialize for FeedbackCtl {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let class_id = u8::from(self.data.switch_expr());
+        let class_id: u8 = self.data.switch_expr();
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
@@ -6353,7 +6353,7 @@ impl Serialize for InputState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
-        let class_id = u8::from(self.data.switch_expr());
+        let class_id: u8 = self.data.switch_expr();
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, class_id);
@@ -7417,7 +7417,7 @@ impl Serialize for DeviceState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let control_id = u16::from(self.data.switch_expr());
+        let control_id: u16 = self.data.switch_expr();
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, control_id);
@@ -8214,7 +8214,7 @@ impl Serialize for DeviceCtl {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let control_id = u16::from(self.data.switch_expr());
+        let control_id: u16 = self.data.switch_expr();
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, control_id);
@@ -8622,7 +8622,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         let property_bytes = self.property.serialize();
         let type_bytes = self.type_.serialize();
         let device_id_bytes = self.device_id.serialize();
-        let format = u8::from(self.items.switch_expr());
+        let format: u8 = self.items.switch_expr();
         let format_bytes = format.serialize();
         let mode_bytes = u8::from(self.mode).serialize();
         let num_items_bytes = self.num_items.serialize();
@@ -10127,7 +10127,7 @@ impl Serialize for HierarchyChange {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let type_ = u16::from(self.data.switch_expr());
+        let type_: u16 = self.data.switch_expr();
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, type_);
@@ -11716,7 +11716,7 @@ impl Serialize for DeviceClass {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(6);
-        let type_ = u16::from(self.data.switch_expr());
+        let type_: u16 = self.data.switch_expr();
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
@@ -13331,7 +13331,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         let length_so_far = 0;
         let deviceid_bytes = self.deviceid.serialize();
         let mode_bytes = u8::from(self.mode).serialize();
-        let format = u8::from(self.items.switch_expr());
+        let format: u8 = self.items.switch_expr();
         let format_bytes = format.serialize();
         let property_bytes = self.property.serialize();
         let type_bytes = self.type_.serialize();

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -745,7 +745,7 @@ pub enum InputInfoInfo {
 }
 impl InputInfoInfo {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(class_id);
+        let switch_expr = class_id;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(InputClass::KEY) {
@@ -800,7 +800,7 @@ impl InputInfoInfo {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `info` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), class_id, "switch `info` has an inconsistent discriminant");
         match self {
             InputInfoInfo::Key(key) => key.serialize_into(bytes),
             InputInfoInfo::Button(button) => button.serialize_into(bytes),
@@ -3971,7 +3971,7 @@ pub enum FeedbackStateData {
 }
 impl FeedbackStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(class_id);
+        let switch_expr = class_id;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(FeedbackClass::KEYBOARD) {
@@ -4062,7 +4062,7 @@ impl FeedbackStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), class_id, "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackStateData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackStateData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -4854,7 +4854,7 @@ pub enum FeedbackCtlData {
 }
 impl FeedbackCtlData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(class_id);
+        let switch_expr = class_id;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(FeedbackClass::KEYBOARD) {
@@ -4945,7 +4945,7 @@ impl FeedbackCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), class_id, "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackCtlData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackCtlData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -6255,7 +6255,7 @@ pub enum InputStateData {
 }
 impl InputStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(class_id);
+        let switch_expr = class_id;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(InputClass::KEY) {
@@ -6310,7 +6310,7 @@ impl InputStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), class_id, "switch `data` has an inconsistent discriminant");
         match self {
             InputStateData::Key(key) => key.serialize_into(bytes),
             InputStateData::Button(button) => button.serialize_into(bytes),
@@ -7285,7 +7285,7 @@ pub enum DeviceStateData {
 }
 impl DeviceStateData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(control_id);
+        let switch_expr = control_id;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(DeviceControl::RESOLUTION) {
@@ -7366,7 +7366,7 @@ impl DeviceStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
-        assert_eq!(self.switch_expr(), u16::from(control_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), control_id, "switch `data` has an inconsistent discriminant");
         match self {
             DeviceStateData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceStateData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -8082,7 +8082,7 @@ pub enum DeviceCtlData {
 }
 impl DeviceCtlData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(control_id);
+        let switch_expr = control_id;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(DeviceControl::RESOLUTION) {
@@ -8163,7 +8163,7 @@ impl DeviceCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
-        assert_eq!(self.switch_expr(), u16::from(control_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), control_id, "switch `data` has an inconsistent discriminant");
         match self {
             DeviceCtlData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceCtlData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -8504,7 +8504,7 @@ pub enum ChangeDevicePropertyAux {
 }
 impl ChangeDevicePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(format);
+        let switch_expr = format;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {
@@ -8573,7 +8573,7 @@ impl ChangeDevicePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), format, "switch `items` has an inconsistent discriminant");
         match self {
             ChangeDevicePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -8909,7 +8909,7 @@ pub enum GetDevicePropertyItems {
 }
 impl GetDevicePropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(format);
+        let switch_expr = format;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {
@@ -10015,7 +10015,7 @@ pub enum HierarchyChangeData {
 }
 impl HierarchyChangeData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(type_);
+        let switch_expr = type_;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(HierarchyChangeType::ADD_MASTER) {
@@ -10082,7 +10082,7 @@ impl HierarchyChangeData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
-        assert_eq!(self.switch_expr(), u16::from(type_), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), type_, "switch `data` has an inconsistent discriminant");
         match self {
             HierarchyChangeData::AddMaster(add_master) => add_master.serialize_into(bytes),
             HierarchyChangeData::RemoveMaster(remove_master) => remove_master.serialize_into(bytes),
@@ -11588,7 +11588,7 @@ pub enum DeviceClassData {
 }
 impl DeviceClassData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(type_);
+        let switch_expr = type_;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(DeviceClassType::KEY) {
@@ -11667,7 +11667,7 @@ impl DeviceClassData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
-        assert_eq!(self.switch_expr(), u16::from(type_), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), type_, "switch `data` has an inconsistent discriminant");
         match self {
             DeviceClassData::Key(key) => key.serialize_into(bytes),
             DeviceClassData::Button(button) => button.serialize_into(bytes),
@@ -13214,7 +13214,7 @@ pub enum XIChangePropertyAux {
 }
 impl XIChangePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(format);
+        let switch_expr = format;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {
@@ -13283,7 +13283,7 @@ impl XIChangePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), format, "switch `items` has an inconsistent discriminant");
         match self {
             XIChangePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -13624,7 +13624,7 @@ pub enum XIGetPropertyItems {
 }
 impl XIGetPropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u8::from(format);
+        let switch_expr = format;
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -741,26 +741,26 @@ pub enum InputInfoInfo {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl InputInfoInfo {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(class_id);
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(InputClass::KEY) {
+        if switch_expr == u8::from(InputClass::KEY) {
             let (key, new_remaining) = InputInfoInfoKey::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputInfoInfo::Key(key));
         }
-        if switch_expr == u32::from(InputClass::BUTTON) {
+        if switch_expr == u8::from(InputClass::BUTTON) {
             let (button, new_remaining) = InputInfoInfoButton::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputInfoInfo::Button(button));
         }
-        if switch_expr == u32::from(InputClass::VALUATOR) {
+        if switch_expr == u8::from(InputClass::VALUATOR) {
             let (valuator, new_remaining) = InputInfoInfoValuator::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -800,7 +800,7 @@ impl InputInfoInfo {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `info` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `info` has an inconsistent discriminant");
         match self {
             InputInfoInfo::Key(key) => key.serialize_into(bytes),
             InputInfoInfo::Button(button) => button.serialize_into(bytes),
@@ -810,11 +810,11 @@ impl InputInfoInfo {
     }
 }
 impl InputInfoInfo {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u8 {
         match self {
-            InputInfoInfo::Key(_) => u32::from(InputClass::KEY),
-            InputInfoInfo::Button(_) => u32::from(InputClass::BUTTON),
-            InputInfoInfo::Valuator(_) => u32::from(InputClass::VALUATOR),
+            InputInfoInfo::Key(_) => u8::from(InputClass::KEY),
+            InputInfoInfo::Button(_) => u8::from(InputClass::BUTTON),
+            InputInfoInfo::Valuator(_) => u8::from(InputClass::VALUATOR),
             InputInfoInfo::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -3967,44 +3967,44 @@ pub enum FeedbackStateData {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl FeedbackStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(class_id);
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(FeedbackClass::KEYBOARD) {
+        if switch_expr == u8::from(FeedbackClass::KEYBOARD) {
             let (keyboard, new_remaining) = FeedbackStateDataKeyboard::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Keyboard(keyboard));
         }
-        if switch_expr == u32::from(FeedbackClass::POINTER) {
+        if switch_expr == u8::from(FeedbackClass::POINTER) {
             let (pointer, new_remaining) = FeedbackStateDataPointer::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Pointer(pointer));
         }
-        if switch_expr == u32::from(FeedbackClass::STRING) {
+        if switch_expr == u8::from(FeedbackClass::STRING) {
             let (string, new_remaining) = FeedbackStateDataString::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::String(string));
         }
-        if switch_expr == u32::from(FeedbackClass::INTEGER) {
+        if switch_expr == u8::from(FeedbackClass::INTEGER) {
             let (integer, new_remaining) = FeedbackStateDataInteger::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Integer(integer));
         }
-        if switch_expr == u32::from(FeedbackClass::LED) {
+        if switch_expr == u8::from(FeedbackClass::LED) {
             let (led, new_remaining) = FeedbackStateDataLed::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackStateData::Led(led));
         }
-        if switch_expr == u32::from(FeedbackClass::BELL) {
+        if switch_expr == u8::from(FeedbackClass::BELL) {
             let (bell, new_remaining) = FeedbackStateDataBell::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -4062,7 +4062,7 @@ impl FeedbackStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackStateData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackStateData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -4075,14 +4075,14 @@ impl FeedbackStateData {
     }
 }
 impl FeedbackStateData {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u8 {
         match self {
-            FeedbackStateData::Keyboard(_) => u32::from(FeedbackClass::KEYBOARD),
-            FeedbackStateData::Pointer(_) => u32::from(FeedbackClass::POINTER),
-            FeedbackStateData::String(_) => u32::from(FeedbackClass::STRING),
-            FeedbackStateData::Integer(_) => u32::from(FeedbackClass::INTEGER),
-            FeedbackStateData::Led(_) => u32::from(FeedbackClass::LED),
-            FeedbackStateData::Bell(_) => u32::from(FeedbackClass::BELL),
+            FeedbackStateData::Keyboard(_) => u8::from(FeedbackClass::KEYBOARD),
+            FeedbackStateData::Pointer(_) => u8::from(FeedbackClass::POINTER),
+            FeedbackStateData::String(_) => u8::from(FeedbackClass::STRING),
+            FeedbackStateData::Integer(_) => u8::from(FeedbackClass::INTEGER),
+            FeedbackStateData::Led(_) => u8::from(FeedbackClass::LED),
+            FeedbackStateData::Bell(_) => u8::from(FeedbackClass::BELL),
             FeedbackStateData::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -4850,44 +4850,44 @@ pub enum FeedbackCtlData {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl FeedbackCtlData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(class_id);
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(FeedbackClass::KEYBOARD) {
+        if switch_expr == u8::from(FeedbackClass::KEYBOARD) {
             let (keyboard, new_remaining) = FeedbackCtlDataKeyboard::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Keyboard(keyboard));
         }
-        if switch_expr == u32::from(FeedbackClass::POINTER) {
+        if switch_expr == u8::from(FeedbackClass::POINTER) {
             let (pointer, new_remaining) = FeedbackCtlDataPointer::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Pointer(pointer));
         }
-        if switch_expr == u32::from(FeedbackClass::STRING) {
+        if switch_expr == u8::from(FeedbackClass::STRING) {
             let (string, new_remaining) = FeedbackCtlDataString::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::String(string));
         }
-        if switch_expr == u32::from(FeedbackClass::INTEGER) {
+        if switch_expr == u8::from(FeedbackClass::INTEGER) {
             let (integer, new_remaining) = FeedbackCtlDataInteger::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Integer(integer));
         }
-        if switch_expr == u32::from(FeedbackClass::LED) {
+        if switch_expr == u8::from(FeedbackClass::LED) {
             let (led, new_remaining) = FeedbackCtlDataLed::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(FeedbackCtlData::Led(led));
         }
-        if switch_expr == u32::from(FeedbackClass::BELL) {
+        if switch_expr == u8::from(FeedbackClass::BELL) {
             let (bell, new_remaining) = FeedbackCtlDataBell::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -4945,7 +4945,7 @@ impl FeedbackCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackCtlData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackCtlData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -4958,14 +4958,14 @@ impl FeedbackCtlData {
     }
 }
 impl FeedbackCtlData {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u8 {
         match self {
-            FeedbackCtlData::Keyboard(_) => u32::from(FeedbackClass::KEYBOARD),
-            FeedbackCtlData::Pointer(_) => u32::from(FeedbackClass::POINTER),
-            FeedbackCtlData::String(_) => u32::from(FeedbackClass::STRING),
-            FeedbackCtlData::Integer(_) => u32::from(FeedbackClass::INTEGER),
-            FeedbackCtlData::Led(_) => u32::from(FeedbackClass::LED),
-            FeedbackCtlData::Bell(_) => u32::from(FeedbackClass::BELL),
+            FeedbackCtlData::Keyboard(_) => u8::from(FeedbackClass::KEYBOARD),
+            FeedbackCtlData::Pointer(_) => u8::from(FeedbackClass::POINTER),
+            FeedbackCtlData::String(_) => u8::from(FeedbackClass::STRING),
+            FeedbackCtlData::Integer(_) => u8::from(FeedbackClass::INTEGER),
+            FeedbackCtlData::Led(_) => u8::from(FeedbackClass::LED),
+            FeedbackCtlData::Bell(_) => u8::from(FeedbackClass::BELL),
             FeedbackCtlData::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -6251,26 +6251,26 @@ pub enum InputStateData {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl InputStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(class_id);
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(InputClass::KEY) {
+        if switch_expr == u8::from(InputClass::KEY) {
             let (key, new_remaining) = InputStateDataKey::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputStateData::Key(key));
         }
-        if switch_expr == u32::from(InputClass::BUTTON) {
+        if switch_expr == u8::from(InputClass::BUTTON) {
             let (button, new_remaining) = InputStateDataButton::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(InputStateData::Button(button));
         }
-        if switch_expr == u32::from(InputClass::VALUATOR) {
+        if switch_expr == u8::from(InputClass::VALUATOR) {
             let (valuator, new_remaining) = InputStateDataValuator::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -6310,7 +6310,7 @@ impl InputStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        assert_eq!(self.switch_expr(), u32::from(class_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             InputStateData::Key(key) => key.serialize_into(bytes),
             InputStateData::Button(button) => button.serialize_into(bytes),
@@ -6320,11 +6320,11 @@ impl InputStateData {
     }
 }
 impl InputStateData {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u8 {
         match self {
-            InputStateData::Key(_) => u32::from(InputClass::KEY),
-            InputStateData::Button(_) => u32::from(InputClass::BUTTON),
-            InputStateData::Valuator(_) => u32::from(InputClass::VALUATOR),
+            InputStateData::Key(_) => u8::from(InputClass::KEY),
+            InputStateData::Button(_) => u8::from(InputClass::BUTTON),
+            InputStateData::Valuator(_) => u8::from(InputClass::VALUATOR),
             InputStateData::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -7281,32 +7281,32 @@ pub enum DeviceStateData {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u16),
 }
 impl DeviceStateData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(control_id);
+        let switch_expr = u16::from(control_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(DeviceControl::RESOLUTION) {
+        if switch_expr == u16::from(DeviceControl::RESOLUTION) {
             let (resolution, new_remaining) = DeviceStateDataResolution::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::Resolution(resolution));
         }
-        if switch_expr == u32::from(DeviceControl::ABSCALIB) {
+        if switch_expr == u16::from(DeviceControl::ABSCALIB) {
             let (abs_calib, new_remaining) = DeviceStateDataAbsCalib::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::AbsCalib(abs_calib));
         }
-        if switch_expr == u32::from(DeviceControl::CORE) {
+        if switch_expr == u16::from(DeviceControl::CORE) {
             let (core, new_remaining) = DeviceStateDataCore::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::Core(core));
         }
-        if switch_expr == u32::from(DeviceControl::ENABLE) {
+        if switch_expr == u16::from(DeviceControl::ENABLE) {
             let remaining = outer_remaining;
             let (enable, remaining) = u8::try_parse(remaining)?;
             let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
@@ -7314,7 +7314,7 @@ impl DeviceStateData {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceStateData::Enable(enable));
         }
-        if switch_expr == u32::from(DeviceControl::ABSAREA) {
+        if switch_expr == u16::from(DeviceControl::ABSAREA) {
             let (abs_area, new_remaining) = DeviceStateDataAbsArea::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -7366,7 +7366,7 @@ impl DeviceStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
-        assert_eq!(self.switch_expr(), u32::from(control_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u16::from(control_id), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceStateData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceStateData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -7382,13 +7382,13 @@ impl DeviceStateData {
     }
 }
 impl DeviceStateData {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u16 {
         match self {
-            DeviceStateData::Resolution(_) => u32::from(DeviceControl::RESOLUTION),
-            DeviceStateData::AbsCalib(_) => u32::from(DeviceControl::ABSCALIB),
-            DeviceStateData::Core(_) => u32::from(DeviceControl::CORE),
-            DeviceStateData::Enable(_) => u32::from(DeviceControl::ENABLE),
-            DeviceStateData::AbsArea(_) => u32::from(DeviceControl::ABSAREA),
+            DeviceStateData::Resolution(_) => u16::from(DeviceControl::RESOLUTION),
+            DeviceStateData::AbsCalib(_) => u16::from(DeviceControl::ABSCALIB),
+            DeviceStateData::Core(_) => u16::from(DeviceControl::CORE),
+            DeviceStateData::Enable(_) => u16::from(DeviceControl::ENABLE),
+            DeviceStateData::AbsArea(_) => u16::from(DeviceControl::ABSAREA),
             DeviceStateData::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -8078,32 +8078,32 @@ pub enum DeviceCtlData {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u16),
 }
 impl DeviceCtlData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(control_id);
+        let switch_expr = u16::from(control_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(DeviceControl::RESOLUTION) {
+        if switch_expr == u16::from(DeviceControl::RESOLUTION) {
             let (resolution, new_remaining) = DeviceCtlDataResolution::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::Resolution(resolution));
         }
-        if switch_expr == u32::from(DeviceControl::ABSCALIB) {
+        if switch_expr == u16::from(DeviceControl::ABSCALIB) {
             let (abs_calib, new_remaining) = DeviceCtlDataAbsCalib::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::AbsCalib(abs_calib));
         }
-        if switch_expr == u32::from(DeviceControl::CORE) {
+        if switch_expr == u16::from(DeviceControl::CORE) {
             let (core, new_remaining) = DeviceCtlDataCore::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::Core(core));
         }
-        if switch_expr == u32::from(DeviceControl::ENABLE) {
+        if switch_expr == u16::from(DeviceControl::ENABLE) {
             let remaining = outer_remaining;
             let (enable, remaining) = u8::try_parse(remaining)?;
             let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
@@ -8111,7 +8111,7 @@ impl DeviceCtlData {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceCtlData::Enable(enable));
         }
-        if switch_expr == u32::from(DeviceControl::ABSAREA) {
+        if switch_expr == u16::from(DeviceControl::ABSAREA) {
             let (abs_area, new_remaining) = DeviceCtlDataAbsArea::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -8163,7 +8163,7 @@ impl DeviceCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
-        assert_eq!(self.switch_expr(), u32::from(control_id), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u16::from(control_id), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceCtlData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceCtlData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -8179,13 +8179,13 @@ impl DeviceCtlData {
     }
 }
 impl DeviceCtlData {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u16 {
         match self {
-            DeviceCtlData::Resolution(_) => u32::from(DeviceControl::RESOLUTION),
-            DeviceCtlData::AbsCalib(_) => u32::from(DeviceControl::ABSCALIB),
-            DeviceCtlData::Core(_) => u32::from(DeviceControl::CORE),
-            DeviceCtlData::Enable(_) => u32::from(DeviceControl::ENABLE),
-            DeviceCtlData::AbsArea(_) => u32::from(DeviceControl::ABSAREA),
+            DeviceCtlData::Resolution(_) => u16::from(DeviceControl::RESOLUTION),
+            DeviceCtlData::AbsCalib(_) => u16::from(DeviceControl::ABSCALIB),
+            DeviceCtlData::Core(_) => u16::from(DeviceControl::CORE),
+            DeviceCtlData::Enable(_) => u16::from(DeviceControl::ENABLE),
+            DeviceCtlData::AbsArea(_) => u16::from(DeviceControl::ABSAREA),
             DeviceCtlData::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -8500,14 +8500,14 @@ pub enum ChangeDevicePropertyAux {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl ChangeDevicePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(format);
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(PropertyFormat::M8_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M8_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items.try_to_usize()?)?;
@@ -8520,7 +8520,7 @@ impl ChangeDevicePropertyAux {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(ChangeDevicePropertyAux::Data8(data8));
         }
-        if switch_expr == u32::from(PropertyFormat::M16_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M16_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data16, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items.try_to_usize()?)?;
@@ -8532,7 +8532,7 @@ impl ChangeDevicePropertyAux {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(ChangeDevicePropertyAux::Data16(data16));
         }
-        if switch_expr == u32::from(PropertyFormat::M32_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M32_BITS) {
             let remaining = outer_remaining;
             let (data32, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -8573,7 +8573,7 @@ impl ChangeDevicePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        assert_eq!(self.switch_expr(), u32::from(format), "switch `items` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             ChangeDevicePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -8594,11 +8594,11 @@ impl ChangeDevicePropertyAux {
     }
 }
 impl ChangeDevicePropertyAux {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u8 {
         match self {
-            ChangeDevicePropertyAux::Data8(_) => u32::from(PropertyFormat::M8_BITS),
-            ChangeDevicePropertyAux::Data16(_) => u32::from(PropertyFormat::M16_BITS),
-            ChangeDevicePropertyAux::Data32(_) => u32::from(PropertyFormat::M32_BITS),
+            ChangeDevicePropertyAux::Data8(_) => u8::from(PropertyFormat::M8_BITS),
+            ChangeDevicePropertyAux::Data16(_) => u8::from(PropertyFormat::M16_BITS),
+            ChangeDevicePropertyAux::Data32(_) => u8::from(PropertyFormat::M32_BITS),
             ChangeDevicePropertyAux::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -8905,14 +8905,14 @@ pub enum GetDevicePropertyItems {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl GetDevicePropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(format);
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(PropertyFormat::M8_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M8_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items.try_to_usize()?)?;
@@ -8925,7 +8925,7 @@ impl GetDevicePropertyItems {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(GetDevicePropertyItems::Data8(data8));
         }
-        if switch_expr == u32::from(PropertyFormat::M16_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M16_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data16, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items.try_to_usize()?)?;
@@ -8937,7 +8937,7 @@ impl GetDevicePropertyItems {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(GetDevicePropertyItems::Data16(data16));
         }
-        if switch_expr == u32::from(PropertyFormat::M32_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M32_BITS) {
             let remaining = outer_remaining;
             let (data32, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -10011,32 +10011,32 @@ pub enum HierarchyChangeData {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u16),
 }
 impl HierarchyChangeData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(type_);
+        let switch_expr = u16::from(type_);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(HierarchyChangeType::ADD_MASTER) {
+        if switch_expr == u16::from(HierarchyChangeType::ADD_MASTER) {
             let (add_master, new_remaining) = HierarchyChangeDataAddMaster::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(HierarchyChangeData::AddMaster(add_master));
         }
-        if switch_expr == u32::from(HierarchyChangeType::REMOVE_MASTER) {
+        if switch_expr == u16::from(HierarchyChangeType::REMOVE_MASTER) {
             let (remove_master, new_remaining) = HierarchyChangeDataRemoveMaster::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(HierarchyChangeData::RemoveMaster(remove_master));
         }
-        if switch_expr == u32::from(HierarchyChangeType::ATTACH_SLAVE) {
+        if switch_expr == u16::from(HierarchyChangeType::ATTACH_SLAVE) {
             let (attach_slave, new_remaining) = HierarchyChangeDataAttachSlave::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(HierarchyChangeData::AttachSlave(attach_slave));
         }
-        if switch_expr == u32::from(HierarchyChangeType::DETACH_SLAVE) {
+        if switch_expr == u16::from(HierarchyChangeType::DETACH_SLAVE) {
             let (detach_slave, new_remaining) = HierarchyChangeDataDetachSlave::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -10082,7 +10082,7 @@ impl HierarchyChangeData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
-        assert_eq!(self.switch_expr(), u32::from(type_), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u16::from(type_), "switch `data` has an inconsistent discriminant");
         match self {
             HierarchyChangeData::AddMaster(add_master) => add_master.serialize_into(bytes),
             HierarchyChangeData::RemoveMaster(remove_master) => remove_master.serialize_into(bytes),
@@ -10093,12 +10093,12 @@ impl HierarchyChangeData {
     }
 }
 impl HierarchyChangeData {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u16 {
         match self {
-            HierarchyChangeData::AddMaster(_) => u32::from(HierarchyChangeType::ADD_MASTER),
-            HierarchyChangeData::RemoveMaster(_) => u32::from(HierarchyChangeType::REMOVE_MASTER),
-            HierarchyChangeData::AttachSlave(_) => u32::from(HierarchyChangeType::ATTACH_SLAVE),
-            HierarchyChangeData::DetachSlave(_) => u32::from(HierarchyChangeType::DETACH_SLAVE),
+            HierarchyChangeData::AddMaster(_) => u16::from(HierarchyChangeType::ADD_MASTER),
+            HierarchyChangeData::RemoveMaster(_) => u16::from(HierarchyChangeType::REMOVE_MASTER),
+            HierarchyChangeData::AttachSlave(_) => u16::from(HierarchyChangeType::ATTACH_SLAVE),
+            HierarchyChangeData::DetachSlave(_) => u16::from(HierarchyChangeType::DETACH_SLAVE),
             HierarchyChangeData::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -11584,38 +11584,38 @@ pub enum DeviceClassData {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u16),
 }
 impl DeviceClassData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(type_);
+        let switch_expr = u16::from(type_);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(DeviceClassType::KEY) {
+        if switch_expr == u16::from(DeviceClassType::KEY) {
             let (key, new_remaining) = DeviceClassDataKey::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Key(key));
         }
-        if switch_expr == u32::from(DeviceClassType::BUTTON) {
+        if switch_expr == u16::from(DeviceClassType::BUTTON) {
             let (button, new_remaining) = DeviceClassDataButton::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Button(button));
         }
-        if switch_expr == u32::from(DeviceClassType::VALUATOR) {
+        if switch_expr == u16::from(DeviceClassType::VALUATOR) {
             let (valuator, new_remaining) = DeviceClassDataValuator::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Valuator(valuator));
         }
-        if switch_expr == u32::from(DeviceClassType::SCROLL) {
+        if switch_expr == u16::from(DeviceClassType::SCROLL) {
             let (scroll, new_remaining) = DeviceClassDataScroll::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(DeviceClassData::Scroll(scroll));
         }
-        if switch_expr == u32::from(DeviceClassType::TOUCH) {
+        if switch_expr == u16::from(DeviceClassType::TOUCH) {
             let (touch, new_remaining) = DeviceClassDataTouch::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
@@ -11667,7 +11667,7 @@ impl DeviceClassData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
-        assert_eq!(self.switch_expr(), u32::from(type_), "switch `data` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u16::from(type_), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceClassData::Key(key) => key.serialize_into(bytes),
             DeviceClassData::Button(button) => button.serialize_into(bytes),
@@ -11679,13 +11679,13 @@ impl DeviceClassData {
     }
 }
 impl DeviceClassData {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u16 {
         match self {
-            DeviceClassData::Key(_) => u32::from(DeviceClassType::KEY),
-            DeviceClassData::Button(_) => u32::from(DeviceClassType::BUTTON),
-            DeviceClassData::Valuator(_) => u32::from(DeviceClassType::VALUATOR),
-            DeviceClassData::Scroll(_) => u32::from(DeviceClassType::SCROLL),
-            DeviceClassData::Touch(_) => u32::from(DeviceClassType::TOUCH),
+            DeviceClassData::Key(_) => u16::from(DeviceClassType::KEY),
+            DeviceClassData::Button(_) => u16::from(DeviceClassType::BUTTON),
+            DeviceClassData::Valuator(_) => u16::from(DeviceClassType::VALUATOR),
+            DeviceClassData::Scroll(_) => u16::from(DeviceClassType::SCROLL),
+            DeviceClassData::Touch(_) => u16::from(DeviceClassType::TOUCH),
             DeviceClassData::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -13210,14 +13210,14 @@ pub enum XIChangePropertyAux {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl XIChangePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(format);
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(PropertyFormat::M8_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M8_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items.try_to_usize()?)?;
@@ -13230,7 +13230,7 @@ impl XIChangePropertyAux {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(XIChangePropertyAux::Data8(data8));
         }
-        if switch_expr == u32::from(PropertyFormat::M16_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M16_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data16, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items.try_to_usize()?)?;
@@ -13242,7 +13242,7 @@ impl XIChangePropertyAux {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(XIChangePropertyAux::Data16(data16));
         }
-        if switch_expr == u32::from(PropertyFormat::M32_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M32_BITS) {
             let remaining = outer_remaining;
             let (data32, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -13283,7 +13283,7 @@ impl XIChangePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        assert_eq!(self.switch_expr(), u32::from(format), "switch `items` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             XIChangePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -13304,11 +13304,11 @@ impl XIChangePropertyAux {
     }
 }
 impl XIChangePropertyAux {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u8 {
         match self {
-            XIChangePropertyAux::Data8(_) => u32::from(PropertyFormat::M8_BITS),
-            XIChangePropertyAux::Data16(_) => u32::from(PropertyFormat::M16_BITS),
-            XIChangePropertyAux::Data32(_) => u32::from(PropertyFormat::M32_BITS),
+            XIChangePropertyAux::Data8(_) => u8::from(PropertyFormat::M8_BITS),
+            XIChangePropertyAux::Data16(_) => u8::from(PropertyFormat::M16_BITS),
+            XIChangePropertyAux::Data32(_) => u8::from(PropertyFormat::M32_BITS),
             XIChangePropertyAux::InvalidValue(switch_expr) => *switch_expr,
         }
     }
@@ -13620,14 +13620,14 @@ pub enum XIGetPropertyItems {
     ///
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
-    InvalidValue(u32),
+    InvalidValue(u8),
 }
 impl XIGetPropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(format);
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
-        if switch_expr == u32::from(PropertyFormat::M8_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M8_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items.try_to_usize()?)?;
@@ -13640,7 +13640,7 @@ impl XIGetPropertyItems {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(XIGetPropertyItems::Data8(data8));
         }
-        if switch_expr == u32::from(PropertyFormat::M16_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M16_BITS) {
             let remaining = outer_remaining;
             let value = remaining;
             let (data16, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_items.try_to_usize()?)?;
@@ -13652,7 +13652,7 @@ impl XIGetPropertyItems {
             assert!(parse_result.is_none(), "The XML should prevent more than one 'if' from matching");
             parse_result = Some(XIGetPropertyItems::Data16(data16));
         }
-        if switch_expr == u32::from(PropertyFormat::M32_BITS) {
+        if switch_expr == u8::from(PropertyFormat::M32_BITS) {
             let remaining = outer_remaining;
             let (data32, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_items.try_to_usize()?)?;
             outer_remaining = remaining;

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -843,7 +843,7 @@ impl Serialize for InputInfo {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
-        let class_id = u8::try_from(self.info.switch_expr()).unwrap();
+        let class_id = u8::from(self.info.switch_expr());
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.info.serialize_into(bytes, class_id);
@@ -4113,7 +4113,7 @@ impl Serialize for FeedbackState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let class_id = u8::try_from(self.data.switch_expr()).unwrap();
+        let class_id = u8::from(self.data.switch_expr());
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
@@ -4996,7 +4996,7 @@ impl Serialize for FeedbackCtl {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let class_id = u8::try_from(self.data.switch_expr()).unwrap();
+        let class_id = u8::from(self.data.switch_expr());
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
@@ -6353,7 +6353,7 @@ impl Serialize for InputState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
-        let class_id = u8::try_from(self.data.switch_expr()).unwrap();
+        let class_id = u8::from(self.data.switch_expr());
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, class_id);
@@ -7417,7 +7417,7 @@ impl Serialize for DeviceState {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let control_id = u16::try_from(self.data.switch_expr()).unwrap();
+        let control_id = u16::from(self.data.switch_expr());
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, control_id);
@@ -8214,7 +8214,7 @@ impl Serialize for DeviceCtl {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let control_id = u16::try_from(self.data.switch_expr()).unwrap();
+        let control_id = u16::from(self.data.switch_expr());
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, control_id);
@@ -8622,7 +8622,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         let property_bytes = self.property.serialize();
         let type_bytes = self.type_.serialize();
         let device_id_bytes = self.device_id.serialize();
-        let format = u8::try_from(self.items.switch_expr()).unwrap();
+        let format = u8::from(self.items.switch_expr());
         let format_bytes = format.serialize();
         let mode_bytes = u8::from(self.mode).serialize();
         let num_items_bytes = self.num_items.serialize();
@@ -10127,7 +10127,7 @@ impl Serialize for HierarchyChange {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        let type_ = u16::try_from(self.data.switch_expr()).unwrap();
+        let type_ = u16::from(self.data.switch_expr());
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.data.serialize_into(bytes, type_);
@@ -11716,7 +11716,7 @@ impl Serialize for DeviceClass {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(6);
-        let type_ = u16::try_from(self.data.switch_expr()).unwrap();
+        let type_ = u16::from(self.data.switch_expr());
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
@@ -13331,7 +13331,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         let length_so_far = 0;
         let deviceid_bytes = self.deviceid.serialize();
         let mode_bytes = u8::from(self.mode).serialize();
-        let format = u8::try_from(self.items.switch_expr()).unwrap();
+        let format = u8::from(self.items.switch_expr());
         let format_bytes = format.serialize();
         let property_bytes = self.property.serialize();
         let type_bytes = self.type_.serialize();

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -7578,9 +7578,9 @@ pub struct GetMapMap {
 }
 impl GetMapMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(present);
+        let switch_expr = u16::from(present);
         let mut outer_remaining = value;
-        let types_rtrn = if switch_expr & u32::from(MapPart::KEY_TYPES) != 0 {
+        let types_rtrn = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
             let (types_rtrn, remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7588,7 +7588,7 @@ impl GetMapMap {
         } else {
             None
         };
-        let syms_rtrn = if switch_expr & u32::from(MapPart::KEY_SYMS) != 0 {
+        let syms_rtrn = if switch_expr & u16::from(MapPart::KEY_SYMS) != 0 {
             let remaining = outer_remaining;
             let (syms_rtrn, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7596,14 +7596,14 @@ impl GetMapMap {
         } else {
             None
         };
-        let bitcase3 = if switch_expr & u32::from(MapPart::KEY_ACTIONS) != 0 {
+        let bitcase3 = if switch_expr & u16::from(MapPart::KEY_ACTIONS) != 0 {
             let (bitcase3, new_remaining) = GetMapMapBitcase3::try_parse(outer_remaining, n_key_actions, total_actions)?;
             outer_remaining = new_remaining;
             Some(bitcase3)
         } else {
             None
         };
-        let behaviors_rtrn = if switch_expr & u32::from(MapPart::KEY_BEHAVIORS) != 0 {
+        let behaviors_rtrn = if switch_expr & u16::from(MapPart::KEY_BEHAVIORS) != 0 {
             let remaining = outer_remaining;
             let (behaviors_rtrn, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7611,7 +7611,7 @@ impl GetMapMap {
         } else {
             None
         };
-        let vmods_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MODS) != 0 {
+        let vmods_rtrn = if switch_expr & u16::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
             let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
@@ -7625,7 +7625,7 @@ impl GetMapMap {
         } else {
             None
         };
-        let explicit_rtrn = if switch_expr & u32::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
+        let explicit_rtrn = if switch_expr & u16::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
             let (explicit_rtrn, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_to_usize()?)?;
@@ -7638,7 +7638,7 @@ impl GetMapMap {
         } else {
             None
         };
-        let modmap_rtrn = if switch_expr & u32::from(MapPart::MODIFIER_MAP) != 0 {
+        let modmap_rtrn = if switch_expr & u16::from(MapPart::MODIFIER_MAP) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
             let (modmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_to_usize()?)?;
@@ -7651,7 +7651,7 @@ impl GetMapMap {
         } else {
             None
         };
-        let vmodmap_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
+        let vmodmap_rtrn = if switch_expr & u16::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
             let remaining = outer_remaining;
             let (vmodmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7789,9 +7789,9 @@ pub struct SetMapAux {
 }
 impl SetMapAux {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(present);
+        let switch_expr = u16::from(present);
         let mut outer_remaining = value;
-        let types = if switch_expr & u32::from(MapPart::KEY_TYPES) != 0 {
+        let types = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
             let (types, remaining) = crate::x11_utils::parse_list::<SetKeyType>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7799,7 +7799,7 @@ impl SetMapAux {
         } else {
             None
         };
-        let syms = if switch_expr & u32::from(MapPart::KEY_SYMS) != 0 {
+        let syms = if switch_expr & u16::from(MapPart::KEY_SYMS) != 0 {
             let remaining = outer_remaining;
             let (syms, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7807,14 +7807,14 @@ impl SetMapAux {
         } else {
             None
         };
-        let bitcase3 = if switch_expr & u32::from(MapPart::KEY_ACTIONS) != 0 {
+        let bitcase3 = if switch_expr & u16::from(MapPart::KEY_ACTIONS) != 0 {
             let (bitcase3, new_remaining) = SetMapAuxBitcase3::try_parse(outer_remaining, n_key_actions, total_actions)?;
             outer_remaining = new_remaining;
             Some(bitcase3)
         } else {
             None
         };
-        let behaviors = if switch_expr & u32::from(MapPart::KEY_BEHAVIORS) != 0 {
+        let behaviors = if switch_expr & u16::from(MapPart::KEY_BEHAVIORS) != 0 {
             let remaining = outer_remaining;
             let (behaviors, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7822,7 +7822,7 @@ impl SetMapAux {
         } else {
             None
         };
-        let vmods = if switch_expr & u32::from(MapPart::VIRTUAL_MODS) != 0 {
+        let vmods = if switch_expr & u16::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
             let (vmods, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
@@ -7836,7 +7836,7 @@ impl SetMapAux {
         } else {
             None
         };
-        let explicit = if switch_expr & u32::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
+        let explicit = if switch_expr & u16::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
             let remaining = outer_remaining;
             let (explicit, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7844,7 +7844,7 @@ impl SetMapAux {
         } else {
             None
         };
-        let modmap = if switch_expr & u32::from(MapPart::MODIFIER_MAP) != 0 {
+        let modmap = if switch_expr & u16::from(MapPart::MODIFIER_MAP) != 0 {
             let remaining = outer_remaining;
             let (modmap, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7852,7 +7852,7 @@ impl SetMapAux {
         } else {
             None
         };
-        let vmodmap = if switch_expr & u32::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
+        let vmodmap = if switch_expr & u16::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
             let remaining = outer_remaining;
             let (vmodmap, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -7872,7 +7872,7 @@ impl SetMapAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
-        assert_eq!(self.switch_expr(), u32::from(present), "switch `values` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u16::from(present), "switch `values` has an inconsistent discriminant");
         if let Some(ref types) = self.types {
             assert_eq!(types.len(), usize::try_from(n_types).unwrap(), "`types` has an incorrect length");
             types.serialize_into(bytes);
@@ -7908,31 +7908,31 @@ impl SetMapAux {
     }
 }
 impl SetMapAux {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u16 {
         let mut expr_value = 0;
         if self.types.is_some() {
-            expr_value |= u32::from(MapPart::KEY_TYPES);
+            expr_value |= u16::from(MapPart::KEY_TYPES);
         }
         if self.syms.is_some() {
-            expr_value |= u32::from(MapPart::KEY_SYMS);
+            expr_value |= u16::from(MapPart::KEY_SYMS);
         }
         if self.bitcase3.is_some() {
-            expr_value |= u32::from(MapPart::KEY_ACTIONS);
+            expr_value |= u16::from(MapPart::KEY_ACTIONS);
         }
         if self.behaviors.is_some() {
-            expr_value |= u32::from(MapPart::KEY_BEHAVIORS);
+            expr_value |= u16::from(MapPart::KEY_BEHAVIORS);
         }
         if self.vmods.is_some() {
-            expr_value |= u32::from(MapPart::VIRTUAL_MODS);
+            expr_value |= u16::from(MapPart::VIRTUAL_MODS);
         }
         if self.explicit.is_some() {
-            expr_value |= u32::from(MapPart::EXPLICIT_COMPONENTS);
+            expr_value |= u16::from(MapPart::EXPLICIT_COMPONENTS);
         }
         if self.modmap.is_some() {
-            expr_value |= u32::from(MapPart::MODIFIER_MAP);
+            expr_value |= u16::from(MapPart::MODIFIER_MAP);
         }
         if self.vmodmap.is_some() {
-            expr_value |= u32::from(MapPart::VIRTUAL_MOD_MAP);
+            expr_value |= u16::from(MapPart::VIRTUAL_MOD_MAP);
         }
         expr_value
     }
@@ -10353,9 +10353,9 @@ pub struct GetKbdByNameRepliesTypesMap {
 }
 impl GetKbdByNameRepliesTypesMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(present);
+        let switch_expr = u16::from(present);
         let mut outer_remaining = value;
-        let types_rtrn = if switch_expr & u32::from(MapPart::KEY_TYPES) != 0 {
+        let types_rtrn = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
             let (types_rtrn, remaining) = crate::x11_utils::parse_list::<KeyType>(remaining, n_types.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -10363,7 +10363,7 @@ impl GetKbdByNameRepliesTypesMap {
         } else {
             None
         };
-        let syms_rtrn = if switch_expr & u32::from(MapPart::KEY_SYMS) != 0 {
+        let syms_rtrn = if switch_expr & u16::from(MapPart::KEY_SYMS) != 0 {
             let remaining = outer_remaining;
             let (syms_rtrn, remaining) = crate::x11_utils::parse_list::<KeySymMap>(remaining, n_key_syms.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -10371,14 +10371,14 @@ impl GetKbdByNameRepliesTypesMap {
         } else {
             None
         };
-        let bitcase3 = if switch_expr & u32::from(MapPart::KEY_ACTIONS) != 0 {
+        let bitcase3 = if switch_expr & u16::from(MapPart::KEY_ACTIONS) != 0 {
             let (bitcase3, new_remaining) = GetKbdByNameRepliesTypesMapBitcase3::try_parse(outer_remaining, n_key_actions, total_actions)?;
             outer_remaining = new_remaining;
             Some(bitcase3)
         } else {
             None
         };
-        let behaviors_rtrn = if switch_expr & u32::from(MapPart::KEY_BEHAVIORS) != 0 {
+        let behaviors_rtrn = if switch_expr & u16::from(MapPart::KEY_BEHAVIORS) != 0 {
             let remaining = outer_remaining;
             let (behaviors_rtrn, remaining) = crate::x11_utils::parse_list::<SetBehavior>(remaining, total_key_behaviors.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -10386,7 +10386,7 @@ impl GetKbdByNameRepliesTypesMap {
         } else {
             None
         };
-        let vmods_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MODS) != 0 {
+        let vmods_rtrn = if switch_expr & u16::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
             let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
@@ -10400,7 +10400,7 @@ impl GetKbdByNameRepliesTypesMap {
         } else {
             None
         };
-        let explicit_rtrn = if switch_expr & u32::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
+        let explicit_rtrn = if switch_expr & u16::from(MapPart::EXPLICIT_COMPONENTS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
             let (explicit_rtrn, remaining) = crate::x11_utils::parse_list::<SetExplicit>(remaining, total_key_explicit.try_to_usize()?)?;
@@ -10413,7 +10413,7 @@ impl GetKbdByNameRepliesTypesMap {
         } else {
             None
         };
-        let modmap_rtrn = if switch_expr & u32::from(MapPart::MODIFIER_MAP) != 0 {
+        let modmap_rtrn = if switch_expr & u16::from(MapPart::MODIFIER_MAP) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
             let (modmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyModMap>(remaining, total_mod_map_keys.try_to_usize()?)?;
@@ -10426,7 +10426,7 @@ impl GetKbdByNameRepliesTypesMap {
         } else {
             None
         };
-        let vmodmap_rtrn = if switch_expr & u32::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
+        let vmodmap_rtrn = if switch_expr & u16::from(MapPart::VIRTUAL_MOD_MAP) != 0 {
             let remaining = outer_remaining;
             let (vmodmap_rtrn, remaining) = crate::x11_utils::parse_list::<KeyVModMap>(remaining, total_v_mod_map_keys.try_to_usize()?)?;
             outer_remaining = remaining;
@@ -10847,37 +10847,37 @@ pub struct GetKbdByNameReplies {
 }
 impl GetKbdByNameReplies {
     fn try_parse(value: &[u8], reported: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(reported);
+        let switch_expr = u16::from(reported);
         let mut outer_remaining = value;
-        let types = if switch_expr & u32::from(GBNDetail::TYPES) != 0 || switch_expr & u32::from(GBNDetail::CLIENT_SYMBOLS) != 0 || switch_expr & u32::from(GBNDetail::SERVER_SYMBOLS) != 0 {
+        let types = if switch_expr & u16::from(GBNDetail::TYPES) != 0 || switch_expr & u16::from(GBNDetail::CLIENT_SYMBOLS) != 0 || switch_expr & u16::from(GBNDetail::SERVER_SYMBOLS) != 0 {
             let (types, new_remaining) = GetKbdByNameRepliesTypes::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(types)
         } else {
             None
         };
-        let compat_map = if switch_expr & u32::from(GBNDetail::COMPAT_MAP) != 0 {
+        let compat_map = if switch_expr & u16::from(GBNDetail::COMPAT_MAP) != 0 {
             let (compat_map, new_remaining) = GetKbdByNameRepliesCompatMap::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(compat_map)
         } else {
             None
         };
-        let indicator_maps = if switch_expr & u32::from(GBNDetail::INDICATOR_MAPS) != 0 {
+        let indicator_maps = if switch_expr & u16::from(GBNDetail::INDICATOR_MAPS) != 0 {
             let (indicator_maps, new_remaining) = GetKbdByNameRepliesIndicatorMaps::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(indicator_maps)
         } else {
             None
         };
-        let key_names = if switch_expr & u32::from(GBNDetail::KEY_NAMES) != 0 || switch_expr & u32::from(GBNDetail::OTHER_NAMES) != 0 {
+        let key_names = if switch_expr & u16::from(GBNDetail::KEY_NAMES) != 0 || switch_expr & u16::from(GBNDetail::OTHER_NAMES) != 0 {
             let (key_names, new_remaining) = GetKbdByNameRepliesKeyNames::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(key_names)
         } else {
             None
         };
-        let geometry = if switch_expr & u32::from(GBNDetail::GEOMETRY) != 0 {
+        let geometry = if switch_expr & u16::from(GBNDetail::GEOMETRY) != 0 {
             let (geometry, new_remaining) = GetKbdByNameRepliesGeometry::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(geometry)

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6198,7 +6198,7 @@ pub struct SelectEventsAux {
 }
 impl SelectEventsAux {
     fn try_parse(value: &[u8], affect_which: u16, clear: u16, select_all: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(affect_which) & ((!u16::from(clear)) & (!u16::from(select_all)));
+        let switch_expr = affect_which & ((!clear) & (!select_all));
         let mut outer_remaining = value;
         let bitcase1 = if switch_expr & u16::from(EventType::NEW_KEYBOARD_NOTIFY) != 0 {
             let (bitcase1, new_remaining) = SelectEventsAuxBitcase1::try_parse(outer_remaining)?;
@@ -6289,7 +6289,7 @@ impl SelectEventsAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, affect_which: u16, clear: u16, select_all: u16) {
-        assert_eq!(self.switch_expr(), u16::from(affect_which) & ((!u16::from(clear)) & (!u16::from(select_all))), "switch `details` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), affect_which & ((!clear) & (!select_all)), "switch `details` has an inconsistent discriminant");
         if let Some(ref bitcase1) = self.bitcase1 {
             bitcase1.serialize_into(bytes);
         }
@@ -6442,7 +6442,7 @@ impl<'input> SelectEventsRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let affect_which = u16::from(self.details.switch_expr() | (u16::from(self.clear) | u16::from(self.select_all)));
+        let affect_which = u16::from(self.details.switch_expr() | (self.clear | self.select_all));
         let affect_which_bytes = affect_which.serialize();
         let clear_bytes = self.clear.serialize();
         let select_all_bytes = self.select_all.serialize();
@@ -7578,7 +7578,7 @@ pub struct GetMapMap {
 }
 impl GetMapMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(present);
+        let switch_expr = present;
         let mut outer_remaining = value;
         let types_rtrn = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
@@ -7789,7 +7789,7 @@ pub struct SetMapAux {
 }
 impl SetMapAux {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(present);
+        let switch_expr = present;
         let mut outer_remaining = value;
         let types = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
@@ -7872,7 +7872,7 @@ impl SetMapAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
-        assert_eq!(self.switch_expr(), u16::from(present), "switch `values` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), present, "switch `values` has an inconsistent discriminant");
         if let Some(ref types) = self.types {
             assert_eq!(types.len(), usize::try_from(n_types).unwrap(), "`types` has an incorrect length");
             types.serialize_into(bytes);
@@ -10353,7 +10353,7 @@ pub struct GetKbdByNameRepliesTypesMap {
 }
 impl GetKbdByNameRepliesTypesMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(present);
+        let switch_expr = present;
         let mut outer_remaining = value;
         let types_rtrn = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
@@ -10847,7 +10847,7 @@ pub struct GetKbdByNameReplies {
 }
 impl GetKbdByNameReplies {
     fn try_parse(value: &[u8], reported: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(reported);
+        let switch_expr = reported;
         let mut outer_remaining = value;
         let types = if switch_expr & u16::from(GBNDetail::TYPES) != 0 || switch_expr & u16::from(GBNDetail::CLIENT_SYMBOLS) != 0 || switch_expr & u16::from(GBNDetail::SERVER_SYMBOLS) != 0 {
             let (types, new_remaining) = GetKbdByNameRepliesTypes::try_parse(outer_remaining)?;

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6442,7 +6442,7 @@ impl<'input> SelectEventsRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let affect_which = u16::from(self.details.switch_expr() | (self.clear | self.select_all));
+        let affect_which: u16 = self.details.switch_expr() | (self.clear | self.select_all);
         let affect_which_bytes = affect_which.serialize();
         let clear_bytes = self.clear.serialize();
         let select_all_bytes = self.select_all.serialize();
@@ -8020,7 +8020,7 @@ impl<'input> SetMapRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let present = u16::from(self.values.switch_expr());
+        let present: u16 = self.values.switch_expr();
         let present_bytes = present.serialize();
         let flags_bytes = self.flags.serialize();
         let min_key_code_bytes = self.min_key_code.serialize();
@@ -9748,7 +9748,7 @@ impl<'input> SetNamesRequest<'input> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
         let virtual_mods_bytes = self.virtual_mods.serialize();
-        let which = self.values.switch_expr();
+        let which: u32 = self.values.switch_expr();
         let which_bytes = which.serialize();
         let first_type_bytes = self.first_type.serialize();
         let n_types_bytes = self.n_types.serialize();

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6198,79 +6198,79 @@ pub struct SelectEventsAux {
 }
 impl SelectEventsAux {
     fn try_parse(value: &[u8], affect_which: u16, clear: u16, select_all: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(affect_which) & ((!u32::from(clear)) & (!u32::from(select_all)));
+        let switch_expr = u16::from(affect_which) & ((!u16::from(clear)) & (!u16::from(select_all)));
         let mut outer_remaining = value;
-        let bitcase1 = if switch_expr & u32::from(EventType::NEW_KEYBOARD_NOTIFY) != 0 {
+        let bitcase1 = if switch_expr & u16::from(EventType::NEW_KEYBOARD_NOTIFY) != 0 {
             let (bitcase1, new_remaining) = SelectEventsAuxBitcase1::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase1)
         } else {
             None
         };
-        let bitcase2 = if switch_expr & u32::from(EventType::STATE_NOTIFY) != 0 {
+        let bitcase2 = if switch_expr & u16::from(EventType::STATE_NOTIFY) != 0 {
             let (bitcase2, new_remaining) = SelectEventsAuxBitcase2::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase2)
         } else {
             None
         };
-        let bitcase3 = if switch_expr & u32::from(EventType::CONTROLS_NOTIFY) != 0 {
+        let bitcase3 = if switch_expr & u16::from(EventType::CONTROLS_NOTIFY) != 0 {
             let (bitcase3, new_remaining) = SelectEventsAuxBitcase3::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase3)
         } else {
             None
         };
-        let bitcase4 = if switch_expr & u32::from(EventType::INDICATOR_STATE_NOTIFY) != 0 {
+        let bitcase4 = if switch_expr & u16::from(EventType::INDICATOR_STATE_NOTIFY) != 0 {
             let (bitcase4, new_remaining) = SelectEventsAuxBitcase4::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase4)
         } else {
             None
         };
-        let bitcase5 = if switch_expr & u32::from(EventType::INDICATOR_MAP_NOTIFY) != 0 {
+        let bitcase5 = if switch_expr & u16::from(EventType::INDICATOR_MAP_NOTIFY) != 0 {
             let (bitcase5, new_remaining) = SelectEventsAuxBitcase5::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase5)
         } else {
             None
         };
-        let bitcase6 = if switch_expr & u32::from(EventType::NAMES_NOTIFY) != 0 {
+        let bitcase6 = if switch_expr & u16::from(EventType::NAMES_NOTIFY) != 0 {
             let (bitcase6, new_remaining) = SelectEventsAuxBitcase6::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase6)
         } else {
             None
         };
-        let bitcase7 = if switch_expr & u32::from(EventType::COMPAT_MAP_NOTIFY) != 0 {
+        let bitcase7 = if switch_expr & u16::from(EventType::COMPAT_MAP_NOTIFY) != 0 {
             let (bitcase7, new_remaining) = SelectEventsAuxBitcase7::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase7)
         } else {
             None
         };
-        let bitcase8 = if switch_expr & u32::from(EventType::BELL_NOTIFY) != 0 {
+        let bitcase8 = if switch_expr & u16::from(EventType::BELL_NOTIFY) != 0 {
             let (bitcase8, new_remaining) = SelectEventsAuxBitcase8::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase8)
         } else {
             None
         };
-        let bitcase9 = if switch_expr & u32::from(EventType::ACTION_MESSAGE) != 0 {
+        let bitcase9 = if switch_expr & u16::from(EventType::ACTION_MESSAGE) != 0 {
             let (bitcase9, new_remaining) = SelectEventsAuxBitcase9::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase9)
         } else {
             None
         };
-        let bitcase10 = if switch_expr & u32::from(EventType::ACCESS_X_NOTIFY) != 0 {
+        let bitcase10 = if switch_expr & u16::from(EventType::ACCESS_X_NOTIFY) != 0 {
             let (bitcase10, new_remaining) = SelectEventsAuxBitcase10::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase10)
         } else {
             None
         };
-        let bitcase11 = if switch_expr & u32::from(EventType::EXTENSION_DEVICE_NOTIFY) != 0 {
+        let bitcase11 = if switch_expr & u16::from(EventType::EXTENSION_DEVICE_NOTIFY) != 0 {
             let (bitcase11, new_remaining) = SelectEventsAuxBitcase11::try_parse(outer_remaining)?;
             outer_remaining = new_remaining;
             Some(bitcase11)
@@ -6289,7 +6289,7 @@ impl SelectEventsAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, affect_which: u16, clear: u16, select_all: u16) {
-        assert_eq!(self.switch_expr(), u32::from(affect_which) & ((!u32::from(clear)) & (!u32::from(select_all))), "switch `details` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u16::from(affect_which) & ((!u16::from(clear)) & (!u16::from(select_all))), "switch `details` has an inconsistent discriminant");
         if let Some(ref bitcase1) = self.bitcase1 {
             bitcase1.serialize_into(bytes);
         }
@@ -6326,40 +6326,40 @@ impl SelectEventsAux {
     }
 }
 impl SelectEventsAux {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u16 {
         let mut expr_value = 0;
         if self.bitcase1.is_some() {
-            expr_value |= u32::from(EventType::NEW_KEYBOARD_NOTIFY);
+            expr_value |= u16::from(EventType::NEW_KEYBOARD_NOTIFY);
         }
         if self.bitcase2.is_some() {
-            expr_value |= u32::from(EventType::STATE_NOTIFY);
+            expr_value |= u16::from(EventType::STATE_NOTIFY);
         }
         if self.bitcase3.is_some() {
-            expr_value |= u32::from(EventType::CONTROLS_NOTIFY);
+            expr_value |= u16::from(EventType::CONTROLS_NOTIFY);
         }
         if self.bitcase4.is_some() {
-            expr_value |= u32::from(EventType::INDICATOR_STATE_NOTIFY);
+            expr_value |= u16::from(EventType::INDICATOR_STATE_NOTIFY);
         }
         if self.bitcase5.is_some() {
-            expr_value |= u32::from(EventType::INDICATOR_MAP_NOTIFY);
+            expr_value |= u16::from(EventType::INDICATOR_MAP_NOTIFY);
         }
         if self.bitcase6.is_some() {
-            expr_value |= u32::from(EventType::NAMES_NOTIFY);
+            expr_value |= u16::from(EventType::NAMES_NOTIFY);
         }
         if self.bitcase7.is_some() {
-            expr_value |= u32::from(EventType::COMPAT_MAP_NOTIFY);
+            expr_value |= u16::from(EventType::COMPAT_MAP_NOTIFY);
         }
         if self.bitcase8.is_some() {
-            expr_value |= u32::from(EventType::BELL_NOTIFY);
+            expr_value |= u16::from(EventType::BELL_NOTIFY);
         }
         if self.bitcase9.is_some() {
-            expr_value |= u32::from(EventType::ACTION_MESSAGE);
+            expr_value |= u16::from(EventType::ACTION_MESSAGE);
         }
         if self.bitcase10.is_some() {
-            expr_value |= u32::from(EventType::ACCESS_X_NOTIFY);
+            expr_value |= u16::from(EventType::ACCESS_X_NOTIFY);
         }
         if self.bitcase11.is_some() {
-            expr_value |= u32::from(EventType::EXTENSION_DEVICE_NOTIFY);
+            expr_value |= u16::from(EventType::EXTENSION_DEVICE_NOTIFY);
         }
         expr_value
     }
@@ -6442,7 +6442,7 @@ impl<'input> SelectEventsRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let affect_which = u16::try_from(self.details.switch_expr() | (u32::from(self.clear) | u32::from(self.select_all))).unwrap();
+        let affect_which = u16::from(self.details.switch_expr() | (u16::from(self.clear) | u16::from(self.select_all)));
         let affect_which_bytes = affect_which.serialize();
         let clear_bytes = self.clear.serialize();
         let select_all_bytes = self.select_all.serialize();
@@ -8020,7 +8020,7 @@ impl<'input> SetMapRequest<'input> {
     fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let present = u16::try_from(self.values.switch_expr()).unwrap();
+        let present = u16::from(self.values.switch_expr());
         let present_bytes = present.serialize();
         let flags_bytes = self.flags.serialize();
         let min_key_code_bytes = self.min_key_code.serialize();

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -7609,7 +7609,7 @@ pub struct ConfigureWindowAux {
 }
 impl ConfigureWindowAux {
     fn try_parse(value: &[u8], value_mask: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u16::from(value_mask);
+        let switch_expr = value_mask;
         let mut outer_remaining = value;
         let x = if switch_expr & u16::from(ConfigWindow::X) != 0 {
             let remaining = outer_remaining;
@@ -7680,7 +7680,7 @@ impl ConfigureWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u16) {
-        assert_eq!(self.switch_expr(), u16::from(value_mask), "switch `value_list` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
         if let Some(x) = self.x {
             x.serialize_into(bytes);
         }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -7609,9 +7609,9 @@ pub struct ConfigureWindowAux {
 }
 impl ConfigureWindowAux {
     fn try_parse(value: &[u8], value_mask: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = u32::from(value_mask);
+        let switch_expr = u16::from(value_mask);
         let mut outer_remaining = value;
-        let x = if switch_expr & u32::from(ConfigWindow::X) != 0 {
+        let x = if switch_expr & u16::from(ConfigWindow::X) != 0 {
             let remaining = outer_remaining;
             let (x, remaining) = i32::try_parse(remaining)?;
             outer_remaining = remaining;
@@ -7619,7 +7619,7 @@ impl ConfigureWindowAux {
         } else {
             None
         };
-        let y = if switch_expr & u32::from(ConfigWindow::Y) != 0 {
+        let y = if switch_expr & u16::from(ConfigWindow::Y) != 0 {
             let remaining = outer_remaining;
             let (y, remaining) = i32::try_parse(remaining)?;
             outer_remaining = remaining;
@@ -7627,7 +7627,7 @@ impl ConfigureWindowAux {
         } else {
             None
         };
-        let width = if switch_expr & u32::from(ConfigWindow::WIDTH) != 0 {
+        let width = if switch_expr & u16::from(ConfigWindow::WIDTH) != 0 {
             let remaining = outer_remaining;
             let (width, remaining) = u32::try_parse(remaining)?;
             outer_remaining = remaining;
@@ -7635,7 +7635,7 @@ impl ConfigureWindowAux {
         } else {
             None
         };
-        let height = if switch_expr & u32::from(ConfigWindow::HEIGHT) != 0 {
+        let height = if switch_expr & u16::from(ConfigWindow::HEIGHT) != 0 {
             let remaining = outer_remaining;
             let (height, remaining) = u32::try_parse(remaining)?;
             outer_remaining = remaining;
@@ -7643,7 +7643,7 @@ impl ConfigureWindowAux {
         } else {
             None
         };
-        let border_width = if switch_expr & u32::from(ConfigWindow::BORDER_WIDTH) != 0 {
+        let border_width = if switch_expr & u16::from(ConfigWindow::BORDER_WIDTH) != 0 {
             let remaining = outer_remaining;
             let (border_width, remaining) = u32::try_parse(remaining)?;
             outer_remaining = remaining;
@@ -7651,7 +7651,7 @@ impl ConfigureWindowAux {
         } else {
             None
         };
-        let sibling = if switch_expr & u32::from(ConfigWindow::SIBLING) != 0 {
+        let sibling = if switch_expr & u16::from(ConfigWindow::SIBLING) != 0 {
             let remaining = outer_remaining;
             let (sibling, remaining) = Window::try_parse(remaining)?;
             outer_remaining = remaining;
@@ -7659,7 +7659,7 @@ impl ConfigureWindowAux {
         } else {
             None
         };
-        let stack_mode = if switch_expr & u32::from(ConfigWindow::STACK_MODE) != 0 {
+        let stack_mode = if switch_expr & u16::from(ConfigWindow::STACK_MODE) != 0 {
             let remaining = outer_remaining;
             let (stack_mode, remaining) = u32::try_parse(remaining)?;
             let stack_mode = stack_mode.into();
@@ -7680,7 +7680,7 @@ impl ConfigureWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u16) {
-        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
+        assert_eq!(self.switch_expr(), u16::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(x) = self.x {
             x.serialize_into(bytes);
         }
@@ -7705,28 +7705,28 @@ impl ConfigureWindowAux {
     }
 }
 impl ConfigureWindowAux {
-    fn switch_expr(&self) -> u32 {
+    fn switch_expr(&self) -> u16 {
         let mut expr_value = 0;
         if self.x.is_some() {
-            expr_value |= u32::from(ConfigWindow::X);
+            expr_value |= u16::from(ConfigWindow::X);
         }
         if self.y.is_some() {
-            expr_value |= u32::from(ConfigWindow::Y);
+            expr_value |= u16::from(ConfigWindow::Y);
         }
         if self.width.is_some() {
-            expr_value |= u32::from(ConfigWindow::WIDTH);
+            expr_value |= u16::from(ConfigWindow::WIDTH);
         }
         if self.height.is_some() {
-            expr_value |= u32::from(ConfigWindow::HEIGHT);
+            expr_value |= u16::from(ConfigWindow::HEIGHT);
         }
         if self.border_width.is_some() {
-            expr_value |= u32::from(ConfigWindow::BORDER_WIDTH);
+            expr_value |= u16::from(ConfigWindow::BORDER_WIDTH);
         }
         if self.sibling.is_some() {
-            expr_value |= u32::from(ConfigWindow::SIBLING);
+            expr_value |= u16::from(ConfigWindow::SIBLING);
         }
         if self.stack_mode.is_some() {
-            expr_value |= u32::from(ConfigWindow::STACK_MODE);
+            expr_value |= u16::from(ConfigWindow::STACK_MODE);
         }
         expr_value
     }

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -7867,7 +7867,7 @@ impl<'input> ConfigureWindowRequest<'input> {
     fn serialize(self) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
-        let value_mask = u16::try_from(self.value_list.switch_expr()).unwrap();
+        let value_mask = u16::from(self.value_list.switch_expr());
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             CONFIGURE_WINDOW_REQUEST,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -5751,7 +5751,7 @@ impl<'input> CreateWindowRequest<'input> {
         let border_width_bytes = self.border_width.serialize();
         let class_bytes = u16::from(self.class).serialize();
         let visual_bytes = self.visual.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             CREATE_WINDOW_REQUEST,
@@ -6306,7 +6306,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
     fn serialize(self) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             CHANGE_WINDOW_ATTRIBUTES_REQUEST,
@@ -7867,7 +7867,7 @@ impl<'input> ConfigureWindowRequest<'input> {
     fn serialize(self) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
-        let value_mask = u16::from(self.value_list.switch_expr());
+        let value_mask: u16 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             CONFIGURE_WINDOW_REQUEST,
@@ -16267,7 +16267,7 @@ impl<'input> CreateGCRequest<'input> {
         let length_so_far = 0;
         let cid_bytes = self.cid.serialize();
         let drawable_bytes = self.drawable.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             CREATE_GC_REQUEST,
@@ -16932,7 +16932,7 @@ impl<'input> ChangeGCRequest<'input> {
     fn serialize(self) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let gc_bytes = self.gc.serialize();
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             CHANGE_GC_REQUEST,
@@ -23308,7 +23308,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     fn serialize(self) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
-        let value_mask = self.value_list.switch_expr();
+        let value_mask: u32 = self.value_list.switch_expr();
         let value_mask_bytes = value_mask.serialize();
         let mut request0 = vec![
             CHANGE_KEYBOARD_CONTROL_REQUEST,


### PR DESCRIPTION
When sending a request with a `<switch>`, we had code like this in the request's `serialize()` function:
```rust
let value_mask = u16::try_from(self.value_list.switch_expr()).unwrap();
```
This PR makes the code generating `switch_expr()` more intelligent about picking its return type so that the above can use `From` instead of `TryFrom`, removing some `unwrap()`s. This helps with #178.

To pick the right type for `switch_expr()`, the underlying enum is considered. For example, xproto's `ConfigureWindow` request uses an `u16` field for sending the `<switch>`'s discrimimant, thus this PR changes `switch_expr()` to return `u16`.