### PR TITLE
Add special event queues to the protocol crate

### DIFF
--- a/x11rb-protocol/src/connection/mod.rs
+++ b/x11rb-protocol/src/connection/mod.rs
@@ -4,8 +4,8 @@ use std::collections::{HashMap, VecDeque};
 use std::error::Error as StdError;
 use std::fmt;
 
-use crate::utils::RawFdContainer;
 use crate::protocol::xproto::GE_GENERIC_EVENT;
+use crate::utils::RawFdContainer;
 use crate::{DiscardMode, SequenceNumber};
 
 pub type BufWithFds = crate::BufWithFds<Vec<u8>>;
@@ -339,21 +339,31 @@ impl Connection {
     }
 
     /// Initialize a special event queue.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// If a special event queue with the same EID was initialized earlier, this
     /// function returns [`QueueAlreadyInitialized`].
-    pub fn initialize_special_event_queue(&mut self, queue_id: u32) -> Result<(), QueueAlreadyInitialized> {
-        if self.pending_special_events.insert(queue_id, VecDeque::new()).is_some() {
-           Err(QueueAlreadyInitialized(queue_id))
+    pub fn initialize_special_event_queue(
+        &mut self,
+        queue_id: u32,
+    ) -> Result<(), QueueAlreadyInitialized> {
+        if self
+            .pending_special_events
+            .insert(queue_id, VecDeque::new())
+            .is_some()
+        {
+            Err(QueueAlreadyInitialized(queue_id))
         } else {
             Ok(())
         }
     }
 
     /// Pop an event from a special event queue.
-    pub fn poll_for_special_event_with_sequence(&mut self, queue_id: u32) -> Option<RawEventAndSeqNumber> {
+    pub fn poll_for_special_event_with_sequence(
+        &mut self,
+        queue_id: u32,
+    ) -> Option<RawEventAndSeqNumber> {
         self.pending_special_events
             .get_mut(&queue_id)
             .and_then(|queue| queue.pop_front())


### PR DESCRIPTION
Special event registration is necessary for certain X11 use cases, e.g. [usage of the Present extension](https://github.com/mesa3d/mesa/blob/main/src/loader/loader_dri3_helper.c#L605). This PR adds them into the `x11rb_protocol` crate, by adding a hash map of queues into the crate, as well as a mechanism for differentiating events into those queues.

I'm not sure what API you'd want to do for the main crate, so I just did them for the protocol crate.