### PR TITLE
Add xcb-dl to comparison

### DIFF
--- a/doc/comparison.md
+++ b/doc/comparison.md
@@ -53,6 +53,18 @@ dereference](https://github.com/rtbo/rust-xcb/issues/64) and re-discovered an
 already known [leak](https://github.com/rtbo/rust-xcb/issues/57).
 
 
+## xcb-dl
+
+The [xcb-dl](https://github.com/mahkoh/xcb-dl) project seems to be similar to
+rust-xcb: It provides FFI bindings to the libxcb C library. It uses the XML
+description to generate this binding and the necessary types. It thus also has
+many instances of `unsafe` and requires `unsafe` for using it.
+
+The big difference to rust-xcb is that this library uses the libloading crate to
+dynamically load function pointers at runtime instead of linking at compile
+time.
+
+
 ## rust-xcbalt
 
 The [alternative Rust wrappers for


### PR DESCRIPTION
@mahkoh Hi,

first, sorry for being wrong in https://github.com/maroider/winit/pull/6#issuecomment-1001044953. The bug that I thought I saw there does not exist. I edited this comment to remove this part.

I took a quick look at xcb-dl. This PR adds it to the comparison file that x11rb has laying around. I don't really know what to say about xcb-dl, but it seems similar to the rust-xcb with the big feature being lazy loading (as mentioned in xcb-dl's README). Do you think I am missing something or do you have some suggestions for what else should be changed here?

Thanks!
