### PR TITLE
Add poll for reply functions and poll for queued events.

### DIFF
--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -214,6 +214,21 @@ mod test {
             unimplemented!()
         }
 
+        fn poll_for_reply_or_raw_error(
+            &self,
+            _sequence: SequenceNumber,
+        ) -> Result<Option<ReplyOrError<Self::Buf>>, ConnectionError> {
+            unimplemented!();
+        }
+
+        fn poll_for_reply_with_fds_raw(
+            &self,
+            _sequence: SequenceNumber,
+        ) -> Result<Option<ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>>, ConnectionError>
+        {
+            unimplemented!();
+        }
+
         fn wait_for_reply_or_raw_error(
             &self,
             sequence: SequenceNumber,

--- a/src/xcb_ffi/pending_errors.rs
+++ b/src/xcb_ffi/pending_errors.rs
@@ -32,12 +32,16 @@ impl PendingErrors {
         self.inner.lock().unwrap().in_flight.push(Reverse(sequence));
     }
 
-    pub(crate) fn get(&self, conn: &XCBConnection) -> Option<(SequenceNumber, Buffer)> {
+    pub(crate) fn get(
+        &self,
+        conn: &XCBConnection,
+        queued: bool,
+    ) -> Option<(SequenceNumber, Buffer)> {
         let mut inner = self.inner.lock().unwrap();
 
         // Check if we already have an element at hand
         let err = inner.pending.pop_front();
-        if err.is_some() {
+        if err.is_some() || queued {
             return err;
         }
 

--- a/src/xcb_ffi/raw_ffi/ffi.rs
+++ b/src/xcb_ffi/raw_ffi/ffi.rs
@@ -136,6 +136,7 @@ make_ffi_fn_defs! {
     fn xcb_prefetch_maximum_request_length(c: *mut xcb_connection_t);
     fn xcb_wait_for_event(c: *mut xcb_connection_t) -> *mut xcb_generic_event_t;
     fn xcb_poll_for_event(c: *mut xcb_connection_t) -> *mut xcb_generic_event_t;
+    fn xcb_poll_for_queued_event(c: *mut xcb_connection_t) -> *mut xcb_generic_event_t;
     fn xcb_request_check(
         c: *mut xcb_connection_t,
         void_cookie: xcb_void_cookie_t

--- a/src/xcb_ffi/raw_ffi/test.rs
+++ b/src/xcb_ffi/raw_ffi/test.rs
@@ -38,6 +38,12 @@ pub(crate) unsafe fn xcb_poll_for_event(_c: *mut xcb_connection_t) -> *mut xcb_g
     unimplemented!();
 }
 
+pub(crate) unsafe fn xcb_poll_for_queued_event(
+    _c: *mut xcb_connection_t,
+) -> *mut xcb_generic_event_t {
+    unimplemented!();
+}
+
 pub(crate) unsafe fn xcb_request_check(
     _c: *mut xcb_connection_t,
     _void_cookie: xcb_void_cookie_t,

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -127,6 +127,20 @@ impl RequestConnection for FakeConnection {
         unimplemented!()
     }
 
+    fn poll_for_reply_or_raw_error(
+        &self,
+        _sequence: SequenceNumber,
+    ) -> Result<Option<ReplyOrError<Vec<u8>>>, ConnectionError> {
+        unimplemented!();
+    }
+
+    fn poll_for_reply_with_fds_raw(
+        &self,
+        _sequence: SequenceNumber,
+    ) -> Result<Option<ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>>, ConnectionError> {
+        unimplemented!();
+    }
+
     fn wait_for_reply_with_fds_raw(
         &self,
         _sequence: SequenceNumber,

--- a/tests/resource_manager.rs
+++ b/tests/resource_manager.rs
@@ -226,6 +226,20 @@ mod test {
             unimplemented!()
         }
 
+        fn poll_for_reply_or_raw_error(
+            &self,
+            _sequence: SequenceNumber,
+        ) -> Result<Option<ReplyOrError<Self::Buf>>, ConnectionError> {
+            unimplemented!()
+        }
+
+        fn poll_for_reply_with_fds_raw(
+            &self,
+            _sequence: SequenceNumber,
+        ) -> Result<Option<ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>>, ConnectionError> {
+            unimplemented!()
+        }
+
         fn check_for_raw_error(
             &self,
             _: SequenceNumber,
@@ -258,6 +272,12 @@ mod test {
         }
 
         fn poll_for_raw_event_with_sequence(
+            &self,
+        ) -> Result<Option<RawEventAndSeqNumber<Self::Buf>>, ConnectionError> {
+            unimplemented!()
+        }
+
+        fn poll_for_queued_raw_event_with_sequence(
             &self,
         ) -> Result<Option<RawEventAndSeqNumber<Self::Buf>>, ConnectionError> {
             unimplemented!()


### PR DESCRIPTION
Hey, I wanted to know what it would look like to integrate cookie reply polling and dispatching into event loop and I have been wondering whether these are the kind of changes that would be needed in x11rb. Poll for queued events is there because it seemed to be the only way to ensure with libxcb that both reply and event queues have been emptied. Is there any interest in this kind of functionality or could I get better pointers about how using both event and reply polling in event loop should be done? I'm not sure how useful this functionality is either as I didn't find examples of how to do it.

Gotchas/TODO:
* I have been looking at XcbConnection mainly.
* Polling replies with rust connection does not read from socket (yet). Though I think it would be better if it didn't. If I understood correctly, in libxcb both poll_for_events and poll_for_reply read in events and replies from the socket which seems to make it hard to ensure that queues for both are empty. So complicated that I think I must have missed something (I'm trying it [here](https://github.com/user827/xaskpass/blob/37d22fa5399a9f36dccfc9a795332518bb2efd7f/src/event.rs#L226])).
* I haven't implemented a version of poll_for_reply similar to wait_for_reply where the errors are left in the event loop. I'm not sure if it would even be useful as a polled version.
* With these functions it isn't possible to know if there are still any errors from discarded replies left in queue when ending a cycle. Isn't that how it has been with poll_for_event always though?