### PR TITLE
Silence a clippy warning from v1.59

### DIFF
--- a/generator/src/generator/requests_replies.rs
+++ b/generator/src/generator/requests_replies.rs
@@ -68,7 +68,7 @@ pub(super) fn generate(out: &mut Output, module: &xcbdefs::Module, mut enum_case
                 out,
                 "// Might not be used if none of the extensions that use FD passing is enabled",
             );
-            outln!(out, "#[allow(unused_variables)]");
+            outln!(out, "#[allow(unused_variables, clippy::ptr_arg)]");
             outln!(out, "fds: &mut Vec<RawFdContainer>,");
             outln!(out, "ext_info_provider: &dyn ExtInfoProvider,");
         });

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1271,7 +1271,7 @@ impl<'input> Request<'input> {
         header: RequestHeader,
         body: &'input [u8],
         // Might not be used if none of the extensions that use FD passing is enabled
-        #[allow(unused_variables)]
+        #[allow(unused_variables, clippy::ptr_arg)]
         fds: &mut Vec<RawFdContainer>,
         ext_info_provider: &dyn ExtInfoProvider,
     ) -> Result<Self, ParseError> {


### PR DESCRIPTION
When building without features, this variable is unused and clippy wants to
change the argument type, but that's only possible because of the disabled
features, thus we cannot do that.
```
error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
    --> src/protocol/mod.rs:1275:14
     |
1275 |         fds: &mut Vec<RawFdContainer>,
     |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&mut [RawFdContainer]`
     |
     = note: `-D clippy::ptr-arg` implied by `-D warnings`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
```
Signed-off-by: Uli Schlachter <psychon@znc.in>