### PR TITLE
Fix with clippy 1.57

### DIFF
--- a/examples/simple_window_manager.rs
+++ b/examples/simple_window_manager.rs
@@ -24,7 +24,6 @@ struct WindowState {
     x: i16,
     y: i16,
     width: u16,
-    height: u16,
 }
 
 impl WindowState {
@@ -35,7 +34,6 @@ impl WindowState {
             x: geom.x,
             y: geom.y,
             width: geom.width,
-            height: geom.height,
         }
     }
 

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -493,7 +493,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         self,
                         field,
                         &HashMap::new(),
-                        |field| to_rust_variable_name(field),
+                        to_rust_variable_name,
                         &mut result_bytes,
                         out,
                     );

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -666,7 +666,7 @@ fn emit_fixed_size_switch_serialize(
                                         generator,
                                         field,
                                         &deducible_fields,
-                                        |field| to_rust_variable_name(field),
+                                        to_rust_variable_name,
                                         &mut result_bytes,
                                         out,
                                     );
@@ -729,7 +729,7 @@ fn emit_fixed_size_switch_serialize(
                                     generator,
                                     field,
                                     &deducible_fields,
-                                    |field| to_rust_variable_name(field),
+                                    to_rust_variable_name,
                                     "bytes",
                                     out,
                                 );
@@ -847,7 +847,7 @@ fn emit_variable_size_switch_serialize(
                                         generator,
                                         field,
                                         &deducible_fields,
-                                        |field| to_rust_variable_name(field),
+                                        to_rust_variable_name,
                                         "bytes",
                                         out,
                                     );
@@ -920,7 +920,7 @@ fn emit_variable_size_switch_serialize(
                                             generator,
                                             field,
                                             &deducible_fields,
-                                            |field| to_rust_variable_name(field),
+                                            to_rust_variable_name,
                                             "bytes",
                                             out,
                                         );

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -16,31 +16,31 @@ mod generator;
 #[derive(Debug)]
 enum Error {
     FileReadFailed {
-        path: PathBuf,
+        _path: PathBuf,
         _error: std::io::Error,
     },
     FileWriteFailed {
-        path: PathBuf,
+        _path: PathBuf,
         _error: std::io::Error,
     },
     DirOpenFailed {
-        path: PathBuf,
+        _path: PathBuf,
         _error: std::io::Error,
     },
     DirReadFailed {
-        path: PathBuf,
+        _path: PathBuf,
         _error: std::io::Error,
     },
     FileIsNotUtf8 {
-        path: PathBuf,
+        _path: PathBuf,
         _error: std::str::Utf8Error,
     },
     XmlParseFailed {
-        path: PathBuf,
+        _path: PathBuf,
         _error: roxmltree::Error,
     },
     XcbParseFailed {
-        path: PathBuf,
+        _path: PathBuf,
         _error: xcbgen::ParseError,
     },
     XcbResolveFailed {
@@ -51,12 +51,12 @@ enum Error {
 fn list_xmls(dir_path: &Path) -> Result<Vec<PathBuf>, Error> {
     let mut files = Vec::new();
     let dir_reader = std::fs::read_dir(dir_path).map_err(|e| Error::DirOpenFailed {
-        path: dir_path.to_path_buf(),
+        _path: dir_path.to_path_buf(),
         _error: e,
     })?;
     for entry in dir_reader {
         let entry = entry.map_err(|e| Error::DirReadFailed {
-            path: dir_path.to_path_buf(),
+            _path: dir_path.to_path_buf(),
             _error: e,
         })?;
         let file_path = entry.path();
@@ -70,21 +70,21 @@ fn list_xmls(dir_path: &Path) -> Result<Vec<PathBuf>, Error> {
 
 fn load_namespace(path: &Path, parser: &mut xcbgen::Parser) -> Result<(), Error> {
     let file_bytes = std::fs::read(path).map_err(|e| Error::FileReadFailed {
-        path: path.to_path_buf(),
+        _path: path.to_path_buf(),
         _error: e,
     })?;
     let file_string = String::from_utf8(file_bytes).map_err(|e| Error::FileIsNotUtf8 {
-        path: path.to_path_buf(),
+        _path: path.to_path_buf(),
         _error: e.utf8_error(),
     })?;
     let xml_doc = roxmltree::Document::parse(&file_string).map_err(|e| Error::XmlParseFailed {
-        path: path.to_path_buf(),
+        _path: path.to_path_buf(),
         _error: e,
     })?;
     parser
         .parse_namespace(xml_doc.root().first_element_child().unwrap())
         .map_err(|e| Error::XcbParseFailed {
-            path: path.to_path_buf(),
+            _path: path.to_path_buf(),
             _error: e,
         })?;
     Ok(())
@@ -96,7 +96,7 @@ fn load_namespace(path: &Path, parser: &mut xcbgen::Parser) -> Result<(), Error>
 fn replace_file_if_different(file_path: &Path, data: &[u8]) -> Result<(), Error> {
     if file_path.exists() {
         let existing_data = std::fs::read(file_path).map_err(|e| Error::FileReadFailed {
-            path: file_path.to_path_buf(),
+            _path: file_path.to_path_buf(),
             _error: e,
         })?;
         if existing_data == data {
@@ -105,7 +105,7 @@ fn replace_file_if_different(file_path: &Path, data: &[u8]) -> Result<(), Error>
     }
 
     std::fs::write(file_path, data).map_err(|e| Error::FileWriteFailed {
-        path: file_path.to_path_buf(),
+        _path: file_path.to_path_buf(),
         _error: e,
     })?;
 

--- a/src/cursor/find_cursor.rs
+++ b/src/cursor/find_cursor.rs
@@ -223,7 +223,6 @@ pub(crate) fn find_cursor(theme: &str, name: &str) -> Result<Cursor<File>, Error
         "~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons".into()
     });
     let open_cursor = |file: &Path| File::open(file);
-    let parse_inherits = |file: &Path| parse_inherits(file);
     find_cursor_impl(
         &home,
         &cursor_path,

--- a/src/resource_manager/parser.rs
+++ b/src/resource_manager/parser.rs
@@ -308,9 +308,12 @@ mod test {
         ];
         for data in tests.iter() {
             let result = parse_query(*data);
-            if result.is_some() {
-                panic!("Unexpected success parsing '{:?}': {:?}", data, result);
-            }
+            assert!(
+                result.is_none(),
+                "Unexpected success parsing '{:?}': {:?}",
+                data,
+                result,
+            );
         }
     }
 

--- a/src/rust_connection/inner.rs
+++ b/src/rust_connection/inner.rs
@@ -205,15 +205,14 @@ impl ConnectionInner {
             let fds = if request.filter(|r| r.has_fds).is_some() {
                 // This reply has FDs, the number of FDs is always in the second byte
                 let num_fds = usize::from(packet[1]);
-                if num_fds > self.pending_fds.len() {
-                    // FIXME Turn this into some kind of "permanent error state" (so that
-                    // everything fails with said error) instead of using a panic (this panic will
-                    // likely poison some Mutex and produce an error state that way).
-                    panic!(
-                        "FIXME: The server sent us too few FDs. The connection is now unusable \
-                         since we will never be sure again which FD belongs to which reply."
-                    );
-                }
+                // FIXME Turn this into some kind of "permanent error state" (so that
+                // everything fails with said error) instead of using a panic (this panic will
+                // likely poison some Mutex and produce an error state that way).
+                assert!(
+                    num_fds <= self.pending_fds.len(),
+                    "FIXME: The server sent us too few FDs. The connection is now unusable \
+                     since we will never be sure again which FD belongs to which reply."
+                );
                 self.pending_fds.drain(..num_fds).collect()
             } else {
                 Vec::new()

--- a/src/xcb_ffi/raw_ffi/test.rs
+++ b/src/xcb_ffi/raw_ffi/test.rs
@@ -77,9 +77,11 @@ pub(crate) unsafe fn xcb_connect(
     screenp: *mut c_int,
 ) -> *mut xcb_connection_t {
     // Test that the provided displayname is correct
-    if CStr::from_ptr(displayname).to_str().unwrap() != "display name" {
-        panic!("Did not get the expected displayname");
-    }
+    assert_eq!(
+        CStr::from_ptr(displayname).to_str().unwrap(),
+        "display name",
+        "Did not get the expected displayname",
+    );
     std::ptr::write(screenp, 0);
 
     let length_field = 10;

--- a/tests/resource_manager.rs
+++ b/tests/resource_manager.rs
@@ -66,9 +66,7 @@ mod test {
                 errors += 1;
             }
         }
-        if errors != 0 {
-            panic!("Had {} errors", errors);
-        }
+        assert_eq!(errors, 0, "Had {} errors", errors);
     }
 
     #[test]


### PR DESCRIPTION
This fixes the following complaint from clippy:

error: only a `panic!` in `if`-then statement
   --> src/rust_connection/inner.rs:208:17
    |
208 | /                 if num_fds > self.pending_fds.len() {
209 | |                     // FIXME Turn this into some kind of "permanent error state" (so that
210 | |                     // everything fails with said error) instead of using a panic (this panic will
211 | |                     // likely poison some Mutex and produce an error state that way).
...   |
215 | |                     );
216 | |                 }
    | |_________________^
    |
    = note: `-D clippy::if-then-panic` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_then_panic
help: try
    |
208 ~                 assert!(!(num_fds > self.pending_fds.len()), "FIXME: The server sent us too few FDs. The connection is now unusable \
209 +                          since we will never be sure again which FD belongs to which reply.");
    |

Signed-off-by: Uli Schlachter <psychon@znc.in>