### PR TITLE
Add #[must_use] to switches

### DIFF
--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -126,6 +126,7 @@ pub(super) fn emit_switch_type(
     if !derives.is_empty() {
         outln!(out, "#[derive({})]", derives.join(", "));
     }
+    outln!(out, "#[must_use]");
 
     if switch.kind == xcbdefs::SwitchKind::BitCase {
         outln!(out, "pub struct {} {{", name);

--- a/src/protocol/render.rs
+++ b/src/protocol/render.rs
@@ -1582,6 +1582,7 @@ impl QueryPictIndexValuesReply {
 
 /// Auxiliary and optional information for the `create_picture` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct CreatePictureAux {
     pub repeat: Option<Repeat>,
     pub alphamap: Option<Picture>,
@@ -1984,6 +1985,7 @@ where
 
 /// Auxiliary and optional information for the `change_picture` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct ChangePictureAux {
     pub repeat: Option<Repeat>,
     pub alphamap: Option<Picture>,

--- a/src/protocol/screensaver.rs
+++ b/src/protocol/screensaver.rs
@@ -487,6 +487,7 @@ where
 
 /// Auxiliary and optional information for the `set_attributes` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct SetAttributesAux {
     pub background_pixmap: Option<xproto::Pixmap>,
     pub background_pixel: Option<u32>,

--- a/src/protocol/sync.rs
+++ b/src/protocol/sync.rs
@@ -1105,6 +1105,7 @@ where
 
 /// Auxiliary and optional information for the `create_alarm` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct CreateAlarmAux {
     pub counter: Option<Counter>,
     pub value_type: Option<VALUETYPE>,
@@ -1345,6 +1346,7 @@ where
 
 /// Auxiliary and optional information for the `change_alarm` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct ChangeAlarmAux {
     pub counter: Option<Counter>,
     pub value_type: Option<VALUETYPE>,

--- a/src/protocol/xinput.rs
+++ b/src/protocol/xinput.rs
@@ -729,6 +729,7 @@ impl InputInfoInfoValuator {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum InputInfoInfo {
     Key(InputInfoInfoKey),
     Button(InputInfoInfoButton),
@@ -3952,6 +3953,7 @@ impl Serialize for FeedbackStateDataBell {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum FeedbackStateData {
     Keyboard(FeedbackStateDataKeyboard),
     Pointer(FeedbackStateDataPointer),
@@ -4835,6 +4837,7 @@ impl Serialize for FeedbackCtlDataBell {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum FeedbackCtlData {
     Keyboard(FeedbackCtlDataKeyboard),
     Pointer(FeedbackCtlDataPointer),
@@ -6239,6 +6242,7 @@ impl InputStateDataValuator {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum InputStateData {
     Key(InputStateDataKey),
     Button(InputStateDataButton),
@@ -7267,6 +7271,7 @@ impl Serialize for DeviceStateDataAbsArea {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum DeviceStateData {
     Resolution(DeviceStateDataResolution),
     AbsCalib(DeviceStateDataAbsCalib),
@@ -8064,6 +8069,7 @@ impl Serialize for DeviceCtlDataAbsArea {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum DeviceCtlData {
     Resolution(DeviceCtlDataResolution),
     AbsCalib(DeviceCtlDataAbsCalib),
@@ -8488,6 +8494,7 @@ impl std::fmt::Debug for PropertyFormat  {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum ChangeDevicePropertyAux {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -8893,6 +8900,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum GetDevicePropertyItems {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -9998,6 +10006,7 @@ impl Serialize for HierarchyChangeDataDetachSlave {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum HierarchyChangeData {
     AddMaster(HierarchyChangeDataAddMaster),
     RemoveMaster(HierarchyChangeDataRemoveMaster),
@@ -11570,6 +11579,7 @@ impl Serialize for DeviceClassDataTouch {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum DeviceClassData {
     Key(DeviceClassDataKey),
     Button(DeviceClassDataButton),
@@ -13198,6 +13208,7 @@ impl XIListPropertiesReply {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum XIChangePropertyAux {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -13608,6 +13619,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum XIGetPropertyItems {
     Data8(Vec<u8>),
     Data16(Vec<u16>),

--- a/src/protocol/xkb.rs
+++ b/src/protocol/xkb.rs
@@ -6183,6 +6183,7 @@ impl Serialize for SelectEventsAuxBitcase11 {
 }
 /// Auxiliary and optional information for the `select_events` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct SelectEventsAux {
     pub bitcase1: Option<SelectEventsAuxBitcase1>,
     pub bitcase2: Option<SelectEventsAuxBitcase2>,
@@ -7566,6 +7567,7 @@ impl GetMapMapBitcase3 {
     }
 }
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct GetMapMap {
     pub types_rtrn: Option<Vec<KeyType>>,
     pub syms_rtrn: Option<Vec<KeySymMap>>,
@@ -7777,6 +7779,7 @@ impl SetMapAuxBitcase3 {
 }
 /// Auxiliary and optional information for the `set_map` function
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct SetMapAux {
     pub types: Option<Vec<SetKeyType>>,
     pub syms: Option<Vec<KeySymMap>>,
@@ -9181,6 +9184,7 @@ impl GetNamesValueListBitcase8 {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[must_use]
 pub struct GetNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -9403,6 +9407,7 @@ impl SetNamesAuxBitcase8 {
 }
 /// Auxiliary and optional information for the `set_names` function
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[must_use]
 pub struct SetNamesAux {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -10341,6 +10346,7 @@ impl GetKbdByNameRepliesTypesMapBitcase3 {
     }
 }
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct GetKbdByNameRepliesTypesMap {
     pub types_rtrn: Option<Vec<KeyType>>,
     pub syms_rtrn: Option<Vec<KeySymMap>>,
@@ -10614,6 +10620,7 @@ impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[must_use]
 pub struct GetKbdByNameRepliesKeyNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -10838,6 +10845,7 @@ impl TryParse for GetKbdByNameRepliesGeometry {
     }
 }
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct GetKbdByNameReplies {
     pub types: Option<GetKbdByNameRepliesTypes>,
     pub compat_map: Option<GetKbdByNameRepliesCompatMap>,

--- a/src/protocol/xproto.rs
+++ b/src/protocol/xproto.rs
@@ -5330,6 +5330,7 @@ impl std::fmt::Debug for Gravity  {
 
 /// Auxiliary and optional information for the `create_window` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct CreateWindowAux {
     pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
@@ -5936,6 +5937,7 @@ where
 
 /// Auxiliary and optional information for the `change_window_attributes` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct ChangeWindowAttributesAux {
     pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
@@ -7597,6 +7599,7 @@ impl std::fmt::Debug for StackMode  {
 
 /// Auxiliary and optional information for the `configure_window` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct ConfigureWindowAux {
     pub x: Option<i32>,
     pub y: Option<i32>,
@@ -15717,6 +15720,7 @@ impl std::fmt::Debug for ArcMode  {
 
 /// Auxiliary and optional information for the `create_gc` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct CreateGCAux {
     pub function: Option<GX>,
     pub plane_mask: Option<u32>,
@@ -16362,6 +16366,7 @@ where
 
 /// Auxiliary and optional information for the `change_gc` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct ChangeGCAux {
     pub function: Option<GX>,
     pub plane_mask: Option<u32>,
@@ -23085,6 +23090,7 @@ impl std::fmt::Debug for AutoRepeatMode  {
 
 /// Auxiliary and optional information for the `change_keyboard_control` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[must_use]
 pub struct ChangeKeyboardControlAux {
     pub key_click_percent: Option<i32>,
     pub bell_percent: Option<i32>,


### PR DESCRIPTION
Switches just contain values and have no side effects. Thus, building a
value of this type and not using it makes no sense.

Also, this fixes a clippy warning:

error: missing `#[must_use]` attribute on a method returning `Self`
    --> src/protocol/xproto.rs:5649:5
     |
5649 | /     pub fn event_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
5650 | |         self.event_mask = value.into();
5651 | |         self
5652 | |     }
     | |_____^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use

Fixes: https://github.com/psychon/x11rb/issues/652
Signed-off-by: Uli Schlachter <psychon@znc.in>