### PR TITLE
Add a "ConnectInstruction" type to further abstract out connection parsing

### DIFF
--- a/x11rb-protocol/src/parse_display/connect_instruction.rs
+++ b/x11rb-protocol/src/parse_display/connect_instruction.rs
@@ -1,0 +1,99 @@
+//! Provides the `ConnectInstruction` structure, which allows for a `ParsedDisplay`
+//! to be transformed into a server connection.
+
+use super::ParsedDisplay;
+use std::path::PathBuf;
+
+/// Either a hostname and port to connect to, or a socket to connect to.
+// Do we want to make this #[non_exhaustive], in case we add more connection
+// instructions in the future? i.e. what if we want to do X11 over QUIC?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectAddress<'a> {
+    /// Connect to this hostname and port over TCP.
+    Hostname(&'a str, u16),
+    /// Connect to this Unix socket.
+    Socket(PathBuf),
+}
+
+/// Get an iterator over all of the addresses we should target with a
+/// `ParsedDisplay`.
+pub(super) fn connect_addresses(p: &ParsedDisplay) -> impl Iterator<Item = ConnectAddress<'_>> {
+    const TCP_PORT_BASE: u16 = 6000;
+    let ParsedDisplay {
+        host,
+        protocol,
+        display,
+        ..
+    } = p;
+
+    let mut targets = Vec::new();
+
+    if (protocol.is_none() || protocol.as_deref() != Some("unix"))
+        && !host.is_empty()
+        && host != "unix"
+    {
+        targets.push(ConnectAddress::Hostname(host, TCP_PORT_BASE + display));
+    } else {
+        if protocol.is_none() || protocol.as_deref() == Some("unix") {
+            let file_name = format!("/tmp/.X11-unix/X{}", display);
+            targets.push(ConnectAddress::Socket(file_name.into()));
+
+            // TODO: Try abstract socket (file name with prepended '\0')
+            // Not supported on Rust right now: https://github.com/rust-lang/rust/issues/42048
+        }
+
+        if protocol.is_none() && host.is_empty() {
+            targets.push(ConnectAddress::Hostname(
+                "localhost",
+                TCP_PORT_BASE + display,
+            ));
+        }
+    }
+
+    targets.into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    // make sure iterator properties are clean
+    use super::{super::parse_display, ConnectAddress};
+    use std::path::PathBuf;
+
+    #[test]
+    fn basic_test() {
+        let pd = parse_display(Some(":0")).unwrap();
+        let ci = pd.connect_instruction();
+        let ci = ci.collect::<Vec<_>>();
+
+        assert_eq!(
+            ci,
+            vec![
+                ConnectAddress::Socket(PathBuf::from("/tmp/.X11-unix/X0")),
+                ConnectAddress::Hostname("localhost", 6000),
+            ]
+        );
+    }
+
+    #[test]
+    fn try_over_hostname() {
+        let pd = parse_display(Some("192.168.1.111:0")).unwrap();
+        let ci = pd.connect_instruction();
+
+        let ci = ci.collect::<Vec<_>>();
+
+        assert_eq!(ci, vec![ConnectAddress::Hostname("192.168.1.111", 6000),]);
+    }
+
+    #[test]
+    fn try_over_unix_hostname() {
+        let pd = parse_display(Some("unix/host:0")).unwrap();
+        let ci = pd.connect_instruction();
+
+        let ci = ci.collect::<Vec<_>>();
+
+        assert_eq!(
+            ci,
+            vec![ConnectAddress::Socket(PathBuf::from("/tmp/.X11-unix/X0")),]
+        );
+    }
+}

--- a/x11rb-protocol/src/parse_display/mod.rs
+++ b/x11rb-protocol/src/parse_display/mod.rs
@@ -1,5 +1,8 @@
 //! Utilities for parsing X11 display strings.
 
+mod connect_instruction;
+pub use connect_instruction::ConnectAddress;
+
 /// A parsed X11 display string.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedDisplay {
@@ -18,6 +21,14 @@ pub struct ParsedDisplay {
     /// The index of the screen that we are using as the
     /// default screen.
     pub screen: u16,
+}
+
+impl ParsedDisplay {
+    /// Get an iterator over `ConnectAddress`es from this parsed display for connecting
+    /// to the server.
+    pub fn connect_instruction(&self) -> impl Iterator<Item = ConnectAddress<'_>> {
+        connect_instruction::connect_addresses(self)
+    }
 }
 
 /// Parse an X11 display string.


### PR DESCRIPTION
Not 100% happy with how this is done, would love suggestions. The point is to take a `ParsedDisplay` and convert it into one of:

- A hostname and port to connect to over TCP.
- A path to connect to over a Unix socket, with a port to use as a backup.