### PR TITLE
Move packet reading machinery over to the protocol crate

### DIFF
--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -38,6 +38,7 @@ pub mod connection;
 pub mod x11_utils;
 pub mod errors;
 pub mod id_allocator;
+pub mod packet_reader;
 pub mod parse_display;
 #[rustfmt::skip]
 #[allow(missing_docs)]

--- a/x11rb-protocol/src/packet_reader.rs
+++ b/x11rb-protocol/src/packet_reader.rs
@@ -1,0 +1,232 @@
+//! Collects X11 data into "packets" to be parsed by a display.
+
+use std::convert::TryInto;
+use std::fmt;
+use std::mem::replace;
+
+/// Minimal length of an X11 packet.
+const MINIMAL_PACKET_LENGTH: usize = 32;
+
+/// A wrapper around a buffer used to read X11 packets.
+pub struct PacketReader {
+    /// A paritally-read packet.
+    pending_packet: Vec<u8>,
+
+    /// The point at which the packet is already read.
+    already_read: usize,
+}
+
+impl fmt::Debug for PacketReader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PacketReader")
+            .field(&format_args!(
+                "{}/{}",
+                self.already_read,
+                self.pending_packet.len()
+            ))
+            .finish()
+    }
+}
+
+impl Default for PacketReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PacketReader {
+    /// Create a new, empty `PacketReader`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use x11rb_protocol::packet_reader::PacketReader;
+    /// let reader = PacketReader::new();
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            pending_packet: vec![0; MINIMAL_PACKET_LENGTH],
+            already_read: 0,
+        }
+    }
+
+    /// Get the buffer that the reader should fill with data.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use x11rb_protocol::packet_reader::PacketReader;
+    /// # use x11rb_protocol::protocol::xproto::{GetInputFocusReply, InputFocus, Window};
+    /// let mut reader = PacketReader::new();
+    /// let buffer: [u8; 32] = read_in_buffer();
+    ///
+    /// reader.buffer().copy_from_slice(&buffer);
+    ///
+    /// # fn read_in_buffer() -> [u8; 32] { [0; 32] }
+    /// ```
+    pub fn buffer(&mut self) -> &mut [u8] {
+        &mut self.pending_packet[self.already_read..]
+    }
+
+    /// The remaining capacity that needs to be filled.
+    pub fn remaining_capacity(&self) -> usize {
+        self.pending_packet.len() - self.already_read
+    }
+
+    /// Advance this buffer by the given amount.
+    ///
+    /// This will return the packet that was read, if enough bytes were read in order
+    /// to form a complete packet.
+    pub fn advance(&mut self, amount: usize) -> Option<Vec<u8>> {
+        self.already_read += amount;
+        debug_assert!(self.already_read <= self.pending_packet.len());
+
+        if self.already_read == MINIMAL_PACKET_LENGTH {
+            // we've read in the minimal packet, compute the amount of data we need to read
+            // to form a complete packet
+            let extra_length = extra_length(&self.pending_packet);
+
+            // tell if we need to read more
+            if extra_length > 0 {
+                let total_length = MINIMAL_PACKET_LENGTH + extra_length;
+                self.pending_packet.resize(total_length, 0);
+                return None;
+            }
+        } else if self.already_read != self.pending_packet.len() {
+            // we haven't read the full packet yet, return
+            return None;
+        }
+
+        // we've read in the full packet, return it
+        self.already_read = 0;
+        Some(replace(
+            &mut self.pending_packet,
+            vec![0; MINIMAL_PACKET_LENGTH],
+        ))
+    }
+}
+
+/// Compute the length of the data we need to read, beyond the `MINIMAL_PACKET_LENGTH`.
+fn extra_length(buffer: &[u8]) -> usize {
+    use crate::protocol::xproto::GE_GENERIC_EVENT;
+    const REPLY: u8 = 1;
+
+    let response_type = buffer[0];
+
+    if response_type == REPLY || response_type & 0x7f == GE_GENERIC_EVENT {
+        let length_field = buffer[4..8].try_into().unwrap();
+        let length_field = u32::from_ne_bytes(length_field) as usize;
+        4 * length_field
+    } else {
+        // Fixed size packet: error or event that is not GE_GENERIC_EVENT
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PacketReader;
+
+    fn test_packets(packets: Vec<Vec<u8>>) {
+        let mut reader = PacketReader::new();
+        for mut packet in packets {
+            let original_packet = packet.clone();
+
+            loop {
+                let buffer = reader.buffer();
+                let amount = std::cmp::min(buffer.len(), packet.len());
+                buffer.copy_from_slice(&packet[..amount]);
+                let _ = packet.drain(..amount);
+
+                if let Some(read_packet) = reader.advance(amount) {
+                    assert_eq!(read_packet, original_packet);
+                    return;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn fixed_size_packet() {
+        // packet with a fixed size
+        let packet = vec![0; 32];
+        test_packets(vec![packet]);
+    }
+
+    #[test]
+    fn variable_size_packet() {
+        // packet with a variable size
+        let mut len = 1200;
+        let mut packet = vec![0; len];
+        len = (len - 32) / 4;
+
+        // write "len" to bytes 4..8 in the packet
+        let len_bytes = (len as u32).to_ne_bytes();
+        packet[4..8].copy_from_slice(&len_bytes);
+        packet[0] = 1;
+
+        test_packets(vec![packet]);
+    }
+
+    #[test]
+    fn test_many_fixed_size_packets() {
+        let mut packets = vec![];
+        for _ in 0..100 {
+            packets.push(vec![0; 32]);
+        }
+        test_packets(packets);
+    }
+
+    #[test]
+    fn test_many_variable_size_packets() {
+        let mut packets = vec![];
+        for i in 0..100 {
+            // for maximum variation, increase packet size in a curved parabola
+            // defined by -1/25 (x - 50)^2 + 100
+            let variation = ((i - 50) * (i - 50)) as f32;
+            let variation = -1.0 / 25.0 * variation + 100.0;
+            let variation = variation as usize;
+
+            let mut len = 1200 + variation;
+            let mut packet = vec![0; len];
+            len = (len - 32) / 4;
+
+            // write "len" to bytes 4..8 in the packet
+            let len_bytes = (len as u32).to_ne_bytes();
+            packet[4..8].copy_from_slice(&len_bytes);
+            packet[0] = 1;
+
+            packets.push(packet);
+        }
+        test_packets(packets);
+    }
+
+    #[test]
+    fn text_many_size_packets_mixed() {
+        let mut packets = vec![];
+        for i in 0..100 {
+            // on odds, do a varsize packet
+            let mut len = if i & 1 == 1 {
+                // for maximum variation, increase packet size in a curved parabola
+                // defined by -1/25 (x - 50)^2 + 100
+                let variation = ((i - 50) * (i - 50)) as f32;
+                let variation = -1.0 / 25.0 * variation + 100.0;
+                let variation = variation as usize;
+
+                1200 + variation
+            } else {
+                32
+            };
+            let mut packet = vec![0; len];
+            len = (len - 32) / 4;
+
+            // write "len" to bytes 4..8 in the packet
+            let len_bytes = (len as u32).to_ne_bytes();
+            packet[4..8].copy_from_slice(&len_bytes);
+            packet[0] = 1;
+
+            packets.push(packet);
+        }
+        test_packets(packets);
+    }
+}

--- a/x11rb/src/rust_connection/packet_reader.rs
+++ b/x11rb/src/rust_connection/packet_reader.rs
@@ -1,23 +1,30 @@
 //! Read X11 packets from a reader
 
-use std::convert::TryInto;
 use std::io::{Error, ErrorKind, Result};
+use std::{cmp, fmt, io};
 
 use super::Stream;
 use crate::utils::RawFdContainer;
-
-/// Minimal length of an X11 packet
-const MINIMAL_PACKET_LENGTH: usize = 32;
+use x11rb_protocol::packet_reader::PacketReader as ProtoPacketReader;
 
 /// A wrapper around a reader that reads X11 packet.
-#[derive(Debug)]
 pub(crate) struct PacketReader {
+    /// The read buffer to store incoming bytes in.
     read_buffer: Box<[u8]>,
+    /// The inner reader that breaks these bytes into packets.
+    inner: ProtoPacketReader,
+}
 
-    // A packet that was partially read.
-    pending_packet: Vec<u8>,
-    // Up to where the packet is already read.
-    already_read: usize,
+impl fmt::Debug for PacketReader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PacketReader")
+            .field(
+                "read_buffer",
+                &format_args!("[buffer of size {}]", self.read_buffer.len()),
+            )
+            .field("inner", &self.inner)
+            .finish()
+    }
 }
 
 impl PacketReader {
@@ -26,36 +33,7 @@ impl PacketReader {
         Self {
             // Buffer size chosen by checking what libxcb does
             read_buffer: vec![0; 4096].into_boxed_slice(),
-            pending_packet: vec![0; MINIMAL_PACKET_LENGTH],
-            already_read: 0,
-        }
-    }
-
-    /// To be called after `nread` bytes have been writen into `pending_packet`.
-    fn handle_partial_read(&mut self, nread: usize, out_packets: &mut Vec<Vec<u8>>) {
-        self.already_read += nread;
-        // Do we still need to compute the length field? (length == MINIMAL_PACKET_LENGTH)
-        if self.already_read == MINIMAL_PACKET_LENGTH {
-            // Yes, then compute the packet length and resize the `Vec` to its final size.
-            let extra = extra_length(self.pending_packet[..].try_into().unwrap());
-            self.pending_packet.reserve_exact(extra);
-            self.pending_packet.resize(MINIMAL_PACKET_LENGTH + extra, 0);
-        }
-
-        // Has the packet been completely read?
-        if self.already_read == self.pending_packet.len() {
-            // Check that we really read the whole packet
-            let initial_packet = &self.pending_packet[0..MINIMAL_PACKET_LENGTH]
-                .try_into()
-                .unwrap();
-            let extra = extra_length(initial_packet);
-            assert_eq!(self.pending_packet.len(), MINIMAL_PACKET_LENGTH + extra);
-
-            out_packets.push(std::mem::replace(
-                &mut self.pending_packet,
-                vec![0; MINIMAL_PACKET_LENGTH],
-            ));
-            self.already_read = 0;
+            inner: ProtoPacketReader::new(),
         }
     }
 
@@ -67,44 +45,54 @@ impl PacketReader {
         fd_storage: &mut Vec<RawFdContainer>,
     ) -> Result<()> {
         loop {
-            if (self.pending_packet.len() - self.already_read) >= self.read_buffer.len() {
-                assert_ne!(self.already_read, self.pending_packet.len());
-                // Bypass the read buffer
-                match stream.read(&mut self.pending_packet[self.already_read..], fd_storage) {
+            // if the necessary packet size is larger than our buffer, just fill straight
+            // into the buffer
+            if self.inner.remaining_capacity() >= self.read_buffer.len() {
+                match stream.read(self.inner.buffer(), fd_storage) {
                     Ok(0) => {
                         return Err(Error::new(
                             ErrorKind::UnexpectedEof,
                             "The X11 server closed the connection",
                         ));
                     }
-                    Ok(nread) => self.handle_partial_read(nread, out_packets),
-                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Ok(n) => {
+                        if let Some(packet) = self.inner.advance(n) {
+                            out_packets.push(packet);
+                        }
+                    }
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                     Err(e) => return Err(e),
                 }
             } else {
-                // Fill the read buffer
-                match stream.read(&mut self.read_buffer, fd_storage) {
+                // read into our buffer
+                let nread = match stream.read(&mut self.read_buffer, fd_storage) {
                     Ok(0) => {
                         return Err(Error::new(
                             ErrorKind::UnexpectedEof,
                             "The X11 server closed the connection",
                         ));
                     }
-                    Ok(nread) => {
-                        let mut used_from_buffer = 0;
-                        // Take packets from `read_buffer`.
-                        while used_from_buffer != nread {
-                            let rem_read_buffer = &self.read_buffer[used_from_buffer..nread];
-                            let rem_packet = &mut self.pending_packet[self.already_read..];
-                            let to_copy = rem_read_buffer.len().min(rem_packet.len());
-                            assert_ne!(to_copy, 0);
-                            rem_packet[..to_copy].copy_from_slice(&rem_read_buffer[..to_copy]);
-                            used_from_buffer += to_copy;
-                            self.handle_partial_read(to_copy, out_packets);
-                        }
-                    }
-                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Ok(n) => n,
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                     Err(e) => return Err(e),
+                };
+
+                // begin reading that data into packets
+                let mut src = &self.read_buffer[..nread];
+                while !src.is_empty() {
+                    let dest = self.inner.buffer();
+                    let amt_to_read = cmp::min(src.len(), dest.len());
+
+                    // copy slices over
+                    dest[..amt_to_read].copy_from_slice(&src[..amt_to_read]);
+
+                    // reborrow src
+                    src = &src[amt_to_read..];
+
+                    // advance by the given amount
+                    if let Some(packet) = self.inner.advance(amt_to_read) {
+                        out_packets.push(packet);
+                    }
                 }
             }
         }
@@ -113,19 +101,95 @@ impl PacketReader {
     }
 }
 
-// Compute the length beyond `MINIMAL_PACKET_LENGTH` of an X11 packet.
-fn extra_length(buffer: &[u8; MINIMAL_PACKET_LENGTH]) -> usize {
-    use crate::protocol::xproto::GE_GENERIC_EVENT;
+#[cfg(test)]
+mod tests {
+    use super::PacketReader;
+    use crate::rust_connection::{PollMode, Stream};
+    use crate::utils::RawFdContainer;
+    use std::cell::RefCell;
+    use std::cmp;
+    use std::io::{Error, ErrorKind, Result};
 
-    let response_type = buffer[0];
+    // make a Stream that just reads from a Vec<u8>
+    struct TestStream {
+        data: RefCell<Vec<u8>>,
+    }
 
-    const REPLY: u8 = 1;
-    if response_type == REPLY || response_type & 0x7f == GE_GENERIC_EVENT {
-        let length_field = buffer[4..8].try_into().unwrap();
-        let length_field = u32::from_ne_bytes(length_field) as usize;
-        4 * length_field
-    } else {
-        // Fixed size packet: error or event that is not GE_GENERIC_EVENT
-        0
+    impl TestStream {
+        fn new(data: Vec<u8>) -> Self {
+            Self {
+                data: RefCell::new(data),
+            }
+        }
+    }
+
+    impl Stream for TestStream {
+        fn read(&self, buf: &mut [u8], _: &mut Vec<RawFdContainer>) -> Result<usize> {
+            let mut data = self.data.borrow_mut();
+            if data.len() == 0 {
+                return Err(Error::from(ErrorKind::WouldBlock));
+            }
+
+            let nread = cmp::min(data.len(), buf.len());
+            buf[..nread].copy_from_slice(&data[..nread]);
+            let _ = data.drain(..nread);
+            Ok(nread)
+        }
+
+        fn poll(&self, _: PollMode) -> Result<()> {
+            Ok(())
+        }
+
+        fn write(&self, _: &[u8], _: &mut Vec<RawFdContainer>) -> Result<usize> {
+            unreachable!()
+        }
+    }
+
+    fn test_packet(packet: Vec<u8>) {
+        let mut reader = PacketReader::new();
+        let original_packet = packet.clone();
+        let stream = TestStream::new(packet);
+
+        let mut packets = Vec::new();
+        let mut fd_storage = Vec::new();
+
+        reader
+            .try_read_packets(&stream, &mut packets, &mut fd_storage)
+            .unwrap();
+
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0], original_packet);
+    }
+
+    #[test]
+    fn fixed_size_packet() {
+        let packet = vec![0; 32];
+        test_packet(packet);
+    }
+
+    #[test]
+    fn variable_size_packet() {
+        let mut len = 120;
+        let mut packet = vec![0; len];
+        len = (len - 32) / 4;
+
+        // copy len to 4..8
+        packet[4..8].copy_from_slice(&(len as u32).to_ne_bytes());
+        packet[0] = 1;
+
+        test_packet(packet);
+    }
+
+    #[test]
+    fn very_large_packet() {
+        let mut len = 4800;
+        let mut packet = vec![0; len];
+        len = (len - 32) / 4;
+
+        // copy len to 4..8
+        packet[4..8].copy_from_slice(&(len as u32).to_ne_bytes());
+        packet[0] = 1;
+
+        test_packet(packet);
     }
 }


### PR DESCRIPTION
This crate splits the `PacketReader` type into two:

- One that exposes a mutable slice that the reader should fill with bytes. This has become a part of the protocol crate.
- One that takes the `Stream`, fills a buffer, and then pushes that buffer into the former structure. This remains in its original place in the main crate.

In addition, I also gave them new `Debug` implementations that represents their contents more concisely.