### PR TITLE
Remove `string_len` field documentation from `image_text8` function

### DIFF
--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -667,7 +667,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             };
 
         if let Some(ref doc) = enum_def.doc {
-            self.emit_doc(doc, out);
+            self.emit_doc(doc, out, None);
         }
 
         outln!(out, "#[derive(Clone, Copy, PartialEq, Eq)]");
@@ -996,7 +996,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         }
     }
 
-    fn emit_doc(&self, doc: &xcbdefs::Doc, out: &mut Output) {
+    fn emit_doc(&self, doc: &xcbdefs::Doc, out: &mut Output, deducible_fields: Option<&HashMap<String, DeducibleField>>) {
         let mut has_doc = false;
         if let Some(ref brief) = doc.brief {
             outln!(out, "/// {}.", brief);
@@ -1023,6 +1023,9 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             outln!(out, "/// # Fields");
             outln!(out, "///");
             for field in doc.fields.iter() {
+                if deducible_fields.map(|deducible_fields| deducible_fields.contains_key(&field.name)).unwrap_or(false) {
+                    continue;
+                }
                 let text = format!(
                     " * `{}` - {}",
                     field.name,

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -996,7 +996,12 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         }
     }
 
-    fn emit_doc(&self, doc: &xcbdefs::Doc, out: &mut Output, deducible_fields: Option<&HashMap<String, DeducibleField>>) {
+    fn emit_doc(
+        &self,
+        doc: &xcbdefs::Doc,
+        out: &mut Output,
+        deducible_fields: Option<&HashMap<String, DeducibleField>>,
+    ) {
         let mut has_doc = false;
         if let Some(ref brief) = doc.brief {
             outln!(out, "/// {}.", brief);
@@ -1023,7 +1028,10 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             outln!(out, "/// # Fields");
             outln!(out, "///");
             for field in doc.fields.iter() {
-                if deducible_fields.map(|deducible_fields| deducible_fields.contains_key(&field.name)).unwrap_or(false) {
+                if deducible_fields
+                    .map(|deducible_fields| deducible_fields.contains_key(&field.name))
+                    .unwrap_or(false)
+                {
                     continue;
                 }
                 let text = format!(

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -386,7 +386,7 @@ fn emit_request_struct(
     let is_send_event = is_xproto && request_def.name == "SendEvent";
 
     if let Some(ref doc) = request_def.doc {
-        generator.emit_doc(doc, out, Some(&deducible_fields));
+        generator.emit_doc(doc, out, Some(deducible_fields));
     }
 
     let mut derives = Derives::all();

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -386,7 +386,7 @@ fn emit_request_struct(
     let is_send_event = is_xproto && request_def.name == "SendEvent";
 
     if let Some(ref doc) = request_def.doc {
-        generator.emit_doc(doc, out);
+        generator.emit_doc(doc, out, Some(&deducible_fields));
     }
 
     let mut derives = Derives::all();
@@ -1160,7 +1160,7 @@ fn emit_request_function(
     }
 
     if let Some(ref doc) = request_def.doc {
-        generator.emit_doc(doc, out);
+        generator.emit_doc(doc, out, None);
     }
     outln!(
         out,
@@ -1271,7 +1271,7 @@ fn emit_request_trait_function(
     };
 
     if let Some(ref doc) = request_def.doc {
-        generator.emit_doc(doc, out);
+        generator.emit_doc(doc, out, Default::default());
     }
     outln!(
         out,

--- a/generator/src/generator/namespace/struct_type.rs
+++ b/generator/src/generator/namespace/struct_type.rs
@@ -39,7 +39,7 @@ pub(super) fn emit_struct_type(
     );
 
     if let Some(doc) = doc {
-        generator.emit_doc(doc, out);
+        generator.emit_doc(doc, out, Some(&deducible_fields));
     }
     let derives = derives.to_list();
     if !derives.is_empty() {

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -6282,7 +6282,6 @@ pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// # Fields
 ///
 /// * `window` - The window to change.
-/// * `value_mask` -
 /// * `value_list` - Values for each of the attributes specified in the bitmask `value_mask`. The
 /// order has to correspond to the order of possible `value_mask` bits. See the
 /// example.
@@ -7814,7 +7813,6 @@ pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 /// # Fields
 ///
 /// * `window` - The window to configure.
-/// * `value_mask` - Bitmask of attributes to change.
 /// * `value_list` - New values, corresponding to the attributes in value_mask. The order has to
 /// correspond to the order of possible `value_mask` bits. See the example.
 ///
@@ -8477,7 +8475,6 @@ where
 ///
 /// * `root` - The root window of `window`.
 /// * `parent` - The parent window of `window`.
-/// * `children_len` - The number of child windows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryTreeReply {
     pub sequence: u16,
@@ -8538,7 +8535,6 @@ pub const INTERN_ATOM_REQUEST: u8 = 16;
 ///
 /// # Fields
 ///
-/// * `name_len` - The length of the following `name`.
 /// * `name` - The name of the atom.
 /// * `only_if_exists` - Return a valid atom id only if the atom already exists.
 ///
@@ -13637,7 +13633,6 @@ pub const OPEN_FONT_REQUEST: u8 = 45;
 /// # Fields
 ///
 /// * `fid` - The ID with which you will refer to the font, created by `xcb_generate_id`.
-/// * `name_len` - Length (in bytes) of `name`.
 /// * `name` - A pattern describing an X core font.
 ///
 /// # Errors
@@ -14047,7 +14042,6 @@ where
 /// * `min_char_or_byte2` - first character
 /// * `max_char_or_byte2` - last character
 /// * `default_char` - char to print for undefined character
-/// * `properties_len` - how many properties there are
 /// * `all_chars_exist` - flag if all characters have nonzero size
 /// * `font_ascent` - baseline to top edge of raster
 /// * `font_descent` - baseline to bottom edge of raster
@@ -14385,7 +14379,6 @@ pub const LIST_FONTS_REQUEST: u8 = 49;
 ///
 /// # Fields
 ///
-/// * `pattern_len` - The length (in bytes) of `pattern`.
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
 /// The asterisk (*) is a wildcard for any number of characters. The question mark
@@ -14485,7 +14478,6 @@ where
 
 /// # Fields
 ///
-/// * `names_len` - The number of font names.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListFontsReply {
     pub sequence: u16,
@@ -14536,7 +14528,6 @@ pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
 ///
 /// # Fields
 ///
-/// * `pattern_len` - The length (in bytes) of `pattern`.
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
 /// The asterisk (*) is a wildcard for any number of characters. The question mark
@@ -14636,13 +14627,11 @@ where
 
 /// # Fields
 ///
-/// * `name_len` - The number of matched font names.
 /// * `min_bounds` - minimum bounds over all existing char
 /// * `max_bounds` - maximum bounds over all existing char
 /// * `min_char_or_byte2` - first character
 /// * `max_char_or_byte2` - last character
 /// * `default_char` - char to print for undefined character
-/// * `properties_len` - how many properties there are
 /// * `all_chars_exist` - flag if all characters have nonzero size
 /// * `font_ascent` - baseline to top edge of raster
 /// * `font_descent` - baseline to bottom edge of raster
@@ -16884,7 +16873,6 @@ pub const CHANGE_GC_REQUEST: u8 = 56;
 /// # Fields
 ///
 /// * `gc` - The graphics context to change.
-/// * `value_mask` -
 /// * `value_list` - Values for each of the components specified in the bitmask `value_mask`. The
 /// order has to correspond to the order of possible `value_mask` bits. See the
 /// example.
@@ -19580,8 +19568,6 @@ pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 /// # Fields
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
-/// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
-/// using 8 bits!
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
 /// type of `string_len`.
 /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
@@ -19753,8 +19739,6 @@ pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 /// # Fields
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
-/// * `string_len` - The length of the `string` in characters. Note that this parameter limited by
-/// 255 due to using 8 bits!
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
 /// type of `string_len`. Every character uses 2 bytes (hence the 16 in this
 /// request's name).
@@ -22502,7 +22486,6 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 ///
 /// # Fields
 ///
-/// * `name_len` - The length of `name` in bytes.
 /// * `name` - The name of the extension to query, for example "RANDR". This is case
 /// sensitive!
 ///
@@ -27238,6 +27221,8 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
+    /// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
+    /// using 8 bits!
     /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
     /// type of `string_len`.
     /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -27238,8 +27238,6 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
-    /// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
-    /// using 8 bits!
     /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
     /// type of `string_len`.
     /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.


### PR DESCRIPTION
A minor change to `image_text8` function documentation.

Currently, this function accept a `&[u8]` as input and calculate the length internally, so we should remove the `string_len` field from the function documentation to avoid confusion.