### PR TITLE
CI: clear the `src/protocol` directory before running the generator

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,8 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
+    - name: Clear src/protocol directory
+      run: rm src/protocol/*
     - name: Run code generator
       run: make
     - name: Check for changes


### PR DESCRIPTION
This would allow to detect if some unwanted garbage got into that directory