### PR TITLE
Move id_allocator and parse_display to the protocol crate

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,8 @@
 //! This module contains the current mess that is error handling.
 
-use crate::protocol::xproto::{SetupAuthenticate, SetupFailed};
 use crate::x11_utils::X11Error;
 
-pub use x11rb_protocol::errors::ParseError;
+pub use x11rb_protocol::errors::{ConnectError, IdsExhausted, ParseError};
 
 /// An error occurred  while dynamically loading libxcb.
 #[cfg(feature = "dl-libxcb")]
@@ -40,92 +39,6 @@ impl std::fmt::Display for LibxcbLoadError {
 
 #[cfg(feature = "dl-libxcb")]
 impl std::error::Error for LibxcbLoadError {}
-
-/// An error that occurred while connecting to an X11 server
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum ConnectError {
-    /// An unknown error occurred.
-    ///
-    /// One situation were this error is used when libxcb indicates an error that does not match
-    /// any of the defined error conditions. Thus, libxcb is violating its own API (or new error
-    /// cases were defined, but are not yet handled by x11rb).
-    UnknownError,
-
-    /// Error while parsing some data, see `ParseError`.
-    ParseError(ParseError),
-
-    /// Out of memory.
-    ///
-    /// This is `XCB_CONN_CLOSED_MEM_INSUFFICIENT`.
-    InsufficientMemory,
-
-    /// Error during parsing of display string.
-    ///
-    /// This is `XCB_CONN_CLOSED_PARSE_ERR`.
-    DisplayParsingError,
-
-    /// Server does not have a screen matching the display.
-    ///
-    /// This is `XCB_CONN_CLOSED_INVALID_SCREEN`.
-    InvalidScreen,
-
-    /// An I/O error occurred on the connection.
-    IoError(std::io::Error),
-
-    /// Invalid ID mask provided by the server.
-    ///
-    /// The value of `resource_id_mask` in the `Setup` provided by the server was zero.
-    ZeroIdMask,
-
-    /// The server rejected the connection with a `SetupAuthenticate` message.
-    SetupAuthenticate(SetupAuthenticate),
-
-    /// The server rejected the connection with a `SetupFailed` message.
-    SetupFailed(SetupFailed),
-}
-
-impl std::error::Error for ConnectError {}
-
-impl std::fmt::Display for ConnectError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fn display(
-            f: &mut std::fmt::Formatter<'_>,
-            prefix: &str,
-            value: &[u8],
-        ) -> std::fmt::Result {
-            match std::str::from_utf8(value).ok() {
-                Some(value) => write!(f, "{}: '{}'", prefix, value),
-                None => write!(f, "{}: {:?} [message is not utf8]", prefix, value),
-            }
-        }
-        match self {
-            ConnectError::UnknownError => write!(f, "Unknown connection error"),
-            ConnectError::InsufficientMemory => write!(f, "Insufficient memory"),
-            ConnectError::DisplayParsingError => write!(f, "Display parsing error"),
-            ConnectError::InvalidScreen => write!(f, "Invalid screen"),
-            ConnectError::ParseError(err) => err.fmt(f),
-            ConnectError::IoError(err) => err.fmt(f),
-            ConnectError::ZeroIdMask => write!(f, "XID mask was zero"),
-            ConnectError::SetupFailed(err) => display(f, "X11 setup failed", &err.reason),
-            ConnectError::SetupAuthenticate(err) => {
-                display(f, "X11 authentication failed", &err.reason)
-            }
-        }
-    }
-}
-
-impl From<ParseError> for ConnectError {
-    fn from(err: ParseError) -> Self {
-        ConnectError::ParseError(err)
-    }
-}
-
-impl From<std::io::Error> for ConnectError {
-    fn from(err: std::io::Error) -> Self {
-        ConnectError::IoError(err)
-    }
-}
 
 /// An error that occurred on an already established X11 connection
 #[derive(Debug)]
@@ -286,5 +199,11 @@ impl From<ReplyError> for ReplyOrIdError {
             ReplyError::ConnectionError(err) => ReplyOrIdError::ConnectionError(err),
             ReplyError::X11Error(err) => ReplyOrIdError::X11Error(err),
         }
+    }
+}
+
+impl From<IdsExhausted> for ReplyOrIdError {
+    fn from(_: IdsExhausted) -> Self {
+        ReplyOrIdError::IdsExhausted
     }
 }

--- a/x11rb-protocol/src/connection/mod.rs
+++ b/x11rb-protocol/src/connection/mod.rs
@@ -66,7 +66,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    /// Crate a new `Connection`.
+    /// Create a new `Connection`.
     ///
     /// It is assumed that the connection was just established. This means that the next request
     /// that is sent will have sequence number one.

--- a/x11rb-protocol/src/errors.rs
+++ b/x11rb-protocol/src/errors.rs
@@ -1,5 +1,9 @@
 //! This module contains the current mess that is error handling.
 
+use crate::protocol::xproto::{SetupAuthenticate, SetupFailed};
+
+pub use crate::id_allocator::IdsExhausted;
+
 /// An error occurred while parsing some data
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -63,5 +67,91 @@ impl std::fmt::Display for ParseError {
             }
             ParseError::MissingFileDescriptors => write!(f, "Missing file descriptors"),
         }
+    }
+}
+
+/// An error that occurred while connecting to an X11 server
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ConnectError {
+    /// An unknown error occurred.
+    ///
+    /// One situation were this error is used when libxcb indicates an error that does not match
+    /// any of the defined error conditions. Thus, libxcb is violating its own API (or new error
+    /// cases were defined, but are not yet handled by x11rb).
+    UnknownError,
+
+    /// Error while parsing some data, see `ParseError`.
+    ParseError(ParseError),
+
+    /// Out of memory.
+    ///
+    /// This is `XCB_CONN_CLOSED_MEM_INSUFFICIENT`.
+    InsufficientMemory,
+
+    /// Error during parsing of display string.
+    ///
+    /// This is `XCB_CONN_CLOSED_PARSE_ERR`.
+    DisplayParsingError,
+
+    /// Server does not have a screen matching the display.
+    ///
+    /// This is `XCB_CONN_CLOSED_INVALID_SCREEN`.
+    InvalidScreen,
+
+    /// An I/O error occurred on the connection.
+    IoError(std::io::Error),
+
+    /// Invalid ID mask provided by the server.
+    ///
+    /// The value of `resource_id_mask` in the `Setup` provided by the server was zero.
+    ZeroIdMask,
+
+    /// The server rejected the connection with a `SetupAuthenticate` message.
+    SetupAuthenticate(SetupAuthenticate),
+
+    /// The server rejected the connection with a `SetupFailed` message.
+    SetupFailed(SetupFailed),
+}
+
+impl std::error::Error for ConnectError {}
+
+impl std::fmt::Display for ConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn display(
+            f: &mut std::fmt::Formatter<'_>,
+            prefix: &str,
+            value: &[u8],
+        ) -> std::fmt::Result {
+            match std::str::from_utf8(value).ok() {
+                Some(value) => write!(f, "{}: '{}'", prefix, value),
+                None => write!(f, "{}: {:?} [message is not utf8]", prefix, value),
+            }
+        }
+        match self {
+            ConnectError::UnknownError => write!(f, "Unknown connection error"),
+            ConnectError::InsufficientMemory => write!(f, "Insufficient memory"),
+            ConnectError::DisplayParsingError => write!(f, "Display parsing error"),
+            ConnectError::InvalidScreen => write!(f, "Invalid screen"),
+            ConnectError::ParseError(err) => err.fmt(f),
+            ConnectError::IoError(err) => err.fmt(f),
+            ConnectError::ZeroIdMask => write!(f, "XID mask was zero"),
+            ConnectError::SetupFailed(err) => display(f, "X11 setup failed", &err.reason),
+            ConnectError::SetupAuthenticate(err) => {
+                display(f, "X11 authentication failed", &err.reason)
+            }
+        }
+    }
+}
+
+impl From<ParseError> for ConnectError {
+    fn from(err: ParseError) -> Self {
+        ConnectError::ParseError(err)
+    }
+}
+
+impl From<std::io::Error> for ConnectError {
+    fn from(err: std::io::Error) -> Self {
+        ConnectError::IoError(err)
     }
 }

--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -30,6 +30,8 @@ pub mod connection;
 #[macro_use]
 pub mod x11_utils;
 pub mod errors;
+pub mod id_allocator;
+pub mod parse_display;
 #[rustfmt::skip]
 #[allow(missing_docs)]
 pub mod protocol;

--- a/x11rb-protocol/src/parse_display.rs
+++ b/x11rb-protocol/src/parse_display.rs
@@ -1,12 +1,29 @@
+//! Utilities for parsing X11 display strings.
+
+/// A parsed X11 display string.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ParsedDisplay {
-    pub(crate) host: String,
-    pub(crate) protocol: Option<String>,
-    pub(crate) display: u16,
-    pub(crate) screen: u16,
+pub struct ParsedDisplay {
+    /// The hostname of the computer we nned to connect to.
+    ///
+    /// This is an empty string if we are connecting to the
+    /// local host.
+    pub host: String,
+    /// The protocol we are communicating over.
+    ///
+    /// This is `None` if the protocol may be determined
+    /// automatically.
+    pub protocol: Option<String>,
+    /// The index of the display we are connecting to.
+    pub display: u16,
+    /// The index of the screen that we are using as the
+    /// default screen.
+    pub screen: u16,
 }
 
-pub(crate) fn parse_display(dpy_name: Option<&str>) -> Option<ParsedDisplay> {
+/// Parse an X11 display string.
+///
+/// If `dpy_name` is `None`, the display is parsed from the environment variable `DISPLAY`.
+pub fn parse_display(dpy_name: Option<&str>) -> Option<ParsedDisplay> {
     // If no dpy name was provided, use the env var. If no env var exists, return None.
     match dpy_name {
         Some(dpy_name) => parse_display_impl(dpy_name),


### PR DESCRIPTION
I finally found the time to look at #673 (sorry for the delay) and the change itself looks good, but the squashing somehow went wrong, so I tried to clean that up.

I created a new commit from `git diff master..FETCH_HEAD | git apply` (where `FETCH_HEAD` refers to the branch from the PR in #673). I set all three `GIT_AUTHOR_*` env vars for the commit from the values of the latest commit in #673, so @notgull is still tracked as author. For the commit message, I also (tried to) take the original commit message.

@notgull Is this okay with you or do you mind / did I do something wrong?