### PR TITLE
Improve the docs

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -49,7 +49,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> Vec<Generated> {
     outln!(main_proto_out, "use std::borrow::Cow;");
     outln!(main_proto_out, "use std::convert::TryInto;");
     outln!(main_proto_out, "use crate::errors::ParseError;");
-    outln!(main_proto_out, "use crate::utils::RawFdContainer;");
+    outln!(main_proto_out, "use crate::RawFdContainer;");
     outln!(
         main_proto_out,
         "use crate::x11_utils::{{TryParse, TryParseFd, X11Error, ReplyRequest, ReplyFDsRequest}};"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -79,8 +79,8 @@ pub trait RequestConnection {
 
     /// Send a request with a reply to the server.
     ///
-    /// This function is a wrapper around [`send_request_with_reply`]. This function gets a
-    /// [`ReplyRequest`] as its argument to specify the request to send.
+    /// This function is a wrapper around [`RequestConnection::send_request_with_reply`]. This
+    /// function gets a [`ReplyRequest`] as its argument to specify the request to send.
     fn send_trait_request_with_reply<R>(
         &self,
         request: R,
@@ -129,8 +129,8 @@ pub trait RequestConnection {
 
     /// Send a request with a reply containing file descriptors to the server.
     ///
-    /// This function is a wrapper around [`send_request_with_reply_with_fds`]. This function gets
-    /// a [`ReplyFDsRequest`] as its argument to specify the request to send.
+    /// This function is a wrapper around [`RequestConnection::send_request_with_reply_with_fds`].
+    /// This function gets a [`ReplyFDsRequest`] as its argument to specify the request to send.
     fn send_trait_request_with_reply_with_fds<R>(
         &self,
         request: R,
@@ -177,8 +177,8 @@ pub trait RequestConnection {
 
     /// Send a request without a reply to the server.
     ///
-    /// This function is a wrapper around [`send_request_without_reply`]. This function gets a
-    /// [`VoidRequest`] as its argument to specify the request to send.
+    /// This function is a wrapper around [`RequestConnection::send_request_without_reply`]. This
+    /// function gets a [`VoidRequest`] as its argument to specify the request to send.
     fn send_trait_request_without_reply<R>(
         &self,
         request: R,

--- a/src/rust_connection/xauth.rs
+++ b/src/rust_connection/xauth.rs
@@ -8,7 +8,7 @@ const MIT_MAGIC_COOKIE_1: &[u8] = b"MIT-MAGIC-COOKIE-1";
 
 /// A family describes how to interpret some bytes as an address in an `AuthEntry`.
 ///
-/// Compared to [`x11rb::protocol::xproto::Family`], this is a `u16` and not an `u8`.
+/// Compared to [`x11rb_protocol::protocol::xproto::Family`], this is a `u16` and not an `u8`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Family(u16);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@
 //!
 //! `CSlice` is only available when the `allow-unsafe-code` feature is enabled.
 
-pub use x11rb_protocol::utils::RawFdContainer;
+pub use x11rb_protocol::RawFdContainer;
 
 #[cfg(feature = "allow-unsafe-code")]
 mod unsafe_code {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -103,10 +103,12 @@ pub trait ConnectionExt: XProtoConnectionExt {
 }
 impl<C: XProtoConnectionExt + ?Sized> ConnectionExt for C {}
 
-/// A RAII-like wrapper around [grab_server] and [ungrab_server].
+/// A RAII-like wrapper around [super::protocol::xproto::grab_server] and
+/// [super::protocol::xproto::ungrab_server].
 ///
-/// Instances of this struct represent that we sent a [grab_server] request. When this struct is
-/// dropped, an [ungrab_server] request is sent.
+/// Instances of this struct represent that we sent a [super::protocol::xproto::grab_server]
+/// request. When this struct is dropped, an [super::protocol::xproto::ungrab_server] request is
+/// sent.
 ///
 /// Any errors during `Drop` are silently ignored. Most likely an error here means that your
 /// X11 connection is broken and later requests will also fail.
@@ -114,9 +116,9 @@ impl<C: XProtoConnectionExt + ?Sized> ConnectionExt for C {}
 pub struct GrabServer<'c, C: XProtoConnectionExt>(&'c C);
 
 impl<'c, C: XProtoConnectionExt> GrabServer<'c, C> {
-    /// Grab the server by sending a [grab_server] request.
+    /// Grab the server by sending a [super::protocol::xproto::grab_server] request.
     ///
-    /// The returned type will call [ungrab_server] when it is dropped.
+    /// The returned type will call [super::protocol::xproto::ungrab_server] when it is dropped.
     pub fn grab(conn: &'c C) -> Result<Self, ConnectionError> {
         // Grab the server, return any errors, ignore the resulting VoidCookie
         drop(conn.grab_server()?);

--- a/x11rb-protocol/src/connection/mod.rs
+++ b/x11rb-protocol/src/connection/mod.rs
@@ -1,4 +1,4 @@
-//! A pure-rust implementation of a connection to an X11 server.
+//! Helper types for implementing an X11 client.
 
 use std::collections::VecDeque;
 
@@ -8,7 +8,7 @@ use crate::{DiscardMode, SequenceNumber};
 /// A combination of a buffer and a list of file descriptors.
 pub type BufWithFds = crate::BufWithFds<Vec<u8>>;
 
-/// The raw bytes of an event received by [`RustConnection`] and its sequence number.
+/// The raw bytes of an X11 event and its sequence number.
 pub type RawEventAndSeqNumber = crate::RawEventAndSeqNumber<Vec<u8>>;
 
 /// Information about the reply to an X11 request.

--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -1,4 +1,10 @@
-//! TODO: Docs
+//! X11 rust bindings.
+//!
+//! This crate provides a representation of the X11 protocol in Rust. With this protocol, raw X11
+//! bytes can be parsed into a structured representation or raw bytes can be produces.
+//!
+//! This protocol does not do any I/O. If you need an X11 client library, look at
+//! <https://docs.rs/x11rb/latest/x11rb/>.
 
 #![forbid(
     missing_copy_implementations,
@@ -33,12 +39,14 @@ pub mod errors;
 #[rustfmt::skip]
 #[allow(missing_docs)]
 pub mod protocol;
-pub mod utils;
+mod utils;
 pub mod wrapper;
+
+pub use utils::RawFdContainer;
 
 // Used to avoid too-complex types.
 /// A combination of a buffer and a list of file descriptors.
-pub type BufWithFds<B> = (B, Vec<utils::RawFdContainer>);
+pub type BufWithFds<B> = (B, Vec<RawFdContainer>);
 /// A buffer that is logically continuous, but presented in a number of pieces.
 pub type PiecewiseBuf<'a> = Vec<Cow<'a, [u8]>>;
 

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -14,7 +14,7 @@
 use std::borrow::Cow;
 use std::convert::TryInto;
 use crate::errors::ParseError;
-use crate::utils::RawFdContainer;
+use crate::RawFdContainer;
 use crate::x11_utils::{TryParse, TryParseFd, X11Error, ReplyRequest, ReplyFDsRequest};
 use crate::x11_utils::{ExtInfoProvider, ReplyParsingFunction, RequestHeader};
 

--- a/x11rb-protocol/src/wrapper.rs
+++ b/x11rb-protocol/src/wrapper.rs
@@ -3,10 +3,15 @@
 use super::x11_utils::TryParse;
 use std::marker::PhantomData;
 
-/// Iterator implementation used by `GetPropertyReply`.
+/// Iterator implementation used by [GetPropertyReply].
 ///
-/// This is the actual type returned by `GetPropertyReply::value8`, `GetPropertyReply::value16`,
-/// and `GetPropertyReply::value32`. This type needs to be public due to Rust's visibility rules.
+/// This is the actual type returned by [GetPropertyReply::value8], [GetPropertyReply::value16],
+/// and [GetPropertyReply::value32]. This type needs to be public due to Rust's visibility rules.
+///
+/// [GetPropertyReply]: crate::protocol::xproto::GetPropertyReply
+/// [GetPropertyReply::value8]: crate::protocol::xproto::GetPropertyReply::value8
+/// [GetPropertyReply::value16]: crate::protocol::xproto::GetPropertyReply::value16
+/// [GetPropertyReply::value32]: crate::protocol::xproto::GetPropertyReply::value32
 #[derive(Debug, Clone)]
 pub struct PropertyIterator<'a, T>(&'a [u8], PhantomData<T>);
 

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -414,7 +414,7 @@ tuple_impls!(A:0 B:1 C:2 D:3 E:4 F:5 G:6 H:7 I:8 J:9 K:10 L:11 M:12 N:13 O:14);
 ///
 /// This function parses a list of objects where the length of the list was specified externally.
 /// The wire format for `list_length` instances of `T` will be read from the given data.
-pub fn parse_list<T>(data: &[u8], list_length: usize) -> Result<(Vec<T>, &[u8]), ParseError>
+pub(crate) fn parse_list<T>(data: &[u8], list_length: usize) -> Result<(Vec<T>, &[u8]), ParseError>
 where
     T: TryParse,
 {
@@ -429,7 +429,7 @@ where
 }
 
 /// Parse a list of `u8` from the given data.
-pub fn parse_u8_list(data: &[u8], list_length: usize) -> Result<(&[u8], &[u8]), ParseError> {
+pub(crate) fn parse_u8_list(data: &[u8], list_length: usize) -> Result<(&[u8], &[u8]), ParseError> {
     if data.len() < list_length {
         Err(ParseError::InsufficientData)
     } else {

--- a/xcbgen-rs/src/defs/top_level.rs
+++ b/xcbgen-rs/src/defs/top_level.rs
@@ -621,7 +621,7 @@ impl EventRef {
 
     /// Upgrade this event reference to an event definition.
     ///
-    /// See [`Weak::Upgrade`] for more about what this really does.
+    /// See [`Weak::upgrade`] for more about what this really does.
     pub fn as_event_def(&self) -> EventDef {
         match self {
             Self::Full(event_full_def) => EventDef::Full(event_full_def.upgrade().unwrap()),
@@ -734,7 +734,7 @@ impl ErrorRef {
 
     /// Upgrade this error reference to an error definition.
     ///
-    /// See [`Weak::Upgrade`] for more about what this really does.
+    /// See [`Weak::upgrade`] for more about what this really does.
     pub fn as_error_def(&self) -> ErrorDef {
         match self {
             Self::Full(error_full_def) => ErrorDef::Full(error_full_def.upgrade().unwrap()),


### PR DESCRIPTION
This commit adds some docs and fixes some warnings from "cargo doc".
This also contains some API changes:

- x11rb-protocol::x11_utils switch from pub to pub(crate) since they do
  not really seem useful outside of the crate
- x11rb-protocol::util is made non-pub and its only member
  (RawFdContainer) is publically re-exported at the crate root since the
  "util" module was pretty empty.

Signed-off-by: Uli Schlachter <psychon@znc.in>