### PR TITLE
Restrict xtrace-example to older futures version

### DIFF
--- a/xtrace-example/Cargo.toml
+++ b/xtrace-example/Cargo.toml
@@ -14,10 +14,10 @@ path = "../"
 features = ["all-extensions"]
 
 [dependencies.futures-util]
-version = "0.3"
+version = ">= 0.3.0, <= 0.3.17"
 default-features = false
 features = ["async-await", "async-await-macro", "io", "std"]
 
 [dependencies.futures-io]
-version = "0.3"
+version = ">= 0.3.0, <= 0.3.17"
 default-features = false


### PR DESCRIPTION
A week ago, futures 0.3.18 was released and apparently this does not
work with Rust 1.41.0:
```
   Compiling xtrace-example v0.0.0 (/home/runner/work/x11rb/x11rb/xtrace-example)
     Running `rustc --edition=2018 --crate-name xtrace_example xtrace-example/src/main.rs --error-format=json --json=diagnostic-rendered-ansi --emit=dep-info,link -C debuginfo=2 --test -C metadata=516abdc358c39888 -C extra-filename=-516abdc358c39888 --out-dir /home/runner/work/x11rb/x11rb/target/debug/deps -C incremental=/home/runner/work/x11rb/x11rb/target/debug/incremental -L dependency=/home/runner/work/x11rb/x11rb/target/debug/deps --extern futures_io=/home/runner/work/x11rb/x11rb/target/debug/deps/libfutures_io-3756b09c8a44e206.rlib --extern futures_util=/home/runner/work/x11rb/x11rb/target/debug/deps/libfutures_util-411815ec4958698e.rlib --extern smol=/home/runner/work/x11rb/x11rb/target/debug/deps/libsmol-b079add982015d84.rlib --extern x11rb=/home/runner/work/x11rb/x11rb/target/debug/deps/libx11rb-768ac55e45ccd24c.rlib`
error[E0658]: procedural macros cannot be expanded to statements
  --> xtrace-example/src/main.rs:90:5
   |
90 |     futures_util::try_join!(future1, future2)?;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```
See https://github.com/psychon/x11rb/runs/4375081831

Signed-off-by: Uli Schlachter <psychon@znc.in>